### PR TITLE
Deployment name is unique wrt product

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
@@ -5,16 +5,18 @@ defmodule NervesHubCore.Deployments.Deployment do
   import Ecto.Query
 
   alias NervesHubCore.Firmwares.Firmware
+  alias NervesHubCore.Products.Product
   alias NervesHubCore.Repo
 
   alias __MODULE__
 
   @type t :: %__MODULE__{}
-  @required_fields [:firmware_id, :name, :conditions, :is_active]
+  @required_fields [:firmware_id, :name, :conditions, :is_active, :product_id]
   @optional_fields []
 
   schema "deployments" do
     belongs_to(:firmware, Firmware)
+    belongs_to(:product, Product)
 
     field(:name, :string)
     field(:conditions, :map)
@@ -24,9 +26,13 @@ defmodule NervesHubCore.Deployments.Deployment do
   end
 
   def creation_changeset(%Deployment{} = deployment, params) do
+    # set product_id by getting it from firmware
+    with_product_id = handle_product_id(deployment, params)
+
     deployment
-    |> cast(params, @required_fields ++ @optional_fields)
+    |> cast(with_product_id, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:name, name: :deployments_product_id_name_index)
     |> validate_change(:is_active, fn :is_active, is_active ->
       creation_errors(:is_active, is_active)
     end)
@@ -40,10 +46,34 @@ defmodule NervesHubCore.Deployments.Deployment do
     end
   end
 
+  defp handle_product_id(%Deployment{}, %{firmware: %Firmware{product_id: p_id}} = params) do
+    params |> Map.put(:product_id, p_id)
+  end
+
+  defp handle_product_id(%Deployment{firmware: %Firmware{product_id: p_id}}, params) do
+    params |> Map.put(:product_id, p_id)
+  end
+
+  defp handle_product_id(%Deployment{} = d, %{firmware_id: f_id} = params) do
+    handle_product_id(d, params |> Map.put(:firmware, Firmware |> Repo.get!(f_id)))
+  end
+
+  defp handle_product_id(%Deployment{firmware_id: nil}, params) do
+    params
+  end
+
+  defp handle_product_id(%Deployment{} = d, params) do
+    handle_product_id(d |> with_firmware(), params)
+  end
+
   def changeset(%Deployment{} = deployment, params) do
+    # set product_id by getting it from firmware
+    with_product_id = handle_product_id(deployment, params)
+
     deployment
-    |> cast(params, @required_fields ++ @optional_fields)
+    |> cast(with_product_id, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:name, name: :deployments_product_id_name_index)
     |> validate_conditions()
   end
 

--- a/apps/nerves_hub_core/priv/repo/migrations/20180829201933_unique_deployment_per_product.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180829201933_unique_deployment_per_product.exs
@@ -1,0 +1,11 @@
+defmodule NervesHubCore.Repo.Migrations.UniqueDeploymentPerProduct do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add(:product_id, references(:products), null: false)
+    end
+
+    create(unique_index(:deployments, [:product_id, :name]))
+  end
+end

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -23,37 +23,57 @@ defmodule NervesHubCore.DeploymentsTest do
      }}
   end
 
-  test "create_deployment with valid parameters", %{
-    firmware: firmware
-  } do
-    params = %{
-      firmware_id: firmware.id,
-      name: "my deployment",
-      conditions: %{
-        "version" => "< 1.0.0",
-        "tags" => ["beta", "beta-edge"]
-      },
-      is_active: false
-    }
+  describe "create deployment" do
+    test "create_deployment with valid parameters", %{
+      firmware: firmware
+    } do
+      params = %{
+        firmware_id: firmware.id,
+        name: "a different name",
+        conditions: %{
+          "version" => "< 1.0.0",
+          "tags" => ["beta", "beta-edge"]
+        },
+        is_active: false
+      }
 
-    {:ok, %Deployments.Deployment{} = deployment} = Deployments.create_deployment(params)
+      {:ok, %Deployments.Deployment{} = deployment} = Deployments.create_deployment(params)
 
-    for key <- Map.keys(params) do
-      assert Map.get(deployment, key) == Map.get(params, key)
+      for key <- Map.keys(params) do
+        assert Map.get(deployment, key) == Map.get(params, key)
+      end
     end
-  end
 
-  test "create_deployment with invalid parameters" do
-    params = %{
-      name: "my deployment",
-      conditions: %{
-        "version" => "< 1.0.0",
-        "tags" => ["beta", "beta-edge"]
-      },
-      is_active: true
-    }
+    test "deployments have unique names wrt product", %{
+      firmware: firmware,
+      deployment: existing_deployment
+    } do
+      params = %{
+        name: existing_deployment.name,
+        firmware_id: firmware.id,
+        conditions: %{
+          "version" => "< 1.0.0",
+          "tags" => ["beta", "beta-edge"]
+        },
+        is_active: false
+      }
 
-    assert {:error, %Changeset{}} = Deployments.create_deployment(params)
+      assert {:error, %Ecto.Changeset{errors: [name: {"has already been taken", _}]}} =
+               Deployments.create_deployment(params)
+    end
+
+    test "create_deployment with invalid parameters" do
+      params = %{
+        name: "my deployment",
+        conditions: %{
+          "version" => "< 1.0.0",
+          "tags" => ["beta", "beta-edge"]
+        },
+        is_active: true
+      }
+
+      assert {:error, %Changeset{}} = Deployments.create_deployment(params)
+    end
   end
 
   describe "update_deployment" do
@@ -108,7 +128,7 @@ defmodule NervesHubCore.DeploymentsTest do
 
         params = %{
           firmware_id: new_firmware.id,
-          name: "my deployment",
+          name: "my deployment #{d_params.identifier}",
           conditions: %{
             "version" => "< 1.0.0",
             "tags" => ["beta", "beta-edge"]

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -211,7 +211,7 @@ defmodule NervesHubCore.DevicesTest do
 
       params = %{
         firmware_id: new_firmware.id,
-        name: "my deployment",
+        name: "my deployment #{d_params.identifier}",
         conditions: %{
           "version" => "< 1.0.0",
           "tags" => ["beta", "beta-edge"]
@@ -238,6 +238,7 @@ defmodule NervesHubCore.DevicesTest do
   } do
     old_deployment =
       Fixtures.deployment_fixture(firmware, %{
+        name: "a different name",
         conditions: %{"tags" => ["beta", "beta-edge"], "version" => ""}
       })
 

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -181,6 +181,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
         })
 
       Fixtures.deployment_fixture(firmware2, %{
+        name: "a different name",
         conditions: %{
           "version" => ">=0.0.1",
           "tags" => ["beta", "beta-edge"]
@@ -241,6 +242,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
 
       deployment =
         Fixtures.deployment_fixture(firmware, %{
+          name: "a different name",
           conditions: %{
             "version" => ">=0.0.1",
             "tags" => ["beta", "beta-edge"]


### PR DESCRIPTION
Why:

* Humans will reference deployments by name, not by firmware uuid.
* https://github.com/nerves-hub/nerves_hub_web/issues/225

This change addresses the need by:

* Adding `product_id` back onto a `Deployment`
* Adding a `unique_index` for `product_id`-`name` combinations on a
`Deployment`
* Testing that this constraint is in place.