### PR TITLE
Many to many for orgs and users

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
@@ -6,6 +6,11 @@ defmodule NervesHubAPIWeb.UserController do
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
+  defp whitelist(params, keys) do
+    keys
+    |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
+  end
+
   def me(%{assigns: %{user: user}} = conn, _params) do
     render(conn, "show.json", user: user)
   end
@@ -13,10 +18,10 @@ defmodule NervesHubAPIWeb.UserController do
   def register(conn, params) do
     params =
       params
-      |> Map.take(["name", "email", "password"])
-      |> Map.put("org_name", params["name"])
+      |> whitelist([:name, :email, :password])
+      |> Map.put(:orgs, [%{name: params["name"]}])
 
-    with {:ok, {_org, user}} <- Accounts.create_org_with_user(params) do
+    with {:ok, user} <- Accounts.create_user(params) do
       render(conn, "show.json", user: user)
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/user.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/user.ex
@@ -23,7 +23,7 @@ defmodule NervesHubAPIWeb.Plugs.User do
           |> :public_key.pem_encode()
 
         {:ok, serial} = Certificate.get_serial_number(cert)
-        Accounts.get_user_with_certificate_serial(serial)
+        Accounts.get_user_by_certificate_serial(serial)
     end
     |> case do
       nil ->
@@ -33,11 +33,11 @@ defmodule NervesHubAPIWeb.Plugs.User do
         |> halt()
 
       %User{} = user ->
-        user = NervesHubCore.Repo.preload(user, org: [:org_keys])
+        [org | _] = user.orgs
 
         conn
         |> assign(:user, user)
-        |> assign(:org, user.org)
+        |> assign(:org, org)
     end
   end
 end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -61,7 +61,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
 
     {:ok, serial} = Certificate.get_serial_number(cert)
 
-    user = Accounts.get_user_with_certificate_serial(serial)
+    user = Accounts.get_user_by_certificate_serial(serial)
     assert user.email == params.email
   end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -81,6 +81,17 @@ defmodule NervesHubCore.Accounts do
     end
   end
 
+  def get_user_by_email(email) do
+    query = from(u in User, where: u.email == ^email)
+
+    query
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      user -> {:ok, user}
+    end
+  end
+
   @spec get_user_certificates(User.t()) ::
           {:ok, [UserCertificate.t()]}
           | {:error, :not_found}
@@ -273,7 +284,9 @@ defmodule NervesHubCore.Accounts do
           {:ok, User.t()}
           | {:error}
   def create_user_from_invite(invite, org, user_params) do
-    user_params = %{user_params | email: invite.email}
+    user_params =
+      %{email: invite.email, name: invite.name}
+      |> Enum.into(user_params)
 
     Repo.transaction(fn ->
       with {:ok, user} <- create_user(%{orgs: [org]} |> Enum.into(user_params)),

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
@@ -11,10 +11,11 @@ defmodule NervesHubCore.Accounts.Org do
   @type t :: %__MODULE__{}
 
   schema "orgs" do
-    has_many(:users, User)
     has_many(:org_keys, OrgKey)
     has_many(:products, Product)
     has_many(:devices, Device)
+
+    many_to_many(:users, User, join_through: "users_orgs")
 
     field(:name, :string)
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
@@ -49,13 +49,9 @@ defmodule NervesHubCore.Deployments.Deployment do
 
   def with_firmware(%Deployment{firmware: %Firmware{}} = d), do: d
 
-  def with_firmware(%Deployment{id: id}) do
-    from(
-      d in Deployment,
-      where: d.id == ^id
-    )
-    |> preload(:firmware)
-    |> Repo.one!()
+  def with_firmware(%Deployment{} = d) do
+    d
+    |> Repo.preload(:firmware)
   end
 
   def with_firmware(deployment_query) do

--- a/apps/nerves_hub_core/priv/repo/migrations/20180813204454_many_orgs_many_users.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180813204454_many_orgs_many_users.exs
@@ -1,0 +1,14 @@
+defmodule NervesHubCore.Repo.Migrations.ManyOrgsManyUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users_orgs) do
+      add(:user_id, references(:users, on_delete: :delete_all))
+      add(:org_id, references(:orgs, on_delete: :delete_all))
+    end
+
+    alter table(:users) do
+      remove(:org_id)
+    end
+  end
+end

--- a/apps/nerves_hub_core/priv/repo/seeds.exs
+++ b/apps/nerves_hub_core/priv/repo/seeds.exs
@@ -33,7 +33,8 @@ root_org =
 if root_user = Repo.get_by(User, email: root_user_email) do
   root_user
 else
