### PR TITLE
Note tags are comma delimited in edit.leex

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
@@ -15,7 +15,7 @@
 
 <%= form_for @changeset, "#", [phx_change: :validate, phx_submit: :save], fn f -> %>
   <div class="form-group">
-    <label for="tags">Tags</label>
+    <label for="tags"><strong>Tags</strong> <i>(comma delimited)<i/></label>
     <%= text_input f, :tags, class: "form-control", id: "tags", value: tags_to_string(@changeset) %>
     <div class="has-error"><%= error_tag f, :tags %></div>
   </div>


### PR DESCRIPTION
Last part of https://github.com/nerves-hub/nerves_hub_web/issues/379

Forgot to add a note when editing/adding tags to specify they are comma delimited, so adding here.

![device_tags_comma_delimit_note](https://user-images.githubusercontent.com/11321326/55562823-f5875d00-56b1-11e9-97c3-867583321ecd.png)
