### PR TITLE
Firmware TTL

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web.ex
@@ -23,6 +23,12 @@ defmodule NervesHubAPIWeb do
       import Plug.Conn
       import NervesHubAPIWeb.Router.Helpers
       import NervesHubAPIWeb.Gettext
+
+      def whitelist(params, keys) do
+        keys
+        |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
+        |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
+      end
     end
   end
 

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
@@ -6,12 +6,6 @@ defmodule NervesHubAPIWeb.DeploymentController do
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
-  defp whitelist(params, keys) do
-    keys
-    |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
-    |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
-  end
-
   def index(%{assigns: %{product: product}} = conn, _params) do
     deployments = Deployments.get_deployments_by_product(product.id)
     render(conn, "index.json", deployments: deployments)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
@@ -20,14 +20,6 @@ defmodule NervesHubAPIWeb.FallbackController do
     |> render(:"404")
   end
 
-  def call(conn, {:error, reason}) when is_atom(reason) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> put_status(400)
-    |> put_view(NervesHubAPIWeb.ErrorView)
-    |> send_resp(400, Jason.encode!(%{status: reason}))
-  end
-
   def call(conn, {:error, reason}) when is_binary(reason) or is_atom(reason) do
     conn
     |> put_resp_content_type("application/json")

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -9,15 +9,18 @@ defmodule NervesHubAPIWeb.FirmwareController do
     render(conn, "index.json", firmwares: firmwares)
   end
 
-  def create(%{assigns: %{org: org, org_limit: org_limit, product: product}} = conn, _params) do
-    %{firmware_size: size_limit} = org_limit
+  def create(%{assigns: %{org: org, product: product}} = conn, params) do
+    params = whitelist(params, [:ttl, :firmware])
 
-    with {:ok, filepath, conn} <- read_firmware(conn, size_limit),
-         {:ok, firmware} <- Firmwares.create_firmware(org, filepath) do
+    with {%{path: filepath}, params} <- Map.pop(params, :firmware),
+         {:ok, firmware} <- Firmwares.create_firmware(org, filepath, params) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", firmware_path(conn, :show, org, product, firmware))
       |> render("show.json", firmware: firmware)
+    else
+      {nil, %{}} -> {:error, :no_firmware_uploaded}
+      error -> error
     end
   end
 
@@ -31,42 +34,6 @@ defmodule NervesHubAPIWeb.FirmwareController do
     with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid),
          :ok <- Firmwares.delete_firmware(firmware) do
       send_resp(conn, :no_content, "")
-    end
-  end
-
-  defp read_firmware(_, _, _ \\ 0, _ \\ "")
-
-  defp read_firmware(_conn, size_limit, size, _buffer) when size >= size_limit do
-    {:error, "Firmware exceeds size limit of #{size_limit} bytes"}
-  end
-
-  defp read_firmware(conn, size_limit, size, buffer) do
-    case Plug.Conn.read_body(conn) do
-      {:more, data, conn} ->
-        size = byte_size(data) + size
-        read_firmware(conn, size_limit, size, buffer <> data)
-
-      {:ok, data, conn} ->
-        size = byte_size(data) + size
-
-        if size >= size_limit do
-          {:error, "Firmware exceeds size limit of #{size_limit} bytes"}
-        else
-          content = buffer <> data
-
-          case byte_size(content) do
-            0 ->
-              {:error, "invalid byte length"}
-
-            _ ->
-              filepath = Plug.Upload.random_file!("firmware")
-              File.write!(filepath, content)
-              {:ok, filepath, conn}
-          end
-        end
-
-      error ->
-        error
     end
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
@@ -6,11 +6,6 @@ defmodule NervesHubAPIWeb.UserController do
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
-  defp whitelist(params, keys) do
-    keys
-    |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
-  end
-
   def me(%{assigns: %{user: user}} = conn, _params) do
     render(conn, "show.json", user: user)
   end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -34,7 +34,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
 
     test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do
       conn = post(conn, deployment_path(conn, :create, org.name, product.name))
-      assert json_response(conn, 400)["errors"] != %{}
+      assert json_response(conn, 500)["errors"] != %{}
     end
   end
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_limit.ex
@@ -9,18 +9,44 @@ defmodule NervesHubCore.Accounts.OrgLimit do
   @type t :: %__MODULE__{}
 
   @required_params [:org_id]
-  @optional_params [:firmware_size, :firmware_per_product, :devices]
+  @optional_params [
+    :devices,
+    :firmware_per_product,
+    :firmware_size,
+    :firmware_ttl_seconds_default,
+    :firmware_ttl_seconds
+  ]
+
+  @defaults [
+    # Max number of devices per org
+    devices: 5,
+    # Max number of firmwares per product
+    firmware_per_product: 5,
+    # Max firmware size (160 Mb)
+    firmware_size: 167_772_160,
+    # Default firmwre ttl seconds (7 days)
+    firmware_ttl_seconds_default: 604_800,
+    # Max firmwre ttl seconds (7 days)
+    firmware_ttl_seconds: 604_800
+  ]
 
   schema "org_limits" do
     belongs_to(:org, Org)
 
