### PR TITLE
Add API for managing firmware keys

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -31,7 +31,15 @@ defmodule NervesHubAPIWeb.Router do
     scope "/firmwares" do
       get("/", FirmwareController, :index)
       get("/:uuid", FirmwareController, :show)
+
       delete("/:uuid", FirmwareController, :delete)
+    end
+
+    scope "/keys" do
+      get("/", KeyController, :index)
+      post("/", KeyController, :create)
+      get("/:name", KeyController, :show)
+      delete("/:name", KeyController, :delete)
     end
 
     scope "/deployments" do

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/key_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/key_view.ex
@@ -1,0 +1,19 @@
+defmodule NervesHubAPIWeb.KeyView do
+  use NervesHubAPIWeb, :view
+  alias NervesHubAPIWeb.KeyView
+
+  def render("index.json", %{keys: keys}) do
+    %{data: render_many(keys, KeyView, "key.json")}
+  end
+
+  def render("show.json", %{key: key}) do
+    %{data: render_one(key, KeyView, "key.json")}
+  end
+
+  def render("key.json", %{key: key}) do
+    %{
+      name: key.name,
+      key: key.key
+    }
+  end
+end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller.test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller.test.exs
@@ -1,0 +1,51 @@
+defmodule NervesHubAPIWeb.KeyControllerTest do
+  use NervesHubAPIWeb.ConnCase
+
+  alias NervesHubCore.Fixtures
+
+  @test_firmware_path Path.expand("../../../../../test/fixtures/firmware", __DIR__)
+  @fw_key_path Path.join(@test_firmware_path, "fwup-key1.pub")
+
+  describe "index" do
+    test "lists all keys", %{conn: conn} do
+      conn = get(conn, key_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create keys" do
+    test "renders key when data is valid", %{org: org, conn: conn} do
+      name = "test"
+      key = %{name: name, key: File.read!(@fw_key_path), org_id: org.id}
+
+      conn = post(conn, key_path(conn, :create), key)
+      assert json_response(conn, 201)["data"]
+
+      conn = get(conn, key_path(conn, :show, key.name))
+      assert json_response(conn, 200)["data"]["name"] == name
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, key_path(conn, :create))
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete key" do
+    setup [:create_key]
+
+    test "deletes chosen key", %{conn: conn, key: key} do
+      conn = delete(conn, key_path(conn, :delete, key.name))
+      assert response(conn, 204)
+
+      conn = get(conn, key_path(conn, :show, key.name))
+
+      assert response(conn, 404)
+    end
+  end
+
+  defp create_key(%{org: org}) do
+    key = Fixtures.org_key_fixture(org)
+    {:ok, %{key: key}}
+  end
+end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
@@ -45,7 +45,7 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
   end
 
   defp create_key(%{org: org}) do
-    key = Fixtures.org_key_fixture(org)
+    key = Fixtures.org_key_fixture(org, %{name: "api"})
     {:ok, %{key: key}}
   end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -259,19 +259,25 @@ defmodule NervesHubCore.Accounts do
   end
 
   def get_org_key(%Org{id: org_id}, tk_id) do
-    query =
-      from(
-        tk in OrgKey,
-        where: tk.org_id == ^org_id,
-        where: tk.id == ^tk_id
-      )
-
-    query
+    get_org_key_query(org_id, tk_id)
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}
       key -> {:ok, key}
     end
+  end
+
+  def get_org_key!(%Org{id: org_id}, tk_id) do
+    get_org_key_query(org_id, tk_id)
+    |> Repo.one!()
+  end
+
+  defp get_org_key_query(org_id, tk_id) do
+    from(
+      tk in OrgKey,
+      where: tk.org_id == ^org_id,
+      where: tk.id == ^tk_id
+    )
   end
 
   def get_org_key_by_name(%Org{id: org_id}, name) do

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -267,10 +267,26 @@ defmodule NervesHubCore.Accounts do
       )
 
     query
-    |> Repo.one!()
+    |> Repo.one()
     |> case do
       nil -> {:error, :not_found}
-      device -> {:ok, device}
+      key -> {:ok, key}
+    end
+  end
+
+  def get_org_key_by_name(%Org{id: org_id}, name) do
+    query =
+      from(
+        k in OrgKey,
+        where: k.org_id == ^org_id,
+        where: k.name == ^name
+      )
+
+    query
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      key -> {:ok, key}
     end
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
@@ -29,7 +29,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
   end
 
   def show(%{assigns: %{org: org}} = conn, %{"id" => id}) do
-    {:ok, org_key} = Accounts.get_org_key(org, id)
+    org_key = Accounts.get_org_key!(org, id)
     render(conn, "show.html", org_key: org_key)
   end
 


### PR DESCRIPTION
This PR adds routes for managing firmware keys

* get `/keys` - list all keys for the org
* post `/keys` - create a new key
* delete `/keys/:name` - delete a key by name
* get `/keys/:name` - show information about a single key