### PR TITLE
Async tests where possible

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.DeploymentControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   alias NervesHubCore.Fixtures
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_certificate_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.DeviceCertificateControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   alias NervesHubCore.{Devices, Certificate}
   alias NervesHubCore.Fixtures

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.DeviceControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
   alias NervesHubCore.{Devices, Fixtures}
 
   describe "create devices" do

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.FirmwareControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Firmwares

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.KeyControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   alias NervesHubCore.Fixtures
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.ProductControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Accounts

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.UserControllerTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Certificate
@@ -25,11 +25,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
            }
   end
 
-  test "authenticate existing accounts" do
-    password = "12345678"
-    org = Fixtures.org_fixture()
-    user = Fixtures.user_fixture(org, %{email: "account_test@test.com", password: password})
-
+  test "authenticate existing accounts", %{user: %{password: password} = user} do
     conn = build_conn()
     conn = post(conn, user_path(conn, :auth), %{email: user.email, password: password})
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/nerves_hub_api_web_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/nerves_hub_api_web_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWebTest do
-  use NervesHubAPIWeb.ConnCase
+  use NervesHubAPIWeb.ConnCase, async: true
 
   test "conn missing certificate is rejected" do
     conn = Phoenix.ConnTest.build_conn()

--- a/apps/nerves_hub_core/config/test.exs
+++ b/apps/nerves_hub_core/config/test.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :bcrypt_elixir,
+  log_rounds: 4
+
 config :nerves_hub_core, firmware_upload: NervesHubCore.Firmwares.Upload.File
 
 config :nerves_hub_core, NervesHubCore.Firmwares.Upload.File,

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubCore.AccountsTest do
-  use NervesHubCore.DataCase
+  use NervesHubCore.DataCase, async: true
 
   alias Ecto.Changeset
 

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubCore.DeploymentsTest do
-  use NervesHubCore.DataCase
+  use NervesHubCore.DataCase, async: true
   use Phoenix.ChannelTest
 
   alias NervesHubCore.Fixtures

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubCore.DevicesTest do
-  use NervesHubCore.DataCase
+  use NervesHubCore.DataCase, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Devices

--- a/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubCore.FirmwaresTest do
-  use NervesHubCore.DataCase
+  use NervesHubCore.DataCase, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.{Firmwares, Repo}

--- a/apps/nerves_hub_core/test/nerves_hub_core/products/products_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/products/products_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubCore.ProductsTest do
-  use NervesHubCore.DataCase
+  use NervesHubCore.DataCase, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Products

--- a/apps/nerves_hub_core/test/test_helper.exs
+++ b/apps/nerves_hub_core/test/test_helper.exs
@@ -2,3 +2,5 @@ Logger.remove_backend(:console)
 Code.compiler_options(ignore_module_conflict: true)
 
 ExUnit.start()
+
+Ecto.Adapters.SQL.Sandbox.mode(NervesHubCore.Repo, :manual)

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubDeviceWeb.WebsocketTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
   use NervesHubDeviceWeb.ChannelCase
   alias NervesHubCore.Fixtures
   alias NervesHubCore.{Accounts, Deployments, Devices, Repo}

--- a/apps/nerves_hub_www/test/nerves_hub_www/integration/certificate_authority_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www/integration/certificate_authority_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWW.Integration.CertificateAuthorityTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   @tag :ca_integration
   test "Can generate new device certificates" do

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Accounts

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.AccountControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Accounts
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.DeploymentControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Deployments

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.DeviceControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Devices

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.FirmwareControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.OrgControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.OrgKeyControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/password_reset_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/password_reset_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.PasswordResetControllerTest do
-  use NervesHubWWWWeb.ConnCase
+  use NervesHubWWWWeb.ConnCase, async: true
   use Bamboo.Test
 
   alias NervesHubCore.Fixtures

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/policy_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/policy_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.PolicyControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   describe "policies" do
     test "renders terms of service", %{

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.ProductControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.Fixtures
   alias NervesHubCore.Products

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.SessionControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   alias NervesHubCore.{Accounts, Fixtures}
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/sponsor_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/sponsor_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.SponsorControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
 
   test "renders sponsors", %{
     conn: conn

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/plugs/allow_uninvited_signups_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/plugs/allow_uninvited_signups_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.Plugs.AllowUninvitedSignupsTest do
-  use NervesHubWWWWeb.ConnCase.Browser
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
   use Plug.Test
 
   test "user is redirected when signups are disabled", %{conn: conn} do

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/views/layout_view_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/views/layout_view_test.exs
@@ -1,3 +1,0 @@
-defmodule NervesHubWWWWeb.LayoutViewTest do
-  use NervesHubWWWWeb.ConnCase, async: true
-end

--- a/apps/nerves_hub_www/test/support/browser_case.ex
+++ b/apps/nerves_hub_www/test/support/browser_case.ex
@@ -2,14 +2,14 @@ defmodule NervesHubWWWWeb.ConnCase.Browser do
   @moduledoc """
   conn case for browser related tests
   """
-  use ExUnit.CaseTemplate
+  alias NervesHubCore.{Accounts, Fixtures}
+  alias NervesHubWWWWeb.ConnCase
+  alias Plug.Test
 
-  alias NervesHubCore.Accounts
-
-  using do
+  defmacro __using__(opts) do
     quote do
-      use NervesHubWWWWeb.ConnCase
-      import Plug.Test
+      use ConnCase, unquote(opts)
+      import Test
 
       setup do
         %{
@@ -19,7 +19,7 @@ defmodule NervesHubWWWWeb.ConnCase.Browser do
           firmware: firmware,
           deployment: deployment,
           product: product
-        } = NervesHubCore.Fixtures.standard_fixture()
+        } = Fixtures.standard_fixture()
 
         {:ok, org_key} =
           Accounts.create_org_key(%{


### PR DESCRIPTION
The majority of this PR simply adds `async: true` to tests. There was some other
minor changes made. Notably, setting Bcrypt's `:log_rounds` config to a lower
value in test.

`$ time make test`

master 83d9bf6
```
make test  49.32s user 1.75s system 109% cpu 46.670 total
make test  49.90s user 1.93s system 110% cpu 46.777 total
```

async-tests a5e717b
```
make test  11.95s user 1.95s system 186% cpu 7.454 total
make test  11.50s user 1.84s system 182% cpu 7.309 total
```