### PR TITLE
Render error for org key with existing firmware

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts.ex
@@ -310,7 +310,9 @@ defmodule NervesHubCore.Accounts do
   end
 
   def delete_org_key(%OrgKey{} = org_key) do
-    Repo.delete(org_key)
+    org_key
+    |> OrgKey.delete_changeset(%{})
+    |> Repo.delete()
   end
 
   def change_org_key(org_key, params \\ %{})

--- a/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_key.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/accounts/org_key.ex
@@ -32,13 +32,19 @@ defmodule NervesHubCore.Accounts.OrgKey do
     |> unique_constraint(:key)
   end
 
-  def update_changeset(%OrgKey{id: _} = org, params) do
+  def update_changeset(%OrgKey{id: _} = org_key, params) do
     # don't allow org_id to change
-    org
+    org_key
     |> cast(params, @required_params -- [:org_id])
     |> validate_required(@required_params)
     |> unique_constraint(:name, name: :org_keys_org_id_name_index)
     |> unique_constraint(:key)
+  end
+
+  def delete_changeset(%OrgKey{id: _} = org_key, params) do
+    org_key
+    |> cast(params, @required_params ++ @optional_params)
+    |> foreign_key_constraint(:firmwares, name: :firmwares_tenant_key_id_fkey)
   end
 
   def with_org(%OrgKey{} = o) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
@@ -61,10 +61,14 @@ defmodule NervesHubWWWWeb.OrgKeyController do
 
   def delete(%{assigns: %{current_org: org}} = conn, %{"id" => id}) do
     {:ok, org_key} = Accounts.get_org_key(org, id)
-    {:ok, _org_key} = Accounts.delete_org_key(org_key)
 
-    conn
-    |> put_flash(:info, "Org Key deleted successfully.")
-    |> redirect(to: org_path(conn, :edit, org))
+    with {:ok, _org_key} <- Accounts.delete_org_key(org_key) do
+      conn
+      |> put_flash(:info, "Org Key deleted successfully.")
+      |> redirect(to: org_path(conn, :edit, org))
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", org_key: org_key, changeset: changeset)
+    end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/form.html.eex
@@ -1,7 +1,7 @@
 <%= form_for @changeset, @action, fn f -> %>
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
-      <p>Oops, something went wrong! Please check the errors below.</p>
+      <p> <%= top_level_error_message(@changeset) %> </p>
     </div>
   <% end %>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_key_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_key_view.ex
@@ -1,3 +1,11 @@
 defmodule NervesHubWWWWeb.OrgKeyView do
   use NervesHubWWWWeb, :view
+
+  def top_level_error_message(%Ecto.Changeset{errors: errors}) do
+    if Keyword.has_key?(errors, :firmwares) do
+      "Key is in use. You must delete any firmwares signed by the corresponding private key"
+    else
+      "Oops, something went wrong! Please check the errors below."
+    end
+  end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
@@ -81,5 +81,15 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
         get(conn, org_key_path(conn, :show, org_key))
       end)
     end
+
+    test "returns error when key cannot be deleted", %{conn: conn, current_org: org} do
+      org_key = Fixtures.org_key_fixture(org)
+
+      product = Fixtures.product_fixture(org)
+      Fixtures.firmware_fixture(org_key, product)
+
+      conn = delete(conn, org_key_path(conn, :delete, org_key))
+      assert html_response(conn, 200) =~ "Key is in use."
+    end
   end
 end


### PR DESCRIPTION
Why:

* Server was returning 500 when users tried to delete a key that was
tied to an existing firmware: https://github.com/nerves-hub/nerves_hub_web/issues/291

This change addresses the need by:

* Checking the constraint in a changeset.
* Rendering a sensible error in the UI.
* Testing this behavior