### PR TITLE
Only open socket on devices page

### DIFF
--- a/apps/nerves_hub_www/assets/js/app.js
+++ b/apps/nerves_hub_www/assets/js/app.js
@@ -1,3 +1,6 @@
 import "phoenix_html"
 import 'bootstrap';
-import socket from "./socket"
+
+if(window.location.pathname === '/devices') {
+  require("./socket")
+}


### PR DESCRIPTION
Resolves #268 

Why
---

- Connecting to this socket will fail on non-authed / non-devices pages flooding
client and server logs with failures

How
---

- Only `require` the `socket.js` code when on the devices page

---

This is a somewhat naive approach but gets the job done now while dodging
heavier front end efforts. Open to discussion about alternate approaches.