### PR TITLE
Add clarity around addition/subtraction of user-orgs

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -341,6 +341,24 @@ defmodule NervesHubCore.Accounts do
     |> Repo.update()
   end
 
+  def add_user_to_org(%User{} = user, %Org{} = org) do
+    all_orgs = user |> User.with_all_orgs() |> Map.get(:orgs, [])
+    params = %{orgs: all_orgs ++ [org]}
+
+    user
+    |> User.update_orgs_changeset(params)
+    |> Repo.update()
+  end
+
+  def remove_user_from_org(%User{} = user, %Org{} = org) do
+    all_orgs = user |> User.with_all_orgs() |> Map.get(:orgs, [])
+    params = %{orgs: all_orgs -- [org]}
+
+    user
+    |> User.update_orgs_changeset(params)
+    |> Repo.update()
+  end
+
   defp set_invite_accepted(invite) do
     invite
     |> Invite.changeset(%{accepted: true})

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -343,7 +343,7 @@ defmodule NervesHubCore.Accounts do
 
   def add_user_to_org(%User{} = user, %Org{} = org) do
     all_orgs = user |> User.with_all_orgs() |> Map.get(:orgs, [])
-    params = %{orgs: all_orgs ++ [org]}
+    params = %{orgs: [org | all_orgs]}
 
     user
     |> User.update_orgs_changeset(params)
@@ -352,7 +352,9 @@ defmodule NervesHubCore.Accounts do
 
   def remove_user_from_org(%User{} = user, %Org{} = org) do
     all_orgs = user |> User.with_all_orgs() |> Map.get(:orgs, [])
-    params = %{orgs: all_orgs -- [org]}
+
+    {_, remaining_orgs} = Enum.split_with(all_orgs, fn x -> x == org end)
+    params = %{orgs: remaining_orgs}
 
     user
     |> User.update_orgs_changeset(params)

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -94,7 +94,9 @@ defmodule NervesHubCore.AccountsTest do
     assert user.name == user_params.name
 
     {:ok, user} = Accounts.add_user_to_org(user, org_2)
-    assert [^org_1, ^org_2 | _] = user.orgs
+    assert org_1 in user.orgs
+    assert org_2 in user.orgs
+    assert Enum.count(user.orgs) == 2
 
     {:ok, user} = Accounts.remove_user_from_org(user, org_2)
 


### PR DESCRIPTION
Why:

* Calling "update" on a user while passing `%{orgs: [org1, org2]}` is
confusing and requires a lot of work _outside_ of the `nerves_hub_core`
application in order to ensure the desired effect occurs.

* I think there were some bugs (of no consequence elsewhere in the outside application yet) around updates

This change addresses the need by:

* adding `add_user_to_org` and `remove_user_from_org` functions which
clarify what's going on.