### PR TITLE
Standardize emails

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www/accounts/email.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www/accounts/email.ex
@@ -9,7 +9,7 @@ defmodule NervesHubWWW.Accounts.Email do
     new_email()
     |> from(@from)
     |> to(invite.email)
-    |> subject("Welcome to NervesHub!")
+    |> subject("[NervesHub] Hi from NervesHub!")
     |> put_layout({NervesHubWWWWeb.LayoutView, :email})
     |> render("invite.html", invite: invite, org: org)
   end
@@ -19,7 +19,7 @@ defmodule NervesHubWWW.Accounts.Email do
     new_email()
     |> from(@from)
     |> to(email)
-    |> subject("Reset NervesHub Password")
+    |> subject("[NervesHub] Reset NervesHub Password")
     |> put_layout({NervesHubWWWWeb.LayoutView, :email})
     |> render("forgot_password.html", user: user)
   end
@@ -28,7 +28,7 @@ defmodule NervesHubWWW.Accounts.Email do
     new_email()
     |> from(@from)
     |> to(email)
-    |> subject("New NervesHub Organization Added")
+    |> subject("[NervesHub] Welcome to #{org.name}")
     |> put_layout({NervesHubWWWWeb.LayoutView, :email})
     |> render("org_user_created.html", org: org)
   end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/forgot_password.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/forgot_password.html.eex
@@ -4,4 +4,4 @@
 
 <a href="<%= "#{base_url()}/password-reset/#{@user.password_reset_token}"%>">Reset Password</a>
 
-<p>The link is only valid for a short time.</p>
+<%= raw(closing()) %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/invite.html.eex
@@ -1,7 +1,8 @@
+<p>Hi!</p>
 <p>You've been invited to join <%= @org.name %> on nerves-hub.org.</p>
 
 <p>To get started click on the link below to register your account and set up your password:</p>
 
 <a href="<%= "#{base_url()}/invite/#{@invite.token}" %>">Create Account</a>
 
-<p>If you do not set your password within 48 hours of receiving this email, the invite will expire and you'll have to request a new invite from <%= @org.name %>.</p>
+<%= raw(closing()) %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/org_user_created.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/org_user_created.html.eex
@@ -1,5 +1,6 @@
-<p>You've been added to the <strong><%= @org.name %><strong> organization on nerves-hub.org.</p>
+<p>Welcome!</p>
+<p>You've been added to the <strong><%= @org.name %></strong> organization on nerves-hub.org.</p>
 
 <p><a href="<%= "#{base_url()}/login" %>">Login</a> to view it's details.</p>
 
-
+<%= raw(closing()) %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/email_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/email_view.ex
@@ -17,7 +17,7 @@ defmodule NervesHubWWWWeb.EmailView do
 
   def closing do
     """
-        <p>If you run into problems, please contact support by visiting https://nerves-hub.org/contact.
+        <p>If you run into problems, please file an <a href="https://github.com/nerves-hub/nerves_hub_web/issues">issue</a> or email support@nerves-hub.org.</p>
         <p>Thanks,</p>
         <p>Your frends at NervesHub</p>
     """

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/email_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/email_view.ex
@@ -10,4 +10,16 @@ defmodule NervesHubWWWWeb.EmailView do
 
     "#{scheme}://#{host}#{port}"
   end
+
+  @doc """
+  Standard closing words.
+  """
+
+  def closing do
+    """
+        <p>If you run into problems, please contact support by visiting https://nerves-hub.org/contact.
+        <p>Thanks,</p>
+        <p>Your frends at NervesHub</p>
+    """
+  end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www/accounts/email_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www/accounts/email_test.exs
@@ -40,6 +40,6 @@ defmodule NervesHubWWW.Accounts.EmailTest do
     assert email.to == "nunya@bidness.com"
 
     assert email.html_body =~
-             "You've been added to the <strong>#{org.name}<strong> organization on nerves-hub.org."
+             "You've been added to the <strong>#{org.name}</strong> organization on nerves-hub.org."
   end
 end


### PR DESCRIPTION
Fixes #404
Subject contains "[NervesHub]"
Common closing.