### PR TITLE
add charts to dashboard pages

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
@@ -53,7 +53,11 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
 
     test "renders deployment when data is valid", %{conn: conn, org: org, product: product} do
       conn =
-        put(conn, product_path(conn, :update, org.name, product.name), product: %{"name" => "new"})
+        put(
+          conn,
+          product_path(conn, :update, org.name, product.name),
+          product: %{"name" => "new"}
+        )
 
       assert %{"name" => "new"} = json_response(conn, 200)["data"]
 

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -39,6 +39,9 @@ main {
   margin-top: 20px;
 }
 
+.dash_charts {
+    background-color: whitesmoke;
+}
 .footer {
   background-color: #827f7d;
   padding: 0px 5%;
@@ -104,6 +107,9 @@ main {
       span {
         margin-right: 3px;
       }
+    }
+    .selected {
+      background-color: #E1CDE2 !important;
     }
   }
   table {

--- a/apps/nerves_hub_www/lib/nerves_hub_www/statistics.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www/statistics.ex
@@ -1,0 +1,58 @@
+defmodule NervesHubWWW.Statistics do
+  def devices_per_product(org) do
+    pd_counts =
+      Enum.reduce(org.devices, %{}, fn d, a ->
+        Map.get_and_update(a, d.last_known_firmware.product_id, &count_instances/1)
+        |> elem(1)
+      end)
+
+    data =
+      Enum.reduce(org.products, %{pds: [], cnt: []}, fn p, a ->
+        a
+        |> Map.merge(%{pds: [p.name | a[:pds]]})
+        |> Map.merge(%{cnt: [pd_counts[p.id] | a[:cnt]]})
+      end)
+
+    %{
+      labels: prep_string_array_for_js(data[:pds]),
+      values: prep_array_for_js(data[:cnt])
+    }
+  end
+
+  def devices_per_firmware(org, product) do
+    fw_counts =
+      Enum.reduce(org.devices, %{}, fn d, a ->
+        Map.get_and_update(a, d.last_known_firmware_id, &count_instances/1)
+        |> elem(1)
+      end)
+
+    data =
+      product.firmwares
+      |> Enum.sort(&(&1.inserted_at >= &2.inserted_at))
+      |> Enum.reduce(%{fws: [], cnt: []}, fn f, a ->
+        a
+        |> Map.merge(%{fws: [f.version | a[:fws]]})
+        |> Map.merge(%{cnt: [fw_counts[f.id] | a[:cnt]]})
+      end)
+
+    %{
+      labels: prep_string_array_for_js(data[:fws]),
+      values: prep_array_for_js(data[:cnt])
+    }
+  end
+
+  defp count_instances(curr_val) do
+    new_val = if is_nil(curr_val), do: 1, else: curr_val + 1
+    {curr_val, new_val}
+  end
+
+  defp prep_array_for_js(arr) do
+    "[" <> Enum.join(arr, ", ") <> "]"
+  end
+
+  defp prep_string_array_for_js(arr) do
+    arr
+    |> Enum.map(fn i -> "\"" <> i <> "\"" end)
+    |> prep_array_for_js
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/dashboard_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/dashboard_controller.ex
@@ -1,8 +1,23 @@
 defmodule NervesHubWWWWeb.DashboardController do
   use NervesHubWWWWeb, :controller
 
-  def index(conn, _params) do
+  alias NervesHubCore.Products
+  alias NervesHubCore.Devices
+
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
+    org = NervesHubCore.Repo.preload(org, devices: [:last_known_firmware], products: [])
+    stats = NervesHubWWW.Statistics.devices_per_product(org)
+
     conn
-    |> render("index.html")
+    |> render("index.html", products: org.products, stats: stats)
+  end
+
+  def show(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
+    org = NervesHubCore.Repo.preload(org, [:devices, :products])
+    product = Products.get_product!(id) |> NervesHubCore.Repo.preload(:firmwares)
+
+    stats = NervesHubWWW.Statistics.devices_per_firmware(org, product)
+
+    render(conn, "show.html", products: org.products, product: product, stats: stats)
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -54,7 +54,7 @@ defmodule NervesHubWWWWeb.Router do
 
     put("/set_org", SessionController, :set_org)
 
-    resources("/dashboard", DashboardController, only: [:index])
+    resources("/dashboard", DashboardController, only: [:index, :show])
     resources("/org", OrgController)
 
     resources("/org_keys", OrgKeyController)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/dashboard/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/dashboard/show.html.eex
@@ -17,7 +17,7 @@
     <ul class="list-group" id="product_listing">
 
       <%= for product <- @products do %>
-        <li class="list-group-item">
+        <li class="<%= dashboard_row_class(product, @product) %>">
           <div class="row">
             <div class="col-8">
               <a href="<%= dashboard_path(@conn, :show, product) %>">
@@ -45,6 +45,7 @@
     <canvas id="chart1" class="dash_charts" width="400" height="150"></canvas>
     <canvas id="chart2" width="400" height="200"></canvas>
   </div>
+</div>
 
 <script>
     var ctx = document.getElementById("chart1");
@@ -68,7 +69,7 @@
       options: {
         title: {
           display: true,
-          text: "Devices / Product"
+          text: "Devices / Firmware for <%= @product.name %>"
         },
         legend: {
           display: false
@@ -83,4 +84,3 @@
     }
     });
 </script>
-</div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/dashboard_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/dashboard_view.ex
@@ -1,3 +1,11 @@
 defmodule NervesHubWWWWeb.DashboardView do
   use NervesHubWWWWeb, :view
+
+  def dashboard_row_class(current_product, selected_product) do
+    if current_product.id == selected_product.id do
+      "list-group-item selected"
+    else
+      "list-group-item"
+    end
+  end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWWWWeb.LayoutView do
 
   def navigation_links(conn) do
     [
+      {"Dashboard", dashboard_path(conn, :index)},
       {"Products", product_path(conn, :index)},
       {"All Devices", device_path(conn, :index)}
     ]


### PR DESCRIPTION
I know its last minute. I went a bit rogue on the dashboard pages, dressing them up with some charts. I'm not sure if charts are useful, or if these specific charts are, so feel free not to merge if you don't want to.
Its also a bit of a hack, the best way to do this would be using a Phoenix channel to get realtime updates. But thats probably an issue for discussion after ElixirConf.