### PR TITLE
Add richer seeds for :dev env

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -25,8 +25,8 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       product = Fixtures.product_fixture(org)
       org_key = Fixtures.org_key_fixture(org)
       firmware = Fixtures.firmware_fixture(org_key, product)
-      deployment = Fixtures.deployment_fixture(firmware)
-      Fixtures.device_fixture(org, firmware, deployment)
+
+      Fixtures.device_fixture(org, firmware)
 
       [to_delete | _] = Devices.get_devices(org)
       conn = delete(conn, device_path(conn, :delete, org.name, to_delete.identifier))

--- a/apps/nerves_hub_core/mix.exs
+++ b/apps/nerves_hub_core/mix.exs
@@ -27,6 +27,7 @@ defmodule NervesHubCore.MixProject do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support", "../../test/support"]
+  defp elixirc_paths(:dev), do: ["lib", "test/support", "../../test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.

--- a/apps/nerves_hub_core/priv/repo/seeds.exs
+++ b/apps/nerves_hub_core/priv/repo/seeds.exs
@@ -13,21 +13,72 @@
 # The seeds are run on every deploy. Therefore, it is important
 # that first check to see if the data you are trying to insert
 # has been run yet.
+alias NervesHubCore.{Accounts, Accounts.User, Repo}
 
-alias NervesHubCore.{Repo, Accounts}
-alias NervesHubCore.Accounts.User
+defmodule NervesHubCore.SeedHelpers do
+  alias NervesHubCore.Fixtures
 
-# Create the root org and user
+  def seed_product(product_name, org) do
+    product = Fixtures.product_fixture(org, %{name: product_name})
+
+    firmware_versions = ["0.1.0", "0.1.1", "0.1.2", "1.0.0"]
+
+    org_with_keys_and_users =
+      org |> NervesHubCore.Accounts.Org.with_org_keys() |> Repo.preload(:users)
+
+    org_keys = org_with_keys_and_users |> Map.get(:org_keys)
+    user_names = org_with_keys_and_users |> Map.get(:users) |> Enum.map(fn x -> x.username end)
+
+    firmwares =
+      for v <- firmware_versions,
+          do:
+            Fixtures.firmware_fixture(Enum.random(org_keys), product, %{
+              version: v,
+              author: Enum.random(user_names)
+            })
+
+    firmwares = firmwares |> List.to_tuple()
+
+    Fixtures.deployment_fixture(firmwares |> elem(2), %{
+      conditions: %{"version" => "< 1.0.0", "tags" => ["beta"]}
+    })
+
+    Fixtures.device_fixture(org, firmwares |> elem(1))
+    |> Fixtures.device_certificate_fixture()
+  end
+
+  def nerves_team_seed(root_user_params) do
+    org = Fixtures.org_fixture(%{name: "Nerves Team"})
+
+    for _ <- 0..2, do: Fixtures.org_key_fixture(org)
+
+    %{orgs: [default_user_org | _]} =
+      Fixtures.user_fixture(root_user_params |> Enum.into(%{orgs: [org]}))
+
+    for _ <- 0..2, do: Fixtures.org_key_fixture(default_user_org)
+
+    ["SmartKiosk", "SmartRentHub"]
+    |> Enum.map(fn name -> seed_product(name, org) end)
+
+    ["ToyProject", "ConsultingProject"]
+    |> Enum.map(fn name -> seed_product(name, default_user_org) end)
+  end
+end
+
+# Create the root user
 root_user_name = "nerveshub"
 root_user_email = "nerveshub@nerves-hub.org"
-
 # Add a default user
 if root_user = Repo.get_by(User, email: root_user_email) do
   root_user
 else
-  Accounts.create_user(%{
-    username: root_user_name,
-    email: root_user_email,
-    password: "nerveshub"
-  })
+  if Mix.env() == :dev do
+    NervesHubCore.SeedHelpers.nerves_team_seed(%{email: root_user_email, username: root_user_name})
+  else
+    Accounts.create_user(%{
+      username: root_user_name,
+      email: root_user_email,
+      password: "nerveshub"
+    })
+  end
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/deployments/deployments_test.exs
@@ -81,10 +81,9 @@ defmodule NervesHubCore.DeploymentsTest do
       org: org,
       org_key: org_key,
       firmware: firmware,
-      deployment: old_deployment,
       product: product
     } do
-      device = Fixtures.device_fixture(org, firmware, old_deployment)
+      device = Fixtures.device_fixture(org, firmware, %{tags: ["beta", "beta-edge"]})
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.1"})
 
       params = %{
@@ -112,7 +111,6 @@ defmodule NervesHubCore.DeploymentsTest do
       org: org,
       org_key: org_key,
       firmware: firmware,
-      deployment: old_deployment,
       product: product
     } do
       incorrect_params = [
@@ -123,7 +121,7 @@ defmodule NervesHubCore.DeploymentsTest do
       ]
 
       for {f_params, d_params} <- incorrect_params do
