### PR TITLE
Rename references to org to organization

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -17,7 +17,7 @@ defmodule NervesHubWWWWeb.OrgController do
 
     with {:ok, org} <- Accounts.create_org(with_user_params) do
       conn
-      |> put_flash(:info, "Org created successfully.")
+      |> put_flash(:info, "Organization created successfully.")
       |> redirect(to: org_path(conn, :edit, org))
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -45,7 +45,7 @@ defmodule NervesHubWWWWeb.OrgController do
     |> case do
       {:ok, _org} ->
         conn
-        |> put_flash(:info, "Org Updated")
+        |> put_flash(:info, "Organization Updated")
         |> redirect(to: org_path(conn, :edit, org))
 
       {:error, changeset} ->

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
@@ -18,7 +18,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
     case Accounts.create_org_key(org_key_params |> Enum.into(%{"org_id" => org.id})) do
       {:ok, _org_key} ->
         conn
-        |> put_flash(:info, "Org keys created successfully.")
+        |> put_flash(:info, "Organization key created successfully.")
         |> redirect(to: org_path(conn, :edit, org))
 
       {:error, %Ecto.Changeset{}} ->
@@ -51,7 +51,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
          ) do
       {:ok, _org_key} ->
         conn
-        |> put_flash(:info, "Org Key updated successfully.")
+        |> put_flash(:info, "Organization key updated successfully.")
         |> redirect(to: org_path(conn, :edit, org))
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -64,7 +64,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
 
     with {:ok, _org_key} <- Accounts.delete_org_key(org_key) do
       conn
-      |> put_flash(:info, "Org Key deleted successfully.")
+      |> put_flash(:info, "Organization key deleted successfully.")
       |> redirect(to: org_path(conn, :edit, org))
     else
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -19,7 +19,7 @@
               <%= link org.name, class: "dropdown-item", to: session_path(@conn, :set_org, org: org), method: :put%>
                 <% end %>
         <% end %>
-        <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New Org</a>
+        <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New organization</a>
           </div>
         </li>
         <%= for {name, path} <- navigation_links(@conn) do %>
@@ -32,7 +32,7 @@
             Settings
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.current_org)%>">Org settings</a>
+            <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.current_org)%>">Organization settings</a>
             <a class="dropdown-item" href="<%= account_path(@conn, :edit)%>">User settings</a>
             <div class="dropdown-divider"></div>
             <a class="dropdown-item" href="<%= session_path(@conn, :delete)%>">Logout</a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -31,7 +31,7 @@
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Settings
           </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
             <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.current_org)%>">Organization settings</a>
             <a class="dropdown-item" href="<%= account_path(@conn, :edit)%>">User settings</a>
             <div class="dropdown-divider"></div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -1,14 +1,14 @@
 <h1>
-  Org Settings
+  Organization settings
 
   <a class="btn btn-lg btn-success pull-right" href="<%= org_path(@conn, :invite) %>">
-    Invite User
+    Invite user
   </a>
 </h1>
 
 <table class="table table-striped">
   <div class="panel-heading">
-    Org Limits
+    Organization limits
   </div>
 
   <div class="panel-body">
@@ -43,7 +43,7 @@
         <div class="has-error"><%= error_tag f, :name %></div>
       </div>
 
-      <%= submit "Update Org", class: "btn btn-primary" %>
+      <%= submit "Update organization", class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
@@ -1,4 +1,4 @@
-<h2>New Org</h2>
+<h2>New organization</h2>
 
 <%= render "form.html", Map.put(assigns, :action, org_path(@conn, :create)) %>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/edit.html.eex
@@ -1,4 +1,4 @@
-<h2>Edit Org Key</h2>
+<h2>Edit organization key</h2>
 
 <%= render "form.html", Map.put(assigns, :action, org_key_path(@conn, :update, @org_key)) %>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/index.html.eex