-    # 160 Mb
-    field(:firmware_size, :integer, default: 167_772_160)
-    field(:firmware_per_product, :integer, default: 5)
-    field(:devices, :integer, default: 5)
+    field(:devices, :integer, default: @defaults[:devices])
+    field(:firmware_per_product, :integer, default: @defaults[:firmware_per_product])
+    field(:firmware_size, :integer, default: @defaults[:firmware_size])
+
+    field(:firmware_ttl_seconds_default, :integer,
+      default: @defaults[:firmware_ttl_seconds_default]
+    )
+
+    field(:firmware_ttl_seconds, :integer, default: @defaults[:firmware_ttl_seconds])
 
     timestamps()
   end
+
+  def defaults(), do: @defaults
 
   def changeset(%OrgLimit{} = org_limit, params) do
     org_limit
@@ -32,7 +58,7 @@ defmodule NervesHubCore.Accounts.OrgLimit do
   def update_changeset(%OrgLimit{id: _} = org_limit, params) do
     # don't allow org_id to change
     org_limit
-    |> cast(params, @required_params -- [:org_id])
+    |> cast(params, (@required_params -- [:org_id]) ++ @optional_params)
     |> validate_required(@required_params)
     |> unique_constraint(:org_id)
   end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/application.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/application.ex
@@ -7,12 +7,14 @@ defmodule NervesHubCore.Application do
     import Supervisor.Spec
 
     pubsub_config = Application.get_env(:nerves_hub_core, NervesHubWeb.PubSub)
+    firmware_gc_config = Application.get_env(:nerves_hub_core, NervesHubCore.Firmwares.GC, [])
 
     # Define workers and child supervisors to be supervised
     children = [
       # Start the Ecto repository
       supervisor(NervesHubCore.Repo, []),
       supervisor(Phoenix.PubSub.PG2, [pubsub_config[:name], pubsub_config]),
+      {NervesHubCore.Firmwares.GC, firmware_gc_config},
       {Task.Supervisor, name: NervesHubCore.TaskSupervisor}
     ]
 

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
@@ -130,10 +130,26 @@ defmodule NervesHubCore.Devices do
     %Device{}
     |> Device.changeset(params)
     |> Repo.insert()
+    |> case do
+      {:ok, device} ->
+        Firmwares.update_firmware_ttl(device.last_known_firmware_id)
+        {:ok, device}
+
+      error ->
+        error
+    end
   end
 
   def delete_device(%Device{} = device) do
     Repo.delete(device)
+    |> case do
+      {:ok, device} ->
+        Firmwares.update_firmware_ttl(device.last_known_firmware_id)
+        {:ok, device}
+
+      error ->
+        error
+    end
   end
 
   @spec create_device_certificate(Device.t(), map) ::
@@ -213,6 +229,7 @@ defmodule NervesHubCore.Devices do
     |> Repo.update()
     |> case do
       {:ok, device} ->
+        Firmwares.update_firmware_ttl(device.last_known_firmware_id)
         {:ok, Repo.preload(device, :last_known_firmware, force: true)}
 
       error ->

--- a/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/gc.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/firmwares/gc.ex
@@ -1,0 +1,41 @@
+defmodule NervesHubCore.Firmwares.GC do
+  use GenServer
+
+  require Logger
+
+  alias NervesHubCore.Repo
+  alias NervesHubCore.Firmwares
+
+  @interval 30_000
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(opts) do
+    interval = opts[:interval] || @interval
+    Process.send_after(self(), :gc, interval)
+    {:ok, interval}
+  end
+
+  def handle_info(:gc, interval) do
+    Firmwares.get_firmware_by_expired_ttl()
+    |> delete()
+
+    Process.send_after(self(), :gc, interval)
+    {:noreply, interval}
+  end
+
+  defp delete(firmwares) when is_list(firmwares) do
+    firmwares
+    |> Enum.each(fn firmware ->
+      case Repo.delete(firmware) do
+        {:ok, _firmware} ->
+          Logger.debug("Garbage collected firmware #{firmware.uuid}")
+
+        {:error, reason} ->
+          Logger.error("Unable to garbage collect firmware #{inspect(reason)}")
+      end
+    end)
+  end
+end

