### PR TITLE
Enable real time device status updates

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -400,4 +400,17 @@ defmodule NervesHubCore.Accounts do
         {:error, :not_found}
     end
   end
+
+  @spec user_in_org?(integer(), integer()) :: boolean()
+  def user_in_org?(user_id, org_id) do
+    from(row in "users_orgs",
+      select: %{},
+      where: row.user_id == ^user_id and row.org_id == ^org_id
+    )
+    |> Repo.one()
+    |> case do
+      nil -> false
+      _ -> true
+    end
+  end
 end

--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -2,4 +2,49 @@ defmodule NervesHubDevice.Presence do
   use Phoenix.Presence,
     otp_app: :nerves_hub_device,
     pubsub_server: NervesHubWeb.PubSub
+
+  alias NervesHubCore.Devices.Device
+  alias NervesHubDevice.Presence
+
+  def fetch("devices:" <> _, entries) do
+    Enum.reduce(entries, %{}, fn
+      {key, %{metas: [%{last_known_firmware_id: nil}]} = val}, acc ->
+        Map.put(acc, key, Map.put(val, :status, "offline"))
+
+      {key, %{metas: [%{update_available: true}]} = val}, acc ->
+        Map.put(acc, key, Map.put(val, :status, "update pending"))
+
+      {key, val}, acc ->
+        Map.put(acc, key, Map.put(val, :status, "online"))
+    end)
+  end
+
+  def fetch(_, entries), do: entries
+
+  @doc """
+  Return the status of a device.
+
+  ## Statuses
+
+  - `"online"` - The device has a `:last_known_firmware_id` and is connected to Presence
+  - `"update pending"` - The device has a `:last_known_firmware_id`, is connected to presence, and
+    its presence meta includes `update_available: true`
+  - `"offline"` - The device does not have a `:last_known_firmware_id` or is not connected to
+    Presence
+  """
+  @spec device_status(Device.t()) :: Strint.t()
+  def device_status(%Device{id: device_id, last_known_firmware_id: lkf_id, org_id: org_id})
+      when not is_nil(lkf_id) do
+    "devices:#{org_id}"
+    |> Presence.list()
+    |> Map.get("#{device_id}")
+    |> case do
+      %{metas: [%{update_available: true}]} -> "update pending"
+      _ -> "online"
+    end
+  end
+
+  def device_status(_) do
+    "offline"
+  end
 end

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -2,8 +2,8 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
   use ExUnit.Case, async: false
   use NervesHubDeviceWeb.ChannelCase
   alias NervesHubCore.Fixtures
-  alias NervesHubCore.{Accounts, Deployments, Devices, Repo}
-  alias NervesHubDeviceWeb.DeviceChannel
+  alias NervesHubCore.{Accounts, Deployments, Devices, Devices.Device, Repo}
+  alias NervesHubDevice.Presence
 
   @valid_serial "device-1234"
   @valid_product "test-product"
@@ -110,10 +110,11 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
       )
 
       device =
-        NervesHubCore.Repo.get(Devices.Device, device.id)
-        |> NervesHubCore.Repo.preload(:last_known_firmware)
+        NervesHubCore.Repo.get(Device, device.id)
+        |> NervesHubCore.Repo.preload(:org)
 
-      assert DeviceChannel.online?(device)
+      assert Presence.device_status(device) == "online"
+      refute_receive({"presence_diff", _})
     end
 
     test "authentication rejected to channel using incorrect client ssl certificate" do
@@ -214,10 +215,11 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
       )
 
       device =
-        NervesHubCore.Repo.get(Devices.Device, device.id)
-        |> NervesHubCore.Repo.preload(:last_known_firmware)
+        Device
+        |> NervesHubCore.Repo.get(device.id)
+        |> NervesHubCore.Repo.preload(:org)
 
-      assert DeviceChannel.update_pending?(device)
+      assert Presence.device_status(device) == "update pending"
     end
 
     test "receives update message once deployment is available" do
@@ -249,11 +251,10 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
           }
         })
 
-      opts =
+      {:ok, _} =
         @ssl_socket_config
         |> Keyword.put(:caller, self())
