### PR TITLE
Allow device certificates to have a null subject key id

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/certificate.ex
@@ -24,8 +24,15 @@ defmodule NervesHubWebCore.Certificate do
     otp_certificate
     |> X509.Certificate.extensions()
     |> X509.Certificate.Extension.find(:subject_key_identifier)
-    |> extension()
-    |> Keyword.get(:extnValue)
+    |> case do
+      nil ->
+        nil
+
+      extension ->
+        extension
+        |> extension()
+        |> Keyword.get(:extnValue)
+    end
   end
 
   def get_common_name(otp_certificate) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device_certificate.ex
@@ -6,13 +6,15 @@ defmodule NervesHubWebCore.Devices.DeviceCertificate do
 
   @type t :: %__MODULE__{}
 
-  @params [
+  @required_params [
     :device_id,
     :serial,
     :aki,
-    :ski,
     :not_after,
     :not_before
+  ]
+  @optional_params [
+    :ski
   ]
 
   schema "device_certificates" do
@@ -29,8 +31,8 @@ defmodule NervesHubWebCore.Devices.DeviceCertificate do
 
   def changeset(%DeviceCertificate{} = device_certificate, params) do
     device_certificate
-    |> cast(params, @params)
-    |> validate_required(@params)
+    |> cast(params, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
     |> unique_constraint(:serial, name: :device_certificates_device_id_serial_index)
   end
 end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20181214143504_device_certificate_allow_lin_ski.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20181214143504_device_certificate_allow_lin_ski.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubWebCore.Repo.Migrations.DeviceCertificateAllowLinSki do
+  use Ecto.Migration
+
+  def change do
+    alter table(:device_certificates) do
+      modify :ski, :binary, null: true
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -155,6 +155,22 @@ defmodule NervesHubWebCore.DevicesTest do
              Devices.create_device_certificate(device, params)
   end
 
+  test "create device certificate without subject key id", %{device: device} do
+    now = DateTime.utc_now()
+    device_id = device.id
+
+    params = %{
+      serial: "12345",
+      not_before: now,
+      not_after: now,
+      device_id: device_id,
+      aki: "1234"
+    }
+
+    assert {:ok, %DeviceCertificate{device_id: ^device_id}} =
+             Devices.create_device_certificate(device, params)
+  end
+
   test "select one device when it has two certificates", %{device: device} do
     now = DateTime.utc_now()
 


### PR DESCRIPTION
Device certificates should not be required to present a subject key identifier in their certificates. This is a non critical extension.