### PR TITLE
Capture additional certificate information required for revocation

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_certificate_controller.ex
@@ -16,8 +16,15 @@ defmodule NervesHubAPIWeb.DeviceCertificateController do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
          {:ok, %{"cert" => cert}} <- CertificateAuthority.sign_device_csr(csr),
          {:ok, serial} <- Certificate.get_serial_number(cert),
-         {not_before, not_after} <- Certificate.get_validity(cert),
-         params <- %{serial: serial, not_before: not_before, not_after: not_after},
+         {:ok, authority_key_id} <- Certificate.get_authority_key_id(cert),
+         authority_key_id <- Certificate.binary_to_hex_string(authority_key_id),
+         {:ok, {not_before, not_after}} <- Certificate.get_validity(cert),
+         params <- %{
+           serial: serial,
+           authority_key_id: authority_key_id,
+           not_before: not_before,
+           not_after: not_after
+         },
          {:ok, _db_cert} <- Devices.create_device_certificate(device, params) do
       render(conn, "cert.json", cert: cert, device_certificate: cert)
     end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/user_controller.ex
@@ -35,8 +35,17 @@ defmodule NervesHubAPIWeb.UserController do
     with {:ok, user} <- Accounts.authenticate(email, password),
          {:ok, %{"cert" => cert}} <- CertificateAuthority.sign_user_csr(csr),
          {:ok, serial} <- Certificate.get_serial_number(cert),
-         {:ok, _db_cert} <-
-           Accounts.create_user_certificate(user, %{serial: serial, description: description}) do
+         {:ok, authority_key_id} <- Certificate.get_authority_key_id(cert),
+         authority_key_id <- Certificate.binary_to_hex_string(authority_key_id),
+         {:ok, {not_before, not_after}} <- Certificate.get_validity(cert),
+         params <- %{
+           description: description,
+           serial: serial,
+           authority_key_id: authority_key_id,
+           not_before: not_before,
+           not_after: not_after
+         },
+         {:ok, _db_cert} <- Accounts.create_user_certificate(user, params) do
       render(conn, "cert.json", cert: cert)
     end
   end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user_certificate.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/user_certificate.ex
@@ -6,19 +6,31 @@ defmodule NervesHubCore.Accounts.UserCertificate do
 
   @type t :: %__MODULE__{}
 
+  @params [
+    :user_id,
+    :serial,
+    :description,
+    :authority_key_id,
+    :not_before,
+    :not_after
+  ]
+
   schema "user_certificates" do
     belongs_to(:user, User)
 
-    field(:description, :string)
     field(:serial, :string)
+    field(:description, :string)
+    field(:authority_key_id, :string)
+    field(:not_before, :utc_datetime)
+    field(:not_after, :utc_datetime)
 
     timestamps()
   end
 
   def changeset(%UserCertificate{} = user_certificate, params) do
     user_certificate
-    |> cast(params, [:serial, :description])
-    |> validate_required([:serial, :description])
+    |> cast(params, @params)
+    |> validate_required(@params)
     |> unique_constraint(:serial, name: :user_certificates_user_id_serial_index)
   end
 end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices/device_certificate.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices/device_certificate.ex
@@ -6,22 +6,29 @@ defmodule NervesHubCore.Devices.DeviceCertificate do
 
   @type t :: %__MODULE__{}
 
-  @required_params [:serial, :not_after, :not_before, :device_id]
+  @params [
+    :device_id,
+    :serial,
+    :authority_key_id,
+    :not_after,
+    :not_before
+  ]
 
   schema "device_certificates" do
     belongs_to(:device, Device)
 
     field(:serial, :string)
-    field(:not_after, :utc_datetime)
+    field(:authority_key_id, :string)
     field(:not_before, :utc_datetime)
+    field(:not_after, :utc_datetime)
 
     timestamps()
   end
 
   def changeset(%DeviceCertificate{} = device_certificate, params) do
     device_certificate
