### PR TITLE
Override quantity of firmware per product per Org

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
@@ -9,13 +9,14 @@ defmodule NervesHubCore.Accounts.OrgLimit do
   @type t :: %__MODULE__{}
 
   @required_params [:org_id]
-  @optional_params [:firmware_size]
+  @optional_params [:firmware_size, :firmware_per_product]
 
   schema "org_limits" do
     belongs_to(:org, Org)
 
     # 160 Mb
     field(:firmware_size, :integer, default: 167_772_160)
+    field(:firmware_per_product, :integer, default: 5)
 
     timestamps()
   end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/firmware.ex
@@ -4,6 +4,7 @@ defmodule NervesHubCore.Firmwares.Firmware do
   import Ecto.Changeset
   import Ecto.Query
 
+  alias NervesHubCore.Accounts
   alias NervesHubCore.Accounts.OrgKey
   alias NervesHubCore.Deployments.Deployment
   alias NervesHubCore.Products.Product
@@ -22,6 +23,8 @@ defmodule NervesHubCore.Firmwares.Firmware do
   @required_params [
     :architecture,
     :platform,
+    :org_id,
+    :size,
     :product_id,
     :uuid,
     :upload_metadata,
@@ -36,7 +39,9 @@ defmodule NervesHubCore.Firmwares.Firmware do
     field(:architecture, :string)
     field(:author, :string)
     field(:description, :string)
+    field(:size, :integer, virtual: true)
     field(:misc, :string)
+    field(:org_id, :integer, virtual: true)
     field(:platform, :string)
     field(:upload_metadata, :map)
     field(:uuid, :string)
@@ -50,30 +55,65 @@ defmodule NervesHubCore.Firmwares.Firmware do
     firmware
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
-    |> validate_firmware_limit()
+    |> validate_limits()
     |> unique_constraint(:uuid, name: :firmwares_product_id_uuid_index)
     |> foreign_key_constraint(:deployments, name: :deployments_firmware_id_fkey)
   end
 
-  defp validate_firmware_limit(%Ecto.Changeset{changes: %{product_id: product_id}} = cs) do
-    if too_many_firmwares?(product_id) do
-      cs |> add_error(:product, "firmware limit reached")
+  def delete_changeset(%Firmware{} = firmware, params) do
+    firmware
+    |> cast(params, @required_params ++ @optional_params)
+    |> foreign_key_constraint(:deployments, name: :deployments_firmware_id_fkey)
+  end
+
+  defp validate_limits(%Ecto.Changeset{changes: %{org_id: org_id}} = cs) do
+    limits = Accounts.get_org_limit_by_org_id(org_id)
+
+    cs
+    |> validate_firmware_size(limits)
+    |> validate_firmware_limit(limits)
+  end
+
+  defp validate_limits(cs), do: cs
+
+  defp validate_firmware_size(%Ecto.Changeset{changes: %{size: firmware_size}} = cs, %{
+         firmware_size: firmware_size_limit
+       }) do
+    if firmware_size > firmware_size_limit do
+      add_error(cs, :firmware, "firmware exceeds maximum size",
+        size: firmware_size,
+        limit: firmware_size_limit
+      )
     else
       cs
     end
   end
 
-  defp validate_firmware_limit(%Ecto.Changeset{} = cs) do
+  defp validate_firmware_size(%Ecto.Changeset{} = cs, _limits) do
     cs
   end
 
-  defp too_many_firmwares?(product_id) do
+  defp validate_firmware_limit(%Ecto.Changeset{changes: %{product_id: product_id}} = cs, limits) do
+    if too_many_firmwares?(product_id, limits) do
+      add_error(cs, :product, "firmware limit reached")
+    else
+      cs
+    end
+  end
+
+  defp validate_firmware_limit(%Ecto.Changeset{} = cs, _limits) do
+    cs
+  end
+
+  defp too_many_firmwares?(product_id, %{firmware_per_product: limit}) do
     firmware_count =
-      from(f in Firmware, where: f.product_id == ^product_id, select: count(f.id))
+      from(f in Firmware,
+        where: f.product_id == ^product_id,
+        select: count(f.id)
+      )
       |> Repo.one()
 
-    product_firmware_limit = Application.get_env(:nerves_hub_core, :product_firmware_limit)
-    firmware_count + 1 > product_firmware_limit
+    firmware_count + 1 > limit
   end
 
   def with_product(firmware_query) do

--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/s3.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/s3.ex
@@ -4,7 +4,7 @@ defmodule NervesHubCore.Firmwares.Upload.S3 do
   @spec upload_file(String.t(), String.t()) ::
           :ok
           | {:error, atom()}
-  def upload_file(source_path, %{"s3_key" => s3_key}) do
+  def upload_file(source_path, %{s3_key: s3_key}) do
     bucket = Application.get_env(:nerves_hub_core, __MODULE__)[:bucket]
 
     source_path

--- a/apps/nerves_hub_core/priv/repo/migrations/20180926192828_add_firmware_per_product_org_limit.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180926192828_add_firmware_per_product_org_limit.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubCore.Repo.Migrations.AddFirmwarePerProductOrgLimit do
+  use Ecto.Migration
+
+  def change do
+    alter table(:org_limits) do
+      add(:firmware_per_product, :integer)
+    end
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -45,6 +45,12 @@ defmodule NervesHubWWWWeb.FirmwareController do
        } = changeset} ->
         render_error(conn, "No matching product could be found.", changeset)
 
+      {:error,
+       %Changeset{
+         errors: [firmware: {"firmware exceeds maximum size", [size: size, limit: limit]}]
+       } = changeset} ->
+        render_error(conn, "firmware size #{size} exceeds maximum size #{limit}", changeset)
+
       {:error, %Changeset{} = changeset} ->
         render_error(conn, "Unknown error uploading firmware.", changeset)
 

--- a/test/support/fwup.ex
+++ b/test/support/fwup.ex
@@ -40,7 +40,7 @@ defmodule NervesHubCore.Support.Fwup do
       File.rm(key_path_no_extension <> ext)
     end
 
-    System.cmd("fwup", ["-g", "-o", key_path_no_extension])
+    System.cmd("fwup", ["-g", "-o", key_path_no_extension], [stderr_to_stdout: true])
   end
 
   @doc """
@@ -85,7 +85,7 @@ defmodule NervesHubCore.Support.Fwup do
       Path.join([dir, firmware_name <> ".fw"]),
       "-o",
       output_path
-    ])
+    ], [stderr_to_stdout: true])
 
     {:ok, output_path}
   end
@@ -103,7 +103,7 @@ defmodule NervesHubCore.Support.Fwup do
   """
   def corrupt_firmware_file(input_path, output_name \\ "corrupt") do
     output_path = Path.join([System.tmp_dir(), output_name <> ".fw"])
-    System.cmd("dd", ["if=" <> input_path, "of=" <> output_path, "bs=512", "count=1"])
+    System.cmd("dd", ["if=" <> input_path, "of=" <> output_path, "bs=512", "count=1"], [stderr_to_stdout: true])
 
     {:ok, output_path}
   end


### PR DESCRIPTION
The quantity of firmware per product is currently a global limit. This PR allows that to be configured per `Org` by doing the following:

* Add `:firmware_per_product` to `org_limits`
* Moved common limit validation logic to `firmware.ex` to minimize queries to resolve `org_id`

While I was doing this I also noticed that the fwup std err output was noisy so I also added a commit to silence it by sending it to std_out