### PR TITLE
fix device#show when firmware_metadata: nil

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.eex
@@ -9,8 +9,10 @@
 </p>
 
 <ul>
-  <%= for kv <- Map.from_struct(@device.firmware_metadata) do %>
-    <li><strong><%= elem(kv, 0) %>: </strong> <%= elem(kv, 1) %></li>
+  <% if @device.firmware_metadata do %>
+    <%= for kv <- Map.from_struct(@device.firmware_metadata) do %>
+      <li><strong><%= elem(kv, 0) %>: </strong> <%= elem(kv, 1) %></li>
+    <% end %>
   <% end %>
 </ul>
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -118,4 +118,19 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       end)
     end
   end
+
+  describe "show" do
+    test "renders show page", %{conn: conn, current_org: org} do
+      [device | _] = Devices.get_devices(org)
+      show_conn = get(conn, device_path(conn, :show, device.id))
+      assert html_response(show_conn, 200) =~ "<h2>Show Device</h2>"
+    end
+
+    test "renders show page when firmware_metadata is nil", %{conn: conn, current_org: org} do
+      [device | _] = Devices.get_devices(org)
+      {:ok, device} = Devices.update_device(device, %{firmware_metadata: nil})
+      show_conn = get(conn, device_path(conn, :show, device.id))
+      assert html_response(show_conn, 200) =~ "<h2>Show Device</h2>"
+    end
+  end
 end


### PR DESCRIPTION
This is kind of an edge case, but I have devices created without any firmware meta data. This was done from the CLI using `nerves_hub.device create`. Then trying to update or view the device would fail. So protect a little bit here so #show still renders when `firmware_metadata` is nil on a device