### PR TITLE
Allow devices with unknown firmware to connect.

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -282,7 +282,7 @@ defmodule NervesHubWebCore.Devices do
   def update_last_known_firmware(%Device{org: org} = device, fw_uuid) do
     case Firmwares.get_firmware_by_uuid(org, fw_uuid) do
       {:ok, firmware} -> update_device(device, %{last_known_firmware_id: firmware.id})
-      _ -> {:error, :no_firmware_found}
+      _ -> update_device(device, %{last_known_firmware_id: nil})
     end
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
@@ -24,7 +24,7 @@
           <td class="col-2"><%= device.identifier %></td>
           <td class="col-2">
             <%= if is_nil(device.last_known_firmware) do %>
-              no firmware
+              unknown
             <% else %>
               <%= device.last_known_firmware.version %>
             <% end %>


### PR DESCRIPTION
This will allow devices that don't have a known firmware connect to the channel, enabling them to get a later update.