### PR TITLE
Record time on device disconnect

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -64,6 +64,13 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     {:noreply, socket}
   end
 
+  def terminate(reason, %{assigns: %{device: device}} = socket) do
+    Devices.update_device(device, %{last_communication: DateTime.utc_now()})
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
   defp get_certificate(%{assigns: %{certificate: certificate}}), do: {:ok, certificate}
 
   defp get_certificate(_), do: {:error, :no_device_or_org}


### PR DESCRIPTION
Fixes https://github.com/nerves-hub/nerves_hub_web/issues/365

This assumes that a device socket being terminated is a "last connection"
and piggy backs on that field. So looking at the status of `offline`, you
would assume the `last_connection` time being displayed is when it disconnected.

I debated adding a new field for this so open to that if others would rather that be implemented.