### PR TITLE
Transactional firmware creation and deletion

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -1,8 +1,6 @@
 defmodule NervesHubAPIWeb.FirmwareController do
   use NervesHubAPIWeb, :controller
-
   alias NervesHubCore.Firmwares
-  alias NervesHubCore.Firmwares.Firmware
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
@@ -15,8 +13,7 @@ defmodule NervesHubAPIWeb.FirmwareController do
     %{firmware_size: size_limit} = org_limit
 
     with {:ok, filepath, conn} <- read_firmware(conn, size_limit),
-         {:ok, firmware_params} <- Firmwares.prepare_firmware_params(org, filepath),
-         {:ok, firmware} <- Firmwares.create_firmware(firmware_params) do
+         {:ok, firmware} <- Firmwares.create_firmware(org, filepath) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", firmware_path(conn, :show, org, product, firmware))
@@ -32,7 +29,7 @@ defmodule NervesHubAPIWeb.FirmwareController do
 
   def delete(%{assigns: %{org: org}} = conn, %{"uuid" => uuid}) do
     with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid),
-         {:ok, %Firmware{}} <- Firmwares.delete_firmware(firmware) do
+         :ok <- Firmwares.delete_firmware(firmware) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/org.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/org.ex
@@ -10,7 +10,7 @@ defmodule NervesHubAPIWeb.Plugs.Org do
   def call(%{params: %{"org_name" => org_name}, assigns: %{user: user}} = conn, _opts) do
     case Accounts.get_org_by_name_and_user(org_name, user) do
       {:ok, org} ->
-        {:ok, limits} = Accounts.get_org_limit_by_org_id(org.id)
+        limits = Accounts.get_org_limit_by_org_id(org.id)
 
         conn
         |> assign(:org, org)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -55,7 +55,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
       |> Base.encode64()
 
     params =
-      Fixtures.user_params()
+      Fixtures.user_fixture()
       |> Map.take([:email, :password])
       |> Map.put(:csr, csr)
       |> Map.put(:description, "test-machine")

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -32,14 +32,18 @@ defmodule NervesHubCore.Accounts do
     |> Repo.update()
   end
 
+  @doc """
+  Returns a map of limits for the org identified by `org_id`.
+  """
+  @spec get_org_limit_by_org_id(Org.id()) :: OrgLimit.t()
   def get_org_limit_by_org_id(org_id) do
     query = from(ol in OrgLimit, where: ol.org_id == ^org_id)
 
     query
     |> Repo.one()
     |> case do
-      nil -> {:ok, %OrgLimit{}}
-      org_limit -> {:ok, org_limit}
+      nil -> %OrgLimit{}
+      org_limit -> org_limit
     end
   end
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org.ex
@@ -10,7 +10,8 @@ defmodule NervesHubCore.Accounts.Org do
   alias NervesHubCore.Repo
   alias __MODULE__
 
-  @type t :: %__MODULE__{}
+  @type id :: pos_integer() | nil
+  @type t :: %__MODULE__{id: id()}
 
   schema "orgs" do
     has_many(:org_keys, OrgKey)

--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/file.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/file.ex
@@ -1,24 +1,17 @@
 defmodule NervesHubCore.Firmwares.Upload.File do
-  @spec upload_file(String.t(), String.t(), integer()) ::
-          {:ok, map}
+  @moduledoc """
+  Local file adapter for CRUDing firmware files.
+  """
+
+  @type upload_metadata :: %{local_path: String.t(), public_path: String.t()}
+
+  @spec upload_file(String.t(), upload_metadata()) ::
+          :ok
           | {:error, atom()}
