### PR TITLE
Add structure for Audit Logs

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/audit_log.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/audit_log.ex
@@ -1,0 +1,31 @@
+defmodule NervesHubWebCore.Accounts.AuditLog do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import EctoEnum
+
+  alias NervesHubWebCore.Accounts.{Org, User}
+  alias NervesHubWebCore.Types.Resource
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @required_params [:action, :actor_id, :actor_type, :params, :resource_id, :resource_type]
+
+  defenum(Action, :action, [:create, :update, :delete])
+
+  schema "audit_logs" do
+    field(:action, Action)
+    field(:actor_id, :id)
+    field(:actor_type, Resource)
+    field(:params, :map)
+    field(:resource_id, :id)
+    field(:resource_type, Resource)
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(%__MODULE__{} = audit_log, params) do
+    audit_log
+    |> cast(params, @required_params)
+    |> validate_required(@required_params)
+  end
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/types.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/types.ex
@@ -25,4 +25,48 @@ defmodule NervesHubWebCore.Types do
     def load(tags), do: Ecto.Type.load(type(), tags)
     def dump(tags), do: Ecto.Type.dump(type(), tags)
   end
+
+  defmodule Resource do
+    @behaviour Ecto.Type
+
+    def type, do: :string
+
+    def cast(resource) when is_atom(resource) do
+      resource
+      |> to_string()
+      |> cast()
+    end
+
+    def cast(resource) when is_bitstring(resource) do
+      if resource in allowed_resources() do
+        {:ok, String.to_existing_atom(resource)}
+      else
+        :error
+      end
+    end
+
+    def cast(_resource), do: :error
+
+    def dump(resource) when is_atom(resource), do: dump(to_string(resource))
+
+    def dump(resource) when is_bitstring(resource) do
+      if resource in allowed_resources() do
+        {:ok, resource}
+      else
+        :error
+      end
+    end
+
+    def dump(_resource), do: :error
+
+    def load(resource), do: {:ok, String.to_existing_atom(resource)}
+
+    defp allowed_resources do
+      {:ok, modules} = :application.get_key(:nerves_hub_web_core, :modules)
+
+      for module <- modules,
+          Keyword.has_key?(module.__info__(:functions), :__schema__),
+          do: to_string(module)
+    end
+  end
 end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190403164436_create_audit_logs.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190403164436_create_audit_logs.exs
@@ -1,0 +1,25 @@
+defmodule NervesHubWebCore.Repo.Migrations.CreateAuditLogs do
+  use Ecto.Migration
+
+  alias NervesHubWebCore.Accounts.AuditLog.Action
+
+  def change do
+    Action.create_type()
+
+    create table(:audit_logs, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+
+      add(:action, Action.type(), null: false)
+      add(:actor_id, :id, null: false)
+      add(:actor_type, :string, null: false)
+      add(:params, :map, null: false)
+      add(:resource_id, :id, null: false)
+      add(:resource_type, :string, null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    index(:audit_logs, [:actor_id, :actor_type])
+    index(:audit_logs, [:resource_type, :resource_id])
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/types_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/types_test.exs
@@ -1,0 +1,40 @@
+defmodule NervesHubWebCore.TypesTest do
+  use ExUnit.Case, async: true
+
+  alias NervesHubWebCore.Types
+  alias NervesHubWebCore.Accounts.AuditLog
+
+  describe "resource" do
+    test "type" do
+      assert Types.Resource.type() == :string
+    end
+
+    test "cast" do
+      # Valid cast
+      assert Types.Resource.cast(AuditLog) == {:ok, AuditLog}
+      assert Types.Resource.cast(to_string(AuditLog)) == {:ok, AuditLog}
+
+      # Invalid cast
+      assert Types.Resource.cast("AuditLog") == :error
+      assert Types.Resource.cast(NervesHubWebCore) == :error
+      assert Types.Resource.cast(:wat) == :error
+      assert Types.Resource.cast(1234) == :error
+    end
+
+    test "dump" do
+      # Valid dump
+      assert Types.Resource.dump(AuditLog) == {:ok, to_string(AuditLog)}
+      assert Types.Resource.dump(to_string(AuditLog)) == {:ok, to_string(AuditLog)}
+
+      # Invalid dump
+      assert Types.Resource.dump("AuditLog") == :error
+      assert Types.Resource.dump(NervesHubWebCore) == :error
+      assert Types.Resource.dump(:wat) == :error
+      assert Types.Resource.dump(1234) == :error
+    end
+
+    test "load" do
+      assert Types.Resource.load(to_string(AuditLog)) == {:ok, AuditLog}
+    end
+  end
+end


### PR DESCRIPTION
Initial structure to start saving audit logs (no implementation). Heavily inspired by [Hexpm audit log](https://github.com/hexpm/hexpm/blob/master/lib/hexpm/accounts/audit_log.ex)
* adds `NervesHubWebCore.Accounts.AuditLog` schema
* adds `NervesHubWebCore.Types.Resource` to handle the resource type of AuditLog
* migration to create table and fields for AuditLog

Few things to note:
* The `resource_type` is stored in the DB as a string, but when loaded it represented as an atom of an existing module. I went back and forth on whether to just have it as a string when loaded in the structs and changesets so if you have an opinion, speak up. My guess is we might want to do more with the atom, but maybe not? It'd also be a really easy change later on without affecting the DB
* `resource_type` is only valid if its a module that uses Ecto.Schema and is a runtime check. I'd actually prefer this to be compile time, but that's a bigger change so I'd rather do that separately next. (see `NervesHubWebCore.Types.Resource.allowed_resources/0`)
* ~~`User` and `Org` associations are included more as a convenience but this should still support instances where user or org may not be involved (like device reboot report, etc)~~