### PR TITLE
Add redirect for NervesKey info

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/nerves_key_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/nerves_key_controller.ex
@@ -1,0 +1,7 @@
+defmodule NervesHubWWWWeb.NervesKeyController do
+  use NervesHubWWWWeb, :controller
+
+  def index(conn, _params) do
+    redirect(conn, external: "https://github.com/nerves-hub/nerves_key")
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -49,6 +49,8 @@ defmodule NervesHubWWWWeb.Router do
     end
 
     get("/sponsors", SponsorController, :index)
+
+    get("/nerves_key", NervesKeyController, :index)
   end
 
   scope "/", NervesHubWWWWeb do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
@@ -6,6 +6,7 @@
         NervesHub
       </h6>
       <a href="https://github.com/nerves-hub">Source code</a>
+      <a href="<%= nerves_key_path(@conn, :index) %>">NervesKey</a>
       <a href="<%= sponsor_path(@conn, :index) %>">Sponsors</a>
     </div>
     <div class="p-2 bd-highlight">

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/nerves_key_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/nerves_key_controller_test.exs
@@ -1,0 +1,10 @@
+defmodule NervesHubWWWWeb.NervesKeyControllerTest do
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
+
+  test "renders nerves_key", %{
+    conn: conn
+  } do
+    conn = get(conn, nerves_key_path(conn, :index))
+    assert html_response(conn, 302) =~ "https://github.com/nerves-hub/nerves_key"
+  end
+end


### PR DESCRIPTION
This adds support for the https://nerves-hub.org/nerves_key address for
users wanting to find out more about the NervesKey. Currently it
redirects to the GitHub location.