### PR TITLE
Fix test port numbers

### DIFF
--- a/apps/nerves_hub_api/config/test.exs
+++ b/apps/nerves_hub_api/config/test.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :nerves_hub_api, NervesHubAPIWeb.Endpoint,
-  http: [port: 4001],
+  http: [port: 4002],
   server: false
 
 # Print only warnings and errors during test

--- a/apps/nerves_hub_www/config/test.exs
+++ b/apps/nerves_hub_www/config/test.exs
@@ -3,7 +3,7 @@ use Mix.Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
-  http: [port: 4001],
+  http: [port: 4000],
   server: false
 
 # Print only warnings and errors during test


### PR DESCRIPTION
The ports for test were different then dev which prevented the system from coming up, as a whole, under the test environment.