### PR TITLE
Change pubsub name to NervesHubWeb.PubSub

### DIFF
--- a/apps/nerves_hub_device/config/config.exs
+++ b/apps/nerves_hub_device/config/config.exs
@@ -14,7 +14,7 @@ config :nerves_hub_device,
 # Configures the endpoint
 config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   render_errors: [view: NervesHubWWWWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: NervesHubWWW.PubSub, adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: NervesHubWeb.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/apps/nerves_hub_device/config/dev.exs
+++ b/apps/nerves_hub_device/config/dev.exs
@@ -11,7 +11,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   code_reloader: false,
   check_origin: false,
   watchers: [],
-  pubsub: [name: NervesHubWWW.PubSub, adapter: Phoenix.PubSub.PG2],
+  pubsub: [name: NervesHubWeb.PubSub, adapter: Phoenix.PubSub.PG2],
   https: [
     port: 4443,
     otp_app: :nerves_hub_device,

--- a/apps/nerves_hub_device/config/prod.exs
+++ b/apps/nerves_hub_device/config/prod.exs
@@ -3,7 +3,7 @@ use Mix.Config
 config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   load_from_system_env: true,
   url: [host: "device.nerves-hub.org"],
-  pubsub: [name: NervesHubWWW.PubSub,
+  pubsub: [name: NervesHubWeb.PubSub,
            adapter: Phoenix.PubSub.PG2],
   server: true,
   https: [

--- a/apps/nerves_hub_device/config/test.exs
+++ b/apps/nerves_hub_device/config/test.exs
@@ -12,7 +12,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   check_origin: false,
   watchers: [],
   server: true,
-  pubsub: [name: NervesHubWWW.PubSub, adapter: Phoenix.PubSub.PG2],
+  pubsub: [name: NervesHubWeb.PubSub, adapter: Phoenix.PubSub.PG2],
   https: [
     port: 4443,
     otp_app: :nerves_hub_device,

--- a/apps/nerves_hub_www/config/config.exs
+++ b/apps/nerves_hub_www/config/config.exs
@@ -16,7 +16,7 @@ config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
   url: [host: System.get_env("HOST")],
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
   render_errors: [view: NervesHubWWWWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: NervesHubWWW.PubSub]
+  pubsub: [name: NervesHubWeb.PubSub]
 
 # Configures Elixir's Logger
 config :logger, :console,


### PR DESCRIPTION
The pubsub group is shared across multiple umbrella apps.