### PR TITLE
Show more/better device info on the frontend

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.eex
@@ -12,7 +12,7 @@
       <thead>
         <tr class="d-flex">
           <th class="col-2">Identifier</th>
-          <th class="col-2">Version</th>
+          <th class="col-2">Firmware Info</th>
           <th class="col-2">Status</th>
           <th class="col-2">Last Connection</th>
           <th class="col-2">Tags</th>
@@ -21,12 +21,21 @@
       </thead>
       <%= for device <- @devices do %>
         <tr class="item d-flex">
-          <td class="col-2"><%= device.identifier %></td>
+          <td class="col-2">
+            <a href="<%= device_path(@conn, :show, device.id) %>" class="">
+              <%= device.identifier %>
+            </a>
+          </td>
           <td class="col-2">
             <%= if is_nil(device.firmware_metadata) do %>
               unknown
             <% else %>
-              <%= device.firmware_metadata.version %>
+              <p>
+                <strong>Version:</strong> <%= device.firmware_metadata.version %>
+              </p>
+              <p>
+                <strong>UUID:</strong> <%= device.firmware_metadata.uuid %>
+              </p>
             <% end %>
           </td>
           <td class="col-2 device" data-device-id=<%= "#{device.id}" %>><%= device_status(device) %></td>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.eex
@@ -1,12 +1,41 @@
 <h2>Show Device</h2>
 
+<p>
+  <strong>Identifier:</strong> <%= @device.identifier %>
+</p>
+
+<p>
+  <strong>Firmware Info:</strong>
+</p>
+
 <ul>
-
-  <li>
-    <strong>Identifier:</strong>
-    <%= @device.identifier %>
-  </li>
-
+  <%= for kv <- Map.from_struct(@device.firmware_metadata) do %>
+    <li><strong><%= elem(kv, 0) %>: </strong> <%= elem(kv, 1) %></li>
+  <% end %>
 </ul>
 
-<span><%= link "Back", to: device_path(@conn, :index) %></span>
+<p>
+  <strong>Status:</strong> <%= device_status(@device) %>
+</p>
+
+<p>
+  <strong>Last Connection:</strong>
+  <%= if is_nil(@device.last_communication) do %>
+    never
+  <% else %>
+    <%= @device.last_communication %>
+  <% end %>
+</p>
+
+<p>
+  <strong>Tags:</strong>
+  <%= for tag <- (@device.tags || []) do %>
+    <span class="badge">
+      <%= tag %>
+    </span>
+  <% end %>
+</p>
+
+<div>
+  <%= link "Back", to: device_path(@conn, :index), class: "btn btn-info"%>
+</div>


### PR DESCRIPTION
Why:

* There's a lot of room for improvement
* https://github.com/nerves-hub/nerves_hub_web/issues/381

This change addresses the need by:

* Add the `uuid` to the firmware info on the devices table.
* Change the device identifier in the devices table to a link to the
show page for that device.
* Also added info do the device show page