### PR TITLE
Add configurable per org device limit

### DIFF
--- a/apps/nerves_hub_core/config/config.exs
+++ b/apps/nerves_hub_core/config/config.exs
@@ -4,7 +4,8 @@ use Mix.Config
 
 config :nerves_hub_core,
   ecto_repos: [NervesHubCore.Repo],
-  product_firmware_limit: 5
+  product_firmware_limit: 5,
+  org_device_limit: 5
 
 config :nerves_hub_core, NervesHubWeb.PubSub,
   name: NervesHubWeb.PubSub,

--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
@@ -80,12 +80,8 @@ defmodule NervesHubCore.Deployments.Deployment do
   def with_firmware(%Deployment{firmware: %Firmware{}} = d), do: d
 
   def with_firmware(%Deployment{} = d) do
-    # IO.puts("LOADING FIRMWARE")
-
     d
     |> Repo.preload(:firmware)
-
-    # |> IO.inspect()
   end
 
   def with_firmware(deployment_query) do

--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments/deployment.ex
@@ -80,8 +80,12 @@ defmodule NervesHubCore.Deployments.Deployment do
   def with_firmware(%Deployment{firmware: %Firmware{}} = d), do: d
 
   def with_firmware(%Deployment{} = d) do
+    # IO.puts("LOADING FIRMWARE")
+
     d
     |> Repo.preload(:firmware)
+
+    # |> IO.inspect()
   end
 
   def with_firmware(deployment_query) do

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -44,6 +44,33 @@ defmodule NervesHubCore.DevicesTest do
     end
   end
 
+  test "org cannot have too many devices" do
+    org = Fixtures.org_fixture()
+    product = Fixtures.product_fixture(org)
+    org_key = Fixtures.org_key_fixture(org)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    org_device_limit = Application.get_env(:nerves_hub_core, :org_device_limit)
+
+    for i <- 1..org_device_limit do
+      params = %{
+        org_id: org.id,
+        last_known_firmware_id: firmware.id,
+        identifier: "id #{i}"
+      }
+
+      {:ok, %Devices.Device{}} = Devices.create_device(params)
+    end
+
+    params = %{
+      org_id: org.id,
+      last_known_firmware_id: firmware.id,
+      identifier: "too many"
+    }
+
+    assert {:error, %Changeset{}} = Devices.create_device(params)
+  end
+
   test "delete_device", %{
     org: org,
     device: device


### PR DESCRIPTION
Why:

* We want to limit devices per org in a configurable way.

This change addresses the need by:

* Adding `validate_device_limit` to the `device` changeset.
* Write a test to enforce that the configurable device limit is
enforced.