### PR TITLE
Do not remove last_known_firmware_id until data has been migrated.

### DIFF
--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190209173245_add_device_firmware_metadata_remove_last_link.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190209173245_add_device_firmware_metadata_remove_last_link.exs
@@ -4,7 +4,6 @@ defmodule NervesHubWebCore.Repo.Migrations.AddDeviceFirmwareMetadataRemoveLastLi
   def change do
     alter table(:devices) do
       add :firmware_metadata, :map
-      remove :last_known_firmware_id
     end
   end
 end


### PR DESCRIPTION
We need to wait on removing the last known firmware id from the record until we migrate the data in the database. We need to pre populate all the device records in the database with the firmware_metadata from the last firmware record before the last firmware is garbage collected.