### PR TITLE
Display more info for Account Certificates

### DIFF
--- a/apps/nerves_hub_www/assets/js/app.js
+++ b/apps/nerves_hub_www/assets/js/app.js
@@ -1,15 +1,15 @@
 import 'phoenix_html'
 import 'bootstrap'
 import LiveSocket from 'phoenix_live_view'
+let dates = require('./dates')
 
 let liveSocket = new LiveSocket('/live')
 liveSocket.connect()
 
+document.querySelectorAll('.date-time').forEach(d => {
+  d.innerHTML = dates.formatDateTime(d.innerHTML)
+})
+
 if (window.location.pathname === '/devices') {
   require('./socket')
-  let dates = require('./dates')
-
-  document.querySelectorAll('.date-time').forEach(d => {
-    d.innerHTML = dates.formatLastCommunication(d.innerHTML)
-  })
 }

--- a/apps/nerves_hub_www/assets/js/dates.js
+++ b/apps/nerves_hub_www/assets/js/dates.js
@@ -1,12 +1,20 @@
-let formatLastCommunication = last_communication => {
-  last_communication = last_communication.trim()
+let formatDateTime = datetime => {
+  /*
+    Safari wants strict iso8601 format "YYYY-MM-DDTHH:MM:SSZ",
+    but elixir to_string default supplies as "YYYY-MM-DD HH:MM:SSZ".
+    So this attempts to transform the dates if needed
+  */
+  datetime = datetime
+    .trim()
+    .split(' ')
+    .join('T')
 
-  if (last_communication == 'never') {
-    return last_communication
+  if (datetime == 'never' || datetime == '') {
+    return datetime
   } else {
-    const date = new Date(last_communication)
+    const date = new Date(datetime)
     return date.toLocaleString('en-US', { timeZoneName: 'short' })
   }
 }
 
-module.exports = { formatLastCommunication }
+module.exports = { formatDateTime }

--- a/apps/nerves_hub_www/assets/js/dates.test.js
+++ b/apps/nerves_hub_www/assets/js/dates.test.js
@@ -1,20 +1,20 @@
 const dates = require('./dates')
 
-describe('formatLastCommunication', () => {
+describe('formatDateTime', () => {
   test('formats ISO 8601 dates', () => {
     let date = new Date()
 
     date.setMilliseconds(0)
-    expect(
-      new Date(dates.formatLastCommunication(date.toISOString())).getTime()
-    ).toBe(date.getTime())
+    expect(new Date(dates.formatDateTime(date.toISOString())).getTime()).toBe(
+      date.getTime()
+    )
   })
 
   test('preserves "never" value', () => {
-    expect(dates.formatLastCommunication('never')).toBe('never')
+    expect(dates.formatDateTime('never')).toBe('never')
   })
 
   test('handles white space around "never" value', () => {
-    expect(dates.formatLastCommunication(' never  ')).toBe('never')
+    expect(dates.formatDateTime(' never  ')).toBe('never')
   })
 })

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -1,25 +1,41 @@
-<h1>
-  Account Certificates
-</h1>
-
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>Description</th>
-      <th>Serial</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= for certificate <- @certificates do %>
-      <tr>
-        <td><%= certificate.description %></td>
-        <td><%= certificate.serial %></td>
-        <td>
-          <%= link "Delete", to: account_certificate_path(@conn, :delete, certificate), class: "btn btn-danger", method: :delete, data: [confirm: "Are you sure?"]  %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<span><%= link "New Certificate", to: account_certificate_path(@conn, :new) %></span>
+<h2>Account Certificates <span><%= button "", class: "btn btn-success fa fa-plus", title: "Create New Account Certificate", to: account_certificate_path(@conn, :new), method: :get %></span></h2>
+<div class="row">
+  <div class="w-100 shadow nhw_list">
+    <div class="card">
+      <table id="account_certificates" class="table">
+        <thead>
+          <tr class="d-flex">
+            <th class="col-2">Description</th>
+            <th class="col-2">Serial</th>
+            <th class="col-2">Last Used</th>
+            <th class="col-2">Not Before</th>
+            <th class="col-2">Not After</th>
+            <th class="col-2"></th>
+          </tr>
+        </thead>
+        <%= for cert <- @certificates do %>
+          <tr class="item d-flex">
+            <td class="col-2">
+              <%= cert.description %>
+            </td>
+            <td class="col-2">
+              <%= cert.serial %>
+            </td>
+            <td class="col-2 date-time">
+              <%= cert.last_used %>
+            </td>
+            <td class="col-2 date-time">
+              <%= cert.not_before %>
+            </td>
+            <td class="col-2 date-time">
+              <%= cert.not_after %>
+            </td>
+            <td class="col-2">
+              <center><%= link "Delete", class: "btn btn-danger", to: account_certificate_path(@conn, :delete, cert), method: :delete, data: [confirm: "Are you sure?"]%></center>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
* Adjusts `account_certificates#index` html to display more info about certs
* adjusts date.js to fix displaying dates in Safari

Fixes https://github.com/nerves-hub/nerves_hub_web/issues/389
Fixes https://github.com/nerves-hub/nerves_hub_web/issues/347

![image](https://user-images.githubusercontent.com/11321326/55573620-ad733500-56c7-11e9-9dee-bbdfadec8826.png)
