### PR TITLE
Switch/Create org from dropdown.

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -11,7 +11,7 @@ defmodule NervesHubCore.Accounts do
           | {:error, Changeset.t()}
   def create_org(params) do
     %Org{}
-    |> Org.changeset(params)
+    |> Org.creation_changeset(params)
     |> Repo.insert()
   end
 
@@ -205,7 +205,7 @@ defmodule NervesHubCore.Accounts do
           | {:error, Changeset.t()}
   def update_org(%Org{} = org, attrs) do
     org
-    |> Org.changeset(attrs)
+    |> Org.update_changeset(attrs)
     |> Repo.update()
   end
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
@@ -17,17 +17,62 @@ defmodule NervesHubCore.Accounts.Org do
     has_many(:products, Product)
     has_many(:devices, Device)
 
-    many_to_many(:users, User, join_through: "users_orgs")
+    many_to_many(:users, User, join_through: "users_orgs", on_replace: :delete, unique: true)
 
     field(:name, :string)
 
     timestamps()
   end
 
-  def changeset(%Org{} = org, params) do
+  defp changeset(%Org{} = org, params) do
     org
     |> cast(params, [:name])
     |> validate_required([:name])
+    |> unique_constraint(:users, name: :users_orgs_user_id_org_id_index)
+  end
+
+  def creation_changeset(%Org{} = org, params) do
+    org
+    |> changeset(params)
+    |> handle_users(params)
+  end
+
+  def update_changeset(%Org{} = org, %{users: _} = params) do
+    org
+    |> changeset(params)
+    |> add_error(:users, "update users_orgs with User.update_orgs_changeset/2")
+  end
+
+  def update_changeset(%Org{} = org, params) do
+    org
+    |> changeset(params)
+  end
+
+  defp handle_users(changeset, %{users: nil}) do
+    changeset |> cast_assoc(:users)
+  end
+
+  defp handle_users(changeset, %{users: users}) do
+    changeset
+    |> put_assoc(:users, get_users(users))
+  end
+
+  defp handle_users(changeset, _params) do
+    changeset
+    |> cast_assoc(:users)
+  end
+
+  defp get_users(users) do
+    users
+    |> Enum.map(fn x -> do_get_user(x) end)
+  end
+
+  defp do_get_user(%User{} = user) do
+    user
+  end
+
+  defp do_get_user(user) do
+    struct(User, user)
   end
 
   def with_org_keys(%Org{} = o) do

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user.ex
@@ -73,7 +73,6 @@ defmodule NervesHubCore.Accounts.User do
   def creation_changeset(%User{} = user, params) do
     changeset(user, params)
     |> handle_orgs(params)
-    |> unique_constraint(:orgs, name: :users_orgs_user_id_org_id_index)
   end
 
   def password_changeset(%User{} = user, params) do

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -14,8 +14,23 @@ defmodule NervesHubCore.AccountsTest do
     assert result_org.name == @required_org_params.name
   end
 
+  test "create_org with user" do
+    {:ok, %Accounts.Org{} = org1} = Accounts.create_org(%{name: "An Org"})
+    user = Fixtures.user_fixture(org1)
+
+    {:ok, %Accounts.Org{} = org2} = Accounts.create_org(%{name: "Another Org", users: [user]})
+    {:ok, user_with_orgs} = Accounts.get_user_with_all_orgs(user.id)
+
+    assert org2.id in (user_with_orgs.orgs |> Enum.map(fn x -> x.id end))
+  end
+
   test "create_org without required params" do
     assert {:error, %Changeset{}} = Accounts.create_org(%{})
+  end
+
+  test "cannot modify users_orgs through Org.update_changeset" do
+    {:ok, org} = Accounts.create_org(%{name: "foo"})
+    assert {:error, %Changeset{}} = Accounts.update_org(org, %{users: []})
   end
 
   test "create_user with org" do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
@@ -1,7 +1,6 @@
 defmodule NervesHubWWWWeb.SessionController do
   use NervesHubWWWWeb, :controller
 
-  alias Ecto.Changeset
   alias NervesHubCore.Accounts
   alias NervesHubCore.Accounts.User
 
@@ -41,5 +40,18 @@ defmodule NervesHubWWWWeb.SessionController do
     conn
     |> delete_session(@session_key)
     |> redirect(to: "/")
+  end
+
+  def set_org(%{assigns: %{current_org: _, user: user}} = conn, %{"org" => id}) do
+    {org_id, _} = Integer.parse(id)
+
+    if org_id in (user.orgs |> Enum.map(fn x -> x.id end)) do
+      conn
+      |> put_session("current_org_id", org_id)
+      |> redirect(to: dashboard_path(conn, :index))
+    else
+      conn
+      |> redirect(to: dashboard_path(conn, :index))
+    end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -52,8 +52,10 @@ defmodule NervesHubWWWWeb.Router do
   scope "/", NervesHubWWWWeb do
     pipe_through([:browser, :logged_in])
 
+    put("/set_org", SessionController, :set_org)
+
     resources("/dashboard", DashboardController, only: [:index])
