### PR TITLE
add note in README.md about nerves-hub.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ On Debian/Ubuntu, you will also need to install the following packages:
 sudo apt install docker-compose inotify-tools
 ```
 
+Local development uses the host `nerves-hub.org` for connections and cert validation. To properly map to your local running server, you'll need to add a host record for it:
+
+```sh
+echo "127.0.0.1 nerves-hub.org" | sudo tee -a /etc/hosts
+```
+
 ### First time application setup
 
 1. Create directory for local data storage: `mkdir ~/db`


### PR DESCRIPTION
Looks like local development expects to connect to `nerves-hub.org:4000`. When its not mapped,the logs explode with errors. I _believe_ it is required for dev cert setup, but correct me if Im wrong. Adding a note in here to help others