### PR TITLE
Clean up warnings and format code

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,5 @@
+# Used by "mix format"
 [
-  inputs: [
-    "{lib,config,web,test}/**/*.{ex,exs}",
-    "mix.exs"
-  ]
+  inputs: ["mix.exs", "config/*.exs"],
+  subdirectories: ["apps/*"]
 ]

--- a/apps/nerves_hub_api/config/prod.exs
+++ b/apps/nerves_hub_api/config/prod.exs
@@ -3,8 +3,6 @@ use Mix.Config
 config :nerves_hub_api, NervesHubAPIWeb.Endpoint,
   load_from_system_env: true,
   url: [host: "api.nerves-hub.org"],
-  pubsub: [name: NervesHubWeb.PubSub,
-           adapter: Phoenix.PubSub.PG2],
   server: true,
   https: [
     port: 443,

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
@@ -11,7 +11,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
     render(conn, "index.json", deployments: deployments)
   end
 
-  def show(%{assigns: %{org: org, product: product}} = conn, %{"name" => name}) do
+  def show(%{assigns: %{org: _org, product: product}} = conn, %{"name" => name}) do
     with {:ok, deployment} <- Deployments.get_deployment_by_name(product, name) do
       render(conn, "show.json", deployment: deployment)
     end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
@@ -24,6 +24,6 @@ defmodule NervesHubAPIWeb.FallbackController do
     conn
     |> put_status(500)
     |> put_view(NervesHubAPIWeb.ErrorView)
-    |> render(:"500")
+    |> render(:"500", %{reason: reason})
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/error_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/error_view.ex
@@ -3,8 +3,8 @@ defmodule NervesHubAPIWeb.ErrorView do
 
   # If you want to customize a particular status code
   # for a certain format, you may uncomment below.
-  def render("500.json", _assigns) do
-    %{errors: %{detail: "Internal Server Error"}}
+  def render("500.json", %{error: error}) do
+    %{errors: %{detail: error}}
   end
 
   # By default, Phoenix returns the status message from

--- a/apps/nerves_hub_core/config/config.exs
+++ b/apps/nerves_hub_core/config/config.exs
@@ -5,4 +5,8 @@ use Mix.Config
 config :nerves_hub_core,
   ecto_repos: [NervesHubCore.Repo]
 
-import_config "#{Mix.env}.exs"
+config :nerves_hub_core, NervesHubWeb.PubSub,
+  name: NervesHubWeb.PubSub,
+  adapter: Phoenix.PubSub.PG2
+
+import_config "#{Mix.env()}.exs"

--- a/apps/nerves_hub_core/config/prod.exs
+++ b/apps/nerves_hub_core/config/prod.exs
@@ -1,4 +1,3 @@
 use Mix.Config
 
-config :nerves_hub_core, NervesHubCore.Repo,
-  adapter: Ecto.Adapters.Postgres
+config :nerves_hub_core, NervesHubCore.Repo, adapter: Ecto.Adapters.Postgres

--- a/apps/nerves_hub_core/lib/nerves_hub_core/application.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/application.ex
@@ -6,10 +6,13 @@ defmodule NervesHubCore.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
+    pubsub_config = Application.get_env(:nerves_hub_core, NervesHubWeb.PubSub)
+
     # Define workers and child supervisors to be supervised
     children = [
       # Start the Ecto repository
       supervisor(NervesHubCore.Repo, []),
+      supervisor(Phoenix.PubSub.PG2, [pubsub_config[:name], pubsub_config]),
       {Task.Supervisor, name: NervesHubCore.TaskSupervisor}
     ]
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/certificate.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/certificate.ex
@@ -5,6 +5,7 @@ defmodule NervesHubCore.Certificate do
   def get_common_name(cert) do
     cert = decode_cert(cert)
     [_, _, _ | cert] = cert
+
     cn =
       Enum.filter(cert, &Record.is_record/1)
       |> Enum.reverse()

--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments.ex
@@ -38,7 +38,8 @@ defmodule NervesHubCore.Deployments do
     end
   end
 
-  @spec get_deployment_by_name(Product.t(), String.t()) :: {:ok, Deployment.t()} | {:error, :not_found}
+  @spec get_deployment_by_name(Product.t(), String.t()) ::
+          {:ok, Deployment.t()} | {:error, :not_found}
   def get_deployment_by_name(%Product{id: product_id}, deployment_name) do
     from(
       d in Deployment,
@@ -113,5 +114,4 @@ defmodule NervesHubCore.Deployments do
   end
 
   defp update_relevant_devices({:error, changeset}), do: {:error, changeset}
-
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
@@ -5,7 +5,6 @@ defmodule NervesHubCore.Deployments.Deployment do
   import Ecto.Query
 
   alias NervesHubCore.Firmwares.Firmware
-  alias NervesHubCore.Devices
   alias NervesHubCore.Repo
 
   alias __MODULE__
@@ -16,7 +15,7 @@ defmodule NervesHubCore.Deployments.Deployment do
 
   schema "deployments" do
     belongs_to(:firmware, Firmware)
-    
+
     field(:name, :string)
     field(:conditions, :map)
     field(:is_active, :boolean)

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
@@ -83,10 +83,10 @@ defmodule NervesHubCore.Devices do
     with true <- matches_deployment?(device, deployment) do
       {:ok, url} = @uploader.download_file(deployment.firmware)
 
-      NervesHubDeviceWeb.Endpoint.broadcast(
+      Phoenix.PubSub.broadcast(
+        NervesHubWeb.PubSub,
         "device:#{device.identifier}",
-        "update",
-        %{firmware_url: url}
+        %Phoenix.Socket.Broadcast{event: "update", payload: %{firmware_url: url}}
       )
 
       {:ok, device}

--- a/apps/nerves_hub_core/lib/nerves_hub_core/repo.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/repo.ex
@@ -10,11 +10,12 @@ defmodule NervesHubCore.Repo do
   end
 
   def reload_assoc({:ok, schema}, assoc) do
-    schema = 
+    schema =
       case Map.get(schema, assoc) do
         %Ecto.Association.NotLoaded{} -> schema
         _ -> preload(schema, assoc, force: true)
       end
+
     {:ok, schema}
   end
 

--- a/apps/nerves_hub_core/mix.exs
+++ b/apps/nerves_hub_core/mix.exs
@@ -47,6 +47,11 @@ defmodule NervesHubCore.MixProject do
       # poison can be removed once a new release of postgrex is made
       {:poison, "~> 3.0"},
       {:timex, "~> 3.1"},
+      {:plug, "~> 1.6"},
+      {:jason, "~> 1.0"},
+      {:phoenix, github: "mobileoverlord/phoenix", branch: "ws_extra_params", override: true},
+      {:ex_aws, "~> 2.0"},
+      {:ex_aws_s3, "~> 2.0"}
     ]
   end
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -23,7 +23,7 @@ defmodule NervesHubCore.DeploymentsTest do
      }}
   end
 
