### PR TITLE
Fix wrong path for local firmware downloads

### DIFF
--- a/apps/nerves_hub_core/config/dev.exs
+++ b/apps/nerves_hub_core/config/dev.exs
@@ -3,7 +3,7 @@ use Mix.Config
 config :nerves_hub_core, firmware_upload: NervesHubCore.Firmwares.Upload.File
 
 config :nerves_hub_core, NervesHubCore.Firmwares.Upload.File,
-  local_path: System.tmp_dir(),
+  local_path: Path.join(System.tmp_dir(), "firmware"),
   public_path: "/firmware"
 
 # config :nerves_hub_core, NervesHubCore.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -18,10 +18,12 @@ defmodule NervesHubWWWWeb.Endpoint do
 
   # This should only be enabled if using NervesHubCore.Firmwares.Upload.File
   if @env in [:dev, :test] do
+    @file_config Application.get_env(:nerves_hub_core, NervesHubCore.Firmwares.Upload.File)
+
     plug(
       Plug.Static,
-      at: "/firmware",
-      from: "/tmp/firmware"
+      at: @file_config[:public_path],
+      from: @file_config[:local_path]
     )
   end
 


### PR DESCRIPTION
This was a typo from a [previous
commit](https://github.com/nerves-hub/nerves_hub_web/commit/8669c534c5bb2d880a20e8ca5ffad7f95b096f48#diff-3ee9958556f69d386641ab916f438305R6)

Fixes  #292