### PR TITLE
Fix the new org back button

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
@@ -2,4 +2,4 @@
 
 <%= render "form.html", Map.put(assigns, :action, org_path(@conn, :create)) %>
 
-<span><%= link "Back", to: org_path(@conn, :index) %></span>
+<span><%= link "Back", to: dashboard_path(@conn, :index) %></span>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -7,6 +7,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
     test "renders form", %{conn: conn} do
       conn = get(conn, org_path(conn, :new))
       assert html_response(conn, 200) =~ "New Org"
+      refute html_response(conn, 200) =~ "href=\"" <> org_path(conn, :index) <> "\""
     end
   end
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
@@ -5,7 +5,6 @@ defmodule NervesHubWWWWeb.ProductControllerTest do
   alias NervesHubCore.Products
 
   @create_attrs %{name: "some name"}
-  @update_attrs %{name: "some updated name"}
   @invalid_attrs %{name: nil}
 
   def fixture(:product) do


### PR DESCRIPTION
Why:

* https://github.com/nerves-hub/nerves_hub_web/issues/235
* It was directing to an invalid route.

This change addresses the need by:

* Change the href for the back button.
* Checking that we don't link to the invalid route.