### PR TITLE
Remove device disable button

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
@@ -34,7 +34,6 @@
         <td>
           <a href="<%= device_path(@conn, :edit, device.id) %>" class="btn btn-info">Edit</a>
           <%= link "Delete", class: "btn btn-danger", to: device_path(@conn, :delete, device), method: :delete, data: [confirm: "Are you sure?"]%>
-          <a href="#" class="btn btn-warning">Disable</a>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Why:

* It's functionality was never implemented.
* Non-working buttons are not a feature placeholder, especially when
users will see and interact with the non-working button.

Other Notes:
* I did add an issue to address what this feature should look like: https://github.com/nerves-hub/nerves_hub_web/issues/248