### PR TITLE
Multiple firmware

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -61,11 +61,7 @@ defmodule NervesHubWebCore.Firmwares do
       f in Firmware,
       where: f.uuid == ^uuid
     )
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
+    |> Repo.all()
   end
 
   @spec get_firmware_by_org_and_uuid(Org.t(), String.t()) ::
@@ -368,8 +364,8 @@ defmodule NervesHubWebCore.Firmwares do
 
           uuid ->
             case get_firmware_by_uuid(uuid) do
-              {:ok, firmware} -> metadata_from_firmware(firmware)
-              _ -> {:ok, nil}
+              [firmware | _] -> metadata_from_firmware(firmware)
+              [] -> {:ok, nil}
             end
         end
     end


### PR DESCRIPTION
This PR fixes a few edges that were seen in the production logs.

When looking up the firmware in the db, `get_by_firmware_uuid` was expecting there to only be one result. This updates it to more then 1