### PR TITLE
Connect devices to device topic

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/user_socket.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/user_socket.ex
@@ -4,6 +4,7 @@ defmodule NervesHubDeviceWeb.UserSocket do
   ## Channels
   # channel "room:*", NervesHubWWWWeb.RoomChannel
   channel("firmware:*", NervesHubDeviceWeb.DeviceChannel)
+  channel("device", NervesHubDeviceWeb.DeviceChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/device_channel_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/device_channel_test.exs
@@ -1,0 +1,3 @@
+defmodule NervesHubDeviceWeb.DeviceChannelTest do
+  use NervesHubDeviceWeb.ChannelCase
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -112,7 +112,7 @@ defmodule NervesHubWebCore.Devices do
         "device:#{device.id}",
         %Phoenix.Socket.Broadcast{
           event: "update",
-          payload: %{device_id: device.id, firmware_url: url}
+          payload: %{firmware_url: url}
         }
       )
 

--- a/apps/nerves_hub_www/docs/client-server.md
+++ b/apps/nerves_hub_www/docs/client-server.md
@@ -9,8 +9,8 @@ commands and send updates about its current state.
 
 After booting, the client connects to NervesHub with its certificate. The
 certificate is used to determine the unique identity of the device, which is
-then stored on the socket. The device joins `device:#{firmware_uuid}`.  
-The server compares the running version of the firmware
+then stored on the socket. The device joins the topic: `device`.
+The server then compares the running version of the firmware
 to the target version for that device on `NervesHub`. If those versions are
 different, then the channel queues a firmware update message to be sent as soon
 as the channel finishes the join process. The final step of the join process is


### PR DESCRIPTION
This transitions devices from connecting to the topic `firmware:#{firmware.uuid}` to `device`. The existing `firmware:*` are internally routed to the `device` join logic.