### PR TITLE
Fix Phoenix Presence messages by enabling fastlane

### DIFF
--- a/apps/nerves_hub_core/config/config.exs
+++ b/apps/nerves_hub_core/config/config.exs
@@ -7,6 +7,7 @@ config :nerves_hub_core,
 
 config :nerves_hub_core, NervesHubWeb.PubSub,
   name: NervesHubWeb.PubSub,
-  adapter: Phoenix.PubSub.PG2
+  adapter: Phoenix.PubSub.PG2,
+  fastlane: Phoenix.Channel.Server
 
 import_config "#{Mix.env()}.exs"

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -29,10 +29,6 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  def handle_out("presence_diff", _message, socket) do
-    {:noreply, socket}
-  end
-
   defp build_message(%{assigns: %{device: device, org: org}}, payload) do
     with {:ok, device} <- device_update(device, org, payload) do
       send_update_message(device, org)

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/user_socket.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/user_socket.ex
@@ -67,6 +67,6 @@ defmodule NervesHubDeviceWeb.UserSocket do
   #     NervesHubWWWWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
-  def id(%{assigns: %{device: %Devices.Device{identifier: d_id}}}), do: "device:#{d_id}"
+  def id(%{assigns: %{device: %Devices.Device{identifier: d_id}}}), do: "device_socket:#{d_id}"
   def id(_socket), do: nil
 end


### PR DESCRIPTION
After moving the `Phoenix.PubSub.PG2` server start to `nerves_hub_core` fastlane options were missing that are typically added by default when `Phoenix.Endpoint` would start the PubSub server. This fixes the issue where `%Phoenix.Broadcast.Socket{}` messages were being sent to the `handle_out/2`