-  test 'create_deployment with valid parameters', %{
+  test "create_deployment with valid parameters", %{
     firmware: firmware
   } do
     params = %{
@@ -43,7 +43,7 @@ defmodule NervesHubCore.DeploymentsTest do
     end
   end
 
-  test 'create_deployment with invalid parameters' do
+  test "create_deployment with invalid parameters" do
     params = %{
       name: "my deployment",
       conditions: %{

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -6,8 +6,6 @@ defmodule NervesHubCore.DeploymentsTest do
   alias NervesHubCore.Deployments
   alias Ecto.Changeset
 
-  @endpoint NervesHubDeviceWeb.Endpoint
-
   setup do
     org = Fixtures.org_fixture()
     product = Fixtures.product_fixture(org)
@@ -80,7 +78,7 @@ defmodule NervesHubCore.DeploymentsTest do
       }
 
       device_topic = "device:#{device.identifier}"
-      @endpoint.subscribe(device_topic)
+      Phoenix.PubSub.subscribe(NervesHubWeb.PubSub, device_topic)
 
       {:ok, _deployment} =
         Deployments.create_deployment(params)
@@ -119,7 +117,7 @@ defmodule NervesHubCore.DeploymentsTest do
         }
 
         device_topic = "device:#{device.identifier}"
-        @endpoint.subscribe(device_topic)
+        Phoenix.PubSub.subscribe(NervesHubWeb.PubSub, device_topic)
 
         {:ok, _deployment} =
           Deployments.create_deployment(params)

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -25,7 +25,7 @@ defmodule NervesHubCore.DevicesTest do
      }}
   end
 