-        device = Fixtures.device_fixture(org, firmware, old_deployment, d_params)
+        device = Fixtures.device_fixture(org, firmware, d_params)
         new_firmware = Fixtures.firmware_fixture(org_key, product, f_params)
 
         params = %{

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -13,7 +13,7 @@ defmodule NervesHubCore.DevicesTest do
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
     deployment = Fixtures.deployment_fixture(firmware)
-    device = Fixtures.device_fixture(org, firmware, deployment)
+    device = Fixtures.device_fixture(org, firmware)
     Fixtures.device_certificate_fixture(device)
 
     {:ok,
@@ -185,12 +185,12 @@ defmodule NervesHubCore.DevicesTest do
     org: org,
     org_key: org_key,
     firmware: firmware,
-    deployment: old_deployment,
     product: product
   } do
     device =
-      Fixtures.device_fixture(org, firmware, old_deployment, %{
-        identifier: "new identifier"
+      Fixtures.device_fixture(org, firmware, %{
+        identifier: "new identifier",
+        tags: ["beta", "beta-edge"]
       })
 
     new_firmware = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.1"})
@@ -222,7 +222,6 @@ defmodule NervesHubCore.DevicesTest do
     org: org,
     org_key: org_key,
     firmware: firmware,
-    deployment: old_deployment,
     product: product
   } do
     incorrect_params = [
@@ -233,7 +232,7 @@ defmodule NervesHubCore.DevicesTest do
     ]
 
     for {f_params, d_params} <- incorrect_params do
-      device = Fixtures.device_fixture(org, firmware, old_deployment, d_params)
+      device = Fixtures.device_fixture(org, firmware, d_params)
       new_firmware = Fixtures.firmware_fixture(org_key, product, f_params)
 
       params = %{
@@ -274,8 +273,9 @@ defmodule NervesHubCore.DevicesTest do
     Deployments.update_deployment(old_deployment, %{firmware_id: firmware1.id, is_active: true})
 
     device =
-      Fixtures.device_fixture(org, firmware, old_deployment, %{
-        identifier: "new identifier"
+      Fixtures.device_fixture(org, firmware, %{
+        identifier: "new identifier",
+        tags: ["beta", "beta-edge"]
       })
 
     product2 = Fixtures.product_fixture(org, %{name: "other product"})

--- a/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
@@ -14,7 +14,7 @@ defmodule NervesHubCore.FirmwaresTest do
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
     deployment = Fixtures.deployment_fixture(firmware)
-    device = Fixtures.device_fixture(org, firmware, deployment)
+    device = Fixtures.device_fixture(org, firmware)
 
     {:ok,
      %{

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/websocket_test.exs
@@ -42,9 +42,15 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
         version: "0.0.1"
       })
 
-    deployment = Fixtures.deployment_fixture(firmware)
+    Fixtures.deployment_fixture(firmware)
 
-    device = Fixtures.device_fixture(org, firmware, deployment, device_params)
+    device =
+      Fixtures.device_fixture(
+        org,
+        firmware,
+        device_params |> Enum.into(%{tags: ["beta", "beta-edge"]})
+      )
+
     Fixtures.device_certificate_fixture(device)
 
     {device, firmware}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.eex
@@ -1,9 +1,6 @@
 <h1>
   Deployment:
-  <%= @deployment.name %> --
-  <span class="label <%= if @deployment.is_active, do: "label-success", else: "label-default" %>">
-    <%= status(@deployment) %>
-  </span>
+  <%= @deployment.name %>
 </h1>
 
 <table class="table" style="width: auto">
@@ -11,6 +8,10 @@
     <tr>
       <th>Product</th>
       <td><%= @product.name %></td>
+    </tr>
+    <tr>
+      <th>Active</th>
+      <td><%= active(@deployment) %>
     </tr>
     <tr>
       <th>Version Requirement</th>
@@ -25,10 +26,6 @@
           </span>
         <% end %>
       </td>
-    </tr>
-    <tr>
-      <th>Status</th>
-      <td><%= status(@deployment) %>
     </tr>
     <tr>
       <th>Firmware Info</th>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
@@ -36,8 +36,8 @@ defmodule NervesHubWWWWeb.DeploymentView do
   def version(%Deployment{conditions: %{"version" => ""}}), do: "-"
   def version(%Deployment{conditions: %{"version" => version}}), do: version
 
-  def status(%Deployment{is_active: true}), do: "Active"
-  def status(%Deployment{is_active: false}), do: "Inactive"
+  def active(%Deployment{is_active: true}), do: "Yes"
+  def active(%Deployment{is_active: false}), do: "No"
 
   def opposite_status(%Deployment{is_active: true}), do: "Inactive"
   def opposite_status(%Deployment{is_active: false}), do: "Active"


### PR DESCRIPTION
Why:

* It's useful to see data in the web views to get a feel for how the app
will look/feel.
* I was trying to determine if
https://github.com/nerves-hub/nerves_hub_web/issues/10 was able to be
marked as closed, and realized that I couldn't tell without manually
creating a bunch of stuff.

This change addresses the need by:

* Adding a user with two orgs where each org has multiple devices,
firmwares and deployments in `seeds.exs` when `Mix.env() == :dev`