### PR TITLE
Prevent deployments from updating devices cross product

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
@@ -68,13 +68,20 @@ defmodule NervesHubCore.Devices do
   end
 
   def get_eligible_deployments(
-        %Device{last_known_firmware: %Firmware{id: f_id, architecture: arch, platform: plat}} =
-          device
+        %Device{
+          last_known_firmware: %Firmware{
+            id: f_id,
+            architecture: arch,
+            platform: plat,
+            product_id: product_id
+          }
+        } = device
       ) do
     from(
       d in Deployment,
       where: d.is_active,
       join: f in assoc(d, :firmware),
+      where: f.product_id == ^product_id,
       where: f.architecture == ^arch,
       where: f.platform == ^plat,
       where: f.id != ^f_id

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -58,7 +58,8 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
         last_known_firmware_id: firmware.id
       })
     else
-      _ -> {:error, :no_firmware_found}
+      _ ->
+        {:error, :no_firmware_found}
     end
   end
 


### PR DESCRIPTION
Currently there is an issue where deployments are sending devices firmware updates for other products. This PR fixes the issue and adds some tests to ensure it doesn't happen again.