### PR TITLE
Fix pattern match on s3 key

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/s3.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/s3.ex
@@ -4,7 +4,7 @@ defmodule NervesHubCore.Firmwares.Upload.S3 do
   @spec upload_file(String.t(), String.t()) ::
           :ok
           | {:error, atom()}
-  def upload_file(source_path, %{s3_key: s3_key}) do
+  def upload_file(source_path, %{"s3_key" => s3_key}) do
     bucket = Application.get_env(:nerves_hub_core, __MODULE__)[:bucket]
 
     source_path


### PR DESCRIPTION
I dunno, in one of the merges last night, this some how became undone