### PR TITLE
Add API for creating deployments

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
@@ -22,6 +22,7 @@ defmodule NervesHubAPIWeb.FallbackController do
 
   def call(conn, {:error, reason}) when is_atom(reason) do
     conn
+    |> put_resp_content_type("application/json")
     |> put_status(400)
     |> put_view(NervesHubAPIWeb.ErrorView)
     |> send_resp(400, Jason.encode!(%{status: reason}))

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -70,6 +70,7 @@ defmodule NervesHubAPIWeb.Router do
 
             scope "/deployments" do
               get("/", DeploymentController, :index)
+              post("/", DeploymentController, :create)
               get("/:name", DeploymentController, :show)
               put("/:name", DeploymentController, :update)
             end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -10,6 +10,34 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
     end
   end
 
+  describe "create deployment" do
+    test "renders deployment when data is valid", %{conn: conn, org: org, product: product} do
+      org_key = Fixtures.org_key_fixture(org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+
+      deployment = %{
+        name: "test",
+        firmware: firmware.uuid,
+        conditions: %{
+          version: "",
+          tags: ["test"]
+        },
+        is_active: false
+      }
+
+      conn = post(conn, deployment_path(conn, :create, org.name, product.name), deployment)
+      assert json_response(conn, 201)["data"]
+
+      conn = get(conn, deployment_path(conn, :show, org.name, product.name, deployment.name))
+      assert json_response(conn, 200)["data"]["name"] == deployment.name
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do
+      conn = post(conn, deployment_path(conn, :create, org.name, product.name))
+      assert json_response(conn, 400)["errors"] != %{}
+    end
+  end
+
   describe "update deployment" do
     setup [:create_deployment]
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -5,9 +5,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
 
   describe "index" do
     test "lists all deployments", %{conn: conn, org: org, product: product} do
-      qp = URI.encode_query(%{product_name: product.name})
-      path = deployment_path(conn, :index, org.name, product.name) <> "?" <> qp
-      conn = get(conn, path)
+      conn = get(conn, deployment_path(conn, :index, org.name, product.name))
       assert json_response(conn, 200)["data"] == []
     end
   end
@@ -21,13 +19,12 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       org: org,
       product: product
     } do
-      qp = URI.encode_query(%{product_name: product.name})
-      path = deployment_path(conn, :update, org.name, product.name, deployment.name) <> "?" <> qp
+      path = deployment_path(conn, :update, org.name, product.name, deployment.name)
       conn = put(conn, path, deployment: %{"is_active" => true})
       assert %{"is_active" => true} = json_response(conn, 200)["data"]
 
       conn = build_auth_conn()
-      path = deployment_path(conn, :show, org.name, product.name, deployment.name) <> "?" <> qp
+      path = deployment_path(conn, :show, org.name, product.name, deployment.name)
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["is_active"]
     end
@@ -38,8 +35,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       org: org,
       product: product
     } do
-      qp = URI.encode_query(%{product_name: product.name})
-      path = deployment_path(conn, :update, org.name, product.name, deployment.name) <> "?" <> qp
+      path = deployment_path(conn, :update, org.name, product.name, deployment.name)
       conn = put(conn, path, deployment: %{is_active: "1234"})
       assert json_response(conn, 422)["errors"] != %{}
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
@@ -11,8 +11,7 @@ defmodule NervesHubAPIWeb.FirmwareControllerTest do
 
   describe "index" do
     test "lists all firmwares", %{conn: conn, org: org, product: product} do
-      qp = URI.encode_query(%{product_name: product.name})
-      path = firmware_path(conn, :index, org.name, product.name) <> "?" <> qp
+      path = firmware_path(conn, :index, org.name, product.name)
       conn = get(conn, path)
       assert json_response(conn, 200)["data"] == []
     end


### PR DESCRIPTION
Adds the following endpoint

* POST `/orgs/<org_name>/products/<product_name>/deployments`