### PR TITLE
Create org_limits

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
@@ -28,6 +28,14 @@ defmodule NervesHubAPIWeb.FallbackController do
     |> send_resp(400, Jason.encode!(%{status: reason}))
   end
 
+  def call(conn, {:error, reason}) when is_binary(reason) or is_atom(reason) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> put_status(500)
+    |> put_view(NervesHubAPIWeb.ErrorView)
+    |> send_resp(500, Jason.encode!(%{errors: reason}))
+  end
+
   def call(conn, {:error, reason}) do
     conn
     |> put_status(500)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/endpoint.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/endpoint.ex
@@ -19,6 +19,7 @@ defmodule NervesHubAPIWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
+    length: 1_073_741_824, # 1GB
     json_decoder: Jason
   )
 

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/endpoint.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/endpoint.ex
@@ -19,7 +19,8 @@ defmodule NervesHubAPIWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    length: 1_073_741_824, # 1GB
+    # 1GB
+    length: 1_073_741_824,
     json_decoder: Jason
   )
 

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/org.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/org.ex
@@ -10,8 +10,11 @@ defmodule NervesHubAPIWeb.Plugs.Org do
   def call(%{params: %{"org_name" => org_name}, assigns: %{user: user}} = conn, _opts) do
     case Accounts.get_org_by_name_and_user(org_name, user) do
       {:ok, org} ->
+        {:ok, limits} = Accounts.get_org_limit_by_org_id(org.id)
+
         conn
         |> assign(:org, org)
+        |> assign(:org_limit, limits)
 
       _ ->
         conn

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -2,7 +2,7 @@ defmodule NervesHubCore.Accounts do
   import Ecto.Query
   alias Ecto.Changeset
   alias Ecto.UUID
-  alias NervesHubCore.Accounts.{Org, User, UserCertificate, Invite, OrgKey}
+  alias NervesHubCore.Accounts.{Org, User, UserCertificate, Invite, OrgKey, OrgLimit}
   alias NervesHubCore.Repo
   alias Comeonin.Bcrypt
 
@@ -13,6 +13,34 @@ defmodule NervesHubCore.Accounts do
     %Org{}
     |> Org.creation_changeset(params)
     |> Repo.insert()
+  end
+
+  def create_org_limit(params) do
+    %OrgLimit{}
+    |> OrgLimit.changeset(params)
+    |> Repo.insert()
+  end
+
+  def delete_org_limit(%OrgLimit{} = org_limit) do
+    org_limit
+    |> Repo.delete()
+  end
+
+  def update_org_limit(org_limit, params) do
+    org_limit
+    |> OrgLimit.update_changeset(params)
+    |> Repo.update()
+  end
+
+  def get_org_limit_by_org_id(org_id) do
+    query = from(ol in OrgLimit, where: ol.org_id == ^org_id)
+
+    query
+    |> Repo.one()
+    |> case do
+      nil -> {:ok, %OrgLimit{}}
+      org_limit -> {:ok, org_limit}
+    end
   end
 
   def change_user(user, params \\ %{})

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
@@ -4,7 +4,7 @@ defmodule NervesHubCore.Accounts.Org do
   import Ecto.Changeset
   import Ecto.Query
 
-  alias NervesHubCore.Accounts.{User, OrgKey}
+  alias NervesHubCore.Accounts.{User, OrgKey, OrgLimit}
   alias NervesHubCore.Devices.Device
   alias NervesHubCore.Products.Product
   alias NervesHubCore.Repo
@@ -16,6 +16,7 @@ defmodule NervesHubCore.Accounts.Org do
     has_many(:org_keys, OrgKey)
     has_many(:products, Product)
     has_many(:devices, Device)
+    has_one(:org_limits, OrgLimit)
 
     many_to_many(:users, User, join_through: "users_orgs", on_replace: :delete, unique: true)
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
@@ -1,0 +1,37 @@
+defmodule NervesHubCore.Accounts.OrgLimit do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHubCore.Accounts.Org
+  alias __MODULE__
+
+  @type t :: %__MODULE__{}
+
+  @required_params [:org_id]
+  @optional_params [:firmware_size]
+
+  schema "org_limits" do
+    belongs_to(:org, Org)
+
+    # 160 Mb
+    field(:firmware_size, :integer, default: 167_772_160)
+
+    timestamps()
+  end
+
+  def changeset(%OrgLimit{} = org_limit, params) do
+    org_limit
+    |> cast(params, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
+    |> unique_constraint(:org_id)
+  end
+
+  def update_changeset(%OrgLimit{id: _} = org_limit, params) do
+    # don't allow org_id to change
+    org_limit
+    |> cast(params, @required_params -- [:org_id])
+    |> validate_required(@required_params)
+    |> unique_constraint(:org_id)
+  end
+end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180919161402_create_org_limits_table.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180919161402_create_org_limits_table.exs
@@ -1,0 +1,14 @@
+defmodule NervesHubCore.Repo.Migrations.CreateOrgLimitsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:org_limits) do
+      add(:org_id, references(:orgs, null: false))
+      add(:firmware_size, :integer, null: false)
+
+      timestamps()
+    end
+
+    create(index(:org_limits, [:org_id]))
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -53,6 +53,11 @@ defmodule NervesHubWWWWeb.FirmwareController do
         |> put_flash(:error, "Firmware corrupt, signature invalid or missing public key")
         |> render("upload.html", changeset: %Changeset{data: %Firmware{}})
 
+      {:error, error} when is_binary(error) ->
+        conn
+        |> put_flash(:error, error)
+        |> render("upload.html", changeset: %Changeset{data: %Firmware{}})
+
       _ ->
         conn
         |> put_flash(:error, "Unknown error uploading firmware")

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -46,7 +46,8 @@ defmodule NervesHubWWWWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    length: 1_073_741_824, # 1GB
+    # 1GB
+    length: 1_073_741_824,
     json_decoder: Jason
   )
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -46,7 +46,7 @@ defmodule NervesHubWWWWeb.Endpoint do
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    length: 160_000_000,
+    length: 1_073_741_824, # 1GB
     json_decoder: Jason
   )
 


### PR DESCRIPTION
Currently, firmware upload size is limited by the number defined for `Plug.Parsers` multipart upload byte limit. This is set currently to roughly 160 MB. Some organizations are going to require the ability to upload firmware that is larger than this limit. To accommodate for this I had to increase the overall limit that is enforced in the endpoint by `Plug.Parsers`. I set this value to 1 GB. The second enforcement now happens in the controller when reading the body. It will look up the limits from the `org_limits` table, if there are none, it will pass back the defaults which are set to 160 MB.