### PR TITLE
Add table to Org panel to display limits

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -25,17 +25,21 @@ defmodule NervesHubWWWWeb.OrgController do
     end
   end
 
-  def edit(%{assigns: %{current_org: %{id: _conn_id} = org}} = conn, _params) do
+  def edit(
+        %{assigns: %{current_org: %{id: _conn_id} = org, current_limit: limits}} = conn,
+        _params
+      ) do
     render(
       conn,
       "edit.html",
       org_changeset: %Changeset{data: org},
       org_key_changeset: %Changeset{data: %OrgKey{}},
-      org: org
+      org: org,
+      org_limit: limits
     )
   end
 
-  def update(%{assigns: %{current_org: org}} = conn, %{"org" => org_params}) do
+  def update(%{assigns: %{current_org: org, current_limit: limits}} = conn, %{"org" => org_params}) do
     org
     |> Accounts.update_org(org_params)
     |> case do
@@ -50,7 +54,8 @@ defmodule NervesHubWWWWeb.OrgController do
           "edit.html",
           org_changeset: changeset,
           org_key_changeset: %Changeset{data: %OrgKey{}},
-          org: org
+          org: org,
+          org_limit: limits
         )
     end
   end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/ensure_logged_in.ex
@@ -23,9 +23,12 @@ defmodule NervesHubWWWWeb.Plugs.EnsureLoggedIn do
         {:ok, current_org} =
           get_session(conn, "current_org_id") |> Accounts.get_org_with_org_keys()
 
+        limit = Accounts.get_org_limit_by_org_id(current_org.id)
+
         conn
         |> assign(:user, user)
         |> assign(:current_org, current_org)
+        |> assign(:current_limit, limit)
         |> assign(:user_token, Phoenix.Token.sign(conn, "user salt", user.id))
 
       _ ->

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -6,6 +6,30 @@
   </a>
 </h1>
 
+<table class="table table-striped">
+  <div class="panel-heading">
+    Org Limits
+  </div>
+
+  <div class="panel-body">
+    <thead>
+      <tr>
+        <th>Device Limit</th>
+        <th>Firmware per Product</th>
+        <th>Firmware Size</th>
+        <th>Firmware Max Time to Live Seconds<th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <td> <%= @org_limit.devices %> </td>
+      <td> <%= @org_limit.firmware_per_product %> </td>
+      <td> <%= @org_limit.firmware_size %> </td>
+      <td> <%= @org_limit.firmware_ttl_seconds %> </td>
+    </tbody>
+  </div>
+</table>
+
 <div class="panel panel-default">
   <div class="panel-heading">
     Profile


### PR DESCRIPTION
![screenshot from 2018-12-19 08-12-48](https://user-images.githubusercontent.com/21150830/50232479-e5977780-0365-11e9-8895-9976d9d47030.png)

Doesn't look the greatest in my opinion but i think this is useful. It might even be useful to display the current usage for these things in a followup.