### PR TITLE
Sort devices identifier ascending by default

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -21,6 +21,7 @@ defmodule NervesHubWebCore.Devices do
 
     query
     |> Device.with_firmware()
+    |> order_by(asc: :identifier)
     |> Repo.all()
   end
 
@@ -34,6 +35,7 @@ defmodule NervesHubWebCore.Devices do
 
     query
     |> Device.with_firmware()
+    |> order_by(asc: :identifier)
     |> Repo.all()
   end
 


### PR DESCRIPTION
I think we should have a larger discussion on how we want to sort, search, and paginate tables on the front end, but in the meantime, it makes sense to at least sort the devices by the identifier ascending.