### PR TITLE
Multiple Org Handling in UI

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
@@ -2,10 +2,12 @@ defmodule NervesHubCore.Accounts.Org do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query
 
   alias NervesHubCore.Accounts.{User, OrgKey}
   alias NervesHubCore.Devices.Device
   alias NervesHubCore.Products.Product
+  alias NervesHubCore.Repo
   alias __MODULE__
 
   @type t :: %__MODULE__{}
@@ -26,5 +28,15 @@ defmodule NervesHubCore.Accounts.Org do
     org
     |> cast(params, [:name])
     |> validate_required([:name])
+  end
+
+  def with_org_keys(%Org{} = o) do
+    o
+    |> Repo.preload(:org_keys)
+  end
+
+  def with_org_keys(org_query) do
+    org_query
+    |> preload(:org_keys)
   end
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -52,8 +52,7 @@ defmodule NervesHubCore.AccountsTest do
 
     [result_org | _] = user.orgs
 
-    {:ok, user} = Accounts.update_user(user, %{orgs: [result_org, result_org]})
-    assert Enum.count(user.orgs) == 1
+    assert {:error, %Changeset{}} = Accounts.update_user(user, %{orgs: [result_org, result_org]})
   end
 
   test "create_user with no org" do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -13,6 +13,7 @@ defmodule NervesHubWWWWeb.AccountController do
 
   defp whitelist(params, keys) do
     keys
+    |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
     |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
   end
 
@@ -39,8 +40,12 @@ defmodule NervesHubWWWWeb.AccountController do
   end
 
   def update(conn, params) do
+    cleaned =
+      params["user"]
+      |> whitelist([:current_password, :password, :name, :email, :orgs])
+
     conn.assigns.user
-    |> Accounts.update_user(params["user"])
+    |> Accounts.update_user(cleaned)
     |> case do
       {:ok, _user} ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
@@ -6,12 +6,12 @@ defmodule NervesHubWWWWeb.DeploymentController do
   alias NervesHubCore.Deployments.Deployment
   alias Ecto.Changeset
 
-  def index(%{assigns: %{org: _org, product: %{id: product_id}}} = conn, _params) do
+  def index(%{assigns: %{current_org: _org, product: %{id: product_id}}} = conn, _params) do
     deployments = Deployments.get_deployments_by_product(product_id)
     render(conn, "index.html", deployments: deployments)
   end
 
