### PR TITLE
Fix device status on load is always "online"

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -39,8 +39,9 @@ defmodule NervesHubDevice.Presence do
     |> Presence.list()
     |> Map.get("#{device_id}")
     |> case do
+      nil -> "offline"
       %{metas: [%{update_available: true}]} -> "update pending"
-      _ -> "online"
+      %{} -> "online"
     end
   end
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -10,6 +10,11 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       assert html_response(conn, 200) =~ "Devices"
     end
 
+    test "devices default to offline", %{conn: conn} do
+      conn = get(conn, device_path(conn, :index))
+      refute html_response(conn, 200) =~ "online"
+    end
+
     test "does not list devices for other orgs", %{conn: conn} do
       %{device: device} = Fixtures.smartrent_fixture()
       conn = get(conn, device_path(conn, :index))


### PR DESCRIPTION
When the device page loads all device statuses load initially as "online" and then update quickly to "offline". This is due to presence not handling the nil case for when a device is missing from presence completely. This adds the missing case. I am unsure how to add a test without making a decision on a front end testing library.