### PR TITLE
Rename name on user to username

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
@@ -18,8 +18,8 @@ defmodule NervesHubAPIWeb.UserController do
   def register(conn, params) do
     params =
       params
-      |> whitelist([:name, :email, :password])
-      |> Map.put(:orgs, [%{name: params["name"]}])
+      |> whitelist([:username, :email, :password])
+      |> Map.put(:orgs, [%{name: params["username"]}])
 
     with {:ok, user} <- Accounts.create_user(params) do
       render(conn, "show.json", user: user)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/user_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/user_view.ex
@@ -7,7 +7,7 @@ defmodule NervesHubAPIWeb.UserView do
   end
 
   def render("user.json", %{user: user}) do
-    %{name: user.name, email: user.email}
+    %{username: user.username, email: user.email}
   end
 
   def render("cert.json", %{cert: cert}) do

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -9,28 +9,38 @@ defmodule NervesHubAPIWeb.UserControllerTest do
     conn = get(conn, user_path(conn, :me))
 
     assert json_response(conn, 200)["data"] == %{
-             "name" => user.name,
+             "username" => user.username,
              "email" => user.email
            }
   end
 
   test "register new account" do
     conn = build_conn()
-    body = %{name: "test", password: "12345678", email: "new_test@test.com"}
+    body = %{username: "test", password: "12345678", email: "new_test@test.com"}
     conn = post(conn, user_path(conn, :register), body)
 
     assert json_response(conn, 200)["data"] == %{
-             "name" => body.name,
+             "username" => body.username,
              "email" => body.email
            }
   end
 
-  test "authenticate existing accounts", %{user: %{password: password} = user} do
+  test "authenticate existing accounts" do
+    password = "12345678"
+    org = Fixtures.org_fixture()
+
+    user =
+      Fixtures.user_fixture(org, %{
+        username: "Bob-Smith",
+        email: "account_test@test.com",
+        password: password
+      })
+
     conn = build_conn()
     conn = post(conn, user_path(conn, :auth), %{email: user.email, password: password})
 
     assert json_response(conn, 200)["data"] == %{
-             "name" => user.name,
+             "username" => user.username,
              "email" => user.email
            }
   end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/invite.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/invite.ex
@@ -12,7 +12,6 @@ defmodule NervesHubCore.Accounts.Invite do
     belongs_to(:org, Org)
 
     field(:email, :string)
-    field(:name, :string)
     field(:token, Ecto.UUID)
     field(:accepted, :boolean)
 
@@ -21,7 +20,7 @@ defmodule NervesHubCore.Accounts.Invite do
 
   def changeset(%Invite{} = invite, params) do
     invite
-    |> cast(params, [:email, :name, :token, :org_id, :accepted])
-    |> validate_required([:email, :name, :token, :org_id])
+    |> cast(params, [:email, :token, :org_id, :accepted])
+    |> validate_required([:email, :token, :org_id])
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180810151416_default_user_org.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180810151416_default_user_org.exs
@@ -7,25 +7,29 @@ defmodule NervesHubCore.Repo.Migrations.DefaultUserOrg do
   alias NervesHubCore.Repo
 
   def up do
-    new_org_ids =
-      from(u in User)
-      |> Repo.all()
-      |> Enum.map(fn u ->
-        {:ok, org} = Accounts.create_org(%{name: u.name})
+    # This should have been done outside of a migration. If the User schema ever changes then
+    # executing this migration will fail. Prod will never run it again and it has no impact on
+    # fresh dev/test databases.
+    #
+    # new_org_ids =
+    #   from(u in User)
+    #   |> Repo.all()
+    #   |> Enum.map(fn u ->
+    #     {:ok, org} = Accounts.create_org(%{name: u.name})
 
-        Accounts.update_user(u, %{org_id: org.id})
+    #     Accounts.update_user(u, %{org_id: org.id})
 
-        org.id
-      end)
+    #     org.id
+    #   end)
 
