### PR TITLE
Add users/registration API for creating accounts from the CLI

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
@@ -1,9 +1,19 @@
 defmodule NervesHubAPIWeb.UserController do
   use NervesHubAPIWeb, :controller
 
+  alias NervesHubCore.Accounts
+
   action_fallback(NervesHubAPIWeb.FallbackController)
 
   def me(%{assigns: %{user: user}} = conn, _params) do
     render(conn, "show.json", user: user)
+  end
+
+  def register(conn, params) do
+    params = Map.put(params, "org_name", params["name"])
+
+    with {:ok, {_org, user}} <- Accounts.create_org_with_user(params) do
+      render(conn, "show.json", user: user)
+    end
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -3,12 +3,22 @@ defmodule NervesHubAPIWeb.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
+  end
+
+  pipeline :authenticated do
     plug(NervesHubAPIWeb.Plugs.User)
     plug(NervesHubCore.Plugs.Product)
   end
 
+  scope "/users", NervesHubAPIWeb do
+    pipe_through(:api)
+
+    post("/register", UserController, :register)
+  end
+
   scope "/", NervesHubAPIWeb do
     pipe_through(:api)
+    pipe_through(:authenticated)
 
     scope "/users" do
       get("/me", UserController, :me)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -9,4 +9,15 @@ defmodule NervesHubAPIWeb.UserControllerTest do
              "email" => user.email
            }
   end
+
+  test "register new account", %{} do
+    conn = build_conn()
+    body = %{name: "test", password: "12345678", email: "test@test.com"}
+    conn = post(conn, user_path(conn, :register), body)
+
+    assert json_response(conn, 200)["data"] == %{
+             "name" => body.name,
+             "email" => body.email
+           }
+  end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -69,8 +69,8 @@ defmodule NervesHubCore.Accounts do
 
     Repo.transaction(fn ->
       with {:ok, org} <- create_org(org_params),
-           {:ok, _user} <- create_user(org, user_params) do
-        org
+           {:ok, user} <- create_user(org, user_params) do
+        {org, user}
       else
         {:error, changeset} ->
           # Merge errors into original changeset

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -28,7 +28,7 @@ defmodule NervesHubCore.AccountsTest do
     }
 
     target_org = %Accounts.Org{name: params.org_name}
-    {:ok, %Accounts.Org{} = result_org} = Accounts.create_org_with_user(params)
+    {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
 
     [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
 
@@ -55,7 +55,7 @@ defmodule NervesHubCore.AccountsTest do
     }
 
     target_org = %Accounts.Org{name: params.org_name}
-    {:ok, %Accounts.Org{} = result_org} = Accounts.create_org_with_user(params)
+    {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
 
     [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
 
@@ -78,7 +78,7 @@ defmodule NervesHubCore.AccountsTest do
       password: "test_password"
     }
 
-    {:ok, %Accounts.Org{} = result_org} = Accounts.create_org_with_user(params)
+    {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
 
     [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWWWWeb.AccountController do
     params["user"]
     |> Accounts.create_org_with_user()
     |> case do
-      {:ok, _org} ->
+      {:ok, {_org, _user}} ->
         redirect(conn, to: "/")
 
       {:error, changeset} ->


### PR DESCRIPTION
Adds an API for registering new user accounts fro the CLI

post /users/register
Parameters:
* name: the username and default org name
* email: the email to use
* password: the password to set

Passwords are going to be encrypted through the ssl connection to the API and timing attacks are handled by our use of bcrypt