-  def upload_file(filepath, filename, org_id) do
-    config = Application.get_env(:nerves_hub_core, __MODULE__)
-    random_string = :crypto.strong_rand_bytes(12) |> Base.url_encode64()
-    path = Path.join([Integer.to_string(org_id), random_string])
-    local_path = Path.join([config[:local_path], path])
-
-    with :ok <- File.mkdir_p(local_path),
-         :ok <- File.cp(filepath, Path.join([local_path, filename])) do
-      url = Application.get_env(:nerves_hub_www, NervesHubWWWWeb.Endpoint)[:url]
-      port = if Enum.member?([443, 80], url[:port]), do: "", else: ":#{url[:port]}"
-
-      public_path =
-        "#{url[:scheme]}://#{url[:host]}#{port}/" <>
-          (Path.join([config[:public_path], path, filename])
-           |> String.trim("/"))
-
-      {:ok, %{local_path: Path.join([local_path, filename]), public_path: public_path}}
+  def upload_file(source, %{local_path: local_path}) do
+    with :ok <- local_path |> Path.dirname() |> File.mkdir_p(),
+         :ok <- File.cp(source, local_path) do
+      :ok
     end
   end
 
@@ -29,9 +22,7 @@ defmodule NervesHubCore.Firmwares.Upload.File do
     {:ok, firmware.upload_metadata["public_path"]}
   end
 
-  @spec delete_file(Firmware.t()) ::
-          {:ok, any()}
-          | {:error, any()}
+  @spec delete_file(Firmware.t()) :: :ok
   def delete_file(%{upload_metadata: %{local_path: path}}) do
     File.rm!(path)
   end
@@ -41,5 +32,24 @@ defmodule NervesHubCore.Firmwares.Upload.File do
           | {:error, any()}
   def delete_file(%{upload_metadata: %{"local_path" => path}}) do
     File.rm!(path)
+  end
+
+  @spec metadata(Org.id(), String.t()) :: upload_metadata()
+  def metadata(org_id, filename) do
+    config = Application.get_env(:nerves_hub_core, __MODULE__)
+    common_path = "#{org_id}"
+    local_path = Path.join([config[:local_path], common_path, filename])
+    url = Application.get_env(:nerves_hub_www, NervesHubWWWWeb.Endpoint)[:url]
+    port = if Enum.member?([443, 80], url[:port]), do: "", else: ":#{url[:port]}"
+
+    public_path =
+      "#{url[:scheme]}://#{url[:host]}#{port}/" <>
+        (Path.join([config[:public_path], common_path, filename])
+         |> String.trim("/"))
+
+    %{
+      public_path: public_path,
+      local_path: local_path
+    }
   end
 end

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -22,7 +22,7 @@ defmodule NervesHubCore.AccountsTest do
 
   test "create_org_limits with defaults" do
     {:ok, %Org{} = result_org} = Accounts.create_org(@required_org_params)
-    {:ok, limits} = Accounts.get_org_limit_by_org_id(result_org.id)
+    limits = Accounts.get_org_limit_by_org_id(result_org.id)
     assert limits == %OrgLimit{}
   end
 
@@ -34,7 +34,7 @@ defmodule NervesHubCore.AccountsTest do
     limit_params = %{org_id: result_org.id, firmware_size: org_firmware_size_limit}
     {:ok, %OrgLimit{}} = Accounts.create_org_limit(limit_params)
 
-    {:ok, %{firmware_size: firmware_size_limit}} = Accounts.get_org_limit_by_org_id(result_org.id)
+    %{firmware_size: firmware_size_limit} = Accounts.get_org_limit_by_org_id(result_org.id)
 
     assert firmware_size_limit == org_firmware_size_limit
   end
@@ -47,13 +47,13 @@ defmodule NervesHubCore.AccountsTest do
     limit_params = %{org_id: result_org.id, firmware_size: org_firmware_size_limit}
     {:ok, %OrgLimit{}} = Accounts.create_org_limit(limit_params)
 
