### PR TITLE
Embed firmware_metadata into Device

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ version: 2
 jobs:
   test_elixir:
     docker:
-      - image: circleci/elixir:1.7
+      - image: circleci/elixir:1.8
         environment:
           MIX_ENV: test
           DATABASE_URL: postgres://db:db@localhost:5432/db

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
@@ -17,7 +17,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
         {:error, :no_firmware_uuid}
 
       uuid ->
-        with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid),
+        with {:ok, firmware} <- Firmwares.get_firmware_by_org_and_uuid(org, uuid),
              params <- Map.put(params, "firmware_id", firmware.id),
              {:ok, deployment} <-
                Deployments.create_deployment(
@@ -65,7 +65,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
   end
 
   defp update_params(org, %{"firmware" => uuid} = params) do
-    with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid) do
+    with {:ok, firmware} <- Firmwares.get_firmware_by_org_and_uuid(org, uuid) do
       {:ok, Map.put(params, "firmware_id", firmware.id)}
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -25,13 +25,13 @@ defmodule NervesHubAPIWeb.FirmwareController do
   end
 
   def show(%{assigns: %{org: org}} = conn, %{"uuid" => uuid}) do
-    with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid) do
+    with {:ok, firmware} <- Firmwares.get_firmware_by_org_and_uuid(org, uuid) do
       render(conn, "show.json", firmware: firmware)
     end
   end
 
   def delete(%{assigns: %{org: org}} = conn, %{"uuid" => uuid}) do
-    with {:ok, firmware} <- Firmwares.get_firmware_by_uuid(org, uuid),
+    with {:ok, firmware} <- Firmwares.get_firmware_by_org_and_uuid(org, uuid),
          :ok <- Firmwares.delete_firmware(firmware) do
       send_resp(conn, :no_content, "")
     end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/device_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/device_view.ex
@@ -23,8 +23,8 @@ defmodule NervesHubAPIWeb.DeviceView do
     }
   end
 
-  defp version(%{last_known_firmware_id: nil}), do: "unknown"
-  defp version(%{last_known_firmware: %{version: vsn}}), do: vsn
+  defp version(%{firmware_metadata: nil}), do: "unknown"
+  defp version(%{firmware_metadata: %{version: vsn}}), do: vsn
 
   defp last_communication(%{last_communication: nil}), do: "never"
   defp last_communication(%{last_communication: dt}), do: to_string(dt)

--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -23,8 +23,8 @@ defmodule NervesHubDevice.Presence do
 
   ## Statuses
 
