### PR TITLE
Force device certificates to match on serial, aki, and validity

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubAPIWeb.DeviceController do
   use NervesHubAPIWeb, :controller
 
-  alias NervesHubWebCore.{Certificate, Devices, Devices.DeviceCertificate}
+  alias NervesHubWebCore.{Devices, Devices.DeviceCertificate}
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
@@ -51,9 +51,8 @@ defmodule NervesHubAPIWeb.DeviceController do
   def auth(%{assigns: %{org: org}} = conn, %{"certificate" => cert64}) do
     with {:ok, cert_pem} <- Base.decode64(cert64),
          {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
-         serial <- Certificate.get_serial_number(cert),
          {:ok, %DeviceCertificate{device_id: device_id}} <-
-           Devices.get_device_certificate_by_serial(serial),
+           Devices.get_device_certificate_by_x509(cert),
          {:ok, device} <- Devices.get_device_by_org(org, device_id) do
       conn
       |> put_status(200)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_certificate_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule NervesHubAPIWeb.DeviceCertificateControllerTest do
   use NervesHubAPIWeb.ConnCase, async: true
 
-  alias NervesHubWebCore.{Devices, Certificate}
+  alias NervesHubWebCore.Devices
 
   setup context do
     org = context.org
@@ -36,8 +36,7 @@ defmodule NervesHubAPIWeb.DeviceCertificateControllerTest do
       assert %{"cert" => cert} = resp_data
 
       cert = X509.Certificate.from_pem!(cert)
-      serial = Certificate.get_serial_number(cert)
-      {:ok, cert} = Devices.get_device_certificate_by_serial(serial)
+      {:ok, cert} = Devices.get_device_certificate_by_x509(cert)
 
       assert cert.device_id == device.id
     end

--- a/apps/nerves_hub_device/lib/nerves_hub_device/ssl.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/ssl.ex
@@ -41,9 +41,7 @@ defmodule NervesHubDevice.SSL do
   end
 
   def verify_device(certificate) do
-    serial = Certificate.get_serial_number(certificate)
-
-    case Devices.get_device_certificate_by_serial(serial) do
+    case Devices.get_device_certificate_by_x509(certificate) do
       {:ok, cert} ->
         Devices.update_device_certificate(cert, %{last_used: DateTime.utc_now()})
         {:ok, cert}

--- a/apps/nerves_hub_device/test/nerves_hub_device/ssl_test.ex
+++ b/apps/nerves_hub_device/test/nerves_hub_device/ssl_test.ex
@@ -1,0 +1,118 @@
+defmodule NervesHubDevice.SSLTest do
+  use NervesHubDevice.DataCase, async: true
+
+  alias NervesHubWebCore.Fixtures
+
+  test "verify a certificate" do
+    org = Fixtures.org_fixture(%{name: "verify_device"})
+    product = Fixtures.product_fixture(org)
+    org_key = Fixtures.org_key_fixture(org)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    identifier = "1234"
+
+    %{cert: ca1, key: ca1_key} = Fixtures.ca_certificate_fixture(org)
+    %{cert: ca2, key: ca2_key} = Fixtures.ca_certificate_fixture(org)
+
+    assert ca1 != ca2
+
+    key1 = X509.PrivateKey.new_ec(:secp256r1)
+    key2 = X509.PrivateKey.new_ec(:secp256r1)
+
+    cert1 =
+      key1
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{identifier}", ca1, ca1_key)
+
+    cert2 =
+      key2
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{identifier}", ca2, ca2_key)
+
+    device1 = Fixtures.device_fixture(org, firmware, %{identifier: identifier})
+    db_cert1 = Fixtures.device_certificate_fixture(device1, cert1)
+
+    device2 = Fixtures.device_fixture(org, firmware, %{identifier: identifier})
+    db_cert2 = Fixtures.device_certificate_fixture(device2, cert2)
+
+    assert {:ok, ^db_cert1} = NervesHubDevice.SSL.verify_device(cert1)
+    assert {:ok, ^db_cert2} = NervesHubDevice.SSL.verify_device(cert2)
+  end
+
+  test "refuse a certificate with unknown ca" do
+    ca_key = X509.PrivateKey.new_ec(:secp256r1)
+    ca = X509.Certificate.self_signed(ca_key, "CN=refuse_conn", template: :root_ca)
+
+    key = X509.PrivateKey.new_ec(:secp256r1)
+
+    cert =
+      key
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=1234", ca, ca_key)
+
+    assert :error = NervesHubDevice.SSL.verify_device(cert)
+  end
+
+  test "refuse a certificate with same serial but unknown signer" do
+    org = Fixtures.org_fixture(%{name: "refuse_device"})
+    product = Fixtures.product_fixture(org)
+    org_key = Fixtures.org_key_fixture(org)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    identifier = "1234"
+
+    %{cert: ca1, key: ca1_key} = Fixtures.ca_certificate_fixture(org)
+    ca2_key = X509.PrivateKey.new_ec(:secp256r1)
+    ca2 = X509.Certificate.self_signed(ca2_key, "CN=refuse_conn", template: :root_ca)
+
+    assert ca1 != ca2
+
+    key1 = X509.PrivateKey.new_ec(:secp256r1)
+    key2 = X509.PrivateKey.new_ec(:secp256r1)
+
+    cert1 =
+      key1
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{identifier}", ca1, ca1_key, serial: 999_999)
+
+    cert2 =
+      key2
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{identifier}", ca2, ca2_key, serial: 999_999)
+
+    device1 = Fixtures.device_fixture(org, firmware, %{identifier: identifier})
+    db_cert1 = Fixtures.device_certificate_fixture(device1, cert1)
+
+    assert {:ok, ^db_cert1} = NervesHubDevice.SSL.verify_device(cert1)
+    assert :error = NervesHubDevice.SSL.verify_device(cert2)
+  end
+
+  test "refuse a certificate with same serial but different validity" do
+    org = Fixtures.org_fixture(%{name: "refuse_device"})
+    product = Fixtures.product_fixture(org)
+    org_key = Fixtures.org_key_fixture(org)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    identifier = "1234"
+
+    %{cert: ca1, key: ca1_key} = Fixtures.ca_certificate_fixture(org)
+
+    key1 = X509.PrivateKey.new_ec(:secp256r1)
+
+    cert1 =
+      key1
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{identifier}", ca1, ca1_key, serial: 999_999, validity: 1)
+
+    cert2 =
+      key1
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{identifier}", ca1, ca1_key, serial: 999_999, validity: 2)
+
+    device1 = Fixtures.device_fixture(org, firmware, %{identifier: identifier})
+    db_cert1 = Fixtures.device_certificate_fixture(device1, cert1)
+
+    assert {:ok, ^db_cert1} = NervesHubDevice.SSL.verify_device(cert1)
+    assert :error = NervesHubDevice.SSL.verify_device(cert2)
+  end
+end

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
@@ -320,9 +320,19 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
     end
   end
 
-  def wait_for_socket(socket) do
-    unless Socket.connected?(socket) do
-      wait_for_socket(socket)
+  def wait_for_socket(_, _ \\ nil)
+
+  def wait_for_socket(socket, nil) do
+    timeout = 2_000
+    {:ok, t_ref} = :timer.exit_after(timeout, "Timed out waiting for socket")
+    wait_for_socket(socket, t_ref)
+  end
+
+  def wait_for_socket(socket, timer) do
+    if Socket.connected?(socket) do
+      :timer.cancel(timer)
+    else
+      wait_for_socket(socket, timer)
     end
   end
 end

--- a/apps/nerves_hub_device/test/support/data_case.ex
+++ b/apps/nerves_hub_device/test/support/data_case.ex
@@ -1,0 +1,53 @@
+defmodule NervesHubDevice.DataCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the application's data layer.
+
+  You may define functions here to be used as helpers in
+  your tests.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias NervesHubWebCore.Repo
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+      import NervesHubWebCore.DataCase
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(NervesHubWebCore.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(NervesHubWebCore.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+
+  @doc """
+  A helper that transform changeset errors to a map of messages.
+
+      assert {:error, changeset} = Accounts.create_user(%{password: "short"})
+      assert "password is too short" in errors_on(changeset).password
+      assert %{password: ["password is too short"]} = errors_on(changeset)
+
+  """
+  def errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Enum.reduce(opts, message, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -176,21 +176,26 @@ defmodule NervesHubWebCore.Devices do
     end
   end
 
-  def get_device_certificate_by_serial(serial) do
+  def get_device_certificate_by_x509(cert) do
+    aki = NervesHubWebCore.Certificate.get_aki(cert)
+    serial = NervesHubWebCore.Certificate.get_serial_number(cert)
+    {not_before, not_after} = NervesHubWebCore.Certificate.get_validity(cert)
+
     query =
       from(
         c in DeviceCertificate,
-        where: c.serial == ^serial
+        where:
+          c.serial == ^serial and
+            c.aki == ^aki and
+            c.not_before == ^not_before and
+            c.not_after == ^not_after
       )
 
     query
     |> Repo.one()
     |> case do
-      nil ->
-        {:error, :not_found}
-
-      certificate ->
-        {:ok, certificate}
+      nil -> {:error, :not_found}
+      certificate -> {:ok, certificate}
     end
   end
 

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -120,11 +120,10 @@ defmodule NervesHubWebCore.DevicesTest do
   test "delete_device deletes its certificates", %{
     device: device
   } do
-    [cert] = Devices.get_device_certificates(device)
+    [_cert] = Devices.get_device_certificates(device)
 
     {:ok, _device} = Devices.delete_device(device)
-
-    assert {:error, _} = Devices.get_device_certificate_by_serial(cert.serial)
+    assert [] = Devices.get_device_certificates(device)
   end
 
   test "create_device with invalid parameters", %{firmware: firmware} do


### PR DESCRIPTION
This PR updates the logic which queries the database for existing trusted device certificates to match on serial, authority key id, and validity. This fixes a case where a signer or multiple signers would create certificates with the same certificate serial number.