@@ -1,4 +1,4 @@
-<h2>Listing Org keys</h2>
+<h2>Listing organization keys</h2>
 
 <table>
   <thead>
@@ -21,4 +21,4 @@
   </tbody>
 </table>
 
-<span><%= link "New Org keys", to: org_key_path(@conn, :new) %></span>
+<span><%= link "New organization keys", to: org_key_path(@conn, :new) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/new.html.eex
@@ -1,4 +1,4 @@
-<h2>New Org keys</h2>
+<h2>New organization keys</h2>
 
 <%= render "form.html", Map.put(assigns, :action, org_key_path(@conn, :create)) %>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/show.html.eex
@@ -1,4 +1,4 @@
-<h2>Show Org keys</h2>
+<h2>Show organization keys</h2>
 
 <ul>
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -6,7 +6,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
   describe "new org" do
     test "renders form", %{conn: conn} do
       conn = get(conn, org_path(conn, :new))
-      assert html_response(conn, 200) =~ "New Org"
+      assert html_response(conn, 200) =~ "New organization"
       refute html_response(conn, 200) =~ "href=\"" <> org_path(conn, :index) <> "\""
     end
   end
@@ -19,20 +19,20 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
       assert redirected_to(conn) == org_path(conn, :edit, id)
 
       conn = get(conn, org_path(conn, :edit, id))
-      assert html_response(conn, 200) =~ "Org Settings"
+      assert html_response(conn, 200) =~ "Organization settings"
       assert html_response(conn, 200) =~ org.name
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, org_path(conn, :create), org: %{})
-      assert html_response(conn, 200) =~ "New Org"
+      assert html_response(conn, 200) =~ "New organization"
     end
   end
 
   describe "edit org" do
     test "renders form for editing org on conn", %{conn: conn, current_org: org} do
       conn = get(conn, org_path(conn, :edit, org))
-      assert html_response(conn, 200) =~ "Org Settings"
+      assert html_response(conn, 200) =~ "Organization settings"
     end
 
     test "does not render form for org not on conn", %{conn: conn, current_org: _org} do
@@ -75,7 +75,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
           org: %{name: ""}
         )
 
-      assert html_response(conn, 200) =~ "Org Settings"
+      assert html_response(conn, 200) =~ "Organization settings"
       assert html_response(conn, 200) =~ "be blank"
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
@@ -9,14 +9,14 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
   describe "index" do
     test "lists all org_keys", %{conn: conn} do
       conn = get(conn, org_key_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing Org keys"
+      assert html_response(conn, 200) =~ "Listing organization keys"
     end
   end
 
   describe "new org_keys" do
     test "renders form", %{conn: conn} do
       conn = get(conn, org_key_path(conn, :new))
-      assert html_response(conn, 200) =~ "New Org keys"
+      assert html_response(conn, 200) =~ "New organization keys"
     end
   end
 
@@ -41,7 +41,7 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
     test "renders form for editing chosen org_keys", %{conn: conn, current_org: org} do
       org_key = Fixtures.org_key_fixture(org)
       conn = get(conn, org_key_path(conn, :edit, org_key))
-      assert html_response(conn, 200) =~ "Edit Org Key"
+      assert html_response(conn, 200) =~ "Edit organization key"
     end
   end
 
@@ -66,7 +66,7 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
           org_key: @invalid_attrs
         )
 
-      assert html_response(conn, 200) =~ "Edit Org Key"
+      assert html_response(conn, 200) =~ "Edit organization key"
     end
   end
 


### PR DESCRIPTION
This only affects the UI. I didn't make any code changes especially since "org" seems clear and easy to type. Spelling out "organization" reads better to me in the docs. I saw that GitHub also uses the term "organization" rather than "org", and since our user/org setup is similar, it made sense to emulate their decision.

Note that there's a inconsistency in sentence vs. title case, but it's more than just the org/organization. I was going to make a pass at that in a future PR.