### PR TITLE
Fix unique indices

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user_certificate.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user_certificate.ex
@@ -19,5 +19,6 @@ defmodule NervesHubCore.Accounts.UserCertificate do
     user_certificate
     |> cast(params, [:serial, :description])
     |> validate_required([:serial, :description])
+    |> unique_constraint(:serial, name: :user_certificates_user_id_serial_index)
   end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/products/product.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/products/product.ex
@@ -23,5 +23,6 @@ defmodule NervesHubCore.Products.Product do
     product
     |> cast(attrs, @required_params ++ @optional_params)
     |> validate_required(@required_params)
+    |> unique_constraint(:name, name: :products_tenant_id_name_index)
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180216143258_deployments.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180216143258_deployments.exs
@@ -11,7 +11,5 @@ defmodule NervesHubCore.Repo.Migrations.Deployments do
 
       timestamps()
     end
-
-    unique_index(:deployments, [:tenant_id, :name], name: :deployments_tenant_id_name_index)
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180710140434_create_products.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180710140434_create_products.exs
@@ -25,8 +25,6 @@ defmodule NervesHubCore.Repo.Migrations.CreateProducts do
     end
 
     create(index(:products, [:tenant_id]))
-    unique_index(:products, [:tenant_id, :name], name: :products_tenant_id_name_index)
-    unique_index(:deployments, [:product_id, :name], name: :deployments_product_id_name_index)
   end
 
   def down do

--- a/apps/nerves_hub_core/priv/repo/migrations/20180724191309_create_user_certificates.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180724191309_create_user_certificates.exs
@@ -12,6 +12,5 @@ defmodule NervesHubCore.Repo.Migrations.CreateUserCertificates do
 
     create(index(:user_certificates, [:user_id]))
     create(index(:user_certificates, [:serial]))
-    unique_index(:user_certificates, [:user_id, :serial], name: :user_certificates_user_id_serial_index)
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180730195025_fix_unique_indices.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180730195025_fix_unique_indices.exs
@@ -1,0 +1,15 @@
+defmodule NervesHubCore.Repo.Migrations.FixUniqueIndices do
+  use Ecto.Migration
+
+  def change do
+    create(unique_index(:products, [:tenant_id, :name], name: :products_tenant_id_name_index))
+
+    create(
+      unique_index(
+        :user_certificates,
+        [:user_id, :serial],
+        name: :user_certificates_user_id_serial_index
+      )
+    )
+  end
+end

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -67,4 +67,25 @@ defmodule NervesHubCore.AccountsTest do
 
     assert {:ok, _cert} = Accounts.create_user_certificate(user, params)
   end
+
+  test "cannot create user certificate with duplicate serial" do
+    params = %{
+      name: "Testy McTesterson",
+      tenant_name: "mctesterson.com",
+      email: "testy@mctesterson.com",
+      password: "test_password"
+    }
+
+    {:ok, %Accounts.Tenant{} = result_tenant} = Accounts.create_tenant_with_user(params)
+
+    [user | _] = result_tenant |> Repo.preload(:users) |> Map.get(:users)
+
+    params = %{
+      description: "abcd",
+      serial: "12345"
+    }
+
+    {:ok, _cert} = Accounts.create_user_certificate(user, params)
+    {:error, %Ecto.Changeset{}} = Accounts.create_user_certificate(user, params)
+  end
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -109,7 +109,7 @@ defmodule NervesHubCore.DeploymentsTest do
         new_firmware = Fixtures.firmware_fixture(tenant_key, product, f_params)
 
         params = %{
-          firmware_id: firmware.id,
+          firmware_id: new_firmware.id,
           name: "my deployment",
           conditions: %{
             "version" => "< 1.0.0",

--- a/apps/nerves_hub_core/test/nerves_hub_core/products/products_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/products/products_test.exs
@@ -13,7 +13,7 @@ defmodule NervesHubWWW.ProductsTest do
 
     setup do
       tenant = Fixtures.tenant_fixture()
-      product = Fixtures.product_fixture(tenant, @valid_attrs)
+      product = Fixtures.product_fixture(tenant, %{name: "a product"})
 
       {:ok, %{product: product, tenant: tenant}}
     end
@@ -37,6 +37,18 @@ defmodule NervesHubWWW.ProductsTest do
 
     test "create_product/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Products.create_product(@invalid_attrs)
+    end
+
+    test "create_product/1 fails with duplicate names", %{tenant: tenant} do
+      {:ok, _product} =
+        %{tenant_id: tenant.id}
+        |> Enum.into(%{name: "same name"})
+        |> Products.create_product()
+
+      assert {:error, %Ecto.Changeset{}} =
+               %{tenant_id: tenant.id}
+               |> Enum.into(%{name: "same name"})
+               |> Products.create_product()
     end
 
     test "update_product/2 with valid data updates the product", %{product: product} do

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -219,7 +219,7 @@ defmodule NervesHubWWW.Integration.WebsocketTest do
         |> device_fixture("not_foobar")
 
       tenant = %Accounts.Tenant{id: device.tenant_id}
-      product = Fixtures.product_fixture(tenant)
+      product = Fixtures.product_fixture(tenant, %{name: "new product"})
       tenant_key = Fixtures.tenant_key_fixture(tenant, %{name: "another key"})
 
       firmware =


### PR DESCRIPTION
Why:

* `create/1` was not called on `:products_tenant_id_name_index` or
`:user_certificates_user_id_serial_index`.

This change addresses the need by:

* Creating a new migration that _actually_ creates these indices.
* Removing the lines where they were defined, but not created in the
original migrations (to avoid developer confusion).
* Testing for uniqueness in these two indices.