### PR TITLE
Support email addresses with capital letters

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
@@ -159,7 +159,6 @@ defmodule NervesHubWebCore.Accounts do
           {:ok, User.t()}
           | {:error, :authentication_failed}
   def authenticate(email, password) do
-    email = String.downcase(email)
     user = Repo.get_by(User, email: email)
 
     with %User{} <- user,

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -182,6 +182,24 @@ defmodule NervesHubWebCore.AccountsTest do
     end
   end
 
+  test "authenticate with an email address with a capital letter" do
+    expected_email = "ThatsTesty@mctesterson.com"
+
+    params = %{
+      username: "Testy-McTesterson",
+      org_name: "mctesterson.com",
+      email: expected_email,
+      password: "test_password"
+    }
+
+    {:ok, %User{} = user} = Accounts.create_user(params)
+
+    assert user.email == expected_email
+
+    assert {:ok, %User{email: expected_email, orgs: [%Org{}]}} =
+             Accounts.authenticate(user.email, user.password)
+  end
+
   test "create_org_with_user_with_certificate with valid params" do
     params = %{
       username: "Testy-McTesterson",


### PR DESCRIPTION
The authentication code previously downcased email addresses. Since the
email address downcase was only done in one place, this location was
inconsistent and it caused authentication failures.

This addresses https://github.com/nerves-hub/nerves_hub_cli/issues/113
and #423. The latter issue talks about normalizing email addresses
throughout but mentions edge cases in the RFCs that appear to make this
non-trivial. This change punts on normalization. If the user wants a
capital letter or something else odd, but legal, in their email address,
they can have it.