### PR TITLE
Prevent user orgs from changing name or inviting users

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -1,9 +1,10 @@
 <h1>
-  Organization settings
-
+  <%= @org.name %> settings
+  <%= if @org.type != :user do %>
   <a class="btn btn-lg btn-success pull-right" href="<%= org_path(@conn, :invite) %>">
     Invite user
   </a>
+  <% end %>
 </h1>
 
 <table class="table table-striped">
@@ -30,23 +31,25 @@
   </div>
 </table>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    Profile
-  </div>
+<%= if @org.type != :user do %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      Profile
+    </div>
 
-  <div class="panel-body">
-    <%= form_for @org_changeset, org_path(@conn, :update, @org), fn f -> %>
-      <div class="form-group">
-        <label for="name_input">Name</label>
-        <%= text_input f, :name, class: "form-control", id: "name_input" %>
-        <div class="has-error"><%= error_tag f, :name %></div>
-      </div>
+    <div class="panel-body">
+        <%= form_for @org_changeset, org_path(@conn, :update, @org), fn f -> %>
+          <div class="form-group">
+            <label for="name_input">Name</label>
+            <%= text_input f, :name, class: "form-control", id: "name_input" %>
+            <div class="has-error"><%= error_tag f, :name %></div>
+          </div>
 
-      <%= submit "Update organization", class: "btn btn-primary" %>
-    <% end %>
+          <%= submit "Update organization", class: "btn btn-primary" %>
+        <% end %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <div class="panel panel-default">
   <div class="panel-heading">


### PR DESCRIPTION
This updates the Web interface to prevent `user` type orgs from changing their name. This also removes the ability for a user to be invited to administrate another user's default org. 
In the future, users will be given roles on individual projects. 