### PR TITLE
fix invitations to support existing users

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
@@ -408,6 +408,17 @@ defmodule NervesHubWebCore.Accounts do
     OrgKey.update_changeset(org_key, params)
   end
 
+  @spec add_or_invite_to_org(%{required(String.t()) => String.t()}, Org.t()) ::
+          {:ok, Invite.t()}
+          | {:ok, OrgUser.t()}
+          | {:error, Changeset.t()}
+  def add_or_invite_to_org(%{"email" => email} = params, org) do
+    case get_user_by_email(email) do
+      {:error, :not_found} -> invite(params, org)
+      {:ok, user} -> add_org_user(org, user, %{role: :admin})
+    end
+  end
+
   @spec invite(%{email: String.t()}, Org.t()) ::
           {:ok, Invite.t()}
           | {:error, Changeset.t()}

--- a/apps/nerves_hub_www/lib/nerves_hub_www/accounts/email.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www/accounts/email.ex
@@ -23,4 +23,13 @@ defmodule NervesHubWWW.Accounts.Email do
     |> put_layout({NervesHubWWWWeb.LayoutView, :email})
     |> render("forgot_password.html", user: user)
   end
+
+  def org_user_created(email, %Org{} = org) do
+    new_email()
+    |> from(@from)
+    |> to(email)
+    |> subject("New NervesHub Organization Added")
+    |> put_layout({NervesHubWWWWeb.LayoutView, :email})
+    |> render("org_user_created.html", org: org)
+  end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/org_user_created.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/org_user_created.html.eex
@@ -1,0 +1,5 @@
+<p>You've been added to the <strong><%= @org.name %><strong> organization on nerves-hub.org.</p>
+
+<p><a href="<%= "#{base_url()}/login" %>">Login</a> to view it's details.</p>
+
+

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
@@ -9,8 +9,9 @@
   <%= form_for @changeset, org_path(@conn, :send_invite), fn f -> %>
     <div class="form-group">
       <label for="email_input">Email</label>
-      <%= email_input f, :email, class: "form-control", id: "email_input" %>
+      <%= email_input f, :email, class: "form-control", id: "email_input", value: assigns[:email] %>
       <div class="has-error"><%= error_tag f, :email %></div>
+      <div class="has-error"><%= error_tag f, :org_users %></div>
     </div>
 
     <%= submit "Send Invite", class: "btn btn-success" %>

--- a/apps/nerves_hub_www/test/nerves_hub_www/accounts/email_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www/accounts/email_test.exs
@@ -31,4 +31,15 @@ defmodule NervesHubWWW.Accounts.EmailTest do
     assert email.html_body =~
              "#{EmailView.base_url()}/password-reset/#{user.password_reset_token}"
   end
+
+  test "org user created email" do
+    org = %Org{name: "My Org Name"}
+
+    email = Email.org_user_created("nunya@bidness.com", org)
+
+    assert email.to == "nunya@bidness.com"
+
+    assert email.html_body =~
+             "You've been added to the <strong>#{org.name}<strong> organization on nerves-hub.org."
+  end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -80,4 +80,34 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
       assert html_response(conn, 200) =~ "be blank"
     end
   end
+
+  describe "send invite" do
+    test "sends invite when user does not exist", %{conn: conn, current_org: org} do
+      conn = post(conn, org_path(conn, :send_invite), invite: %{email: "nunya@bid.ness"})
+
+      assert redirected_to(conn) == org_path(conn, :edit, org.id)
+
+      redirected_conn = get(conn, redirected_to(conn))
+
+      assert html_response(redirected_conn, 200) =~ "User has been invited"
+    end
+
+    test "creates OrgUser when user already exists", %{conn: conn, current_org: org} do
+      user = Fixtures.user_fixture(%{email: "who@der.com"})
+      conn = post(conn, org_path(conn, :send_invite), invite: %{email: user.email})
+
+      assert redirected_to(conn) == org_path(conn, :edit, org.id)
+
+      redirected_conn = get(conn, redirected_to(conn))
+
+      assert html_response(redirected_conn, 200) =~ "User has been added to #{org.name}"
+    end
+
+    test "errors when user exists and already member of org", %{conn: conn, current_user: user} do
+      conn = post(conn, org_path(conn, :send_invite), invite: %{email: user.email})
+
+      assert html_response(conn, 200) =~ user.email
+      assert html_response(conn, 200) =~ "is already member"
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/nerves-hub/nerves_hub_web/issues/317

This will now attempt a user lookup when you try to invite a user to an org.
* If user exists, adds user to the org and sends an email to user to notify
* If user does not exist, functions the same as before (sending an invitation)
* If user exists _and_ already belongs to the org, reports back to org#edit that the user is already a member