### PR TITLE
Fix code snippet scroll bar

### DIFF
--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -1,8 +1,8 @@
-$fa-font-path: '~@fortawesome/fontawesome-free/webfonts'; 
-@import '~@fortawesome/fontawesome-free/scss/fontawesome'; 
-@import '~@fortawesome/fontawesome-free/scss/solid'; 
-@import '~@fortawesome/fontawesome-free/scss/regular'; 
-@import '~@fortawesome/fontawesome-free/scss/brands'; 
+$fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
+@import '~@fortawesome/fontawesome-free/scss/fontawesome';
+@import '~@fortawesome/fontawesome-free/scss/solid';
+@import '~@fortawesome/fontawesome-free/scss/regular';
+@import '~@fortawesome/fontawesome-free/scss/brands';
 
 @import "custom";
 @import "navigation";
@@ -55,8 +55,8 @@ main {
   @extend .text-dark;
   @include hover-focus {
     color: whitesmoke;
-  }  
-}  
+  }
+}
 
 .modal-content {
   @extend .text-dark;
@@ -121,7 +121,10 @@ main {
     }
     span {
       vertical-align: -webkit-baseline-middle;
-    }  
+    }
   }
 }
 
+.code-snippet {
+  overflow: unset;
+}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/home/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/home/index.html.eex
@@ -28,7 +28,7 @@
     </div>
     <div class="d-flex flex-row justify-content-between group-bottom pad">
       <div class="d-flex terminal">
-        <pre>
+        <pre class="code-snippet">
           <%# <code class="language-bash" data-lang="bash"> %>
             <p class="prompt text-left">$ </p>mix nerves_hub.firmware publish --deploy prod
           <%# </code> %>


### PR DESCRIPTION
Why
---

* A scroll bar is showing when it isn't needed and it looks bad with the
  `<pre>` as-is.

How
---

* Add `code-snippet` class to the element that sets the `overflow`
  attribute.
* Some new lines got removed.