### PR TITLE
Limit firmware per product

### DIFF
--- a/apps/nerves_hub_core/config/config.exs
+++ b/apps/nerves_hub_core/config/config.exs
@@ -3,7 +3,8 @@
 use Mix.Config
 
 config :nerves_hub_core,
-  ecto_repos: [NervesHubCore.Repo]
+  ecto_repos: [NervesHubCore.Repo],
+  product_firmware_limit: 5
 
 config :nerves_hub_core, NervesHubWeb.PubSub,
   name: NervesHubWeb.PubSub,

--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares.ex
@@ -130,7 +130,9 @@ defmodule NervesHubCore.Firmwares do
       uploader.delete_file(firmware)
     end
 
-    Repo.delete(firmware)
+    firmware
+    |> Firmware.changeset(%{})
+    |> Repo.delete()
   end
 
   @spec verify_signature(String.t(), [OrgKey.t()]) ::


### PR DESCRIPTION
Why:

* S3 Billz

This change addresses the need by:

* Configurable limit on per-product firmwares
* Tests to enforce