-  Accounts.create_user(root_org, %{
+  Accounts.create_user(%{
+    orgs: [root_org],
     name: root_user_name,
     email: root_user_email,
     password: "nerveshub"

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -19,77 +19,77 @@ defmodule NervesHubCore.AccountsTest do
     assert {:error, %Changeset{}} = Accounts.create_org(%{})
   end
 
-  test "create_org_with_user with valid params" do
-    params = %{
-      name: "Testy McTesterson",
-      org_name: "mctesterson.com",
-      email: "testy@mctesterson.com",
-      password: "test_password"
-    }
+  # test "create_org_with_user with valid params" do
+  # params = %{
+  # name: "Testy McTesterson",
+  # org_name: "mctesterson.com",
+  # email: "testy@mctesterson.com",
+  # password: "test_password"
+  # }
 
-    target_org = %Accounts.Org{name: params.org_name}
-    {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
+  # target_org = %Accounts.Org{name: params.org_name}
+  # {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
 
-    [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
+  # [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
 
-    assert result_org.name == target_org.name
-    assert user.name == params.name
-  end
+  # assert result_org.name == target_org.name
+  # assert user.name == params.name
+  # end
 
-  test "create_org_with_user with missing params" do
-    params = %{
-      name: "Testy McTesterson",
-      email: "testy@mctesterson.com",
-      password: "test_password"
-    }
+  # test "create_org_with_user with missing params" do
+  # params = %{
+  # name: "Testy McTesterson",
+  # email: "testy@mctesterson.com",
+  # password: "test_password"
+  # }
 
-    assert {:error, %Changeset{}} = Accounts.create_org_with_user(params)
-  end
+  # assert {:error, %Changeset{}} = Accounts.create_org_with_user(params)
+  # end
 
-  test "create_org_with_user_with_certificate with valid params" do
-    params = %{
-      name: "Testy McTesterson",
-      org_name: "mctesterson.com",
-      email: "testy@mctesterson.com",
-      password: "test_password"
-    }
+  # test "create_org_with_user_with_certificate with valid params" do
+  # params = %{
+  # name: "Testy McTesterson",
+  # org_name: "mctesterson.com",
+  # email: "testy@mctesterson.com",
+  # password: "test_password"
+  # }
 
-    target_org = %Accounts.Org{name: params.org_name}
-    {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
+  # target_org = %Accounts.Org{name: params.org_name}
+  # {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
 
-    [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
+  # [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
 
-    assert result_org.name == target_org.name
-    assert user.name == params.name
+  # assert result_org.name == target_org.name
+  # assert user.name == params.name
 
-    params = %{
-      description: "abcd",
-      serial: "12345"
-    }
+  # params = %{
+  # description: "abcd",
+  # serial: "12345"
+  # }
 
-    assert {:ok, _cert} = Accounts.create_user_certificate(user, params)
-  end
+  # assert {:ok, _cert} = Accounts.create_user_certificate(user, params)
+  # end
 
-  test "cannot create user certificate with duplicate serial" do
-    params = %{
-      name: "Testy McTesterson",
-      org_name: "mctesterson.com",
-      email: "testy@mctesterson.com",
-      password: "test_password"
-    }
+  # test "cannot create user certificate with duplicate serial" do
+  # params = %{
+  # name: "Testy McTesterson",
+  # org_name: "mctesterson.com",
+  # email: "testy@mctesterson.com",
+  # password: "test_password"
+  # }
 
-    {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
+  # {:ok, {%Accounts.Org{} = result_org, _user}} = Accounts.create_org_with_user(params)
 
-    [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
+  # [user | _] = result_org |> Repo.preload(:users) |> Map.get(:users)
 
-    params = %{
-      description: "abcd",
-      serial: "12345"
-    }
+  # params = %{
+  # description: "abcd",
+  # serial: "12345"
+  # }
 
-    {:ok, _cert} = Accounts.create_user_certificate(user, params)
-    {:error, %Ecto.Changeset{}} = Accounts.create_user_certificate(user, params)
-  end
+  # {:ok, _cert} = Accounts.create_user_certificate(user, params)
+  # {:error, %Ecto.Changeset{}} = Accounts.create_user_certificate(user, params)
+  # end
 
   test "org_key name must be unique" do
     {:ok, org} = Accounts.create_org(@required_org_params)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -72,7 +72,7 @@ defmodule NervesHubWWWWeb.AccountController do
   end
 
   def accept_invite(conn, %{"user" => user_params, "token" => token} = _) do
-    clean_params = user_params |> whitelist([:name, :email, :password])
+    clean_params = user_params |> whitelist([:password])
 
     with {:ok, invite} <- Accounts.get_valid_invite(token),
          {:ok, org} <- Accounts.get_org(invite.org_id),

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
@@ -20,9 +20,11 @@ defmodule NervesHubWWWWeb.Plugs.EnsureLoggedIn do
     end
     |> case do
       {:ok, user} ->
+        [default_org | _] = user.orgs
+
         conn
         |> assign(:user, user)
-        |> assign(:org, user.org)
+        |> assign(:org, default_org)
 
       _ ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
@@ -5,22 +5,6 @@
 <%= form_for @changeset, account_path(@conn, :accept_invite, @token), [as: :user], fn f -> %>
   <p>
     <label>
-      Email:
-      <%= email_input f, :email, readonly: true %>
-      <%= error_tag f, :email %>
-    </label>
-  </p>
-
-  <p>
-    <label>
-      Name:
-      <%= text_input f, :name %>
-      <%= error_tag f, :name %>
-    </label>
-  </p>
-
-  <p>
-    <label>
       Password:
       <%= password_input f, :password %>
       <%= error_tag f, :password %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -19,7 +19,8 @@
             <%= @conn.assigns.org.name %>
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" href="<%= account_path(@conn, :edit)%>">Account settings</a>
+            <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.org)%>">Org settings</a>
+            <a class="dropdown-item" href="<%= account_path(@conn, :edit)%>">User settings</a>
             <div class="dropdown-divider"></div>
             <a class="dropdown-item" href="<%= session_path(@conn, :delete)%>">Logout</a>
           </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
@@ -20,6 +20,6 @@
     </div>
 
     <%= submit "Send Invite", class: "btn btn-success" %>
-    <a class="btn btn-secondary" href="<%= org_path(@conn, :edit) %>">Cancel</a>
+    <a class="btn btn-secondary" href="<%= org_path(@conn, :edit, @conn.assigns.org) %>">Cancel</a>
   <% end %>
 </div>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -50,7 +50,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
           account_path(conn, :accept_invite, invite.token, %{
             "user" => %{
               "name" => "My Name",
-              "email" => "joe@example.com",
+              "email" => "not_joe@example.com",
               "password" => "12345678"
             }
           })
@@ -61,6 +61,8 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       assert get_session(conn, :phoenix_flash) == %{
                "info" => "Account successfully created, login below"
              }
+
+      assert {:ok, %Accounts.User{}} = Accounts.get_user_by_email("joe@example.com")
     end
   end
 

--- a/apps/nerves_hub_www/test/support/browser_case.ex
+++ b/apps/nerves_hub_www/test/support/browser_case.ex
@@ -19,7 +19,7 @@ defmodule NervesHubWWWWeb.ConnCase.Browser do
           firmware: firmware,
           deployment: deployment,
           product: product
-        } = NervesHubCore.Fixtures.very_fixture()
+        } = NervesHubCore.Fixtures.standard_fixture()
 
         {:ok, org_key} =
           Accounts.create_org_key(%{

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -164,6 +164,8 @@ defmodule NervesHubCore.Fixtures do
     params = %{serial: serial, not_before: not_before, not_after: not_after}
     {:ok, device_cert} = Devices.create_device_certificate(device, params)
     device_cert
+  end
+
   def standard_fixture() do
     user_name = "Jeff"
     org = org_fixture(%{name: user_name})

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,4 +1,5 @@
 Code.compiler_options(ignore_module_conflict: true)
+
 defmodule NervesHubCore.Fixtures do
   alias NervesHubCore.{Firmwares, Accounts, Devices, Deployments, Products, Certificate}
 
@@ -67,10 +68,11 @@ defmodule NervesHubCore.Fixtures do
 
   def user_fixture(%Accounts.Org{} = org, params \\ %{}) do
     user_params =
-      params
+      %{orgs: [org]}
+      |> Enum.into(params)
       |> Enum.into(@user_params)
 
-    {:ok, user} = Accounts.create_user(org, user_params)
+    {:ok, user} = Accounts.create_user(user_params)
     {:ok, _certificate} = Accounts.create_user_certificate(user, @user_certificate_params)
     user
   end
@@ -162,6 +164,25 @@ defmodule NervesHubCore.Fixtures do
     params = %{serial: serial, not_before: not_before, not_after: not_after}
     {:ok, device_cert} = Devices.create_device_certificate(device, params)
     device_cert
+  def standard_fixture() do
+    user_name = "Jeff"
+    org = org_fixture(%{name: user_name})
+    user = user_fixture(org, %{name: user_name})
+    product = product_fixture(org, %{name: "Hop"})
+    org_key = org_key_fixture(org)
+    firmware = firmware_fixture(org_key, product)
+    deployment = deployment_fixture(firmware)
+    device = device_fixture(org, firmware, deployment)
+
+    %{
+      org: org,
+      device: device,
+      org_key: org_key,
+      user: user,
+      firmware: firmware,
+      deployment: deployment,
+      product: product
+    }
   end
 
   def very_fixture() do


### PR DESCRIPTION
Why:

* This is a very standard use case for core contributors, and probably
others.

This change addresses the need by:

* Migration to handle the many to many relationship.
* Moving some of the org <> user creation constraints into the user schema.
* Adding some composable user query helpers.
* Creating an org with the same name as the user on account creation.
* Treating the earliest `inserted_at` org as the "default" org for a user.