### PR TITLE
Add endpoint for verifying device auth

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubAPIWeb.DeviceController do
   use NervesHubAPIWeb, :controller
 
-  alias NervesHubWebCore.Devices
+  alias NervesHubWebCore.{Certificate, Devices, Devices.DeviceCertificate}
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
@@ -39,6 +39,23 @@ defmodule NervesHubAPIWeb.DeviceController do
       conn
       |> put_status(201)
       |> render("show.json", device: updated_device)
+    end
+  end
+
+  def auth(%{assigns: %{org: org}} = conn, %{"certificate" => cert64}) do
+    with {:ok, cert_pem} <- Base.decode64(cert64),
+         {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
+         serial <- Certificate.get_serial_number(cert),
+         {:ok, %DeviceCertificate{device_id: device_id}} <-
+           Devices.get_device_certificate_by_serial(serial),
+         {:ok, device} <- Devices.get_device_by_org(org, device_id) do
+      conn
+      |> put_status(200)
+      |> render("show.json", device: device)
+    else
+      _e ->
+        conn
+        |> send_resp(403, Jason.encode!(%{status: "Unauthorized"}))
     end
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -53,6 +53,7 @@ defmodule NervesHubAPIWeb.Router do
 
         scope "/devices" do
           post("/", DeviceController, :create)
+          post("/auth", DeviceController, :auth)
 
           scope "/:device_identifier" do
             get("/", DeviceController, :show)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/device_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/device_view.ex
@@ -1,6 +1,9 @@
 defmodule NervesHubAPIWeb.DeviceView do
   use NervesHubAPIWeb, :view
   alias NervesHubAPIWeb.DeviceView
+  alias NervesHubDevice.Presence
+
+  defdelegate device_status(device), to: Presence
 
   def render("index.json", %{devices: devices}) do
     %{data: render_many(devices, DeviceView, "device.json")}
@@ -12,7 +15,9 @@ defmodule NervesHubAPIWeb.DeviceView do
 
   def render("device.json", %{device: device}) do
     %{
-      identifier: device.identifier
+      identifier: device.identifier,
+      tags: device.tags,
+      status: device_status(device)
     }
   end
 end

--- a/apps/nerves_hub_api/mix.exs
+++ b/apps/nerves_hub_api/mix.exs
@@ -44,6 +44,7 @@ defmodule NervesHubAPI.Mixfile do
       {:gettext, "~> 0.11"},
       {:distillery, "~> 2.0"},
       {:cowboy, "~> 2.1", override: true},
+      {:nerves_hub_device, in_umbrella: true},
       {:nerves_hub_web_core, in_umbrella: true}
     ]
   end

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
@@ -334,24 +334,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
         %{identifier: @valid_serial}
         |> device_fixture(org)
 
-      ca_key = X509.PrivateKey.new_ec(:secp256r1)
-      ca = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", template: :root_ca)
-
-      {not_before, not_after} = NervesHubWebCore.Certificate.get_validity(ca)
-
-      serial = NervesHubWebCore.Certificate.get_serial_number(ca)
-      aki = NervesHubWebCore.Certificate.get_aki(ca)
-
-      params = %{
-        serial: serial,
-        aki: aki,
-        ski: NervesHubWebCore.Certificate.get_ski(ca),
-        not_before: not_before,
-        not_after: not_after,
-        der: X509.Certificate.to_der(ca)
-      }
-
-      {:ok, _cert_record} = Devices.create_ca_certificate(org, params)
+      %{cert: ca, key: ca_key} = Fixtures.ca_certificate_fixture(org)
 
       key = X509.PrivateKey.new_ec(:secp256r1)
 


### PR DESCRIPTION
This PR adds the following endpoint to the API for verifying. 

* POST `/orgs/:org_name/devices/auth

The payload expects to take a base64 encoded PEM formatted certificate. If the certificate is valid for a device in the org, the device record is returned. This allows 3rd party applications to perform certificate validation through the NervesHub API.