-  def new(%{assigns: %{org: org, product: product}} = conn, %{
+  def new(%{assigns: %{current_org: org, product: product}} = conn, %{
         "deployment" => %{"firmware_id" => firmware_id}
       }) do
     case Firmwares.get_firmware(org, firmware_id) do
@@ -44,7 +44,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
     end
   end
 
-  def new(%{assigns: %{org: _org, product: product}} = conn, _params) do
+  def new(%{assigns: %{current_org: _org, product: product}} = conn, _params) do
     firmwares = Firmwares.get_firmwares_by_product(product.id)
 
     if Enum.empty?(firmwares) do
@@ -57,7 +57,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
     end
   end
 
-  def create(%{assigns: %{org: org, product: product}} = conn, %{"deployment" => params}) do
+  def create(%{assigns: %{current_org: org, product: product}} = conn, %{"deployment" => params}) do
     org
     |> Firmwares.get_firmware(params["firmware_id"])
     |> case do
@@ -97,7 +97,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
     end
   end
 
-  def show(%{assigns: %{org: _org, product: product}} = conn, %{"id" => deployment_id}) do
+  def show(%{assigns: %{current_org: _org, product: product}} = conn, %{"id" => deployment_id}) do
     {:ok, deployment} = Deployments.get_deployment(product, deployment_id)
 
     conn
@@ -107,7 +107,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
     )
   end
 
-  def edit(%{assigns: %{org: _org, product: product}} = conn, %{"id" => deployment_id}) do
+  def edit(%{assigns: %{current_org: _org, product: product}} = conn, %{"id" => deployment_id}) do
     {:ok, deployment} = Deployments.get_deployment(product, deployment_id)
 
     conn
@@ -147,7 +147,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
     end
   end
 
-  def delete(%{assigns: %{org: _org, product: product}} = conn, %{"id" => id}) do
+  def delete(%{assigns: %{current_org: _org, product: product}} = conn, %{"id" => id}) do
     {:ok, deployment} = product |> Deployments.get_deployment(id)
 
     Deployments.delete_deployment(deployment)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -5,7 +5,7 @@ defmodule NervesHubWWWWeb.DeviceController do
   alias NervesHubCore.Devices.Device
   alias Ecto.Changeset
 
-  def index(%{assigns: %{org: _org, product: product}} = conn, _params) do
+  def index(%{assigns: %{current_org: _org, product: product}} = conn, _params) do
     conn
     |> render(
       "index.html",
@@ -13,7 +13,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     )
   end
 
-  def index(%{assigns: %{org: org}} = conn, _params) do
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
     conn
     |> render(
       "index.html",
@@ -21,7 +21,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     )
   end
 
-  def new(%{assigns: %{org: _org}} = conn, _params) do
+  def new(%{assigns: %{current_org: _org}} = conn, _params) do
     conn
     |> render(
       "new.html",
@@ -34,7 +34,7 @@ defmodule NervesHubWWWWeb.DeviceController do
   # |> redirect(to: dashboard_path(conn, :index))
   # end
 
-  def create(%{assigns: %{org: org}} = conn, %{"device" => params}) do
+  def create(%{assigns: %{current_org: org}} = conn, %{"device" => params}) do
     params
     |> tags_to_list()
     |> Map.put("org_id", org.id)
@@ -50,7 +50,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     end
   end
 
-  def show(%{assigns: %{org: org}} = conn, %{
+  def show(%{assigns: %{current_org: org}} = conn, %{
         "id" => id
       }) do
     {:ok, device} = Devices.get_device(org, id)
@@ -58,7 +58,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     render(conn, "show.html", device: device)
   end
 
-  def edit(%{assigns: %{org: org}} = conn, %{"id" => id}) do
+  def edit(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
     {:ok, device} = Devices.get_device(org, id)
 
     conn
@@ -69,7 +69,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     )
   end
 
-  def update(%{assigns: %{org: org}} = conn, %{
+  def update(%{assigns: %{current_org: org}} = conn, %{
         "id" => id,
         "device" => params
       }) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -16,7 +16,7 @@ defmodule NervesHubWWWWeb.FirmwareController do
     |> render("upload.html", changeset: %Changeset{data: %Firmware{}})
   end
 
-  def do_upload(%{assigns: %{org: org, product: product}} = conn, %{
+  def do_upload(%{assigns: %{current_org: org, product: product}} = conn, %{
         "firmware" => %{"file" => %{path: filepath}}
       }) do
     with {:ok, firmware_params} <- Firmwares.prepare_firmware_params(org, filepath) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -7,7 +7,7 @@ defmodule NervesHubWWWWeb.OrgController do
   alias NervesHubCore.Accounts.{Invite, OrgKey}
   alias NervesHubWWW.Mailer
 
-  def edit(%{assigns: %{org: %{id: _conn_id} = org}} = conn, _params) do
+  def edit(%{assigns: %{current_org: %{id: _conn_id} = org}} = conn, _params) do
     render(
       conn,
       "edit.html",
@@ -17,7 +17,7 @@ defmodule NervesHubWWWWeb.OrgController do
     )
   end
 
-  def update(%{assigns: %{org: org}} = conn, %{"org" => org_params}) do
+  def update(%{assigns: %{current_org: org}} = conn, %{"org" => org_params}) do
     org
     |> Accounts.update_org(org_params)
     |> case do
@@ -37,11 +37,11 @@ defmodule NervesHubWWWWeb.OrgController do
     end
   end
 
-  def invite(%{assigns: %{org: org}} = conn, _params) do
+  def invite(%{assigns: %{current_org: org}} = conn, _params) do
     render(conn, "invite.html", changeset: %Changeset{data: %Invite{}}, org: org)
   end
 
-  def send_invite(%{assigns: %{org: org}} = conn, %{"invite" => invite_params}) do
+  def send_invite(%{assigns: %{current_org: org}} = conn, %{"invite" => invite_params}) do
     invite_params
     |> Accounts.invite(org)
     |> case do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
   alias NervesHubCore.Accounts
   alias NervesHubCore.Accounts.OrgKey
 
-  def index(%{assigns: %{org: org}} = conn, _params) do
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
     org_keys = Accounts.list_org_keys(org)
     render(conn, "index.html", org_keys: org_keys)
   end
@@ -14,7 +14,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(%{assigns: %{org: org}} = conn, %{"org_key" => org_key_params}) do
+  def create(%{assigns: %{current_org: org}} = conn, %{"org_key" => org_key_params}) do
     case Accounts.create_org_key(org_key_params |> Enum.into(%{"org_id" => org.id})) do
       {:ok, _org_key} ->
         conn
@@ -28,18 +28,18 @@ defmodule NervesHubWWWWeb.OrgKeyController do
     end
   end
 
-  def show(%{assigns: %{org: org}} = conn, %{"id" => id}) do
+  def show(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
     org_key = Accounts.get_org_key!(org, id)
     render(conn, "show.html", org_key: org_key)
   end
 
-  def edit(%{assigns: %{org: org}} = conn, %{"id" => id}) do
+  def edit(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
     {:ok, org_key} = Accounts.get_org_key(org, id)
     changeset = Accounts.change_org_key(org_key)
     render(conn, "edit.html", org_key: org_key, changeset: changeset)
   end
 
-  def update(%{assigns: %{org: org}} = conn, %{
+  def update(%{assigns: %{current_org: org}} = conn, %{
         "id" => id,
         "org_key" => org_key_params
       }) do
@@ -59,7 +59,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
     end
   end
 
-  def delete(%{assigns: %{org: org}} = conn, %{"id" => id}) do
+  def delete(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
     {:ok, org_key} = Accounts.get_org_key(org, id)
     {:ok, _org_key} = Accounts.delete_org_key(org_key)
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/product_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/product_controller.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWWWWeb.ProductController do
   alias NervesHubCore.Products
   alias NervesHubCore.Products.Product
 
-  def index(%{assigns: %{org: org}} = conn, _params) do
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
     products = Products.list_products(org)
     render(conn, "index.html", products: products)
   end
@@ -14,7 +14,7 @@ defmodule NervesHubWWWWeb.ProductController do
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(%{assigns: %{org: org}} = conn, %{"product" => product_params}) do
+  def create(%{assigns: %{current_org: org}} = conn, %{"product" => product_params}) do
     case Products.create_product(product_params |> Enum.into(%{"org_id" => org.id})) do
       {:ok, product} ->
         conn
@@ -37,7 +37,7 @@ defmodule NervesHubWWWWeb.ProductController do
     render(conn, "edit.html", product: product, changeset: changeset)
   end
 
-  def update(%{assigns: %{org: org}} = conn, %{"id" => id, "product" => product_params}) do
+  def update(%{assigns: %{current_org: org}} = conn, %{"id" => id, "product" => product_params}) do
     product = Products.get_product!(id)
 
     case Products.update_product(

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
@@ -12,7 +12,7 @@ defmodule NervesHubWWWWeb.SessionController do
     |> get_session(@session_key)
     |> case do
       nil ->
-        render(conn, "new.html", changeset: %Changeset{data: %User{}})
+        render(conn, "new.html")
 
       _ ->
         conn
@@ -20,13 +20,14 @@ defmodule NervesHubWWWWeb.SessionController do
     end
   end
 
-  def create(conn, %{"user" => %{"email" => email, "password" => password}}) do
+  def create(conn, %{"login" => %{"email" => email, "password" => password}}) do
     email
     |> Accounts.authenticate(password)
     |> case do
-      {:ok, %User{id: user_id}} ->
+      {:ok, %User{id: user_id, orgs: [def_org | _]}} ->
         conn
         |> put_session(@session_key, user_id)
+        |> put_session("current_org_id", def_org.id)
         |> redirect(to: dashboard_path(conn, :index))
 
       {:error, :authentication_failed} ->

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
@@ -16,15 +16,16 @@ defmodule NervesHubWWWWeb.Plugs.EnsureLoggedIn do
     |> Conn.get_session(@session_key)
     |> case do
       nil -> nil
-      user_id -> Accounts.get_user(user_id)
+      user_id -> Accounts.get_user_with_all_orgs(user_id)
     end
     |> case do
       {:ok, user} ->
-        [default_org | _] = user.orgs
+        {:ok, current_org} =
+          get_session(conn, "current_org_id") |> Accounts.get_org_with_org_keys()
 
         conn
         |> assign(:user, user)
-        |> assign(:org, default_org)
+        |> assign(:current_org, current_org)
 
       _ ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/fetch_product.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/fetch_product.ex
@@ -8,7 +8,7 @@ defmodule NervesHubWWWWeb.Plugs.FetchProduct do
   end
 
   def call(%{params: %{"product_id" => product_id}} = conn, _opts) do
-    with {:ok, product} <- Products.get_product_with_org(conn.assigns.org, product_id) do
+    with {:ok, product} <- Products.get_product_with_org(conn.assigns.current_org, product_id) do
       conn
       |> assign(:product, product)
     else

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -32,7 +32,7 @@
       <td><%= firmware.uuid %></td>
       <td><%= firmware.description %></td>
       <td><%= firmware.author %></td>
-      <td><%= format_signed(firmware, @org) %></td>
+      <td><%= format_signed(firmware, @current_org) %></td>
       <td><pre class="pre-scrollable"><%= firmware.misc %></pre></td>
       <td><%= link("Download", to: product_firmware_path(@conn, :download, @product.id, firmware.id)) %></td>
     </tr>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -9,6 +9,19 @@
     <div class="collapse navbar-collapse" id="navbarToggler">
     <%= if logged_in?(@conn) do %>
       <div class="navbar-nav mr-auto">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= @conn.assigns.current_org.name %>
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <%= for org <- @conn.assigns.user.orgs do %>
+              <%= if org.id != @conn.assigns.current_org.id do %>
+                <a class="dropdown-item" href="<%= org_path(@conn, :edit, org)%>"><%= org.name %></a>
+                <% end %>
+        <% end %>
+            <a class="dropdown-item" href="#">New Org</a>
+          </div>
+        </li>
         <%= for {name, path} <- navigation_links(@conn) do %>
             <a class="<%= if @conn.request_path == path, do: "active nav-item nav-link", else: "nav-item nav-link" %>" href="<%= path %>"><%= name %></a>
         <% end %>
@@ -16,10 +29,10 @@
       <div class="navbar-nav mr-3">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= @conn.assigns.org.name %>
+            Settings
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.org)%>">Org settings</a>
+            <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.current_org)%>">Org settings</a>
             <a class="dropdown-item" href="<%= account_path(@conn, :edit)%>">User settings</a>
             <div class="dropdown-divider"></div>
             <a class="dropdown-item" href="<%= session_path(@conn, :delete)%>">Logout</a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/session/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/session/new.html.eex
@@ -5,16 +5,18 @@
         <h3>Log in to your NervesHub account</h3>
       </div>
       <div class="panel-body" style="padding-top: 0px;">
-        <%= form_for @changeset, session_path(@conn, :create), fn f -> %>
+        <%= form_for @conn, session_path(@conn, :create), [as: :login],fn f -> %>
           <div class="form-group text-left">
             <label for="email_input">Email</label>
             <%= email_input f, :email, class: "form-control", id: "email_input" %>
+            <%= label(:login, :email, "Email") %>
             <%= error_tag f, :email %>
           </p>
 
           <div class="form-group text-left">
             <label for="password_input">Password</label>
             <%= password_input f, :password, class: "form-control", id: "password_input" %>
+            <%= label(:login, :password, "Password") %>
             <%= error_tag f, :password %>
           </p>
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -22,12 +22,13 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
             "name" => "Joe",
             "email" => "joe@example.com"
           },
-          conn.assigns.org
+          conn.assigns.current_org
         )
 
       conn = get(conn, account_path(conn, :invite, invite.token))
 
-      assert html_response(conn, 200) =~ "You will be added to the #{conn.assigns.org.name} org"
+      assert html_response(conn, 200) =~
+               "You will be added to the #{conn.assigns.current_org.name} org"
     end
   end
 
@@ -41,7 +42,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
             "name" => "Joe",
             "email" => "joe@example.com"
           },
-          conn.assigns.org
+          conn.assigns.current_org
         )
 
       conn =

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -64,7 +64,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       conn =
         build_conn()
         |> Map.put(:assigns, %{org: org})
-        |> init_test_session(%{"auth_user_id" => user.id})
+        |> init_test_session(%{"auth_user_id" => user.id, "current_org_id" => org.id})
 
       conn = get(conn, product_deployment_path(conn, :new, product.id))
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -28,7 +28,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
       new_conn =
         build_conn()
         |> Map.put(:assigns, %{org: new_org})
-        |> init_test_session(%{"auth_user_id" => user.id})
+        |> init_test_session(%{"auth_user_id" => user.id, "current_org_id" => new_org.id})
 
       updated_conn = get(new_conn, org_path(conn, :edit, new_org))
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule NervesHubWWWWeb.SessionControllerTest do
+  use NervesHubWWWWeb.ConnCase
+
+  alias NervesHubCore.{Accounts, Fixtures}
+
+  setup do
+    org = Fixtures.org_fixture(%{name: "my test org"})
+    user = Fixtures.user_fixture(org, %{name: "Foo Bar", password: "password"})
+    {:ok, %{user: user, org: org}}
+  end
+
+  describe "new session" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, session_path(conn, :new))
+      assert html_response(conn, 200) =~ "Log in to your NervesHub account"
+    end
+  end
+
+  describe "create session" do
+    test "adds current_org_id to session", %{conn: conn, user: user, org: org} do
+      Accounts.update_user(user, %{orgs: [%{name: "another org"}]})
+
+      conn =
+        post(
+          conn,
+          session_path(conn, :create),
+          login: %{email: user.email, password: user.password}
+        )
+
+      assert redirected_to(conn) == dashboard_path(conn, :index)
+      assert get_session(conn, "current_org_id") == org.id
+    end
+  end
+end

--- a/apps/nerves_hub_www/test/support/browser_case.ex
+++ b/apps/nerves_hub_www/test/support/browser_case.ex
@@ -28,10 +28,15 @@ defmodule NervesHubWWWWeb.ConnCase.Browser do
             key: File.read!("../../test/fixtures/firmware/fwup-key1.pub")
           })
 
+        {:ok, org_with_org_keys} = org.id |> Accounts.get_org_with_org_keys()
+
         conn =
           build_conn()
-          |> Map.put(:assigns, %{org: org})
-          |> init_test_session(%{"auth_user_id" => user.id})
+          |> Map.put(:assigns, %{current_org: org_with_org_keys})
+          |> init_test_session(%{
+            "auth_user_id" => user.id,
+            "current_org_id" => org.id
+          })
 
         %{conn: conn, current_user: user, current_org: org, org_key: org_key}
       end


### PR DESCRIPTION
Why:

*  We want it to be easy to switch orgs

This change addresses the need by:

* Adding a dropdown on the left of the nav that shows your current org
and allows you to pick (not implemented) a new org.
* Storing `current_org_id` on the session.

Other Changes:
* Fix bug that overwrote previous orgs when adding new orgs to a user.
* Fix the uniqueness bug with many to many orgs.