-    {:ok, %{firmware_size: firmware_size_limit} = limits} =
-      Accounts.get_org_limit_by_org_id(result_org.id)
+    %{firmware_size: firmware_size_limit} =
+      limits = Accounts.get_org_limit_by_org_id(result_org.id)
 
     assert firmware_size_limit == org_firmware_size_limit
 
     {:ok, _} = Accounts.delete_org_limit(limits)
-    {:ok, limits} = Accounts.get_org_limit_by_org_id(result_org.id)
+    limits = Accounts.get_org_limit_by_org_id(result_org.id)
     assert limits == %OrgLimit{}
   end
 

--- a/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/firmwares/firmwares_test.exs
@@ -1,12 +1,10 @@
 defmodule NervesHubCore.FirmwaresTest do
   use NervesHubCore.DataCase, async: true
 
-  alias NervesHubCore.Fixtures
-  alias NervesHubCore.Support.Fwup
-  alias NervesHubCore.{Firmwares, Repo}
-  alias NervesHubCore.Deployments.Deployment
-
+  alias NervesHubCore.{Firmwares, Fixtures, Support.Fwup}
   alias Ecto.Changeset
+
+  @uploader Application.get_env(:nerves_hub_core, :firmware_upload)
 
   setup do
     org = Fixtures.org_fixture()
@@ -27,62 +25,60 @@ defmodule NervesHubCore.FirmwaresTest do
      }}
   end
 
-  def update_version_condition(%Deployment{} = deployment, version) when is_binary(version) do
-    deployment
-    |> Changeset.change(%{
-      conditions: %{
-        "tags" => deployment.conditions["tags"],
-        "version" => version
-      }
-    })
-    |> Repo.update!()
-  end
-
-  describe "firmware storage" do
-    test "enforces uuid uniqueness within a product", %{firmware: existing} do
-      new_params = %{
-        architecture: "arm",
-        org_key_id: existing.org_key_id,
-        platform: "rpi3",
-        product_id: existing.product_id,
-        upload_metadata: %{},
-        version: "100.0.0",
-        uuid: existing.uuid
-      }
-
-      assert {:error, %Ecto.Changeset{errors: [uuid: {"has already been taken", []}]}} =
-               Firmwares.create_firmware(new_params)
+  describe "create_firmware/2" do
+    test "remote creation failure triggers transaction rollback", %{
+      org: org,
+      org_key: org_key,
+      product: product
+    } do
+      firmwares = Firmwares.get_firmwares_by_product(product.id)
+      upload_file_2 = fn _, _ -> {:error, :nope} end
+      filepath = Fixtures.firmware_file_fixture(org_key, product)
+      assert {:error, _} = Firmwares.create_firmware(org, filepath, upload_file_2: upload_file_2)
+      assert ^firmwares = Firmwares.get_firmwares_by_product(product.id)
     end
 
-    test "enforces firmware limit within product" do
-      org = Fixtures.org_fixture(%{name: "another org"})
-      product = Fixtures.product_fixture(org)
-      org_key = Fixtures.org_key_fixture(org)
+    test "enforces uuid uniqueness within a product",
+         %{firmware: %{upload_metadata: %{local_path: filepath}}, org: org} do
+      assert {:error, %Ecto.Changeset{errors: [uuid: {"has already been taken", []}]}} =
+               Firmwares.create_firmware(org, filepath)
+    end
 
+    test "enforces firmware limit within product", %{
+      firmware: %{upload_metadata: %{local_path: filepath}},
+      org: org,
+      org_key: org_key,
+      product: %{id: product_id} = product
+    } do
       product_firmware_limit = Application.get_env(:nerves_hub_core, :product_firmware_limit)
+      current = product_id |> Firmwares.get_firmwares_by_product() |> length()
 
-      for _ <- 1..product_firmware_limit do
-        _firmware = Fixtures.firmware_fixture(org_key, product)
+      if current < product_firmware_limit do
+        for _ <- 1..(product_firmware_limit - current) do
+          _firmware = Fixtures.firmware_fixture(org_key, product)
+        end
       end
 
