### PR TITLE
Eager Firmware Update Message

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/application.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/application.ex
@@ -10,6 +10,7 @@ defmodule NervesHubCore.Application do
     children = [
       # Start the Ecto repository
       supervisor(NervesHubCore.Repo, []),
+      {Task.Supervisor, name: NervesHubCore.TaskSupervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -17,5 +18,4 @@ defmodule NervesHubCore.Application do
     opts = [strategy: :one_for_one, name: NervesHubCore.Supervisor]
     Supervisor.start_link(children, opts)
   end
-
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -1,9 +1,12 @@
 defmodule NervesHubCore.DeploymentsTest do
   use NervesHubCore.DataCase
+  use Phoenix.ChannelTest
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Deployments
   alias Ecto.Changeset
+
+  @endpoint NervesHubDeviceWeb.Endpoint
 
   setup do
     tenant = Fixtures.tenant_fixture()
@@ -12,11 +15,18 @@ defmodule NervesHubCore.DeploymentsTest do
     firmware = Fixtures.firmware_fixture(tenant_key, product)
     deployment = Fixtures.deployment_fixture(firmware)
 
-    {:ok, %{tenant: tenant, firmware: firmware, deployment: deployment, product: product}}
+    {:ok,
+     %{
+       tenant: tenant,
+       tenant_key: tenant_key,
+       firmware: firmware,
+       deployment: deployment,
+       product: product
+     }}
   end
 
   test 'create_deployment with valid parameters', %{
-    firmware: firmware,
+    firmware: firmware
   } do
     params = %{
       firmware_id: firmware.id,
@@ -25,7 +35,7 @@ defmodule NervesHubCore.DeploymentsTest do
         "version" => "< 1.0.0",
         "tags" => ["beta", "beta-edge"]
       },
-      is_active: true
+      is_active: false
     }
 
     {:ok, %Deployments.Deployment{} = deployment} = Deployments.create_deployment(params)
@@ -46,5 +56,78 @@ defmodule NervesHubCore.DeploymentsTest do
     }
 
     assert {:error, %Changeset{}} = Deployments.create_deployment(params)
+  end
+
+  describe "update_deployment" do
+    test "updates correct devices", %{
+      tenant: tenant,
+      tenant_key: tenant_key,
+      firmware: firmware,
+      deployment: old_deployment,
+      product: product
+    } do
+      device = Fixtures.device_fixture(tenant, firmware, old_deployment)
+      new_firmware = Fixtures.firmware_fixture(tenant_key, product, %{version: "1.0.1"})
+
+      params = %{
+        firmware_id: new_firmware.id,
+        name: "my deployment",
+        conditions: %{
+          "version" => "< 1.0.1",
+          "tags" => ["beta", "beta-edge"]
+        },
+        is_active: false
+      }
+
+      device_topic = "device:#{device.identifier}"
+      @endpoint.subscribe(device_topic)
+
+      {:ok, _deployment} =
+        Deployments.create_deployment(params)
+        |> elem(1)
+        |> Deployments.update_deployment(%{is_active: true})
+
+      assert_broadcast("update", %{firmware_url: _f_url}, 500)
+    end
+
+    test "does not update incorrect devices", %{
+      tenant: tenant,
+      tenant_key: tenant_key,
+      firmware: firmware,
+      deployment: old_deployment,
+      product: product
+    } do
+      incorrect_params = [
+        {%{version: "1.0.0"}, %{identifier: "foo"}},
+        {%{}, %{identifier: "new identifier", tags: ["beta"]}},
+        {%{}, %{identifier: "newnew identifier", architecture: "foo"}},
+        {%{}, %{identifier: "newnewnew identifier", platform: "foo"}}
+      ]
+
+      for {f_params, d_params} <- incorrect_params do
+        device = Fixtures.device_fixture(tenant, firmware, old_deployment, d_params)
+        new_firmware = Fixtures.firmware_fixture(tenant_key, product, f_params)
+
+        params = %{
+          firmware_id: firmware.id,
+          name: "my deployment",
+          conditions: %{
+            "version" => "< 1.0.0",
+            "tags" => ["beta", "beta-edge"]
+          },
+          is_active: false
+        }
+
+        device_topic = "device:#{device.identifier}"
+        @endpoint.subscribe(device_topic)
+
+        {:ok, _deployment} =
+          Deployments.create_deployment(params)
+          |> elem(1)
+          |> Deployments.update_deployment(%{is_active: true})
+
+        refute_broadcast("update", %{firmware_url: _f_url})
+      end
+    end
   end
 end

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -48,10 +48,6 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     |> do_update_message(tenant)
   end
 
-  defp do_update_message([], _) do
-    {:ok, %{update_available: false}}
-  end
-
   defp do_update_message([%Deployments.Deployment{} = deployment | _], tenant) do
     with {:ok, firmware} <- Firmwares.get_firmware(tenant, deployment.firmware_id),
          {:ok, url} <- @uploader.download_file(firmware) do
@@ -59,6 +55,10 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     else
       _ -> {:error, :no_firmware_url}
     end
+  end
+
+  defp do_update_message([], _) do
+    {:ok, %{update_available: false}}
   end
 
   defp do_update_message(_, _), do: {:error, :unknown_error}

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -2,7 +2,7 @@ defmodule NervesHubWWW.Integration.WebsocketTest do
   use ExUnit.Case, async: false
   use NervesHubDeviceWeb.ChannelCase
   alias NervesHubCore.Fixtures
-  alias NervesHubCore.{Repo, Devices, Accounts}
+  alias NervesHubCore.{Accounts, Deployments, Devices, Repo}
 
   @serial_header Application.get_env(:nerves_hub_device, :device_serial_header)
   @valid_serial "device-1234"
@@ -54,7 +54,10 @@ defmodule NervesHubWWW.Integration.WebsocketTest do
         upload_metadata: %{"public_path" => @valid_firmware_url}
       })
 
-    deployment = Fixtures.deployment_fixture(firmware)
+    {:ok, deployment} =
+      Fixtures.deployment_fixture(firmware)
+      |> Deployments.update_deployment(%{is_active: true})
+
     Fixtures.device_fixture(tenant, firmware, deployment, device_params)
   end
 
@@ -232,6 +235,7 @@ defmodule NervesHubWWW.Integration.WebsocketTest do
           "tags" => ["beta", "beta-edge"]
         }
       })
+      |> Deployments.update_deployment(%{is_active: true})
 
       opts =
         @ssl_socket_config

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -23,7 +23,7 @@ defmodule NervesHubCore.Fixtures do
       "version" => "< 1.0.0",
       "tags" => ["beta", "beta-edge"]
     },
-    is_active: true
+    is_active: false
   }
   @device_params %{identifier: "device-1234"}
   @product_params %{name: "valid product"}


### PR DESCRIPTION
Why:

*  We want to tell devices when they need new firmware

This change addresses the need by:

* On an update to a deployment, asyncronously send a message to the
`device:identifier` topic for each relevant device.

Other changes:
* Don't allow for the creation of a deployment with `%{is_active: true}`