### PR TITLE
Fix issues preventing updating firmware for deployments

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
@@ -65,7 +65,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
 
   defp update_params(org, %{"firmware" => uuid} = params) do
     with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid) do
-      {:ok, Map.put(params, :firmware_id, firmware.id)}
+      {:ok, Map.put(params, "firmware_id", firmware.id)}
     end
   end
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/deployments.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/deployments.ex
@@ -100,7 +100,8 @@ defmodule NervesHubCore.Deployments do
         join: f in assoc(d, :last_known_firmware),
         where: f.product_id == ^deployment.firmware.product_id,
         where: f.architecture == ^deployment.firmware.architecture,
-        where: f.platform == ^deployment.firmware.platform
+        where: f.platform == ^deployment.firmware.platform,
+        where: f.uuid != ^deployment.firmware.uuid
       )
       |> Devices.Device.with_firmware()
       |> Repo.all()


### PR DESCRIPTION
This PR addresses the following two issues
1. Could not update firmware_uuid through the API when modifying a deployment.
2. Modifications to the deployment would trigger firmware updates for devices whose firmware is already equal to the deployment target.
