### PR TITLE
Update API to support many to many users and orgs

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_certificate_controller.ex
@@ -5,14 +5,14 @@ defmodule NervesHubAPIWeb.DeviceCertificateController do
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
-  def index(%{assigns: %{org: org}} = conn, %{"identifier" => identifier}) do
+  def index(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier}) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do
       device_certificates = Devices.get_device_certificates(device)
       render(conn, "index.json", device_certificates: device_certificates)
     end
   end
 
-  def sign(%{assigns: %{org: org}} = conn, %{"csr" => csr, "identifier" => identifier}) do
+  def sign(%{assigns: %{org: org}} = conn, %{"csr" => csr, "device_identifier" => identifier}) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
          {:ok, %{"cert" => cert}} <- CertificateAuthority.sign_device_csr(csr),
          {:ok, serial} <- Certificate.get_serial_number(cert),

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -11,12 +11,12 @@ defmodule NervesHubAPIWeb.DeviceController do
     with {:ok, device} <- Devices.create_device(params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", device_path(conn, :show, device))
+      |> put_resp_header("location", device_path(conn, :show, org.name, device))
       |> render("show.json", device: device)
     end
   end
 
-  def show(%{assigns: %{org: org}} = conn, %{"identifier" => identifier}) do
+  def show(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier}) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do
       render(conn, "show.json", device: device)
     end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
@@ -20,6 +20,13 @@ defmodule NervesHubAPIWeb.FallbackController do
     |> render(:"404")
   end
 
+  def call(conn, {:error, reason}) when is_atom(reason) do
+    conn
+    |> put_status(400)
+    |> put_view(NervesHubAPIWeb.ErrorView)
+    |> send_resp(400, Jason.encode!(%{status: reason}))
+  end
+
   def call(conn, {:error, reason}) do
     conn
     |> put_status(500)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -11,13 +11,13 @@ defmodule NervesHubAPIWeb.FirmwareController do
     render(conn, "index.json", firmwares: firmwares)
   end
 
