### PR TITLE
Add API for interacting with CA certificates

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
@@ -1,0 +1,54 @@
+defmodule NervesHubAPIWeb.CACertificateController do
+  use NervesHubAPIWeb, :controller
+
+  alias NervesHubCore.{Devices, Certificate}
+
+  action_fallback(NervesHubAPIWeb.FallbackController)
+
+  def index(%{assigns: %{org: org}} = conn, _params) do
+    ca_certificates = Devices.get_ca_certificates(org)
+    render(conn, "index.json", ca_certificates: ca_certificates)
+  end
+
+  def show(%{assigns: %{org: org}} = conn, %{"serial" => serial}) do
+    with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_org_and_serial(org, serial) do
+      render(conn, "show.json", ca_certificate: ca_certificate)
+    end
+  end
+
+  def create(%{assigns: %{org: org}} = conn, %{"cert" => cert64}) do
+    with {:ok, cert_pem} <- Base.decode64(cert64),
+         {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
+         serial <- Certificate.get_serial_number(cert),
+         aki <- Certificate.get_aki(cert),
+         ski <- Certificate.get_ski(cert),
+         {not_before, not_after} <- Certificate.get_validity(cert),
+         params <- %{
+           serial: serial,
+           aki: aki,
+           ski: ski,
+           not_before: not_before,
+           not_after: not_after,
+           der: X509.Certificate.to_der(cert)
+         },
+         {:ok, ca_certificate} <- Devices.create_ca_certificate(org, params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header(
+        "location",
+        ca_certificate_path(conn, :show, org.name, ca_certificate.serial)
+      )
+      |> render("show.json", ca_certificate: ca_certificate)
+    else
+      {:error, :not_found} -> {:error, "error decoding certificate"}
+      e -> e
+    end
+  end
+
+  def delete(%{assigns: %{org: org}} = conn, %{"serial" => serial}) do
+    with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_org_and_serial(org, serial),
+         {:ok, _ca_certificate} <- Devices.delete_ca_certificate(ca_certificate) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -44,6 +44,13 @@ defmodule NervesHubAPIWeb.Router do
           delete("/:name", KeyController, :delete)
         end
 
+        scope "/ca_certificates" do
+          get("/", CACertificateController, :index)
+          post("/", CACertificateController, :create)
+          get("/:serial", CACertificateController, :show)
+          delete("/:serial", CACertificateController, :delete)
+        end
+
         scope "/devices" do
           post("/", DeviceController, :create)
 

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/ca_certificate_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/ca_certificate_view.ex
@@ -1,0 +1,20 @@
+defmodule NervesHubAPIWeb.CACertificateView do
+  use NervesHubAPIWeb, :view
+  alias NervesHubAPIWeb.CACertificateView
+
+  def render("index.json", %{ca_certificates: ca_certificates}) do
+    %{data: render_many(ca_certificates, CACertificateView, "ca_certificate.json")}
+  end
+
+  def render("show.json", %{ca_certificate: ca_certificate}) do
+    %{data: render_one(ca_certificate, CACertificateView, "ca_certificate.json")}
+  end
+
+  def render("ca_certificate.json", %{ca_certificate: ca_certificate}) do
+    %{
+      serial: ca_certificate.serial,
+      not_before: ca_certificate.not_before,
+      not_after: ca_certificate.not_after
+    }
+  end
+end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
@@ -1,0 +1,64 @@
+defmodule NervesHubAPIWeb.CACertificateControllerTest do
+  use NervesHubAPIWeb.ConnCase, async: true
+
+  alias NervesHubCore.{Devices, Certificate}
+
+  describe "index" do
+    test "lists all ca certificates", %{conn: conn, org: org} do
+      conn = get(conn, ca_certificate_path(conn, :index, org.name))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create ca certificate" do
+    test "renders key when data is valid", %{conn: conn, org: org} do
+      ca_key = X509.PrivateKey.new_ec(:secp256r1)
+      ca_cert = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", template: :root_ca)
+      serial = X509.Certificate.serial(ca_cert) |> to_string
+      ca_cert_pem = X509.Certificate.to_pem(ca_cert)
+
+      params = %{cert: Base.encode64(ca_cert_pem)}
+
+      conn = post(conn, ca_certificate_path(conn, :create, org.name), params)
+      resp_data = json_response(conn, 201)["data"]
+      assert %{"serial" => ^serial} = resp_data
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, org: org} do
+      conn = post(conn, ca_certificate_path(conn, :create, org.name), cert: "")
+
+      assert json_response(conn, 500)["errors"] != %{}
+    end
+  end
+
+  describe "delete ca_certificate" do
+    setup [:create_ca_certificate]
+
+    test "deletes chosen ca_certificate", %{conn: conn, org: org, ca_certificate: ca_certificate} do
+      conn = delete(conn, ca_certificate_path(conn, :delete, org.name, ca_certificate.serial))
+      assert response(conn, 204)
+
+      conn = get(conn, ca_certificate_path(conn, :show, org.name, ca_certificate.serial))
+
+      assert response(conn, 404)
+    end
+  end
+
+  defp create_ca_certificate(%{org: org}) do
+    ca_key = X509.PrivateKey.new_ec(:secp256r1)
+    ca = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", template: :root_ca)
+    {not_before, not_after} = Certificate.get_validity(ca)
+
+    params = %{
+      serial: Certificate.get_serial_number(ca),
+      aki: Certificate.get_aki(ca),
+      ski: Certificate.get_ski(ca),
+      not_before: not_before,
+      not_after: not_after,
+      der: X509.Certificate.to_der(ca)
+    }
+
+    {:ok, ca_certificate} = Devices.create_ca_certificate(org, params)
+    {:ok, %{ca_certificate: ca_certificate}}
+  end
+end

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices.ex
@@ -222,7 +222,12 @@ defmodule NervesHubCore.Devices do
     |> Repo.insert()
   end
 
-  @spec get_ca_certificate_by_aki(binary) :: CACertificate.t() | nil
+  def get_ca_certificates(%Org{id: org_id}) do
+    from(ca in CACertificate, where: ca.org_id == ^org_id)
+    |> Repo.all()
+  end
+
+  @spec get_ca_certificate_by_aki(binary) :: {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_aki(aki) do
     Repo.get_by(CACertificate, aki: aki)
     |> case do
@@ -231,13 +236,37 @@ defmodule NervesHubCore.Devices do
     end
   end
 
-  @spec get_ca_certificate_by_serial(binary) :: CACertificate.t() | nil
+  @spec get_ca_certificate_by_serial(binary) :: {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_serial(serial) do
     Repo.get_by(CACertificate, serial: serial)
     |> case do
       nil -> {:error, :not_found}
       ca_cert -> {:ok, ca_cert}
     end
+  end
+
+  @spec get_ca_certificate_by_org_and_serial(Org.t(), binary) ::
+          {:ok, CACertificate.t()} | {:error, any()}
+  def get_ca_certificate_by_org_and_serial(%Org{id: org_id}, serial) do
+    query =
+      from(
+        ca in CACertificate,
+        where: ca.serial == ^serial and ca.org_id == ^org_id
+      )
+
+    query
+    |> Repo.one()
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      ca_certificate ->
+        {:ok, ca_certificate}
+    end
+  end
+
+  def delete_ca_certificate(%CACertificate{} = ca_certificate) do
+    Repo.delete(ca_certificate)
   end
 
   @doc """

--- a/apps/nerves_hub_core/lib/nerves_hub_core/devices/ca_certificate.ex
+++ b/apps/nerves_hub_core/lib/nerves_hub_core/devices/ca_certificate.ex
@@ -33,6 +33,6 @@ defmodule NervesHubCore.Devices.CACertificate do
     ca_certificate
     |> cast(params, @params)
     |> validate_required(@params)
-    |> unique_constraint(:serial, name: :ca_certificates_org_id_serial_index)
+    |> unique_constraint(:serial, name: :ca_certificates_serial_index)
   end
 end

--- a/apps/nerves_hub_core/priv/repo/migrations/20181201000818_ca_certificate_global_unique.exs
+++ b/apps/nerves_hub_core/priv/repo/migrations/20181201000818_ca_certificate_global_unique.exs
@@ -1,0 +1,19 @@
+defmodule NervesHubCore.Repo.Migrations.CaCertificateGlobalUnique do
+  use Ecto.Migration
+
+  def up do
+    create(
+      unique_index(:ca_certificates, [:serial], name: :ca_certificates_serial_index)
+    )
+    drop(unique_index(:ca_certificates, [:org_id, :serial]))
+  end
+
+
+
+  def down do
+    drop(unique_index(:ca_certificates, [:serial]))
+    create(
+      unique_index(:ca_certificates, [:org_id, :serial], name: :ca_certificates_org_id_serial_index)
+    )
+  end
+end


### PR DESCRIPTION
This PR adds resource endpoints for managing `ca_certificates`. 

The following endpoints are added:

* POST `/:org_name/ca_certificates` - create a new certificate from a pem.
* GET `/:org_name/ca_certificates` - list all ca_certificates
* GET `/:org_name/ca_certificates/:serial` - show information about a single certificate
* DELETE `/:org_name/ca_certificates/:serial` - delete the certificate with the specified serial