### PR TITLE
Show online as status for unknown firmware

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -8,9 +8,6 @@ defmodule NervesHubDevice.Presence do
 
   def fetch("devices:" <> _, entries) do
     Enum.reduce(entries, %{}, fn
-      {key, %{metas: [%{last_known_firmware_id: nil}]} = val}, acc ->
-        Map.put(acc, key, Map.put(val, :status, "unknown firmware"))
-
       {key, %{metas: [%{update_available: true}]} = val}, acc ->
         Map.put(acc, key, Map.put(val, :status, "update pending"))
 
@@ -29,18 +26,16 @@ defmodule NervesHubDevice.Presence do
   - `"online"` - The device has a `:last_known_firmware_id` and is connected to Presence
   - `"update pending"` - The device has a `:last_known_firmware_id`, is connected to presence, and
     its presence meta includes `update_available: true`
-  - `"unknown firmware"` - The device does not have a `:last_known_firmware_id`
   - `"offline"` - The device is not connected to Presence
   """
   @spec device_status(Device.t()) :: Strint.t()
-  def device_status(%Device{id: device_id, last_known_firmware_id: lkf_id, org_id: org_id}) do
+  def device_status(%Device{id: device_id, org_id: org_id}) do
     "devices:#{org_id}"
     |> Presence.list()
     |> Map.get("#{device_id}")
     |> case do
       nil -> "offline"
       %{metas: [%{update_available: true}]} -> "update pending"
-      %{} when is_nil(lkf_id) -> "unknown firmware"
       %{} -> "online"
     end
   end


### PR DESCRIPTION
Since the device status also contains firmware version, and when the firmware is unknown it says `unknown`. I think that we should still illustrate in the status that the device is online instead of also having it say something else.

Before:
<img width="1532" alt="screen shot 2019-01-20 at 15 57 23" src="https://user-images.githubusercontent.com/1391351/51444939-9201ac00-1ccc-11e9-8c18-93418ba65bde.png">

After:
<img width="1532" alt="screen shot 2019-01-20 at 15 58 14" src="https://user-images.githubusercontent.com/1391351/51444940-97f78d00-1ccc-11e9-97ce-5133202f6fe7.png">
