### PR TITLE
Add description to ca_certificates

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
@@ -16,7 +16,7 @@ defmodule NervesHubAPIWeb.CACertificateController do
     end
   end
 
-  def create(%{assigns: %{org: org}} = conn, %{"cert" => cert64}) do
+  def create(%{assigns: %{org: org}} = conn, %{"cert" => cert64} = params) do
     with {:ok, cert_pem} <- Base.decode64(cert64),
          {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
          serial <- Certificate.get_serial_number(cert),
@@ -29,7 +29,8 @@ defmodule NervesHubAPIWeb.CACertificateController do
            ski: ski,
            not_before: not_before,
            not_after: not_after,
-           der: X509.Certificate.to_der(cert)
+           der: X509.Certificate.to_der(cert),
+           description: Map.get(params, "description")
          },
          {:ok, ca_certificate} <- Devices.create_ca_certificate(org, params) do
       conn

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
@@ -16,8 +16,9 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
       ca_cert = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", template: :root_ca)
       serial = X509.Certificate.serial(ca_cert) |> to_string
       ca_cert_pem = X509.Certificate.to_pem(ca_cert)
+      description = "My ca"
 
-      params = %{cert: Base.encode64(ca_cert_pem)}
+      params = %{cert: Base.encode64(ca_cert_pem), description: description}
 
       conn = post(conn, ca_certificate_path(conn, :create, org.name), params)
       resp_data = json_response(conn, 201)["data"]
@@ -55,7 +56,8 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
       ski: Certificate.get_ski(ca),
       not_before: not_before,
       not_after: not_after,
-      der: X509.Certificate.to_der(ca)
+      der: X509.Certificate.to_der(ca),
+      description: "My CA"
     }
 
     {:ok, ca_certificate} = Devices.create_ca_certificate(org, params)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate.ex
@@ -6,7 +6,7 @@ defmodule NervesHubWebCore.Devices.CACertificate do
 
   @type t :: %__MODULE__{}
 
-  @params [
+  @required_params [
     :org_id,
     :serial,
     :aki,
@@ -16,9 +16,14 @@ defmodule NervesHubWebCore.Devices.CACertificate do
     :der
   ]
 
+  @optional_params [
+    :description
+  ]
+
   schema "ca_certificates" do
     belongs_to(:org, Org)
 
+    field(:description, :string)
     field(:serial, :string)
     field(:aki, :binary)
     field(:ski, :binary)
@@ -31,8 +36,8 @@ defmodule NervesHubWebCore.Devices.CACertificate do
 
   def changeset(%__MODULE__{} = ca_certificate, params) do
     ca_certificate
-    |> cast(params, @params)
-    |> validate_required(@params)
+    |> cast(params, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
     |> unique_constraint(:serial, name: :ca_certificates_serial_index)
   end
 end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190203000524_add_description_to_ca_certificates.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190203000524_add_description_to_ca_certificates.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddDescriptionToCaCertificates do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ca_certificates) do
+      add(:description, :string)
+    end
+  end
+end


### PR DESCRIPTION
This adds `description` to the `CACertificate` model
Fixes https://github.com/nerves-hub/nerves_hub_web/issues/349