### PR TITLE
Fix last connection whitespace

### DIFF
--- a/apps/nerves_hub_www/assets/js/dates.js
+++ b/apps/nerves_hub_www/assets/js/dates.js
@@ -1,4 +1,6 @@
 let formatLastCommunication = last_communication => {
+  last_communication = last_communication.trim()
+
   if (last_communication == 'never') {
     return last_communication
   } else {

--- a/apps/nerves_hub_www/assets/js/dates.test.js
+++ b/apps/nerves_hub_www/assets/js/dates.test.js
@@ -13,4 +13,8 @@ describe('formatLastCommunication', () => {
   test('preserves "never" value', () => {
     expect(dates.formatLastCommunication('never')).toBe('never')
   })
+
+  test('handles white space around "never" value', () => {
+    expect(dates.formatLastCommunication(' never  ')).toBe('never')
+  })
 })


### PR DESCRIPTION
Why
---

* Whitespace around "never" value causes formatting to fail.

How
---

* Trim value before inspecting.