-    from(
-      o in Org,
-      where: o.id not in ^new_org_ids,
-      preload: :users
-    )
-    |> Repo.all()
-    |> Enum.filter(fn o -> Enum.empty?(o.users) end)
-    |> Enum.map(fn o -> Repo.delete(o) end)
+    # from(
+    #   o in Org,
+    #   where: o.id not in ^new_org_ids,
+    #   preload: :users
+    # )
+    # |> Repo.all()
+    # |> Enum.filter(fn o -> Enum.empty?(o.users) end)
+    # |> Enum.map(fn o -> Repo.delete(o) end)
   end
 
   def down do

--- a/apps/nerves_hub_core/priv/repo/migrations/20180819002856_associate_users_and_orgs.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180819002856_associate_users_and_orgs.exs
@@ -8,21 +8,24 @@ defmodule NervesHubCore.Repo.Migrations.AssociateUsersAndOrgs do
   alias NervesHubCore.Accounts.{User, Org}
 
   def up do
-    users = Repo.all(User)
-    for user <- users do
-      user = Repo.preload(user, :orgs)
-      org = Repo.get_by!(Org, name: user.name)
-      unless org in user.orgs do
-        orgs = [org | user.orgs]
-        Accounts.change_user(user, %{})
-        |> put_assoc(:orgs, orgs)
-        |> Repo.update!
-      end
-    end
+    # This should have been done outside of a migration. If the User schema ever changes then
+    # executing this migration will fail. Prod will never run it again and it has no impact on
+    # fresh dev/test databases.
+    #
+    # users = Repo.all(User)
+    # for user <- users do
+    #   user = Repo.preload(user, :orgs)
+    #   org = Repo.get_by!(Org, name: user.name)
+    #   unless org in user.orgs do
+    #     orgs = [org | user.orgs]
+    #     Accounts.change_user(user, %{})
+    #     |> put_assoc(:orgs, orgs)
+    #     |> Repo.update!
+    #   end
+    # end
   end
 
   # There is no going back
   def down do
-    
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180903222410_users_name_to_username.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180903222410_users_name_to_username.exs
@@ -1,0 +1,12 @@
+defmodule NervesHubCore.Repo.Migrations.UsersNameToUsername do
+  use Ecto.Migration
+
+  def change do
+    alter table(:invites) do
+      remove(:name)
+    end
+
+    rename(table(:users), :name, to: :username)
+    create(unique_index(:users, :username))
+  end
+end

