### PR TITLE
Ensure apps and repos are started when running GC

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/release/tasks.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/release/tasks.ex
@@ -12,6 +12,14 @@ defmodule NervesHubWebCore.Release.Tasks do
     stop()
   end
 
+  def gc do
+    init(@otp_app, @start_apps)
+
+    NervesHubWebCore.Firmwares.GC.run()
+
+    stop()
+  end
+
   def seed do
     init(@otp_app, @start_apps)
 

--- a/rel/scripts/gc.sh
+++ b/rel/scripts/gc.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "Starting GC Firmware"
-$RELEASE_ROOT_DIR/bin/nerves_hub_www command Elixir.NervesHubWebCore.Firmwares.GC run
-echo "Finished GC Firmware"
+echo "Starting GC"
+$RELEASE_ROOT_DIR/bin/nerves_hub_www command Elixir.NervesHubWebCore.Release.Tasks gc
+echo "Finished GC"


### PR DESCRIPTION
This shares similar logic with running the migration task.