### PR TITLE
Move CA config to nerves_hub_core to prevent release stripping

### DIFF
--- a/apps/nerves_hub_core/config/dev.exs
+++ b/apps/nerves_hub_core/config/dev.exs
@@ -3,3 +3,13 @@ use Mix.Config
 config :nerves_hub_core, NervesHubCore.Repo,
   adapter: Ecto.Adapters.Postgres,
   ssl: false
+
+config :nerves_hub_core, NervesHubCore.CertificateAuthority,
+  host: "0.0.0.0",
+  port: 8443,
+  ssl: [
+    keyfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client-key.pem"]),
+    certfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client.pem"]),
+    cacertfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca.pem"]),
+    server_name_indication: 'ca.nerves-hub.org'
+  ]

--- a/apps/nerves_hub_core/config/prod.exs
+++ b/apps/nerves_hub_core/config/prod.exs
@@ -1,3 +1,14 @@
 use Mix.Config
 
 config :nerves_hub_core, NervesHubCore.Repo, adapter: Ecto.Adapters.Postgres
+
+config :nerves_hub_core, NervesHubCore.CertificateAuthority,
+  host: "nerves-hub-ca.local",
+  port: 8443,
+  ssl: [
+    keyfile: "/etc/cfssl/ca-client-key.pem",
+    certfile: "/etc/cfssl/ca-client.pem",
+    cacertfile: "/etc/cfssl/ca.pem",
+    server_name_indication: 'ca.nerves-hub.org',
+    verify: :verify_peer
+  ]

--- a/apps/nerves_hub_core/config/test.exs
+++ b/apps/nerves_hub_core/config/test.exs
@@ -4,3 +4,13 @@ config :nerves_hub_core, NervesHubCore.Repo,
   adapter: Ecto.Adapters.Postgres,
   ssl: false,
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :nerves_hub_core, NervesHubCore.CertificateAuthority,
+  host: "127.0.0.1",
+  port: 8443,
+  ssl: [
+    keyfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client-key.pem"]),
+    certfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client.pem"]),
+    cacertfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca.pem"]),
+    server_name_indication: 'ca.nerves-hub.org'
+  ]

--- a/apps/nerves_hub_core/lib/nerves_hub_core/certificate_authority.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/certificate_authority.ex
@@ -76,6 +76,6 @@ defmodule NervesHubCore.CertificateAuthority do
   end
 
   def config do
-    Application.get_env(:nerves_hub_www, __MODULE__)
+    Application.get_env(:nerves_hub_core, __MODULE__, [])
   end
 end

--- a/apps/nerves_hub_www/config/dev.exs
+++ b/apps/nerves_hub_www/config/dev.exs
@@ -65,16 +65,6 @@ config :nerves_hub_www, NervesHubCore.Firmwares.Upload.File,
 
 # config :nerves_hub_www, NervesHubCore.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")
 
-config :nerves_hub_www, NervesHubCore.CertificateAuthority,
-  host: "0.0.0.0",
-  port: 8443,
-  ssl: [
-    keyfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client-key.pem"]),
-    certfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client.pem"]),
-    cacertfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca.pem"]),
-    server_name_indication: 'ca.nerves-hub.org'
-  ]
-
 config :nerves_hub_www, NervesHubWWW.Mailer, adapter: Bamboo.LocalAdapter
 
 config :ex_aws,

--- a/apps/nerves_hub_www/config/prod.exs
+++ b/apps/nerves_hub_www/config/prod.exs
@@ -27,17 +27,6 @@ config :nerves_hub_www, NervesHubWWWWeb.AccountController, allow_signups: false
 config :nerves_hub_www, firmware_upload: NervesHubCore.Firmwares.Upload.S3
 config :nerves_hub_www, NervesHubCore.Firmwares.Upload.S3, bucket: "${S3_BUCKET_NAME}"
 
-config :nerves_hub_www, NervesHubCore.CertificateAuthority,
-  host: "nerves-hub-ca.local",
-  port: 8443,
-  ssl: [
-    keyfile: "/etc/cfssl/ca-client-key.pem",
-    certfile: "/etc/cfssl/ca-client.pem",
-    cacertfile: "/etc/cfssl/ca.pem",
-    server_name_indication: 'ca.nerves-hub.org',
-    verify: :verify_peer
-  ]
-
 # Do not print debug messages in production
 config :logger, level: :debug
 

--- a/apps/nerves_hub_www/config/test.exs
+++ b/apps/nerves_hub_www/config/test.exs
@@ -16,13 +16,3 @@ config :nerves_hub_www, NervesHubWWW.Mailer, adapter: Bamboo.TestAdapter
 config :nerves_hub_www, NervesHubCore.Firmwares.Upload.File,
   local_path: "/tmp/firmware",
   public_path: "/firmware"
-
-config :nerves_hub_www, NervesHubCore.CertificateAuthority,
-  host: "127.0.0.1",
-  port: 8443,
-  ssl: [
-    keyfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client-key.pem"]),
-    certfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca-client.pem"]),
-    cacertfile: Path.join([__DIR__, "../../../test/fixtures/cfssl/ca.pem"]),
-    server_name_indication: 'ca.nerves-hub.org'
-  ]


### PR DESCRIPTION
The CA API was moved from `nerves_hub_www` to `nerves_hub_core` but the config reference were not updated. Since `nerves_hub_api` does not depend on `nerves_hub_www`, the configs for the ca under this application were stripped from the final release. This PR fixes the communication between the API and the CA.