### PR TITLE
Delete devices via browser and API

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -21,4 +21,15 @@ defmodule NervesHubAPIWeb.DeviceController do
       render(conn, "show.json", device: device)
     end
   end
+
+  def delete(%{assigns: %{org: org}} = conn, %{
+        "device_identifier" => identifier
+      }) do
+    {:ok, device} = Devices.get_device_by_identifier(org, identifier)
+    {:ok, _device} = Devices.delete_device(device)
+
+    conn
+    |> put_status(204)
+    |> render("show.json", device: device)
+  end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -49,6 +49,7 @@ defmodule NervesHubAPIWeb.Router do
 
           scope "/:device_identifier" do
             get("/", DeviceController, :show)
+            delete("/", DeviceController, :delete)
 
             scope "/certificates" do
               get("/", DeviceCertificateController, :index)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule NervesHubAPIWeb.DeviceControllerTest do
   use NervesHubAPIWeb.ConnCase
+  alias NervesHubCore.{Devices, Fixtures}
 
   describe "create devices" do
     test "renders device when data is valid", %{conn: conn, org: org} do
@@ -16,6 +17,23 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
     test "renders errors when data is invalid", %{conn: conn, org: org} do
       conn = post(conn, key_path(conn, :create, org.name))
       assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete devices" do
+    test "deletes chosen device", %{conn: conn, org: org} do
+      product = Fixtures.product_fixture(org)
+      org_key = Fixtures.org_key_fixture(org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+      deployment = Fixtures.deployment_fixture(firmware)
+      Fixtures.device_fixture(org, firmware, deployment)
+
+      [to_delete | _] = Devices.get_devices(org)
+      conn = delete(conn, device_path(conn, :delete, org.name, to_delete.identifier))
+      assert json_response(conn, 204)["data"]
+
+      conn = get(conn, device_path(conn, :show, org.name, to_delete.identifier))
+      assert json_response(conn, 404)
     end
   end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -353,7 +353,7 @@ defmodule NervesHubCore.Accounts do
   def remove_user_from_org(%User{} = user, %Org{} = org) do
     all_orgs = user |> User.with_all_orgs() |> Map.get(:orgs, [])
 
-    {_, remaining_orgs} = Enum.split_with(all_orgs, fn x -> x == org end)
+    {_, remaining_orgs} = Enum.split_with(all_orgs, fn x -> x.id == org.id end)
     params = %{orgs: remaining_orgs}
 
     user

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
@@ -32,21 +32,28 @@ defmodule NervesHubCore.Devices do
     |> Repo.all()
   end
 
-  def get_device(%Org{id: org_id}, device_id) do
-    query =
-      from(
-        d in Device,
-        where: d.org_id == ^org_id,
-        where: d.id == ^device_id
-      )
+  defp device_by_org_query(org_id, device_id) do
+    from(
+      d in Device,
+      where: d.org_id == ^org_id,
+      where: d.id == ^device_id
+    )
+  end
 
-    query
+  def get_device_by_org(%Org{id: org_id}, device_id) do
+    device_by_org_query(org_id, device_id)
     |> Device.with_firmware()
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}
       device -> {:ok, device}
     end
+  end
+
+  def get_device_by_org!(%Org{id: org_id}, device_id) do
+    device_by_org_query(org_id, device_id)
+    |> Device.with_firmware()
+    |> Repo.one!()
   end
 
   @spec get_device_by_identifier(Org.t(), String.t()) :: {:ok, Device.t()} | {:error, :not_found}
@@ -118,6 +125,10 @@ defmodule NervesHubCore.Devices do
     %Device{}
     |> Device.changeset(params)
     |> Repo.insert()
+  end
+
+  def delete_device(%Device{} = device) do
+    Repo.delete(device)
   end
 
   @spec create_device_certificate(Device.t(), map) ::

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices/device.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices/device.ex
@@ -23,7 +23,7 @@ defmodule NervesHubCore.Devices.Device do
     belongs_to(:org, Org)
     belongs_to(:last_known_firmware, Firmware)
 
-    has_many(:device_certificates, DeviceCertificate)
+    has_many(:device_certificates, DeviceCertificate, on_delete: :delete_all)
 
     field(:identifier, :string)
     field(:description, :string)

--- a/apps/nerves_hub_core/priv/repo/migrations/20180824143209_cascading_device_cert_deletes.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180824143209_cascading_device_cert_deletes.exs
@@ -1,0 +1,19 @@
+defmodule NervesHubCore.Repo.Migrations.CascadingDeviceCertDeletes do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:device_certificates, "device_certificates_device_id_fkey"))
+
+    alter table(:device_certificates) do
+      modify(:device_id, references(:devices, on_delete: :delete_all))
+    end
+  end
+
+  def down do
+    drop(constraint(:device_certificates, "device_certificates_device_id_fkey"))
+
+    alter table(:device_certificates) do
+      modify(:device_id, references(:devices, on_delete: :nothing))
+    end
+  end
+end

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -43,6 +43,15 @@ defmodule NervesHubCore.DevicesTest do
     end
   end
 
