### PR TITLE
Scheduled GC

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/application.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/application.ex
@@ -8,15 +8,11 @@ defmodule NervesHubWebCore.Application do
 
     pubsub_config = Application.get_env(:nerves_hub_web_core, NervesHubWeb.PubSub)
 
-    firmware_gc_config =
-      Application.get_env(:nerves_hub_web_core, NervesHubWebCore.Firmwares.GC, [])
-
     # Define workers and child supervisors to be supervised
     children = [
       # Start the Ecto repository
       supervisor(NervesHubWebCore.Repo, []),
       supervisor(Phoenix.PubSub.PG2, [pubsub_config[:name], pubsub_config]),
-      {NervesHubWebCore.Firmwares.GC, firmware_gc_config},
       {Task.Supervisor, name: NervesHubWebCore.TaskSupervisor}
     ]
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/gc.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/gc.ex
@@ -1,33 +1,11 @@
 defmodule NervesHubWebCore.Firmwares.GC do
-  use GenServer
-
   require Logger
 
   alias NervesHubWebCore.Repo
   alias NervesHubWebCore.Firmwares
 
-  @interval 30_000
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
-  end
-
-  def init(opts) do
-    interval = opts[:interval] || @interval
-    Process.send_after(self(), :gc, interval)
-    {:ok, interval}
-  end
-
-  def handle_info(:gc, interval) do
+  def run() do
     Firmwares.get_firmware_by_expired_ttl()
-    |> delete()
-
-    Process.send_after(self(), :gc, interval)
-    {:noreply, interval}
-  end
-
-  defp delete(firmwares) when is_list(firmwares) do
-    firmwares
     |> Enum.each(fn firmware ->
       case Repo.delete(firmware) do
         {:ok, _firmware} ->

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -46,7 +46,8 @@ end
 
 release :nerves_hub_www do
   set commands: [
-    "migrate": "rel/scripts/migrate-and-seed.sh"
+    migrate: "rel/scripts/migrate-and-seed.sh",
+    gc: "rel/scripts/gc.sh"
   ]
   set version: current_version(:nerves_hub_www)
   set applications: [

--- a/rel/scripts/gc.sh
+++ b/rel/scripts/gc.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting GC Firmware"
+$RELEASE_ROOT_DIR/bin/nerves_hub_www command Elixir.NervesHubWebCore.Firmwares.GC run
+echo "Finished GC Firmware"


### PR DESCRIPTION
Moves the firmware GC task out of the `nerves_hub_web_core` application supervisor so it can be invoked from the command line. In production, since www, device, and api all run in their own containers and they all start `nerves_hub_web_core`, The firmware gc task loop is being called on all these containers. This routine should only ever be run on a single schedule in prod. 