### PR TITLE
Add a button that links to the user certificates

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
@@ -1,5 +1,8 @@
 <h1>
   Edit Account
+  <a class="btn btn-lg btn-success pull-right" href="<%= account_certificate_path(@conn, :index)%>">
+    User Certificates
+  </a>
 </h1>
 
 <%= form_for @changeset, account_path(@conn, :update), fn f -> %>
@@ -29,3 +32,4 @@
 
   <%= submit "Update", class: "btn btn-primary" %>
 <% end %>
+

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -71,6 +71,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
     } do
       conn = get(conn, account_path(conn, :edit))
       assert html_response(conn, 200) =~ "Edit Account"
+      assert html_response(conn, 200) =~ account_certificate_path(conn, :index)
       assert html_response(conn, 200) =~ "type=\"password\""
     end
   end


### PR DESCRIPTION
Why:

* It's good to have that in the UI
* The beginnings of addressing: https://github.com/nerves-hub/nerves_hub_web/issues/144

This change addresses the need by:

* Adding the button.
* Testing for it's presence.