### PR TITLE
Fix login with invalid email

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -50,11 +50,11 @@ defmodule NervesHubCore.Accounts do
           | {:error, :authentication_failed}
   def authenticate(email, password) do
     email = String.downcase(email)
-    user = Repo.get_by(User, email: email) |> User.with_default_org() |> User.with_org_keys()
+    user = Repo.get_by(User, email: email)
 
     with %User{} <- user,
          true <- Bcrypt.checkpw(password, user.password_hash) do
-      {:ok, user}
+      {:ok, user |> User.with_default_org() |> User.with_org_keys()}
     else
       nil ->
         # User wasn't found; do dummy check to make user enumeration more difficult

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -118,6 +118,38 @@ defmodule NervesHubCore.AccountsTest do
     assert user.orgs == [org_1]
   end
 
+  describe "authenticate" do
+    setup do
+      user_params = %{
+        orgs: [%{name: "test org 1"}],
+        name: "Testy McTesterson",
+        email: "testy@mctesterson.com",
+        password: "test_password"
+      }
+
+      {:ok, user} = Accounts.create_user(user_params)
+
+      {:ok, %{user: user}}
+    end
+
+    test "with valid credentials", %{user: user} do
+      target_email = user.email
+
+      assert {:ok, %Accounts.User{email: ^target_email, orgs: [%Accounts.Org{}]}} =
+               Accounts.authenticate(user.email, user.password)
+    end
+
+    test "with invalid credentials", %{user: user} do
+      assert {:error, :authentication_failed} =
+               Accounts.authenticate(user.email, "wrong password")
+    end
+
+    test "with non existent user email" do
+      assert {:error, :authentication_failed} =
+               Accounts.authenticate("non existent email", "wrong password")
+    end
+  end
+
   test "create_org_with_user_with_certificate with valid params" do
     params = %{
       name: "Testy McTesterson",


### PR DESCRIPTION
Why:

* It was broken due to trying to preload attributes from a user that did
not exist.

This change addresses the need by:

* Move the preloads to after we're sure we have an existing user.
* Add tests to make sure that this doesn't happen again.