### PR TITLE
Products api

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -11,7 +11,7 @@ defmodule NervesHubAPIWeb.DeviceController do
     with {:ok, device} <- Devices.create_device(params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", device_path(conn, :show, org.name, device))
+      |> put_resp_header("location", device_path(conn, :show, org.name, device.identifier))
       |> render("show.json", device: device)
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/product_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/product_controller.ex
@@ -1,0 +1,43 @@
+defmodule NervesHubAPIWeb.ProductController do
+  use NervesHubAPIWeb, :controller
+
+  alias NervesHubCore.Products
+  alias NervesHubCore.Products.Product
+
+  action_fallback(NervesHubAPIWeb.FallbackController)
+
+  def index(%{assigns: %{org: org}} = conn, _params) do
+    products = Products.list_products(org)
+    render(conn, "index.json", products: products)
+  end
+
+  def create(%{assigns: %{org: org}} = conn, params) do
+    params =
+      params
+      |> Map.take(["name"])
+      |> Map.put("org_id", org.id)
+
+    with {:ok, product} <- Products.create_product(params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", product_path(conn, :show, org.name, product.name))
+      |> render("show.json", product: product)
+    end
+  end
+
+  def show(%{assigns: %{product: product}} = conn, _params) do
+    render(conn, "show.json", product: product)
+  end
+
+  def delete(%{assigns: %{product: product}} = conn, _params) do
+    with {:ok, %Product{}} <- Products.delete_product(product) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  def update(%{assigns: %{product: product}} = conn, %{"product" => params}) do
+    with {:ok, product} <- Products.update_product(product, params) do
+      render(conn, "show.json", product: product)
+    end
+  end
+end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -58,8 +58,15 @@ defmodule NervesHubAPIWeb.Router do
         end
 
         scope "/products" do
+          get("/", ProductController, :index)
+          post("/", ProductController, :create)
+
           scope "/:product_name" do
             pipe_through(:product)
+
+            get("/", ProductController, :show)
+            delete("/", ProductController, :delete)
+            put("/", ProductController, :update)
 
             scope "/firmwares" do
               get("/", FirmwareController, :index)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/product_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/product_view.ex
@@ -1,0 +1,18 @@
+defmodule NervesHubAPIWeb.ProductView do
+  use NervesHubAPIWeb, :view
+  alias NervesHubAPIWeb.ProductView
+
+  def render("index.json", %{products: products}) do
+    %{data: render_many(products, ProductView, "product.json")}
+  end
+
+  def render("show.json", %{product: product}) do
+    %{data: render_one(product, ProductView, "product.json")}
+  end
+
+  def render("product.json", %{product: product}) do
+    %{
+      name: product.name
+    }
+  end
+end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
@@ -1,0 +1,70 @@
+defmodule NervesHubAPIWeb.ProductControllerTest do
+  use NervesHubAPIWeb.ConnCase
+
+  alias NervesHubCore.Fixtures
+  alias NervesHubCore.Accounts
+
+  setup context do
+    org = Fixtures.org_fixture(%{name: "api-test"})
+    Accounts.add_user_to_org(context.user, org)
+    Map.put(context, :org, org)
+  end
+
+  describe "index" do
+    test "lists all products", %{conn: conn, org: org} do
+      conn = get(conn, product_path(conn, :index, org.name))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create products" do
+    test "renders product when data is valid", %{conn: conn, org: org} do
+      name = "test"
+      product = %{name: name}
+
+      conn = post(conn, product_path(conn, :create, org.name), product)
+      assert json_response(conn, 201)["data"]
+
+      conn = get(conn, product_path(conn, :show, org.name, product.name))
+      assert json_response(conn, 200)["data"]["name"] == name
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, org: org} do
+      conn = post(conn, product_path(conn, :create, org.name))
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete product" do
+    setup [:create_product]
+
+    test "deletes chosen product", %{conn: conn, org: org, product: product} do
+      conn = delete(conn, product_path(conn, :delete, org.name, product.name))
+      assert response(conn, 204)
+
+      conn = get(conn, product_path(conn, :show, org.name, product.name))
+
+      assert response(conn, 403)
+    end
+  end
+
+  describe "update product" do
+    setup [:create_product]
+
+    test "renders deployment when data is valid", %{conn: conn, org: org, product: product} do
+      conn =
+        put(conn, product_path(conn, :update, org.name, product.name), product: %{"name" => "new"})
+
+      assert %{"name" => "new"} = json_response(conn, 200)["data"]
+
+      path = product_path(conn, :show, org.name, "new")
+      conn = get(conn, path)
+      assert json_response(conn, 200)["data"]["name"] == "new"
+    end
+  end
+
+  defp create_product(%{org: org}) do
+    product = Fixtures.product_fixture(org, %{name: "api"})
+    {:ok, %{product: product}}
+  end
+end


### PR DESCRIPTION
Adds the following endpoints

* GET `orgs/<org_name>/products` - List all products for org
* POST `orgs/<org_name>/products` - Create a new product
* GET `orgs/<org_name>/products/<product_name>` - Show a product
* PUT `orgs/<org_name>/products/<product_name>` - Update a product