### PR TITLE
Fix firmware delete on S3

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/s3.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/upload/s3.ex
@@ -47,9 +47,11 @@ defmodule NervesHubCore.Firmwares.Upload.S3 do
     s3_key = firmware.upload_metadata["s3_key"]
     bucket = Application.get_env(:nerves_hub_core, __MODULE__)[:bucket]
 
-    case S3.delete_object(bucket, s3_key) do
+    S3.delete_object(bucket, s3_key)
+    |> ExAws.request()
+    |> case do
       {:ok, _} -> :ok
-      {:error, _} = err -> err
+      error -> error
     end
   end
 end


### PR DESCRIPTION
Deleting firmware from S3 is currently raising. It turns out that in the past, it was just preparing a transaction and not applying the request. This fixes both the return pattern match as well as actually deleting the files.