-  test 'create_device with valid parameters', %{
+  test "create_device with valid parameters", %{
     org: org,
     firmware: firmware
   } do
@@ -42,7 +42,7 @@ defmodule NervesHubCore.DevicesTest do
     end
   end
 
-  test 'create_device with invalid parameters', %{firmware: firmware} do
+  test "create_device with invalid parameters", %{firmware: firmware} do
     params = %{
       identifier: "valid identifier",
       architecture: firmware.architecture,
@@ -52,7 +52,7 @@ defmodule NervesHubCore.DevicesTest do
     assert {:error, %Changeset{}} = Devices.create_device(params)
   end
 
-  test 'get_device_by_identifier with existing device', %{device: target_device} do
+  test "get_device_by_identifier with existing device", %{device: target_device} do
     assert {:ok, result} = Devices.get_device_by_identifier(target_device.identifier)
 
     for key <- [:org_id, :deployment_id, :device_identifier] do
@@ -60,7 +60,7 @@ defmodule NervesHubCore.DevicesTest do
     end
   end
 
-  test 'get_device_by_identifier without existing device' do
+  test "get_device_by_identifier without existing device" do
     assert {:error, :not_found} = Devices.get_device_by_identifier("non existing identifier")
   end
 

--- a/apps/nerves_hub_core/test/nerves_hub_core/products/products_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/products/products_test.exs
@@ -1,5 +1,5 @@
-defmodule NervesHubWWW.ProductsTest do
-  use NervesHubWWW.DataCase
+defmodule NervesHubCore.ProductsTest do
+  use NervesHubCore.DataCase
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Products

--- a/apps/nerves_hub_device/config/config.exs
+++ b/apps/nerves_hub_device/config/config.exs
@@ -14,7 +14,7 @@ config :nerves_hub_device,
 # Configures the endpoint
 config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   render_errors: [view: NervesHubWWWWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: NervesHubWeb.PubSub, adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: NervesHubWeb.PubSub]
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/apps/nerves_hub_device/config/dev.exs
+++ b/apps/nerves_hub_device/config/dev.exs
@@ -11,7 +11,6 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   code_reloader: false,
   check_origin: false,
   watchers: [],
-  pubsub: [name: NervesHubWeb.PubSub, adapter: Phoenix.PubSub.PG2],
   https: [
     port: 4001,
     otp_app: :nerves_hub_device,

--- a/apps/nerves_hub_device/config/prod.exs
+++ b/apps/nerves_hub_device/config/prod.exs
@@ -3,8 +3,6 @@ use Mix.Config
 config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   load_from_system_env: true,
   url: [host: "device.nerves-hub.org"],
-  pubsub: [name: NervesHubWeb.PubSub,
-           adapter: Phoenix.PubSub.PG2],
   server: true,
   https: [
     port: 443,

--- a/apps/nerves_hub_device/config/test.exs
+++ b/apps/nerves_hub_device/config/test.exs
@@ -12,7 +12,6 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
   check_origin: false,
   watchers: [],
   server: true,
-  pubsub: [name: NervesHubWeb.PubSub, adapter: Phoenix.PubSub.PG2],
   https: [
     port: 4001,
     otp_app: :nerves_hub_device,

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -19,7 +19,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     end
   end
 
-  def handle_info({:after_join, %{update_available: update_available} = message}, socket) do
+  def handle_info({:after_join, %{update_available: update_available}}, socket) do
     {:ok, _} =
       Presence.track(socket, socket.assigns.device.identifier, %{
         connected_at: inspect(System.system_time(:seconds)),

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -1,4 +1,4 @@
-defmodule NervesHubWWW.Integration.WebsocketTest do
+defmodule NervesHubDeviceWeb.WebsocketTest do
   use ExUnit.Case, async: false
   use NervesHubDeviceWeb.ChannelCase
   alias NervesHubCore.Fixtures

--- a/apps/nerves_hub_device/test/test_helper.exs
+++ b/apps/nerves_hub_device/test/test_helper.exs
@@ -1,5 +1,9 @@
 Logger.remove_backend(:console)
 
-ExUnit.start()
+assert_timeout = String.to_integer(
+  System.get_env("ELIXIR_ASSERT_TIMEOUT") || "200"
+)
+
+ExUnit.start(assert_receive_timeout: assert_timeout)
 
 Ecto.Adapters.SQL.Sandbox.mode(NervesHubCore.Repo, :manual)

--- a/apps/nerves_hub_device/test/test_helper.exs
+++ b/apps/nerves_hub_device/test/test_helper.exs
@@ -1,5 +1,4 @@
 Logger.remove_backend(:console)
-Code.compiler_options(ignore_module_conflict: true)
 
 ExUnit.start()
 

--- a/apps/nerves_hub_www/config/dev.exs
+++ b/apps/nerves_hub_www/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
-http: [ip: {0, 0, 0, 0}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
@@ -31,7 +31,7 @@ http: [ip: {0, 0, 0, 0}, port: 4000],
 
 # Watch static and templates for browser reloading.
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
-url: [scheme: "http", host: "0.0.0.0", port: 4000],
+  url: [scheme: "http", host: "0.0.0.0", port: 4000],
   live_reload: [
     patterns: [
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
@@ -58,11 +58,12 @@ config :phoenix, :stacktrace_depth, 20
 
 # if using NervesHubCore.Firmwares.Upload.S3, set configuration below accordingly
 config :nerves_hub_www, firmware_upload: NervesHubCore.Firmwares.Upload.File
-config :nerves_hub_www, NervesHubCore.Firmwares.Upload.File, 
+
+config :nerves_hub_www, NervesHubCore.Firmwares.Upload.File,
   local_path: "/tmp/firmware",
   public_path: "/firmware"
-# config :nerves_hub_www, NervesHubCore.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")
 
+# config :nerves_hub_www, NervesHubCore.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")
 
 config :nerves_hub_www, NervesHubCore.CertificateAuthority,
   host: "0.0.0.0",

--- a/apps/nerves_hub_www/config/prod.exs
+++ b/apps/nerves_hub_www/config/prod.exs
@@ -20,8 +20,7 @@ config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
   secret_key_base: "${SECRET_KEY_BASE}",
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
 
-config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
-  server: false
+config :nerves_hub_device, NervesHubDeviceWeb.Endpoint, server: false
 
 config :nerves_hub_www, NervesHubWWWWeb.AccountController, allow_signups: false
 
@@ -48,6 +47,8 @@ config :nerves_hub_www, NervesHubWWW.Mailer,
   port: "${SES_PORT}",
   username: "${SMTP_USERNAME}",
   password: "${SMTP_PASSWORD}",
-  tls: :always, # can be `:always` or `:never`
-  ssl: false, # can be `true`
+  # can be `:always` or `:never`
+  tls: :always,
+  # can be `true`
+  ssl: false,
   retries: 1

--- a/apps/nerves_hub_www/config/test.exs
+++ b/apps/nerves_hub_www/config/test.exs
@@ -11,8 +11,7 @@ config :logger, level: :warn
 
 config :nerves_hub_www, firmware_upload: NervesHubCore.Firmwares.Upload.File
 
-config :nerves_hub_www, NervesHubWWW.Mailer,
-  adapter: Bamboo.TestAdapter
+config :nerves_hub_www, NervesHubWWW.Mailer, adapter: Bamboo.TestAdapter
 
 config :nerves_hub_www, NervesHubCore.Firmwares.Upload.File,
   local_path: "/tmp/firmware",

--- a/apps/nerves_hub_www/lib/mix/tasks/assets.build.ex
+++ b/apps/nerves_hub_www/lib/mix/tasks/assets.build.ex
@@ -4,11 +4,13 @@ defmodule Mix.Tasks.Assets.Build do
   @shortdoc "Build web assets"
   @assets Path.expand("../../../assets", __DIR__)
 
-  def run(_) do    
-    System.cmd("yarn", ["build"], [
+  def run(_) do
+    System.cmd(
+      "yarn",
+      ["build"],
       cd: @assets,
       stderr_to_stdout: true,
       into: IO.stream(:stdio, :line)
-    ])
+    )
   end
 end

--- a/apps/nerves_hub_www/lib/mix/tasks/assets.install.ex
+++ b/apps/nerves_hub_www/lib/mix/tasks/assets.install.ex
@@ -5,10 +5,12 @@ defmodule Mix.Tasks.Assets.Install do
   @assets Path.expand("../../../assets", __DIR__)
 
   def run(_) do
-    System.cmd("npm", ["install"], [
+    System.cmd(
+      "npm",
+      ["install"],
       cd: @assets,
       stderr_to_stdout: true,
       into: IO.stream(:stdio, :line)
-    ])
+    )
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -4,7 +4,6 @@ defmodule NervesHubWWWWeb.FirmwareController do
   alias Ecto.Changeset
   alias NervesHubCore.Firmwares
   alias NervesHubCore.Firmwares.Firmware
-  alias NervesHubCore.Accounts.OrgKey
 
   def index(%{assigns: %{product: %{id: product_id}}} = conn, _params) do
     firmwares = Firmwares.get_firmwares_by_product(product_id)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -15,13 +15,13 @@ defmodule NervesHubWWWWeb.Endpoint do
   )
 
   # This should only be enabled if using NervesHubCore.Firmwares.Upload.File
-if @env in [:dev, :test] do  
-  plug(
-    Plug.Static,
-    at: "/firmware",
-    from: "/tmp/firmware"
-  )
-end
+  if @env in [:dev, :test] do
+    plug(
+      Plug.Static,
+      at: "/firmware",
+      from: "/tmp/firmware"
+    )
+  end
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -1,7 +1,6 @@
 defmodule NervesHubWWWWeb.DeviceView do
   use NervesHubWWWWeb, :view
 
-  alias NervesHubCore.Devices.Device
   alias NervesHubDeviceWeb.DeviceChannel
 
   def device_status(device) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/session_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/session_view.ex
@@ -1,4 +1,3 @@
 defmodule NervesHubWWWWeb.SessionView do
   use NervesHubWWWWeb, :view
-
 end

--- a/apps/nerves_hub_www/mix.exs
+++ b/apps/nerves_hub_www/mix.exs
@@ -62,8 +62,6 @@ defmodule NervesHubWWW.MixProject do
        only: :dev},
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 2.0", override: true},
-      {:ex_aws, "~> 2.0"},
-      {:ex_aws_s3, "~> 2.0"},
       {:hackney, "~> 1.9"},
       {:sweet_xml, "~> 0.6"},
       {:bamboo, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -19,8 +19,7 @@ defmodule NervesHubUmbrella.MixProject do
   defp deps do
     [
       {:excoveralls, "~> 0.8", only: :test},
-      {:mix_test_watch, "~> 0.6", only: :test, runtime: false},
-      {:plug, github: "mobileoverlord/plug", branch: "peer_conn", override: true}
+      {:mix_test_watch, "~> 0.6", only: :test, runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -34,7 +34,7 @@
   "phoenix_html": {:hex, :phoenix_html, "2.11.2", "86ebd768258ba60a27f5578bec83095bdb93485d646fc4111db8844c316602d6", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_live_reload": {:git, "https://github.com/mobileoverlord/phoenix_live_reload.git", "231de7d51623eda49079255e38787b45d25f531f", [branch: "transport"]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
-  "plug": {:git, "https://github.com/mobileoverlord/plug.git", "9ea197dddc5fd0e2aa7ced00f5e54a2d813ef448", [branch: "peer_conn"]},
+  "plug": {:hex, :plug, "1.6.2", "e06a7bd2bb6de5145da0dd950070110dce88045351224bd98e84edfdaaf5ffee", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,5 +1,10 @@
+Code.compiler_options(ignore_module_conflict: true)
 defmodule NervesHubCore.Fixtures do
   alias NervesHubCore.{Firmwares, Accounts, Devices, Deployments, Products}
+
+  @after_compile {__MODULE__, :compiler_options}
+
+  def compiler_options(_, _), do: Code.compiler_options(ignore_module_conflict: false)
 
   @org_params %{name: "Test Org"}
   @org_key_params %{


### PR DESCRIPTION
This PR does the following
* Update Plug to use1.6.2 on hex which includes the PR from my fork
* Allow all application tests to run from the root of their own folder and not just from the top of the umbrella. This required moving the pubsub adapter start to NervesHubCore and calling PubSub.broadcast instead of calling the endpoint with no reverse dependency.
* Clean up warnings and apply formatter.