-      params = %{
-        org_key_id: org_key.id,
-        product_id: product.id,
-        platform: "foo",
-        architecture: "bar",
-        uuid: Ecto.UUID.generate(),
-        upload_metadata: %{"public_url" => "http://example.com", "local_path" => ""},
-        version: "0.0.2"
-      }
-
       assert {:error, %Changeset{errors: [product: {"firmware limit reached", []}]}} =
-               Firmwares.create_firmware(params)
+               Firmwares.create_firmware(org, filepath)
+    end
+  end
+
+  describe "delete_firmware/1" do
+    test "remote deletion failure triggers transaction rollback", %{
+      org: org,
+      org_key: org_key,
+      product: product
+    } do
+      firmware = Fixtures.firmware_fixture(org_key, product)
+      @uploader.delete_file(firmware)
+      assert_raise File.Error, fn -> Firmwares.delete_firmware(firmware) end
+      assert {:ok, _} = Firmwares.get_firmware(org, firmware.id)
     end
 
     test "delete firmware", %{org: org, org_key: org_key, product: product} do
       firmware = Fixtures.firmware_fixture(org_key, product)
-
-      {:ok, _} = Firmwares.delete_firmware(firmware)
+      :ok = Firmwares.delete_firmware(firmware)
       refute File.exists?(firmware.upload_metadata[:local_path])
       assert {:error, :not_found} = Firmwares.get_firmware(org, firmware.id)
     end
@@ -100,7 +96,7 @@ defmodule NervesHubCore.FirmwaresTest do
     assert {:error, %Changeset{}} = Firmwares.delete_firmware(firmware)
   end
 
-  describe "NervesHubWWW.Firmwares.get_firmwares_by_product/2" do
+  describe "get_firmwares_by_product/2" do
     test "returns firmwares", %{product: %{id: product_id} = product} do
       firmwares = Firmwares.get_firmwares_by_product(product.id)
 
@@ -108,7 +104,7 @@ defmodule NervesHubCore.FirmwaresTest do
     end
   end
 
-  describe "NervesHubWWW.Firmwares.get_firmware/2" do
+  describe "get_firmware/2" do
     test "returns firmwares", %{org: %{id: t_id} = org, firmware: %{id: f_id} = firmware} do
       {:ok, gotten_firmware} = Firmwares.get_firmware(org, firmware.id)
 
@@ -116,7 +112,7 @@ defmodule NervesHubCore.FirmwaresTest do
     end
   end
 
-  describe "NervesHubCore.Firmwares.verify_signature/2" do
+  describe "verify_signature/2" do
     test "returns {:error, :no_public_keys} when no public keys are passed" do
       assert Firmwares.verify_signature("/fake/path", []) == {:error, :no_public_keys}
     end


### PR DESCRIPTION
Resolves #258

What
----

- When creating or deleting firmware files always work inside a
transaction and act on the database record before the file persistance
to ensure a persisted file (remote or local) will not be dereferenced
but still exist

How
---

- `NervesHubCore.Firmwares`
  - Remove `prepare_firmware_params/2` and roll functionality into
  `create_firmware/3` to publicly ensure an atomic operation
  - Add `metadata/2` to `Upload.S3` and `Upload.File` modules so that
  information about about where a firmware file will be persisted to is
  available before actually persisting it
- `NervesHubCore.Fixtures`
  - Split firmware file creation into its own fixture apart from
  firmware creation within the application

---

Not overjoyed with https://github.com/nerves-hub/nerves_hub_web/pull/274/files#diff-d43b46de1cbc8975ae36bc46322877beR37. It is using dependency injection to allow me to ensure the DB insertion succeeds but the file persistence fails. In similar cases previously I have used https://github.com/plataformatec/mox. That way we could have an `Upload` behavior and use mocks in test to force it to behave how we wish. That being said, I decided to go the easy route and not force a dependency decision in front of this PR unless discussion justifies it.