### PR TITLE
Fix logo href

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top shadow">
-    <a class="logo navbar-brand circle d-inline-block align-top ml-3" href="<%= home_path(@conn, :index) %>">
+    <a class="logo navbar-brand circle d-inline-block align-top ml-3" href="<%= logo_href(@conn) %>">
       <img src="/images/logo.svg" />
     </a>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -13,6 +13,14 @@ defmodule NervesHubWWWWeb.LayoutView do
   def logged_in?(%{assigns: %{user: %User{}}}), do: true
   def logged_in?(_), do: false
 
+  def logo_href(conn) do
+    if logged_in?(conn) do
+      dashboard_path(conn, :index)
+    else
+      home_path(conn, :index)
+    end
+  end
+
   def permit_uninvited_signups do
     Application.get_env(:nerves_hub_www, NervesHubWWWWeb.AccountController)[:allow_signups]
   end


### PR DESCRIPTION
Why:

* It was sending you to the `home_path` when it shouldn't
* https://github.com/nerves-hub/nerves_hub_web/issues/204

This change addresses the need by:

* Adding a `logo_href` function in the layout view