### PR TITLE
More uniqueness

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -102,7 +102,6 @@ defmodule NervesHubCore.Accounts do
     |> UserCertificate.changeset(params)
     |> Repo.insert()
   end
-  
 
   @doc """
   Authenticates a user by their email and password. Returns the user if the
@@ -160,10 +159,12 @@ defmodule NervesHubCore.Accounts do
   end
 
   def get_user_with_certificate_serial(serial) do
-    query = from(
-      uc in UserCertificate, 
-      where: uc.serial == ^serial,
-      preload: [:user])
+    query =
+      from(
+        uc in UserCertificate,
+        where: uc.serial == ^serial,
+        preload: [:user]
+      )
 
     query
     |> Repo.one()

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/tenant_key.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/tenant_key.ex
@@ -11,7 +11,7 @@ defmodule NervesHubCore.Accounts.TenantKey do
 
   schema "tenant_keys" do
     belongs_to(:tenant, Tenant)
-    has_many(:firmware, Firmware)
+    has_many(:firmwares, Firmware)
 
     field(:name, :string)
     field(:key, :string)
@@ -24,5 +24,6 @@ defmodule NervesHubCore.Accounts.TenantKey do
     |> cast(params, [:tenant_id, :name, :key])
     |> validate_required([:tenant_id, :name, :key])
     |> unique_constraint(:name, name: :tenant_keys_tenant_id_name_index)
+    |> unique_constraint(:key)
   end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/firmware.ex
@@ -49,6 +49,7 @@ defmodule NervesHubCore.Firmwares.Firmware do
     firmware
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
+    |> unique_constraint(:uuid, name: :firmwares_product_id_uuid_index)
   end
 
   def with_product(firmware_query) do

--- a/apps/nerves_hub_core/priv/repo/migrations/20180731143210_unique_firmware_and_tenant_keys.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180731143210_unique_firmware_and_tenant_keys.exs
@@ -1,0 +1,8 @@
+defmodule NervesHubCore.Repo.Migrations.UniqueFirmwareAndTenantKeys do
+  use Ecto.Migration
+
+  def change do
+    create(unique_index(:firmwares, [:product_id, :uuid], name: :firmwares_product_id_uuid_index))
+    create(unique_index(:tenant_keys, [:key]))
+  end
+end

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -88,4 +88,24 @@ defmodule NervesHubCore.AccountsTest do
     {:ok, _cert} = Accounts.create_user_certificate(user, params)
     {:error, %Ecto.Changeset{}} = Accounts.create_user_certificate(user, params)
   end
+
+  test "tenant_key name must be unique" do
+    {:ok, tenant} = Accounts.create_tenant(@required_tenant_params)
+
+    {:ok, _} =
+      Accounts.create_tenant_key(%{name: "tenant's key", tenant_id: tenant.id, key: "foo"})
+
+    {:error, %Ecto.Changeset{errors: [name: {"has already been taken", []}]}} =
+      Accounts.create_tenant_key(%{name: "tenant's key", tenant_id: tenant.id, key: "foobar"})
+  end
+
+  test "tenant_key key must be unique" do
+    {:ok, tenant} = Accounts.create_tenant(@required_tenant_params)
+
+    {:ok, _} =
+      Accounts.create_tenant_key(%{name: "tenant's key", tenant_id: tenant.id, key: "foo"})
+
+    {:error, %Ecto.Changeset{}} =
+      Accounts.create_tenant_key(%{name: "tenant's second key", tenant_id: tenant.id, key: "foo"})
+  end
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
@@ -51,6 +51,23 @@ defmodule NervesHubCore.FirmwaresTest do
     |> Repo.update!()
   end
 
+  describe "create_firmware" do
+    test "enforces uuid uniqueness within a product", %{firmware: existing} do
+      new_params = %{
+        architecture: "arm",
+        tenant_key_id: existing.tenant_key_id,
+        platform: "rpi3",
+        product_id: existing.product_id,
+        upload_metadata: %{},
+        version: "100.0.0",
+        uuid: existing.uuid
+      }
+
+      assert {:error, %Ecto.Changeset{errors: [uuid: {"has already been taken", []}]}} =
+               Firmwares.create_firmware(new_params)
+    end
+  end
+
   describe "NervesHubWWW.Firmwares.get_firmwares_by_product/2" do
     test "returns firmwares", %{product: %{id: product_id} = product} do
       firmwares = Firmwares.get_firmwares_by_product(product.id)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -3,8 +3,7 @@ defmodule NervesHubCore.Fixtures do
 
   @tenant_params %{name: "Test Tenant"}
   @tenant_key_params %{
-    name: "Test Key",
-    key: File.read!("../../test/fixtures/firmware/fwup-key1.pub")
+    name: "Test Key"
   }
   @firmware_params %{
     architecture: "arm",
@@ -14,8 +13,7 @@ defmodule NervesHubCore.Fixtures do
     upload_metadata: %{"public_url" => "http://example.com"},
     version: "1.0.0",
     vcs_identifier: "test_vcs_identifier",
-    misc: "test_misc",
-    uuid: "00000000-0000-0000-0000-000000000000"
+    misc: "test_misc"
   }
   @deployment_params %{
     name: "Test Deployment",
@@ -52,6 +50,7 @@ defmodule NervesHubCore.Fixtures do
       %{tenant_id: tenant.id}
       |> Enum.into(params)
       |> Enum.into(@tenant_key_params)
+      |> Enum.into(%{key: Ecto.UUID.generate()})
       |> Accounts.create_tenant_key()
 
     tenant_key
@@ -98,6 +97,7 @@ defmodule NervesHubCore.Fixtures do
       %{tenant_key_id: tenant_key.id, product_id: product.id}
       |> Enum.into(params)
       |> Enum.into(@firmware_params)
+      |> Enum.into(%{uuid: Ecto.UUID.generate()})
       |> Firmwares.create_firmware()
 
     firmware


### PR DESCRIPTION
Why:

* It's important that some things really are special.
* https://github.com/nerves-hub/nerves_hub_web/issues/152
* https://github.com/nerves-hub/nerves_hub_web/issues/153

This change addresses the need by:

* Enforce uniqueness on firmware uuids within the scope of a product.
* Enforce tenant key `:key` uniqueness across all tenant keys.
* Tests to back it up.