+  test "delete_device with valid parameters", %{
+    org: org,
+    device: device
+  } do
+    {:ok, _device} = Devices.delete_device(device)
+
+    assert {:error, _} = Devices.get_device_by_org(org, device.id)
+  end
+
   test "create_device with invalid parameters", %{firmware: firmware} do
     params = %{
       identifier: "valid identifier",
@@ -163,7 +172,7 @@ defmodule NervesHubCore.DevicesTest do
       |> elem(1)
       |> Deployments.update_deployment(%{is_active: true})
 
-    {:ok, device_with_firmware} = Devices.get_device(org, device.id)
+    {:ok, device_with_firmware} = Devices.get_device_by_org(org, device.id)
 
     [%Deployments.Deployment{id: dep_id} | _] =
       Devices.get_eligible_deployments(device_with_firmware)
@@ -204,7 +213,7 @@ defmodule NervesHubCore.DevicesTest do
         |> elem(1)
         |> Deployments.update_deployment(%{is_active: true})
 
-      {:ok, device_with_firmware} = Devices.get_device(org, device.id)
+      {:ok, device_with_firmware} = Devices.get_device_by_org(org, device.id)
 
       assert [] == Devices.get_eligible_deployments(device_with_firmware)
     end
@@ -248,7 +257,7 @@ defmodule NervesHubCore.DevicesTest do
       |> elem(1)
       |> Deployments.update_deployment(%{is_active: true})
 
-    {:ok, device_with_firmware} = Devices.get_device(org, device.id)
+    {:ok, device_with_firmware} = Devices.get_device_by_org(org, device.id)
 
     deployments =
       Devices.get_eligible_deployments(device_with_firmware)

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -14,6 +14,7 @@ defmodule NervesHubCore.DevicesTest do
     firmware = Fixtures.firmware_fixture(org_key, product)
     deployment = Fixtures.deployment_fixture(firmware)
     device = Fixtures.device_fixture(org, firmware, deployment)
+    Fixtures.device_certificate_fixture(device)
 
     {:ok,
      %{
@@ -43,13 +44,23 @@ defmodule NervesHubCore.DevicesTest do
     end
   end
 
-  test "delete_device with valid parameters", %{
+  test "delete_device", %{
     org: org,
     device: device
   } do
     {:ok, _device} = Devices.delete_device(device)
 
     assert {:error, _} = Devices.get_device_by_org(org, device.id)
+  end
+
+  test "delete_device deletes its certificates", %{
+    device: device
+  } do
+    [cert] = Devices.get_device_certificates(device)
+
+    {:ok, _device} = Devices.delete_device(device)
+
+    assert {:error, _} = Devices.get_device_certificate_by_serial(cert.serial)
   end
 
   test "create_device with invalid parameters", %{firmware: firmware} do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -29,11 +29,6 @@ defmodule NervesHubWWWWeb.DeviceController do
     )
   end
 
-  # def new(%{assigns: %{org: _org}} = conn, _params) do
-  # conn
-  # |> redirect(to: dashboard_path(conn, :index))
-  # end
-
   def create(%{assigns: %{current_org: org}} = conn, %{"device" => params}) do
     params
     |> tags_to_list()
@@ -53,13 +48,12 @@ defmodule NervesHubWWWWeb.DeviceController do
   def show(%{assigns: %{current_org: org}} = conn, %{
         "id" => id
       }) do
-    {:ok, device} = Devices.get_device(org, id)
-
+    device = Devices.get_device_by_org!(org, id)
     render(conn, "show.html", device: device)
   end
 
   def edit(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
-    {:ok, device} = Devices.get_device(org, id)
+    {:ok, device} = Devices.get_device_by_org(org, id)
 
     conn
     |> render(
@@ -73,7 +67,7 @@ defmodule NervesHubWWWWeb.DeviceController do
         "id" => id,
         "device" => params
       }) do
-    {:ok, device} = Devices.get_device(org, id)
+    {:ok, device} = Devices.get_device_by_org(org, id)
 
     device
     |> Devices.update_device(params |> tags_to_list())
@@ -87,6 +81,17 @@ defmodule NervesHubWWWWeb.DeviceController do
         conn
         |> render("edit.html", changeset: changeset)
     end
+  end
+
+  def delete(%{assigns: %{current_org: org}} = conn, %{
+        "id" => id
+      }) do
+    {:ok, device} = Devices.get_device_by_org(org, id)
+    {:ok, _device} = Devices.delete_device(device)
+
+    conn
+    |> put_flash(:info, "device deleted successfully.")
+    |> redirect(to: device_path(conn, :index))
   end
 
   @doc """

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/fetch_device.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/fetch_device.ex
@@ -12,7 +12,7 @@ defmodule NervesHubWWWWeb.Plugs.FetchDevice do
         _opts
       ) do
     org
-    |> Devices.get_device(device_id)
+    |> Devices.get_device_by_org(device_id)
     |> case do
       {:ok, device} ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
@@ -33,7 +33,7 @@
         </td>
         <td>
           <a href="<%= device_path(@conn, :edit, device.id) %>" class="btn btn-info">Edit</a>
-          <a href="#" class="btn btn-danger">Delete</a>
+          <%= link "Delete", class: "btn btn-danger", to: device_path(@conn, :delete, device), method: :delete, data: [confirm: "Are you sure?"]%>
           <a href="#" class="btn btn-warning">Disable</a>
         </td>
       </tr>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -101,4 +101,16 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       assert html_response(show_conn, 200) =~ "new_identifier"
     end
   end
+
+  describe "delete device" do
+    test "deletes chosen device", %{conn: conn, current_org: org} do
+      [to_delete | _] = Devices.get_devices(org)
+      conn = delete(conn, device_path(conn, :delete, to_delete))
+      assert redirected_to(conn) == device_path(conn, :index)
+
+      assert_error_sent(404, fn ->
+        get(conn, device_path(conn, :show, to_delete))
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Why:

* If we want to limit devices per org/product, we need to allow users to
delete devices: https://github.com/nerves-hub/nerves_hub_web/issues/217

This change addresses the need by:

* routes, controller, and context functions.
* tests to verify behavior