### PR TITLE
Fix channels

### DIFF
--- a/apps/nerves_hub_core/config/prod.exs
+++ b/apps/nerves_hub_core/config/prod.exs
@@ -1,9 +1,7 @@
 use Mix.Config
 
 config :ex_aws,
-  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
-  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
-  region: System.get_env("AWS_REGION")
+  region: "${AWS_REGION}"
 
 config :nerves_hub_core, firmware_upload: NervesHubCore.Firmwares.Upload.S3
 config :nerves_hub_core, NervesHubCore.Firmwares.Upload.S3, bucket: "${S3_BUCKET_NAME}"

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
@@ -91,8 +91,11 @@ defmodule NervesHubCore.Devices do
 
       Phoenix.PubSub.broadcast(
         NervesHubWeb.PubSub,
-        "device_socket:#{device.id}",
-        %Phoenix.Socket.Broadcast{event: "update", payload: %{firmware_url: url}}
+        "device:#{device.id}",
+        %Phoenix.Socket.Broadcast{
+          event: "update",
+          payload: %{device_id: device.id, firmware_url: url}
+        }
       )
 
       {:ok, device}

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -77,7 +77,7 @@ defmodule NervesHubCore.DeploymentsTest do
         is_active: false
       }
 
-      device_topic = "device_socket:#{device.id}"
+      device_topic = "device:#{device.id}"
       Phoenix.PubSub.subscribe(NervesHubWeb.PubSub, device_topic)
 
       {:ok, _deployment} =
@@ -116,7 +116,7 @@ defmodule NervesHubCore.DeploymentsTest do
           is_active: false
         }
 
-        device_topic = "device_socket:#{device.id}"
+        device_topic = "device:#{device.id}"
         Phoenix.PubSub.subscribe(NervesHubWeb.PubSub, device_topic)
 
         {:ok, _deployment} =

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/user_socket.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/user_socket.ex
@@ -4,7 +4,7 @@ defmodule NervesHubDeviceWeb.UserSocket do
 
   ## Channels
   # channel "room:*", NervesHubWWWWeb.RoomChannel
-  channel("device:*", NervesHubDeviceWeb.DeviceChannel)
+  channel("firmware:*", NervesHubDeviceWeb.DeviceChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
@@ -54,6 +54,6 @@ defmodule NervesHubDeviceWeb.UserSocket do
   #     NervesHubWWWWeb.Endpoint.broadcast("user_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
-  def id(%{assigns: %{certificate: certificate}}), do: "device:#{certificate.device_id}"
+  def id(%{assigns: %{certificate: certificate}}), do: "device_socket:#{certificate.device_id}"
   def id(_socket), do: nil
 end

--- a/rel/scripts/slack-notification.sh
+++ b/rel/scripts/slack-notification.sh
@@ -52,6 +52,6 @@ fi
 
 escapedText=$(echo $text | sed 's/"/\"/g' | sed "s/'/\'/g" )
 
-json="{\"channel\": \"$channel\", \"username\":\"$username\", \"icon_emoji\":\":rocket:\", \"attachments\":[{\"color\":\"good \" , \"text\": \"$escapedText\"}]}"
+json="{\"channel\": \"$channel\", \"username\":\"$username\", \"icon_emoji\":\":nerves-bot:\", \"attachments\":[{\"color\":\"good \" , \"text\": \"$escapedText\"}]}"
 
 curl -s -d "payload=$json" "$webhook_url"


### PR DESCRIPTION
Turns out that you can only send "disconnect" events to socket id topics. In order to differentiate the recipients we are subscribing to a `device:#{device.id}` topic inside the channel. I have also updated the topics for connecting to represent `firmware:#{uuid}` so there are no collisions between the self subscribed devices and firmwares. I have tested this in prod and its sending update messages. 