-  def create(%{assigns: %{org: org}} = conn, _params) do
+  def create(%{assigns: %{org: org, product: product}} = conn, _params) do
     with {:ok, filepath, conn} <- read_firmware(conn),
          {:ok, firmware_params} <- Firmwares.prepare_firmware_params(org, filepath),
          {:ok, firmware} <- Firmwares.create_firmware(firmware_params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", firmware_path(conn, :show, firmware))
+      |> put_resp_header("location", firmware_path(conn, :show, org, product, firmware))
       |> render("show.json", firmware: firmware)
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/org.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/org.ex
@@ -1,0 +1,23 @@
+defmodule NervesHubAPIWeb.Plugs.Org do
+  import Plug.Conn
+
+  alias NervesHubCore.Accounts
+
+  def init(opts) do
+    opts
+  end
+
+  def call(%{params: %{"org_name" => org_name}, assigns: %{user: user}} = conn, _opts) do
+    case Accounts.get_org_by_name_and_user(org_name, user) do
+      {:ok, org} ->
+        conn
+        |> assign(:org, org)
+
+      _ ->
+        conn
+        |> put_resp_header("content-type", "application/json")
+        |> send_resp(403, Jason.encode!(%{status: "User is not authorized for org: #{org_name}"}))
+        |> halt()
+    end
+  end
+end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/product.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/product.ex
@@ -1,0 +1,23 @@
+defmodule NervesHubAPIWeb.Plugs.Product do
+  import Plug.Conn
+
+  alias NervesHubCore.Products
+
+  def init(opts) do
+    opts
+  end
+
+  def call(%{params: %{"product_name" => product_name}} = conn, _opts) do
+    case Products.get_product_by_org_id_and_name(conn.assigns.org.id, product_name) do
+      {:ok, product} ->
+        conn
+        |> assign(:product, product)
+
+      _ ->
+        conn
+        |> put_resp_header("content-type", "application/json")
+        |> send_resp(403, Jason.encode!(%{status: "Invalid product: #{product_name}"}))
+        |> halt()
+    end
+  end
+end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/user.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/user.ex
@@ -33,11 +33,8 @@ defmodule NervesHubAPIWeb.Plugs.User do
         |> halt()
 
       %User{} = user ->
-        [org | _] = user.orgs
-
         conn
         |> assign(:user, user)
-        |> assign(:org, org)
     end
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/error_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/error_view.ex
@@ -7,6 +7,12 @@ defmodule NervesHubAPIWeb.ErrorView do
     %{errors: %{detail: error}}
   end
 
+  # If you want to customize a particular status code
+  # for a certain format, you may uncomment below.
+  def render("400.json", %{error: error}) do
+    %{errors: %{detail: error}}
+  end
+
   # By default, Phoenix returns the status message from
   # the template name. For example, "404.json" becomes
   # "Not Found".

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -4,9 +4,9 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
   alias NervesHubCore.Fixtures
 
   describe "index" do
-    test "lists all deployments", %{conn: conn, product: product} do
+    test "lists all deployments", %{conn: conn, org: org, product: product} do
       qp = URI.encode_query(%{product_name: product.name})
-      path = deployment_path(conn, :index) <> "?" <> qp
+      path = deployment_path(conn, :index, org.name, product.name) <> "?" <> qp
       conn = get(conn, path)
       assert json_response(conn, 200)["data"] == []
     end
@@ -18,15 +18,16 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
     test "renders deployment when data is valid", %{
       conn: conn,
       deployment: deployment,
+      org: org,
       product: product
     } do
       qp = URI.encode_query(%{product_name: product.name})
-      path = deployment_path(conn, :update, deployment.name) <> "?" <> qp
+      path = deployment_path(conn, :update, org.name, product.name, deployment.name) <> "?" <> qp
       conn = put(conn, path, deployment: %{"is_active" => true})
       assert %{"is_active" => true} = json_response(conn, 200)["data"]
 
       conn = build_auth_conn()
-      path = deployment_path(conn, :show, deployment.name) <> "?" <> qp
+      path = deployment_path(conn, :show, org.name, product.name, deployment.name) <> "?" <> qp
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["is_active"]
     end
@@ -34,10 +35,11 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
     test "renders errors when data is invalid", %{
       conn: conn,
       deployment: deployment,
+      org: org,
       product: product
     } do
       qp = URI.encode_query(%{product_name: product.name})
-      path = deployment_path(conn, :update, deployment.name) <> "?" <> qp
+      path = deployment_path(conn, :update, org.name, product.name, deployment.name) <> "?" <> qp
       conn = put(conn, path, deployment: %{is_active: "1234"})
       assert json_response(conn, 422)["errors"] != %{}
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -2,19 +2,19 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
   use NervesHubAPIWeb.ConnCase
 
   describe "create devices" do
-    test "renders device when data is valid", %{conn: conn} do
+    test "renders device when data is valid", %{conn: conn, org: org} do
       identifier = "api-device-1234"
       device = %{identifier: identifier, description: "test device", tags: ["test"]}
 
-      conn = post(conn, device_path(conn, :create), device)
+      conn = post(conn, device_path(conn, :create, org.name), device)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, device_path(conn, :show, device.identifier))
+      conn = get(conn, device_path(conn, :show, org.name, device.identifier))
       assert json_response(conn, 200)["data"]["identifier"] == identifier
     end
 
-    test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, key_path(conn, :create))
+    test "renders errors when data is invalid", %{conn: conn, org: org} do
+      conn = post(conn, key_path(conn, :create, org.name))
       assert json_response(conn, 422)["errors"] != %{}
     end
   end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
@@ -7,26 +7,26 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
   @fw_key_path Path.join(@test_firmware_path, "fwup-key1.pub")
 
   describe "index" do
-    test "lists all keys", %{conn: conn} do
-      conn = get(conn, key_path(conn, :index))
+    test "lists all keys", %{conn: conn, org: org} do
+      conn = get(conn, key_path(conn, :index, org.name))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "create keys" do
-    test "renders key when data is valid", %{org: org, conn: conn} do
+    test "renders key when data is valid", %{conn: conn, org: org} do
       name = "test"
       key = %{name: name, key: File.read!(@fw_key_path), org_id: org.id}
 
-      conn = post(conn, key_path(conn, :create), key)
+      conn = post(conn, key_path(conn, :create, org.name), key)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, key_path(conn, :show, key.name))
+      conn = get(conn, key_path(conn, :show, org.name, key.name))
       assert json_response(conn, 200)["data"]["name"] == name
     end
 
