### PR TITLE
Allow quantity of devices to be set per Org

### DIFF
--- a/apps/nerves_hub_core/config/config.exs
+++ b/apps/nerves_hub_core/config/config.exs
@@ -3,9 +3,7 @@
 use Mix.Config
 
 config :nerves_hub_core,
-  ecto_repos: [NervesHubCore.Repo],
-  product_firmware_limit: 5,
-  org_device_limit: 5
+  ecto_repos: [NervesHubCore.Repo]
 
 config :nerves_hub_core, NervesHubWeb.PubSub,
   name: NervesHubWeb.PubSub,

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
@@ -9,7 +9,7 @@ defmodule NervesHubCore.Accounts.OrgLimit do
   @type t :: %__MODULE__{}
 
   @required_params [:org_id]
-  @optional_params [:firmware_size, :firmware_per_product]
+  @optional_params [:firmware_size, :firmware_per_product, :devices]
 
   schema "org_limits" do
     belongs_to(:org, Org)
@@ -17,6 +17,7 @@ defmodule NervesHubCore.Accounts.OrgLimit do
     # 160 Mb
     field(:firmware_size, :integer, default: 167_772_160)
     field(:firmware_per_product, :integer, default: 5)
+    field(:devices, :integer, default: 5)
 
     timestamps()
   end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices/device.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices/device.ex
@@ -5,6 +5,7 @@ defmodule NervesHubCore.Devices.Device do
   import Ecto.Query
 
   alias NervesHubCore.Repo
+  alias NervesHubCore.Accounts
   alias NervesHubCore.Accounts.Org
   alias NervesHubCore.Firmwares.Firmware
   alias NervesHubCore.Devices.DeviceCertificate
@@ -60,8 +61,8 @@ defmodule NervesHubCore.Devices.Device do
       from(d in Device, where: d.org_id == ^org_id, select: count(d.id))
       |> Repo.one()
 
-    org_device_limit = Application.get_env(:nerves_hub_core, :org_device_limit)
-    device_count + 1 > org_device_limit
+    %{devices: limit} = Accounts.get_org_limit_by_org_id(org_id)
+    device_count + 1 > limit
   end
 
   def with_firmware(device_query) do

--- a/apps/nerves_hub_core/priv/repo/migrations/20180927020424_add_devices_org_limit.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180927020424_add_devices_org_limit.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubCore.Repo.Migrations.AddDevicesOrgLimit do
+  use Ecto.Migration
+
+  def change do
+    alter table(:org_limits) do
+      add(:devices, :integer)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds `:devices` to `org_limits` and enabled setting the limit per `Org`