-
-      {:ok, _} = ClientSocket.start_link(opts)
+        |> ClientSocket.start_link()
 
       {:ok, _channel} =
         ClientChannel.start_link(
@@ -264,8 +265,12 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
 
       Phoenix.PubSub.subscribe(NervesHubWeb.PubSub, "firmware:#{target_uuid}")
       ClientChannel.join(%{})
-      device_id = to_string(device.id)
-      assert_receive({"presence_diff", %{"joins" => %{^device_id => %{}}, "leaves" => %{}}}, 1000)
+
+      assert_receive(
+        {:ok, :join, %{"response" => %{"update_available" => false}, "status" => "ok"}, _ref},
+        1000
+      )
+
       Deployments.update_deployment(deployment, %{is_active: true})
       device_id = device.id
       assert_receive({"update", %{"device_id" => ^device_id, "firmware_url" => _f_url}}, 1000)
@@ -278,11 +283,10 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
         %{identifier: @valid_serial, product: @valid_product}
         |> device_fixture(query_uuid)
 
-      opts =
+      {:ok, _} =
         @ssl_socket_config
         |> Keyword.put(:caller, self())
-
-      {:ok, _} = ClientSocket.start_link(opts)
+        |> ClientSocket.start_link()
 
       {:ok, _channel} =
         ClientChannel.start_link(
@@ -307,10 +311,10 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
       updated_device =
         Devices.get_device_by_identifier(device.org, device.identifier)
         |> elem(1)
-        |> Repo.preload(:last_known_firmware)
+        |> Repo.preload(:org)
 
       assert updated_device.last_known_firmware.uuid == query_uuid
-      refute DeviceChannel.update_pending?(updated_device)
+      assert "online" == Presence.device_status(updated_device)
     end
   end
 end

--- a/apps/nerves_hub_www/assets/js/app.js
+++ b/apps/nerves_hub_www/assets/js/app.js
@@ -1,3 +1,3 @@
 import "phoenix_html"
 import 'bootstrap';
-
+import socket from "./socket"

--- a/apps/nerves_hub_www/assets/js/socket.js
+++ b/apps/nerves_hub_www/assets/js/socket.js
@@ -6,7 +6,7 @@
 //
 // Pass the token on params as below. Or remove it
 // from the params if you are not using authentication.
-import {Socket} from "phoenix"
+import {Presence, Socket} from "phoenix"
 
 let socket = new Socket("/socket", {params: {token: window.userToken}})
 
@@ -55,9 +55,29 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+let channel = socket.channel(`devices:${window.orgId}`, {})
+
+let presences = {}
+
+let updateStatuses = (presences) => {
+  document.querySelectorAll(".device").forEach((d) => {
+    const {[d.dataset.deviceId]: {status} = {status: 'offline'}} = presences
+    d.innerHTML = status
+  })
+}
+
+channel.on("presence_state", state => {
+  presences = Presence.syncState(presences, state)
+  updateStatuses(presences)
+})
+
+channel.on("presence_diff", diff => {
+  presences = Presence.syncDiff(presences, diff)
+  updateStatuses(presences)
+})
+
 channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+  .receive("ok", resp => {})
+  .receive("error", resp => {})
 
 export default socket

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/channels/devices_channel.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/channels/devices_channel.ex
@@ -1,0 +1,23 @@
+defmodule NervesHubWWWWeb.DevicesChannel do
+  use NervesHubWWWWeb, :channel
+  alias NervesHubCore.Accounts
+  alias NervesHubDevice.Presence
+
+  def join("devices:" <> org_id, _payload, socket) do
+    if authorized?(socket.assigns.auth_user_id, String.to_integer(org_id)) do
+      send(self(), :after_join)
+      {:ok, assign(socket, :org_id, org_id)}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  def handle_info(:after_join, socket) do
+    push(socket, "presence_state", Presence.list(socket))
+    {:noreply, socket}
+  end
+
+  defp authorized?(user_id, org_id) do
+    Accounts.user_in_org?(user_id, org_id)
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/channels/user_socket.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/channels/user_socket.ex
@@ -1,0 +1,24 @@
+defmodule NervesHubWWWWeb.UserSocket do
+  use Phoenix.Socket
+
+  channel("devices:*", NervesHubWWWWeb.DevicesChannel)
+
+  def connect(%{"token" => token}, socket) do
+    case Phoenix.Token.verify(socket, "user salt", token, max_age: 86400) do
+      {:ok, user_id} ->
+        socket = assign(socket, :auth_user_id, user_id)
+        {:ok, socket}
+
+      {:error, _} ->
+        :error
+    end
+  end
+
+  def id(%{assigns: %{auth_user_id: user_id}}) do
+    "user_socket:#{user_id}"
+  end
+
+  def id(_socket) do
+    nil
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -2,6 +2,8 @@ defmodule NervesHubWWWWeb.Endpoint do
   @env Mix.env()
   use Phoenix.Endpoint, otp_app: :nerves_hub_www
 
+  socket("/socket", NervesHubWWWWeb.UserSocket, websocket: true)
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phoenix.digest

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
@@ -26,6 +26,7 @@ defmodule NervesHubWWWWeb.Plugs.EnsureLoggedIn do
         conn
         |> assign(:user, user)
         |> assign(:current_org, current_org)
+        |> assign(:user_token, Phoenix.Token.sign(conn, "user salt", user.id))
 
       _ ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
@@ -28,7 +28,7 @@
               <%= device.last_known_firmware.version %>
             <% end %>
           </td>
-          <td class="col-3"><%= device_status(device) %></td>
+          <td class="col-3 device" data-device-id=<%= "#{device.id}" %>><%= device_status(device) %></td>
           <td class="col-2">
             <%= for tag <- (device.tags || []) do %>
               <span class="badge">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
@@ -53,6 +53,10 @@
     <footer class="footer">
       <%= render("_footer.html", conn: @conn) %>
     </footer>
+    <script>
+      window.userToken = "<%= assigns[:user_token] %>"
+      window.orgId = "<%= assigns[:current_org] && Map.get(assigns[:current_org], :id) %>"
+    </script>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -1,15 +1,6 @@
 defmodule NervesHubWWWWeb.DeviceView do
   use NervesHubWWWWeb, :view
-
-  alias NervesHubDeviceWeb.DeviceChannel
-
-  def device_status(device) do
-    cond do
-      not DeviceChannel.online?(device) -> "offline"
-      DeviceChannel.update_pending?(device) -> "update pending"
-      DeviceChannel.online?(device) -> "online"
-    end
-  end
+  alias NervesHubDevice.Presence
 
   def architecture_options do
     [
@@ -35,4 +26,6 @@ defmodule NervesHubWWWWeb.DeviceView do
       "x86_64"
     ]
   end
+
+  defdelegate device_status(device), to: Presence
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/channels/devices_channel_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/channels/devices_channel_test.exs
@@ -1,0 +1,123 @@
+defmodule NervesHubWWWWeb.DevicesChannelTest do
+  use NervesHubWWWWeb.ChannelCase
+  alias NervesHubCore.{Deployments, Devices.Device, Firmwares.Firmware, Fixtures}
+
+  setup do
+    {:ok, fixture: Fixtures.very_fixture()}
+  end
+
+  describe "can see" do
+    test "in-org devices in initial state", %{fixture: fixture} do
+      %{device_id: device_id} = connect_device(fixture)
+      connect_www(fixture)
+      assert_push("presence_state", %{^device_id => %{metas: [%{}], status: "online"}})
+    end
+
+    test "in-org devices as they join (online)", %{fixture: fixture} do
+      connect_www(fixture)
+      %{device_id: device_id} = connect_device(fixture)
+      assert_push("presence_state", %{})
+
+      assert_broadcast(
+        "presence_diff",
+        %{joins: %{^device_id => %{metas: [%{}], status: "online"}}, leaves: %{}}
+      )
+    end
+
+    test "in-org devices as they join (update pending)", %{fixture: fixture} do
+      connect_www(fixture)
+      release_deployment(fixture)
+      %{device_id: device_id} = connect_device(fixture)
+      assert_push("presence_state", %{})
+
+      assert_broadcast(
+        "presence_diff",
+        %{joins: %{^device_id => %{metas: [%{}], status: "update pending"}}, leaves: %{}}
+      )
+    end
+
+    test "in-org device leaving", %{fixture: fixture} do
+      %{device_id: device_id, socket: device_socket} = connect_device(fixture)
+      connect_www(fixture)
+      assert_push("presence_state", %{^device_id => %{metas: [%{}], status: "online"}})
+      leave(device_socket)
+
+      assert_broadcast(
+        "presence_diff",
+        %{joins: %{}, leaves: %{^device_id => %{metas: [%{}], status: "online"}}}
+      )
+    end
+  end
+
+  describe "cannot see" do
+    setup %{fixture: %{user: %{orgs: [%{id: org_id}]}}} do
+      %{org: %{id: org_id_2}} = fixture_2 = Fixtures.smartrent_fixture()
+      assert org_id != org_id_2
+      {:ok, fixture_2: fixture_2}
+    end
+
+    test "out-of-org devices in initial state", %{fixture: fixture, fixture_2: fixture_2} do
+      %{device_id: device_id} = connect_device(fixture_2)
+      connect_www(fixture)
+      refute_push("presence_state", %{^device_id => %{metas: [%{}], status: "online"}})
+    end
+
+    test "out-of-org devices as they join", %{fixture: fixture, fixture_2: fixture_2} do
+      connect_www(fixture)
+      %{device_id: device_id} = connect_device(fixture_2)
+      assert_push("presence_state", %{})
+      refute_broadcast("presence_diff", %{joins: %{^device_id => _}, leaves: %{}})
+    end
+  end
+
+  defp connect_device(%{
+         device: %Device{id: device_id},
+         firmware: %Firmware{uuid: firmware_uuid},
+         device_certificate: device_certificate
+       }) do
+    {:ok, _, socket} =
+      NervesHubDeviceWeb.UserSocket
+      |> socket("device_socket:#{device_id}", %{
+        certificate: device_certificate
+      })
+      |> Map.put(:endpoint, NervesHubDeviceWeb.Endpoint)
+      |> subscribe_and_join(NervesHubDeviceWeb.DeviceChannel, "firmware:#{firmware_uuid}")
+
+    Process.unlink(socket.channel_pid)
+    %{device_id: to_string(device_id), socket: socket}
+  end
+
+  defp connect_www(%{user: %{id: user_id, orgs: [%{id: org_id} | _]}}) do
+    socket =
+      NervesHubWWWWeb.UserSocket
+      |> socket("user_socket:#{user_id}", %{auth_user_id: user_id})
+      |> subscribe_and_join!(NervesHubWWWWeb.DevicesChannel, "devices:#{org_id}")
+
+    %{socket: socket}
+  end
+
+  defp release_deployment(%{
+         device: device
+       }) do
+    %Device{last_known_firmware: %{product: product}, org: org} =
+      NervesHubCore.Repo.preload(device, [:org, last_known_firmware: [:product]])
+
+    uuid = Ecto.UUID.generate()
+
+    org
+    |> Fixtures.org_key_fixture(%{name: "another key"})
+    |> Fixtures.firmware_fixture(product, %{
+      uuid: uuid,
+      version: "0.0.2",
+      upload_metadata: %{"public_path" => "http://foo.com/bar"}
+    })
+    |> Fixtures.deployment_fixture(%{
+      name: "a different name",
+      conditions: %{
+        "version" => ">=0.0.1",
+        "tags" => ["beta", "beta-edge"]
+      }
+    })
+    |> Deployments.update_deployment(%{is_active: true})
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -196,15 +196,17 @@ defmodule NervesHubCore.Fixtures do
     firmware = firmware_fixture(org_key, product)
     deployment = deployment_fixture(firmware)
     device = device_fixture(org, firmware, deployment)
+    device_certificate = device_certificate_fixture(device)
 
     %{
-      org: org,
-      device: device,
-      org_key: org_key,
-      user: user,
-      firmware: firmware,
       deployment: deployment,
-      product: product
+      device: device,
+      device_certificate: device_certificate,
+      firmware: firmware,
+      org: org,
+      org_key: org_key,
+      product: product,
+      user: user
     }
   end
 
@@ -214,15 +216,16 @@ defmodule NervesHubCore.Fixtures do
     org_key = org_key_fixture(org)
     firmware = firmware_fixture(org_key, product)
     deployment = deployment_fixture(firmware)
-
     device = device_fixture(org, firmware, deployment, %{identifier: "smartrent_1234"})
+    device_certificate = device_certificate_fixture(device)
 
     %{
+      deployment: deployment,
+      device: device,
+      device_certificate: device_certificate,
+      firmware: firmware,
       org: org,
       org_key: org_key,
-      device: device,
-      firmware: firmware,
-      deployment: deployment,
       product: product
     }
   end


### PR DESCRIPTION
Why
---

- So there is a way to hook into an organization's devices' status
lifecycles

How
---

- When a device connects to a `"firmware:#{fw_uuid}"` topic, it
`Presence.track/4`s itself on a `"devices:#{org_id}"` topic
- When a browser connects to a `devices:#{org_id}` topic, it will
receive presence state and diffs regarding all devices within that org