-    resources("/org", OrgController, only: [:edit, :update])
+    resources("/org", OrgController)
 
     resources("/org_keys", OrgKeyController)
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -16,10 +16,10 @@
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <%= for org <- @conn.assigns.user.orgs do %>
               <%= if org.id != @conn.assigns.current_org.id do %>
-                <a class="dropdown-item" href="<%= org_path(@conn, :edit, org)%>"><%= org.name %></a>
+              <%= link org.name, class: "dropdown-item", to: session_path(@conn, :set_org, org: org), method: :put%>
                 <% end %>
         <% end %>
-            <a class="dropdown-item" href="#">New Org</a>
+        <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New Org</a>
           </div>
         </li>
         <%= for {name, path} <- navigation_links(@conn) do %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/form.html.eex
@@ -1,0 +1,15 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
@@ -1,0 +1,5 @@
+<h2>New Org</h2>
+
+<%= render "form.html", Map.put(assigns, :action, org_path(@conn, :create)) %>
+
+<span><%= link "Back", to: org_path(@conn, :index) %></span>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -3,6 +3,31 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
   alias NervesHubCore.Fixtures
 
+  describe "new org" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, org_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Org"
+    end
+  end
+
+  describe "create org" do
+    test "redirects to edit when data is valid", %{conn: conn, current_org: org} do
+      conn = post(conn, org_path(conn, :create), org: %{name: "An Org"})
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == org_path(conn, :edit, id)
+
+      conn = get(conn, org_path(conn, :edit, id))
+      assert html_response(conn, 200) =~ "Org Settings"
+      assert html_response(conn, 200) =~ org.name
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, org_path(conn, :create), org: %{})
+      assert html_response(conn, 200) =~ "New Org"
+    end
+  end
+
   describe "edit org" do
     test "renders form for editing org on conn", %{conn: conn, current_org: org} do
       conn = get(conn, org_path(conn, :edit, org))

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
@@ -1,23 +1,28 @@
 defmodule NervesHubWWWWeb.SessionControllerTest do
-  use NervesHubWWWWeb.ConnCase
+  use NervesHubWWWWeb.ConnCase.Browser
 
   alias NervesHubCore.{Accounts, Fixtures}
 
   setup do
-    org = Fixtures.org_fixture(%{name: "my test org"})
-    user = Fixtures.user_fixture(org, %{name: "Foo Bar", password: "password"})
+    org = Fixtures.org_fixture(%{name: "my test org 1"})
+
+    user =
+      Fixtures.user_fixture(org, %{name: "Foo Bar", email: "foo@bar.com", password: "password"})
+
     {:ok, %{user: user, org: org}}
   end
 
   describe "new session" do
-    test "renders form", %{conn: conn} do
+    test "renders form" do
+      conn = build_conn()
       conn = get(conn, session_path(conn, :new))
       assert html_response(conn, 200) =~ "Log in to your NervesHub account"
     end
   end
 
   describe "create session" do
-    test "adds current_org_id to session", %{conn: conn, user: user, org: org} do
+    test "adds current_org_id to session", %{user: user, org: org} do
+      conn = build_conn()
       Accounts.update_user(user, %{orgs: [%{name: "another org"}]})
 
       conn =
@@ -26,6 +31,29 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
           session_path(conn, :create),
           login: %{email: user.email, password: user.password}
         )
+
+      assert redirected_to(conn) == dashboard_path(conn, :index)
+      assert get_session(conn, "current_org_id") == org.id
+    end
+  end
+
+  describe "set_org" do
+    test "adds org to session if user belongs to org", %{conn: conn, current_user: user} do
+      new_org = Fixtures.org_fixture(%{name: "this org"})
+      {:ok, _user} = Accounts.add_user_to_org(user, new_org)
+
+      result_conn = put(conn, session_path(conn, :set_org, org: new_org))
+
+      assert redirected_to(result_conn) == dashboard_path(result_conn, :index)
+      assert get_session(result_conn, "current_org_id") == new_org.id
+    end
+
+    test "does not add org to session if user does not belong to org", %{
+      conn: conn,
+      current_org: org
+    } do
+      new_org = Fixtures.org_fixture(%{name: "this org"})
+      conn = put(conn, session_path(conn, :set_org, org: new_org))
 
       assert redirected_to(conn) == dashboard_path(conn, :index)
       assert get_session(conn, "current_org_id") == org.id

--- a/apps/nerves_hub_www/test/support/browser_case.ex
+++ b/apps/nerves_hub_www/test/support/browser_case.ex
@@ -32,7 +32,7 @@ defmodule NervesHubWWWWeb.ConnCase.Browser do
 
         conn =
           build_conn()
-          |> Map.put(:assigns, %{current_org: org_with_org_keys})
+          |> Map.put(:assigns, %{current_org: org_with_org_keys, user: user})
           |> init_test_session(%{
             "auth_user_id" => user.id,
             "current_org_id" => org.id


### PR DESCRIPTION
Why:

* We want users to choose their org

This change addresses the need by:

* Implementing a `set_org` endpoint by the session controller which
switches the org that is on the session.
* Implementing a `create` endpoint for the org controller that creates a
new org and adds the current user to that org.