-  - `"online"` - The device has a `:last_known_firmware_id` and is connected to Presence
-  - `"update pending"` - The device has a `:last_known_firmware_id`, is connected to presence, and
+  - `"online"` - The device has `:firmware_metadata` and is connected to Presence
+  - `"update pending"` - The device has `:firmware_metadata`, is connected to presence, and
     its presence meta includes `update_available: true`
   - `"offline"` - The device is not connected to Presence
   """

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWebCore.Firmwares do
   alias Ecto.Changeset
   alias NervesHubWebCore.Accounts
   alias NervesHubWebCore.Accounts.{OrgKey, Org}
-  alias NervesHubWebCore.Firmwares.Firmware
+  alias NervesHubWebCore.Firmwares.{Firmware, FirmwareMetadata}
   alias NervesHubWebCore.Products
   alias NervesHubWebCore.Repo
 
@@ -52,16 +52,37 @@ defmodule NervesHubWebCore.Firmwares do
     end
   end
 
-  @spec get_firmware_by_uuid(Org.t(), String.t()) ::
+  @spec get_firmware_by_uuid(String.t()) ::
           {:ok, Firmware.t()}
           | {:error, :not_found}
-  def get_firmware_by_uuid(%Org{id: t_id}, uuid) do
+
+  def get_firmware_by_uuid(uuid) do
+    from(
+      f in Firmware,
+      where: f.uuid == ^uuid
+    )
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      firmware -> {:ok, firmware}
+    end
+  end
+
+  @spec get_firmware_by_org_and_uuid(Org.t(), String.t()) ::
+          {:ok, Firmware.t()}
+          | {:error, :not_found}
+
+  def get_firmware_by_org_and_uuid(%Org{id: org_id}, uuid) do
+    get_firmware_by_org_and_uuid(org_id, uuid)
+  end
+
+  def get_firmware_by_org_and_uuid(org_id, uuid) do
     from(
       f in Firmware,
       where: f.uuid == ^uuid,
       join: p in assoc(f, :product),
       preload: [product: p],
-      where: p.org_id == ^t_id
+      where: p.org_id == ^org_id
     )
     |> Repo.one()
     |> case do
@@ -129,19 +150,6 @@ defmodule NervesHubWebCore.Firmwares do
     end
   end
 
-  @spec extract_metadata(String.t()) ::
-          {:ok, String.t()}
-          | {:error}
-  def extract_metadata(filepath) do
-    case System.cmd("fwup", ["-m", "-i", filepath]) do
-      {metadata, 0} ->
-        {:ok, metadata}
-
-      _error ->
-        {:error}
-    end
-  end
-
   def update_firmware_ttl(nil), do: :ok
 
   def update_firmware_ttl(firmware_id) do
@@ -149,11 +157,9 @@ defmodule NervesHubWebCore.Firmwares do
       from(f in NervesHubWebCore.Firmwares.Firmware,
         left_join: d in NervesHubWebCore.Deployments.Deployment,
         on: d.firmware_id == f.id,
-        left_join: dd in NervesHubWebCore.Devices.Device,
-        on: dd.last_known_firmware_id == f.id,
         where:
           f.id == ^firmware_id and
-            not (is_nil(d.firmware_id) and is_nil(dd.last_known_firmware_id)),
+            not is_nil(d.firmware_id),
         limit: 1
       )
 
@@ -196,6 +202,85 @@ defmodule NervesHubWebCore.Firmwares do
     |> Repo.all()
   end
 
+  def metadata_from_conn(%Plug.Conn{} = conn) do
+    params = %{
+      uuid: get_metadata_req_header(conn, "uuid"),
+      architecture: get_metadata_req_header(conn, "architecture"),
+      platform: get_metadata_req_header(conn, "platform"),
+      product: get_metadata_req_header(conn, "product"),
+      version: get_metadata_req_header(conn, "version"),
+      author: get_metadata_req_header(conn, "author"),
+      description: get_metadata_req_header(conn, "description"),
+      vcs_identifier: get_metadata_req_header(conn, "vcs-identifier"),
+      misc: get_metadata_req_header(conn, "misc")
+    }
+
+    metadata_or_firmware(params)
+  end
+
+  def metadata_from_firmware(%Firmware{} = firmware) do
+    firmware = Repo.preload(firmware, [:product])
+
+    metadata = %{
+      uuid: firmware.uuid,
+      architecture: firmware.architecture,
+      platform: firmware.platform,
+      product: firmware.product.name,
+      version: firmware.version,
+      author: firmware.author,
+      description: firmware.description,
+      vcs_identifier: firmware.vcs_identifier,
+      misc: firmware.misc
+    }
+
+    {:ok, metadata}
+  end
+
+  def metadata_from_fwup(firmware_file) do
+    with {:ok, fwup_metadata} <- get_fwup_metadata(firmware_file),
+         {:ok, uuid} <- fetch_fwup_metadata_item(fwup_metadata, "meta-uuid"),
+         {:ok, architecture} <- fetch_fwup_metadata_item(fwup_metadata, "meta-architecture"),
+         {:ok, platform} <- fetch_fwup_metadata_item(fwup_metadata, "meta-platform"),
+         {:ok, product} <- fetch_fwup_metadata_item(fwup_metadata, "meta-product"),
+         {:ok, version} <- fetch_fwup_metadata_item(fwup_metadata, "meta-version"),
+         author <- get_fwup_metadata_item(fwup_metadata, "meta-author"),
+         description <- get_fwup_metadata_item(fwup_metadata, "meta-description"),
+         misc <- get_fwup_metadata_item(fwup_metadata, "meta-misc"),
+         vcs_identifier <- get_fwup_metadata_item(fwup_metadata, "meta-vcs-identifier") do
+      metadata = %{
+        uuid: uuid,
+        architecture: architecture,
+        platform: platform,
+        product: product,
+        version: version,
+        author: author,
+        description: description,
+        vcs_identifier: vcs_identifier,
+        misc: misc
+      }
+
+      {:ok, metadata}
+    end
+  end
+
+  def metadata_from_device(metadata) do
+    params = %{
+      uuid: Map.get(metadata, "nerves_fw_uuid"),
+      architecture: Map.get(metadata, "nerves_fw_architecture"),
+      platform: Map.get(metadata, "nerves_fw_platform"),
+      product: Map.get(metadata, "nerves_fw_product"),
+      version: Map.get(metadata, "nerves_fw_version"),
+      author: Map.get(metadata, "nerves_fw_author"),
+      description: Map.get(metadata, "nerves_fw_description"),
+      vcs_identifier: Map.get(metadata, "nerves_fw_vcs_identifier"),
+      misc: Map.get(metadata, "nerves_fw_misc")
+    }
+
+    metadata_or_firmware(params)
+  end
+
+  # Private functions
+
   defp insert_firmware(params) do
     %Firmware{}
     |> Firmware.create_changeset(params)
@@ -206,36 +291,27 @@ defmodule NervesHubWebCore.Firmwares do
     org = NervesHubWebCore.Repo.preload(org, :org_keys)
 
     with {:ok, %{id: org_key_id}} <- verify_signature(filepath, org.org_keys),
-         {:ok, metadata} <- extract_metadata(filepath),
-         {:ok, architecture} <- Firmware.fetch_metadata_item(metadata, "meta-architecture"),
-         {:ok, platform} <- Firmware.fetch_metadata_item(metadata, "meta-platform"),
-         {:ok, product_name} <- Firmware.fetch_metadata_item(metadata, "meta-product"),
-         {:ok, version} <- Firmware.fetch_metadata_item(metadata, "meta-version"),
-         author <- Firmware.get_metadata_item(metadata, "meta-author"),
-         description <- Firmware.get_metadata_item(metadata, "meta-description"),
-         misc <- Firmware.get_metadata_item(metadata, "meta-misc"),
-         uuid <- Firmware.get_metadata_item(metadata, "meta-uuid"),
-         vcs_identifier <- Firmware.get_metadata_item(metadata, "meta-vcs-identifier") do
-      filename = uuid <> ".fw"
+         {:ok, metadata} <- metadata_from_fwup(filepath) do
+      filename = metadata.uuid <> ".fw"
 
       params =
         resolve_product(%{
-          architecture: architecture,
-          author: author,
-          description: description,
+          architecture: metadata.architecture,
+          author: metadata.author,
+          description: metadata.description,
           filename: filename,
           filepath: filepath,
-          misc: misc,
+          misc: metadata.misc,
           org_id: org_id,
           org_key_id: org_key_id,
-          platform: platform,
-          product_name: product_name,
+          platform: metadata.platform,
+          product_name: metadata.product,
           upload_metadata: @uploader.metadata(org_id, filename),
           size: :filelib.file_size(filepath),
           ttl: Map.get(params, :ttl),
-          uuid: uuid,
-          vcs_identifier: vcs_identifier,
-          version: version
+          uuid: metadata.uuid,
+          vcs_identifier: metadata.vcs_identifier,
+          version: metadata.version
         })
 
       {:ok, params}
@@ -277,6 +353,62 @@ defmodule NervesHubWebCore.Firmwares do
       Map.put(params, :product_id, product.id)
     else
       _ -> params
+    end
+  end
+
+  def metadata_or_firmware(metadata) do
+    case FirmwareMetadata.changeset(%FirmwareMetadata{}, metadata).valid? do
+      true ->
+        {:ok, metadata}
+
+      false ->
+        case Map.get(metadata, :uuid) do
+          nil ->
+            {:ok, nil}
+
+          uuid ->
+            case get_firmware_by_uuid(uuid) do
+              {:ok, firmware} -> metadata_from_firmware(firmware)
+              _ -> {:ok, nil}
+            end
+        end
+    end
+  end
+
+  defp get_fwup_metadata(filepath) do
+    case System.cmd("fwup", ["-m", "-i", filepath]) do
+      {metadata, 0} ->
+        {:ok, metadata}
+
+      _error ->
+        {:error}
+    end
+  end
+
+  @spec fetch_fwup_metadata_item(String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, :not_found}
+  defp fetch_fwup_metadata_item(metadata, key) when is_binary(key) do
+    {:ok, regex} = "#{key}=\"(?<item>[^\n]+)\"" |> Regex.compile()
+
+    case Regex.named_captures(regex, metadata) do
+      %{"item" => item} -> {:ok, item}
+      _ -> {:error, {key, :not_found}}
+    end
+  end
+
+  @spec get_fwup_metadata_item(String.t(), String.t(), any()) :: String.t() | nil
+  defp get_fwup_metadata_item(metadata, key, default \\ nil) when is_binary(key) do
+    case fetch_fwup_metadata_item(metadata, key) do
+      {:ok, metadata_item} -> metadata_item
+      {:error, {_, :not_found}} -> default
+    end
+  end
+
+  defp get_metadata_req_header(conn, header) do
+    case Plug.Conn.get_req_header(conn, "x-nerveshub-#{header}") do
+      [] -> nil
+      ["" | _] -> nil
+      [value | _] -> value
     end
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
@@ -148,22 +148,4 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
     firmware_query
     |> preload(:product)
   end
-
-  @spec fetch_metadata_item(String.t(), String.t()) :: {:ok, String.t()} | {:error, :not_found}
-  def fetch_metadata_item(metadata, key) when is_binary(key) do
-    {:ok, regex} = "#{key}=\"(?<item>[^\n]+)\"" |> Regex.compile()
-
-    case Regex.named_captures(regex, metadata) do
-      %{"item" => item} -> {:ok, item}
-      _ -> {:error, :not_found}
-    end
-  end
-
-  @spec get_metadata_item(String.t(), String.t(), any()) :: String.t() | nil
-  def get_metadata_item(metadata, key, default \\ nil) when is_binary(key) do
-    case fetch_metadata_item(metadata, key) do
-      {:ok, metadata_item} -> metadata_item
-      {:error, :not_found} -> default
-    end
-  end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_metadata.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_metadata.ex
@@ -1,0 +1,40 @@
+defmodule NervesHubWebCore.Firmwares.FirmwareMetadata do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @required_params [
+    :uuid,
+    :product,
+    :architecture,
+    :version,
+    :platform
+  ]
+
+  @optional_params [
+    :author,
+    :description,
+    :vcs_identifier,
+    :misc
+  ]
+
+  embedded_schema do
+    field(:uuid)
+    field(:product)
+    field(:version)
+    field(:architecture)
+    field(:platform)
+    field(:author)
+    field(:description)
+    field(:vcs_identifier)
+    field(:misc)
+  end
+
+  def changeset(%__MODULE__{} = metadata, params) do
+    metadata
+    |> cast(params, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
+  end
+end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190209173245_add_device_firmware_metadata_remove_last_link.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190209173245_add_device_firmware_metadata_remove_last_link.exs
@@ -1,0 +1,10 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddDeviceFirmwareMetadataRemoveLastLink do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add :firmware_metadata, :map
+      remove :last_known_firmware_id
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
@@ -7,8 +7,7 @@ defmodule NervesHubWebCore.FirmwaresTest do
     Firmwares,
     Fixtures,
     Support.Fwup,
-    Deployments,
-    Devices
+    Deployments
   }
 
   alias Ecto.Changeset
@@ -251,55 +250,6 @@ defmodule NervesHubWebCore.FirmwaresTest do
       assert firmware.ttl_until == nil
 
       Deployments.delete_deployment(deployment)
-
-      {:ok, firmware} = Firmwares.get_firmware(org, firmware.id)
-
-      assert firmware.ttl != nil
-      assert firmware.ttl_until != nil
-    end
-
-    test "associating firmware with a device unsets ttl", %{
-      org: org,
-      org_key: org_key,
-      product: product
-    } do
-      firmware = Fixtures.firmware_fixture(org_key, product)
-
-      params = %{
-        org_id: org.id,
-        last_known_firmware_id: firmware.id,
-        identifier: "ttl-1"
-      }
-
-      {:ok, _device} = Devices.create_device(params)
-
-      {:ok, firmware} = Firmwares.get_firmware(org, firmware.id)
-
-      assert firmware.ttl != nil
-      assert firmware.ttl_until == nil
-    end
-
-    test "disassociating firmware from a device unsets ttl", %{
-      org: org,
-      org_key: org_key,
-      product: product
-    } do
-      firmware = Fixtures.firmware_fixture(org_key, product)
-
-      params = %{
-        org_id: org.id,
-        last_known_firmware_id: firmware.id,
-        identifier: "ttl-1"
-      }
-
-      {:ok, device} = Devices.create_device(params)
-
-      {:ok, firmware} = Firmwares.get_firmware(org, firmware.id)
-
-      assert firmware.ttl != nil
-      assert firmware.ttl_until == nil
-
-      {:ok, _device} = Devices.delete_device(device)
 
       {:ok, firmware} = Firmwares.get_firmware(org, firmware.id)
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
@@ -23,10 +23,10 @@
         <tr class="item d-flex">
           <td class="col-2"><%= device.identifier %></td>
           <td class="col-2">
-            <%= if is_nil(device.last_known_firmware) do %>
+            <%= if is_nil(device.firmware_metadata) do %>
               unknown
             <% else %>
-              <%= device.last_known_firmware.version %>
+              <%= device.firmware_metadata.version %>
             <% end %>
           </td>
           <td class="col-2 device" data-device-id=<%= "#{device.id}" %>><%= device_status(device) %></td>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/channels/devices_channel_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/channels/devices_channel_test.exs
@@ -97,11 +97,12 @@ defmodule NervesHubWWWWeb.DevicesChannelTest do
     %{socket: socket}
   end
 
-  defp release_deployment(%{
-         device: device
-       }) do
-    %Device{last_known_firmware: %{product: product}, org: org} =
-      NervesHubWebCore.Repo.preload(device, [:org, last_known_firmware: [:product]])
+  defp release_deployment(%{device: device}) do
+    %Device{firmware_metadata: %{product: product_name}, org: org} =
+      NervesHubWebCore.Repo.preload(device, [:org])
+
+    {:ok, product} =
+      NervesHubWebCore.Products.get_product_by_org_id_and_name(org.id, product_name)
 
     uuid = Ecto.UUID.generate()
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -194,10 +194,11 @@ defmodule NervesHubWebCore.Fixtures do
         %Firmwares.Firmware{} = firmware,
         params \\ %{}
       ) do
+    {:ok, metadata} = Firmwares.metadata_from_firmware(firmware)
     {:ok, device} =
       %{
         org_id: org.id,
-        last_known_firmware_id: firmware.id,
+        firmware_metadata: metadata,
         identifier: "device-#{counter()}"
       }
       |> Enum.into(params)


### PR DESCRIPTION
As detailed in https://github.com/nerves-hub/nerves_hub_web/issues/320 our desired functionality is to use the firmware version number supplied with the device connection parameters to determine deployment eligibility. After making that change, it made sense to _always_ use the metadata supplied by the device on the server side. This PR removes the linked `last_know_firmware_id` and adds an embedded schema `firmware_metadata` to the device model.

To get this to fully work, the client will need to be updated to pass the extra metadata for both PhoenixChannel and HTTP requests. The code is structured to allow the current client to remain functional. If _only_ the firmware uuid is provided (the current client), the firmware_metadata will be constructed by first looking up the firmware by uuid. When updating the device.firmware_metadata, if any part fails and returns nil, the device record will not be updated. This behavior will likely change as we migrate to the newer client where every request can include all the metadata by default.