### PR TITLE
Update device delete response to omit the device record

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -36,9 +36,7 @@ defmodule NervesHubAPIWeb.DeviceController do
     {:ok, device} = Devices.get_device_by_identifier(org, identifier)
     {:ok, _device} = Devices.delete_device(device)
 
-    conn
-    |> put_status(204)
-    |> render("show.json", device: device)
+    send_resp(conn, :no_content, "")
   end
 
   def update(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier} = params) do

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -48,10 +48,10 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
 
       [to_delete | _] = Devices.get_devices(org)
       conn = delete(conn, device_path(conn, :delete, org.name, to_delete.identifier))
-      assert json_response(conn, 204)["data"]
+      assert response(conn, 204)
 
       conn = get(conn, device_path(conn, :show, org.name, to_delete.identifier))
-      assert json_response(conn, 404)
+      assert response(conn, 404)
     end
   end
 


### PR DESCRIPTION
This was noticed while doing https://github.com/nerves-hub/nerves_hub_web/issues/344 It normalizes the device delete response to be the same as others. It doesn't seem like we need to send the record back if its been successfully deleted.