### PR TITLE
Unique Org Names

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
@@ -29,6 +29,7 @@ defmodule NervesHubCore.Accounts.Org do
     org
     |> cast(params, [:name])
     |> validate_required([:name])
+    |> unique_constraint(:name)
     |> unique_constraint(:users, name: :users_orgs_user_id_org_id_index)
   end
 

--- a/apps/nerves_hub_core/priv/repo/migrations/20180920134303_unique_org_names.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180920134303_unique_org_names.exs
@@ -1,0 +1,7 @@
+defmodule NervesHubCore.Repo.Migrations.UniqueOrgNames do
+  use Ecto.Migration
+
+  def change do
+    create(unique_index(:orgs, [:name]))
+  end
+end

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -15,6 +15,11 @@ defmodule NervesHubCore.AccountsTest do
     assert result_org.name == @required_org_params.name
   end
 
+  test "create_org with duplicate name" do
+    {:ok, %Org{}} = Accounts.create_org(@required_org_params)
+    assert {:error, %Changeset{}} = Accounts.create_org(@required_org_params)
+  end
+
   test "create_org_limits with defaults" do
     {:ok, %Org{} = result_org} = Accounts.create_org(@required_org_params)
     {:ok, limits} = Accounts.get_org_limit_by_org_id(result_org.id)
@@ -255,7 +260,7 @@ defmodule NervesHubCore.AccountsTest do
     first_id = org.id
     org_key = Fixtures.org_key_fixture(org)
 
-    other_org = Fixtures.org_fixture()
+    other_org = Fixtures.org_fixture(%{name: "another org"})
 
     assert {:ok, %OrgKey{org_id: ^first_id}} =
              Accounts.update_org_key(org_key, %{org_id: other_org.id})

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -45,7 +45,7 @@ defmodule NervesHubCore.DevicesTest do
   end
 
   test "org cannot have too many devices" do
-    org = Fixtures.org_fixture()
+    org = Fixtures.org_fixture(%{name: "an org with no devices"})
     product = Fixtures.product_fixture(org)
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)

--- a/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
@@ -69,7 +69,7 @@ defmodule NervesHubCore.FirmwaresTest do
     end
 
     test "enforces firmware limit within product" do
-      org = Fixtures.org_fixture()
+      org = Fixtures.org_fixture(%{name: "another org"})
       product = Fixtures.product_fixture(org)
       org_key = Fixtures.org_key_fixture(org)
 


### PR DESCRIPTION
Why:

* We need to look up orgs by name via the API.

This change addresses the need by:

* Adding a unique index and test of uniqueness for the org name.