--- a/apps/nerves_hub_core/priv/repo/seeds.exs
+++ b/apps/nerves_hub_core/priv/repo/seeds.exs
@@ -35,7 +35,7 @@ if root_user = Repo.get_by(User, email: root_user_email) do
 else
   Accounts.create_user(%{
     orgs: [root_org],
-    name: root_user_name,
+    username: root_user_name,
     email: root_user_email,
     password: "nerveshub"
   })

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -73,7 +73,7 @@ defmodule NervesHubCore.AccountsTest do
 
   test "create_user with org" do
     params = %{
-      name: "Testy McTesterson",
+      username: "Testy-McTesterson",
       org_name: "mctesterson.com",
       email: "testy@mctesterson.com",
       password: "test_password"
@@ -86,12 +86,12 @@ defmodule NervesHubCore.AccountsTest do
     [result_org | _] = user.orgs
 
     assert result_org.name == target_org.name
-    assert user.name == params.name
+    assert user.username == params.username
   end
 
   test "user cannot have two of the same org" do
     params = %{
-      name: "Testy McTesterson",
+      username: "Testy-McTesterson",
       org_name: "mctesterson.com",
       email: "testy@mctesterson.com",
       password: "test_password"
@@ -108,7 +108,7 @@ defmodule NervesHubCore.AccountsTest do
 
   test "create_user with no org" do
     params = %{
-      name: "Testy McTesterson",
+      username: "Testy-McTesterson",
       email: "testy@mctesterson.com",
       password: "test_password"
     }
@@ -132,7 +132,7 @@ defmodule NervesHubCore.AccountsTest do
 
     user_params = %{
       orgs: [org_1],
-      name: "Testy McTesterson",
+      username: "Testy-McTesterson",
       email: "testy@mctesterson.com",
       password: "test_password"
     }
@@ -142,7 +142,7 @@ defmodule NervesHubCore.AccountsTest do
     [result_org_1 | _] = user.orgs
 
     assert result_org_1.name == org_1.name
-    assert user.name == user_params.name
+    assert user.username == user_params.username
 
     {:ok, user} = Accounts.add_user_to_org(user, org_2)
     assert org_1 in user.orgs
@@ -158,7 +158,7 @@ defmodule NervesHubCore.AccountsTest do
     setup do
       user_params = %{
         orgs: [%{name: "test org 1"}],
-        name: "Testy McTesterson",
+        username: "Testy-McTesterson",
         email: "testy@mctesterson.com",
         password: "test_password"
       }
@@ -188,7 +188,7 @@ defmodule NervesHubCore.AccountsTest do
 
   test "create_org_with_user_with_certificate with valid params" do
     params = %{
-      name: "Testy McTesterson",
+      username: "Testy-McTesterson",
       org_name: "mctesterson.com",
       email: "testy@mctesterson.com",
       password: "test_password"
@@ -201,7 +201,7 @@ defmodule NervesHubCore.AccountsTest do
     [result_org | _] = user.orgs
 
     assert result_org.name == target_org.name
-    assert user.name == params.name
+    assert user.username == params.username
 
     params = %{
       description: "abcd",
@@ -213,7 +213,7 @@ defmodule NervesHubCore.AccountsTest do
 
   test "cannot create user certificate with duplicate serial" do
     params = %{
-      name: "Testy McTesterson",
+      username: "Testy-McTesterson",
       org_name: "mctesterson.com",
       email: "testy@mctesterson.com",
       password: "test_password"

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/user_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/user_test.exs
@@ -1,0 +1,23 @@
+defmodule NervesHubCore.Accounts.UserTest do
+  use NervesHubCore.DataCase
+  alias Ecto.Changeset
+  alias NervesHubCore.Accounts.User
+
+  test "changeset/2 - validates username" do
+    invalid_chars = ~w(! $ * \( \) + ; / ? : @ = & " < > # % { } | \ ^ [ ] \s`)
+
+    Enum.each(invalid_chars, fn char ->
+      %Changeset{errors: errors} =
+        User.creation_changeset(%NervesHubCore.Accounts.User{}, %{username: "username#{char}"})
+
+      assert {"invalid character(s) in username", []} = errors[:username]
+    end)
+
+    %Changeset{errors: errors} =
+      User.creation_changeset(%NervesHubCore.Accounts.User{}, %{
+        username: "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~"
+      })
+
+    assert is_nil(errors[:username])
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -40,7 +40,7 @@ defmodule NervesHubWWWWeb.Router do
     put("/password-reset/:token", PasswordResetController, :reset)
 
     get("/invite/:token", AccountController, :invite)
-    put("/invite/:token", AccountController, :accept_invite)
+    post("/invite/:token", AccountController, :accept_invite)
 
     scope "/policy" do
       get("/tos", PolicyController, :tos)
@@ -57,12 +57,12 @@ defmodule NervesHubWWWWeb.Router do
     put("/set_org", SessionController, :set_org)
 
     resources("/dashboard", DashboardController, only: [:index])
-    resources("/org", OrgController)
-
-    resources("/org_keys", OrgKeyController)
 
     get("/org/invite", OrgController, :invite)
     post("/org/invite", OrgController, :send_invite)
+    resources("/org", OrgController)
+
+    resources("/org_keys", OrgKeyController)
 
     get("/settings", AccountController, :edit)
     put("/settings", AccountController, :update)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
@@ -7,9 +7,9 @@
 
 <%= form_for @changeset, account_path(@conn, :update), fn f -> %>
   <div class="form-group">
-    <label for="name_input">Name</label>
-    <%= text_input f, :name, class: "form-control", id: "name_input" %>
-    <div class="has-error"><%= error_tag f, :name %></div>
+    <label for="username_input">Username</label>
+    <%= text_input f, :username, class: "form-control", id: "username_input" %>
+    <div class="has-error"><%= error_tag f, :username %></div>
   </div>
 
   <div class="form-group">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
@@ -2,7 +2,14 @@
   You will be added to the <%= @org.name %> org
 </p>
 
-<%= form_for @changeset, account_path(@conn, :accept_invite, @token), [as: :user], fn f -> %>
+<%= form_for @changeset, account_path(@conn, :accept_invite, @token), [as: :user, method: "post"], fn f -> %>
+  <p>
+    <label>
+      Username:
+      <%= text_input f, :username %>
+      <%= error_tag f, :username %>
+    </label>
+  </p>
   <p>
     <label>
       Password:

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/new.html.eex
@@ -5,9 +5,9 @@
     </div>
     <div class="modal-body">
       <div class="form-group">
-        <label for="name">Name</label>
-        <%= text_input f, :name, class: "form-control", id: "name" %>
-        <div class="has-error"><%= error_tag f, :name %></div>
+        <label for="username">Username</label>
+        <%= text_input f, :username, class: "form-control", id: "username" %>
+        <div class="has-error"><%= error_tag f, :username %></div>
       </div>
 
       <div class="form-group">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/dashboard/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/dashboard/index.html.eex
@@ -1,5 +1,5 @@
 <div class="jumbotron bg-dark">
-  <h1 class="display-4 text-left">Welcome, <%= @conn.assigns.user.name %>!</h1>
+  <h1 class="display-4 text-left">Welcome, <%= @conn.assigns.user.username %>!</h1>
   <p class="lead text-left">NervesHub helps you manage firmware updates for Nerves devices.</p>
   <hr class="my-4">
   <p class="text-left">To get started, add a product by clicking the button below.</p>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/forgot_password.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/forgot_password.html.eex
@@ -1,4 +1,4 @@
-<p>Hi <%= @user.name %>,</p>
+<p>Hi <%= @user.username %>,</p>
 
 <p>We received a request to reset your password on NervesHubWWW. Click on the link below to begin:</p>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/invite.html.eex
@@ -1,5 +1,3 @@
-<p>Hi <%= @invite.name %>,</p>
-
 <p>You've been invited to join <%= @org.name %> on nerves-hub.org.</p>
 
 <p>To get started click on the link below to register your account and set up your password:</p>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
@@ -8,12 +8,6 @@
 
   <%= form_for @changeset, org_path(@conn, :send_invite), fn f -> %>
     <div class="form-group">
-      <label for="name_input">Name</label>
-      <%= text_input f, :name, class: "form-control", id: "name_input" %>
-      <div class="has-error"><%= error_tag f, :name %></div>
-    </div>
-
-    <div class="form-group">
       <label for="email_input">Email</label>
       <%= email_input f, :email, class: "form-control", id: "email_input" %>
       <div class="has-error"><%= error_tag f, :email %></div>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -16,14 +16,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
     test "renders invite creation form", %{
       conn: conn
     } do
-      {:ok, invite} =
-        Accounts.invite(
-          %{
-            "name" => "Joe",
-            "email" => "joe@example.com"
-          },
-          conn.assigns.current_org
-        )
+      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, conn.assigns.current_org)
 
       conn = get(conn, account_path(conn, :invite, invite.token))
 
@@ -36,21 +29,14 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
     test "accepts submitted invitation", %{
       conn: conn
     } do
-      {:ok, invite} =
-        Accounts.invite(
-          %{
-            "name" => "Joe",
-            "email" => "joe@example.com"
-          },
-          conn.assigns.current_org
-        )
+      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, conn.assigns.current_org)
 
       conn =
-        put(
+        post(
           conn,
           account_path(conn, :accept_invite, invite.token, %{
             "user" => %{
-              "name" => "My Name",
+              "username" => "MyName",
               "email" => "not_joe@example.com",
               "password" => "12345678"
             }
@@ -63,7 +49,8 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
                "info" => "Account successfully created, login below"
              }
 
-      assert {:ok, %Accounts.User{}} = Accounts.get_user_by_email("joe@example.com")
+      assert {:ok, %Accounts.User{username: "MyName"}} =
+               Accounts.get_user_by_email("joe@example.com")
     end
   end
 
@@ -88,7 +75,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
         |> put(
           account_path(conn, :update, %{
             "user" => %{
-              "name" => "My Newest Name",
+              "username" => "MyNewestName",
               "password" => "foobarbaz",
               "current_password" => user.password
             }
@@ -110,7 +97,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
         |> put(
           account_path(conn, :update, %{
             "user" => %{
-              "name" => "My Newest Name",
+              "username" => "MyNewestName",
               "password" => "12345678",
               "current_password" => ""
             }
@@ -128,7 +115,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
         |> put(
           account_path(conn, :update, %{
             "user" => %{
-              "name" => "My Newest Name",
+              "username" => "MyNewestName",
               "password" => "12345678",
               "current_password" => "not the current password"
             }
@@ -148,7 +135,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
           conn,
           account_path(conn, :create, %{
             "user" => %{
-              "name" => "My Name",
+              "username" => "MyName",
               "email" => "joe@example.com",
               "password" => "12345678"
             }
@@ -166,7 +153,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
           conn,
           account_path(conn, :create, %{
             "user" => %{
-              "name" => "My Name",
+              "username" => "MyName",
               "org_name" => "a Org",
               "email" => "joe@example.com",
               "password" => "12345"

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/dashboard_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/dashboard_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule NervesHubWWWWeb.DashboardControllerTest do
+  use NervesHubWWWWeb.ConnCase.Browser
+
+  test "index", %{conn: conn} do
+    conn = get(conn, dashboard_path(conn, :index))
+    assert is_binary(html_response(conn, 200))
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -32,7 +32,7 @@ defmodule NervesHubCore.Fixtures do
   @device_params %{identifier: "device-1234"}
   @product_params %{name: "valid product"}
   @user_params %{
-    name: "Testy McTesterson",
+    username: "Testy-McTesterson",
     org_name: "mctesterson.com",
     email: "testy@mctesterson.com",
     password: "test_password"
@@ -170,7 +170,7 @@ defmodule NervesHubCore.Fixtures do
   def standard_fixture() do
     user_name = "Jeff"
     org = org_fixture(%{name: user_name})
-    user = user_fixture(org, %{name: user_name})
+    user = user_fixture(org, %{username: user_name})
     product = product_fixture(org, %{name: "Hop"})
     org_key = org_key_fixture(org)
     firmware = firmware_fixture(org_key, product)
@@ -190,7 +190,7 @@ defmodule NervesHubCore.Fixtures do
 
   def very_fixture() do
     org = org_fixture(%{name: "Very"})
-    user = user_fixture(org, %{name: "Jeff"})
+    user = user_fixture(org, %{username: "Jeff"})
     product = product_fixture(org, %{name: "Hop"})
     org_key = org_key_fixture(org)
     firmware = firmware_fixture(org_key, product)


### PR DESCRIPTION
Why
---

* Addresses #242

How
---

* User schema name is now username, is unique, and can only contain url
safe characters
* Invites no longer dictate username, it can be choosen on invite
acceptance
* Update fixtures, seeds, controllers, views, and tests to respect
changes