-    test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, key_path(conn, :create))
+    test "renders errors when data is invalid", %{conn: conn, org: org} do
+      conn = post(conn, key_path(conn, :create, org.name))
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -34,11 +34,11 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
   describe "delete key" do
     setup [:create_key]
 
-    test "deletes chosen key", %{conn: conn, key: key} do
-      conn = delete(conn, key_path(conn, :delete, key.name))
+    test "deletes chosen key", %{conn: conn, org: org, key: key} do
+      conn = delete(conn, key_path(conn, :delete, org.name, key.name))
       assert response(conn, 204)
 
-      conn = get(conn, key_path(conn, :show, key.name))
+      conn = get(conn, key_path(conn, :show, org.name, key.name))
 
       assert response(conn, 404)
     end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -166,6 +166,21 @@ defmodule NervesHubCore.Accounts do
     end
   end
 
+  def get_org_by_name_and_user(org_name, %User{id: user_id}) do
+    query =
+      from(
+        o in Org,
+        join: u in assoc(o, :users),
+        where: u.id == ^user_id and o.name == ^org_name
+      )
+
+    Repo.one(query)
+    |> case do
+      nil -> {:error, :not_found}
+      org -> {:ok, org}
+    end
+  end
+
   @spec update_org(Org.t(), map) ::
           {:ok, Org.t()}
           | {:error, Changeset.t()}

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -21,8 +21,8 @@ defmodule NervesHubCore.Accounts do
     User.creation_changeset(user, params)
   end
 
-  def change_user(%User{} = org_key, params) do
-    User.update_changeset(org_key, params)
+  def change_user(%User{} = user, params) do
+    User.update_changeset(user, params)
   end
 
   def create_user(params) do

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user.ex
@@ -20,7 +20,7 @@ defmodule NervesHubCore.Accounts.User do
 
   schema "users" do
     has_many(:user_certificates, UserCertificate)
-    many_to_many(:orgs, Org, join_through: "users_orgs")
+    many_to_many(:orgs, Org, join_through: "users_orgs", on_replace: :delete)
 
     field(:name, :string)
     field(:email, :string)

--- a/apps/nerves_hub_core/priv/repo/migrations/20180819002856_associate_users_and_orgs.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180819002856_associate_users_and_orgs.exs
@@ -1,0 +1,28 @@
+defmodule NervesHubCore.Repo.Migrations.AssociateUsersAndOrgs do
+  use Ecto.Migration
+
+  import Ecto.Changeset
+
+  alias NervesHubCore.Repo
+  alias NervesHubCore.Accounts
+  alias NervesHubCore.Accounts.{User, Org}
+
+  def up do
+    users = Repo.all(User)
+    for user <- users do
+      user = Repo.preload(user, :orgs)
+      org = Repo.get_by!(Org, name: user.name)
+      unless org in user.orgs do
+        orgs = [org | user.orgs]
+        Accounts.change_user(user, %{})
+        |> put_assoc(:orgs, orgs)
+        |> Repo.update!
+      end
+    end
+  end
+
+  # There is no going back
+  def down do
+    
+  end
+end

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -33,7 +33,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  def handle_info(message, socket) do
+  def handle_info(_message, socket) do
     {:noreply, socket}
   end
 


### PR DESCRIPTION
This updates the API to support many to many on users and orgs. The biggest change is in the routing.

Here is what the new routes list looks like.
```
POST    /users/register
POST    /users/auth
POST    /users/sign
GET     /users/me
GET     /orgs/:org_name/keys
POST    /orgs/:org_name/keys
GET     /orgs/:org_name/keys/:name
DELETE  /orgs/:org_name/keys/:name
POST    /orgs/:org_name/devices
GET     /orgs/:org_name/devices/:device_identifier
GET     /orgs/:org_name/devices/:device_identifier/certificates
POST    /orgs/:org_name/devices/:device_identifier/certificates/sign
GET     /orgs/:org_name/products/:product_name/firmwares
GET     /orgs/:org_name/products/:product_name/firmwares/:uuid
POST    /orgs/:org_name/products/:product_name/firmwares
DELETE  /orgs/:org_name/products/:product_name/firmwares/:uuid
GET     /orgs/:org_name/products/:product_name/deployments
GET     /orgs/:org_name/products/:product_name/deployments/:name
PUT     /orgs/:org_name/products/:product_name/deployments/:name
```

It felt pretty good to reorganize things to have more proper paths through narrowing scope.