### PR TITLE
Update devices when tags are updated.

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubAPIWeb.DeviceControllerTest do
-  use NervesHubAPIWeb.ConnCase, async: true
+  use NervesHubAPIWeb.ConnCase, async: false
   alias NervesHubWebCore.{Devices, Fixtures}
 
   describe "create devices" do

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/controllers/device_controller.ex
@@ -1,8 +1,6 @@
 defmodule NervesHubDeviceWeb.DeviceController do
   use NervesHubDeviceWeb, :controller
-  alias NervesHubWebCore.{Devices, Firmwares, Deployments}
-
-  @uploader Application.get_env(:nerves_hub_web_core, :firmware_upload)
+  alias NervesHubWebCore.Devices
 
   def me(%{assigns: %{device: device}} = conn, _params) do
     render(conn, "show.json", device: device)
@@ -10,18 +8,7 @@ defmodule NervesHubDeviceWeb.DeviceController do
 
   def update(%{assigns: %{device: device}} = conn, _params) do
     deployments = Devices.get_eligible_deployments(device)
-    join_reply = resolve_update(device.org, deployments)
+    join_reply = Devices.resolve_update(device.org, deployments)
     render(conn, "update.json", reply: join_reply)
-  end
-
-  defp resolve_update(_org, _deployments = []), do: %{update_available: false}
-
-  defp resolve_update(org, [%Deployments.Deployment{} = deployment | _]) do
-    with {:ok, firmware} <- Firmwares.get_firmware(org, deployment.firmware_id),
-         {:ok, url} <- @uploader.download_file(firmware) do
-      %{update_available: true, firmware_url: url}
-    else
-      _ -> %{update_available: false}
-    end
   end
 end

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/controllers/device_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubDeviceWeb.DeviceControllerTest do
-  use NervesHubDeviceWeb.ConnCase, async: true
+  use NervesHubDeviceWeb.ConnCase, async: false
   alias NervesHubWebCore.{Deployments, Fixtures}
 
   describe "device" do

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/plugs/device_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/plugs/device_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubDeviceWeb.Plugs.DeviceTest do
-  use NervesHubDeviceWeb.ConnCase, async: true
+  use NervesHubDeviceWeb.ConnCase, async: false
   alias NervesHubDeviceWeb.Plugs.Device
   alias NervesHubWebCore.Repo
 

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/deployments/deployments_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWebCore.DeploymentsTest do
-  use NervesHubWebCore.DataCase, async: true
+  use NervesHubWebCore.DataCase, async: false
   use Phoenix.ChannelTest
 
   alias NervesHubWebCore.Fixtures

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWebCore.DevicesTest do
-  use NervesHubWebCore.DataCase, async: true
+  use NervesHubWebCore.DataCase, async: false
 
   alias NervesHubWebCore.{Accounts, Fixtures, Devices, Devices.CACertificate, Deployments}
   alias NervesHubWebCore.Devices.DeviceCertificate

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWWWWeb.DeviceControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser, async: true
+  use NervesHubWWWWeb.ConnCase.Browser, async: false
 
   alias NervesHubWebCore.Fixtures
   alias NervesHubWebCore.Devices


### PR DESCRIPTION
Fixes #309 

This will dispatch eligible update_available channel messages when a `Device` is updated. 