### PR TITLE
Enable fail if no peer cert for device endpoints

### DIFF
--- a/apps/nerves_hub_device/config/dev.exs
+++ b/apps/nerves_hub_device/config/dev.exs
@@ -18,6 +18,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
     # Enable client SSL
     verify: :verify_peer,
     verify_fun: {&NervesHubDevice.SSL.verify_fun/3, nil},
+    fail_if_no_peer_cert: true,
     keyfile: Path.expand("./test/fixtures/ssl/device.nerves-hub.org-key.pem"),
     certfile: Path.expand("./test/fixtures/ssl/device.nerves-hub.org.pem"),
     cacertfile: Path.expand("./test/fixtures/ssl/ca.pem")

--- a/apps/nerves_hub_device/config/prod.exs
+++ b/apps/nerves_hub_device/config/prod.exs
@@ -9,6 +9,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
     otp_app: :nerves_hub_device,
     # Enable client SSL
     verify: :verify_peer,
+    fail_if_no_peer_cert: true,
     keyfile: "/etc/ssl/device.nerves-hub.org-key.pem",
     certfile: "/etc/ssl/device.nerves-hub.org.pem",
     cacertfile: "/etc/ssl/ca.pem"

--- a/apps/nerves_hub_device/config/test.exs
+++ b/apps/nerves_hub_device/config/test.exs
@@ -14,6 +14,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
     # Enable client SSL
     verify: :verify_peer,
     verify_fun: {&NervesHubDevice.SSL.verify_fun/3, nil},
+    fail_if_no_peer_cert: true,
     keyfile: Path.join([__DIR__, "../../../test/fixtures/ssl/device.nerves-hub.org-key.pem"]),
     certfile: Path.join([__DIR__, "../../../test/fixtures/ssl/device.nerves-hub.org.pem"]),
     cacertfile: Path.join([__DIR__, "../../../test/fixtures/ssl/ca.pem"])


### PR DESCRIPTION
This enables `fail_if_no_peer_cert`. It's my understanding that everything that happens on the device endpoint is protected by a peer cert.