### PR TITLE
Set local_ipv4 address for migration container

### DIFF
--- a/apps/nerves_hub_core/lib/nerves_hub_core/release/tasks.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/release/tasks.ex
@@ -22,7 +22,7 @@ defmodule NervesHubCore.Release.Tasks do
 
   defp init(app, start_apps) do
     IO.puts("Loading nerves_hub_www app for migrations...")
-    :ok = Application.load(app)
+    Application.load(app)
 
     IO.puts("Starting dependencies...")
     Enum.each(start_apps, &Application.ensure_all_started/1)

--- a/apps/nerves_hub_www/rel/Dockerfile.build
+++ b/apps/nerves_hub_www/rel/Dockerfile.build
@@ -38,6 +38,8 @@ RUN apk add 'fwup~=1.2.5' \
 EXPOSE 80
 EXPOSE 443
 
+ENV LOCAL_IPV4=127.0.0.1
+
 COPY --from=builder /build/_build/$MIX_ENV/rel/nerves_hub_www/releases/*/nerves_hub_www.tar.gz .
 RUN tar xvfz nerves_hub_www.tar.gz > /dev/null && rm nerves_hub_www.tar.gz
 


### PR DESCRIPTION
The deployment was failing on the migration step because the LOCAL_IPV4 variable that is used for the node name is only being set if the node is started with clustering. 