### PR TITLE
Allow updating a device from the API

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -32,4 +32,13 @@ defmodule NervesHubAPIWeb.DeviceController do
     |> put_status(204)
     |> render("show.json", device: device)
   end
+
+  def update(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier} = params) do
+    with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
+         {:ok, updated_device} <- Devices.update_device(device, params) do
+      conn
+      |> put_status(204)
+      |> render("show.json", device: updated_device)
+    end
+  end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -37,7 +37,7 @@ defmodule NervesHubAPIWeb.DeviceController do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
          {:ok, updated_device} <- Devices.update_device(device, params) do
       conn
-      |> put_status(204)
+      |> put_status(201)
       |> render("show.json", device: updated_device)
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -50,6 +50,7 @@ defmodule NervesHubAPIWeb.Router do
           scope "/:device_identifier" do
             get("/", DeviceController, :show)
             delete("/", DeviceController, :delete)
+            put("/", DeviceController, :update)
 
             scope "/certificates" do
               get("/", DeviceCertificateController, :index)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -52,7 +52,7 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
           tags: ["a", "b", "c", "d"]
         })
 
-      assert json_response(conn, 204)["data"]
+      assert json_response(conn, 201)["data"]
 
       conn = get(conn, device_path(conn, :show, org.name, to_update.identifier))
       assert json_response(conn, 200)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -36,4 +36,27 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       assert json_response(conn, 404)
     end
   end
+
+  describe "update devices" do
+    test "updates chosen device", %{conn: conn, org: org} do
+      product = Fixtures.product_fixture(org)
+      org_key = Fixtures.org_key_fixture(org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+
+      Fixtures.device_fixture(org, firmware)
+
+      [to_update | _] = Devices.get_devices(org)
+
+      conn =
+        put(conn, device_path(conn, :update, org.name, to_update.identifier), %{
+          tags: ["a", "b", "c", "d"]
+        })
+
+      assert json_response(conn, 204)["data"]
+
+      conn = get(conn, device_path(conn, :show, org.name, to_update.identifier))
+      assert json_response(conn, 200)
+      assert conn.assigns.device.tags == ["a", "b", "c", "d"]
+    end
+  end
 end


### PR DESCRIPTION
This adds the ability for `nerves_hub_cli` and other API consuming applications to update existing devices. 