### PR TITLE
Configure LiveView signing salt from prod runtime container environment

### DIFF
--- a/apps/nerves_hub_www/config/prod.exs
+++ b/apps/nerves_hub_www/config/prod.exs
@@ -18,7 +18,8 @@ config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
   server: true,
   url: [host: "www.nerves-hub.org", port: 80],
   secret_key_base: "${SECRET_KEY_BASE}",
-  force_ssl: [rewrite_on: [:x_forwarded_proto]]
+  force_ssl: [rewrite_on: [:x_forwarded_proto]],
+  live_view: [signing_salt: "${LIVE_VIEW_SIGNING_SALT}"]
 
 config :nerves_hub_device, NervesHubDeviceWeb.Endpoint, server: false
 


### PR DESCRIPTION
This will move the value of this variable from being set at compile time to being set from the container runtime. It will pull it from AWS Parameter Store.