--- a/apps/nerves_hub_core/priv/repo/migrations/20180927234934_add_firmware_ttl_org_limit.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20180927234934_add_firmware_ttl_org_limit.exs
@@ -1,0 +1,15 @@
+defmodule NervesHubCore.Repo.Migrations.AddFirmwareTtlOrgLimit do
+  use Ecto.Migration
+
+  def change do
+    alter table(:org_limits) do
+      add(:firmware_ttl_seconds, :integer)
+      add(:firmware_ttl_seconds_default, :integer)
+    end
+
+    alter table(:firmwares) do
+      add(:ttl, :integer, null: false)
+      add(:ttl_until, :utc_datetime)
+    end
+  end
+end

--- a/apps/nerves_hub_core/priv/repo/seeds.exs
+++ b/apps/nerves_hub_core/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 # The seeds are run on every deploy. Therefore, it is important
 # that first check to see if the data you are trying to insert
 # has been run yet.
-alias NervesHubCore.{Accounts, Accounts.User, Repo}
+alias NervesHubCore.{Accounts, Accounts.User, Repo, Firmwares}
 
 defmodule NervesHubCore.SeedHelpers do
   alias NervesHubCore.Fixtures
@@ -38,10 +38,11 @@ defmodule NervesHubCore.SeedHelpers do
             })
 
     firmwares = firmwares |> List.to_tuple()
-
+      
     Fixtures.deployment_fixture(firmwares |> elem(2), %{
       conditions: %{"version" => "< 1.0.0", "tags" => ["beta"]}
     })
+    Firmwares.update_firmware_ttl(elem(firmwares, 2).id)
 
     Fixtures.device_fixture(org, firmwares |> elem(1))
     |> Fixtures.device_certificate_fixture()

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
@@ -23,6 +23,12 @@ defmodule NervesHubWWWWeb do
       import Plug.Conn
       import NervesHubWWWWeb.Router.Helpers
       import NervesHubWWWWeb.Gettext
+
+      def whitelist(params, keys) do
+        keys
+        |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
+        |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
+      end
     end
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -11,12 +11,6 @@ defmodule NervesHubWWWWeb.AccountController do
     render(conn, "new.html", changeset: %Changeset{data: %User{}})
   end
 
-  defp whitelist(params, keys) do
-    keys
-    |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
-    |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
-  end
-
   def create(conn, %{"user" => user_params}) do
     user_params
     |> whitelist([:password, :username, :email])

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
@@ -6,12 +6,6 @@ defmodule NervesHubWWWWeb.DeploymentController do
   alias NervesHubCore.Deployments.Deployment
   alias Ecto.Changeset
 
-  defp whitelist(params, keys) do
-    keys
-    |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
-    |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
-  end
-
   def index(%{assigns: %{current_org: _org, product: %{id: product_id}}} = conn, _params) do
     deployments = Deployments.get_deployments_by_product(product_id)
     render(conn, "index.html", deployments: deployments)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -7,12 +7,6 @@ defmodule NervesHubWWWWeb.OrgController do
   alias NervesHubCore.Accounts.{Invite, OrgKey}
   alias NervesHubWWW.Mailer
 
-  defp whitelist(params, keys) do
-    keys
-    |> Enum.filter(fn x -> !is_nil(params[to_string(x)]) end)
-    |> Enum.into(%{}, fn x -> {x, params[to_string(x)]} end)
-  end
-
   def new(conn, _params) do
     changeset = Accounts.Org.creation_changeset(%Accounts.Org{}, %{})
     render(conn, "new.html", changeset: changeset)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -57,6 +57,7 @@ defmodule NervesHubCore.Fixtures do
       version: "1.0.0",
       vcs_identifier: "test_vcs_identifier",
       misc: "test_misc",
+      ttl: 1_000_000_000,
       upload_metadata: @uploader.metadata(org_id, filepath)
     }
   end
@@ -144,7 +145,7 @@ defmodule NervesHubCore.Fixtures do
       ) do
     org = Repo.get!(Org, org_id)
     filepath = firmware_file_fixture(org_key, product, params)
-    {:ok, firmware} = Firmwares.create_firmware(org, filepath)
+    {:ok, firmware} = Firmwares.create_firmware(org, filepath, params)
     firmware
   end
 


### PR DESCRIPTION
Uploading test firmware from CI can quickly result in clutter and should be garbage collected. This PR introduces a "time to live" setting that is applied to firmware records upon creation. TTL is stored in seconds and represents the time to keep firmware _after_ all its associations have been removed. This is tracked by setting the `tty_until` `utc_datetime` stamp on the firmware record whenever is has been removed from all associations. If an association is made again, the timestamp is removed and it will not get garbage collected. The default `ttl` is set for 7 days and can be configured per org using `org_limits`.

As a side effect, the API needed to change how it accepts the firmware upload from the CLI in order to accept both a file and additional params like `ttl`. This way, CI can configure the test firmware to get garbage collected sooner than other kinds of firmware. Merging this will break existing `nerves_hub_cli` users who are not using the `firmware-ttl` branch.