### PR TITLE
Set last known firmware in device plug

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/plugs/device.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/plugs/device.ex
@@ -14,7 +14,9 @@ defmodule NervesHubDeviceWeb.Plugs.Device do
          {:ok, cert} <- X509.Certificate.from_der(cert),
          serial <- Certificate.get_serial_number(cert),
          {:ok, cert} <- Devices.get_device_certificate_by_serial(serial),
-         {:ok, device} <- Devices.get_device_by_certificate(cert) do
+         {:ok, device} <- Devices.get_device_by_certificate(cert),
+         uuid_header <- get_req_header(conn, "x-nerveshub-uuid"),
+         {:ok, device} <- update_last_known_firmware(uuid_header, device) do
       assign(conn, :device, device)
     else
       _err ->
@@ -23,5 +25,11 @@ defmodule NervesHubDeviceWeb.Plugs.Device do
         |> send_resp(403, Jason.encode!(%{status: "forbidden"}))
         |> halt()
     end
+  end
+
+  defp update_last_known_firmware([], device), do: {:ok, device}
+
+  defp update_last_known_firmware([fw_uuid], device) do
+    Devices.update_last_known_firmware(device, fw_uuid)
   end
 end


### PR DESCRIPTION
Why
---

* A device with no last known firmware that tries to use device apis to
fetch an update would previously fail to resolve new firmware because
eligible deployments can only be resolved if a last known firmware
exists for a device

PR
--

* Resolves #322 
* Is powered by: https://github.com/nerves-hub/nerves_hub/pull/50 but is written to be backwards compatible without it