-    |> cast(params, @required_params)
-    |> validate_required(@required_params)
+    |> cast(params, @params)
+    |> validate_required(@params)
     |> unique_constraint(:serial, name: :device_certificates_device_id_serial_index)
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20181004195340_add_certificate_info.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20181004195340_add_certificate_info.exs
@@ -1,0 +1,15 @@
+defmodule NervesHubCore.Repo.Migrations.AddCertificateInfo do
+  use Ecto.Migration
+
+  def change do
+    alter table(:device_certificates) do
+      add(:authority_key_id, :string)
+    end
+
+    alter table(:user_certificates) do
+      add(:authority_key_id, :string)
+      add(:not_before, :utc_datetime)
+      add(:not_after, :utc_datetime)
+    end
+  end
+end

--- a/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/accounts/accounts_test.exs
@@ -198,7 +198,7 @@ defmodule NervesHubCore.AccountsTest do
       serial: "12345"
     }
 
-    assert {:ok, _cert} = Accounts.create_user_certificate(user, params)
+    assert {:ok, %Accounts.UserCertificate{}} = Fixtures.user_certificate_fixture(user, params)
   end
 
   test "cannot create user certificate with duplicate serial" do
@@ -218,8 +218,8 @@ defmodule NervesHubCore.AccountsTest do
       serial: "12345"
     }
 
-    {:ok, _cert} = Accounts.create_user_certificate(user, params)
-    {:error, %Ecto.Changeset{}} = Accounts.create_user_certificate(user, params)
+    assert {:ok, %Accounts.UserCertificate{}} = Fixtures.user_certificate_fixture(user, params)
+    assert {:error, %Ecto.Changeset{}} = Fixtures.user_certificate_fixture(user, params)
   end
 
   test "org_key name must be unique" do

--- a/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
+++ b/apps/nerves_hub_core/test/nerves_hub_core/devices/devices_test.exs
@@ -146,7 +146,8 @@ defmodule NervesHubCore.DevicesTest do
       serial: "12345",
       not_before: now,
       not_after: now,
-      device_id: device_id
+      device_id: device_id,
+      authority_key_id: "12345"
     }
 
     assert {:ok, %DeviceCertificate{device_id: ^device_id}} =
@@ -160,7 +161,8 @@ defmodule NervesHubCore.DevicesTest do
       serial: "12345",
       not_before: now,
       not_after: now,
-      device_id: device.id
+      device_id: device.id,
+      authority_key_id: "12345"
     }
 
     assert {:ok, %DeviceCertificate{} = cert1} = Devices.create_device_certificate(device, params)
@@ -180,7 +182,8 @@ defmodule NervesHubCore.DevicesTest do
       serial: "12345",
       not_before: now,
       not_after: now,
-      device_id: device.id
+      device_id: device.id,
+      authority_key_id: "12345"
     }
 
     assert {:ok, %DeviceCertificate{}} = Devices.create_device_certificate(device, params)

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
@@ -15,8 +15,11 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
       current_org: org,
       current_user: user
     } do
-      foo_cert = Fixtures.user_certificate_fixture(user, %{description: "foo", serial: "abc123"})
-      bar_cert = Fixtures.user_certificate_fixture(user, %{description: "bar", serial: "321cba"})
+      {:ok, foo_cert} =
+        Fixtures.user_certificate_fixture(user, %{description: "foo", serial: "abc123"})
+
+      {:ok, bar_cert} =
+        Fixtures.user_certificate_fixture(user, %{description: "bar", serial: "321cba"})
 
       other_user = Fixtures.user_fixture(%{orgs: [org], email: "test@email.com"})
 
@@ -40,7 +43,11 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
   @tag :ca_integration
   describe "create product" do
     test "redirects to show when data is valid", %{conn: conn} do
-      conn = post(conn, account_certificate_path(conn, :create), user_certificate: @create_attrs)
+      params =
+        Fixtures.user_certificate_params()
+        |> Map.merge(@create_attrs)
+
+      conn = post(conn, account_certificate_path(conn, :create), user_certificate: params)
 
       assert %{id: id} = redirected_params(conn)
       assert redirected_to(conn) =~ account_certificate_path(conn, :show, id)


### PR DESCRIPTION
In preparation for providing our own certificate revocation lists, we need to begin to track the `authority_key_id` from the certificate in addition to the `serial_number`.