### PR TITLE
Make org list unique

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -76,7 +76,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  def terminate(reason, %{assigns: %{device: device}} = socket) do
+  def terminate(_reason, %{assigns: %{device: device}}) do
     Devices.update_device(device, %{last_communication: DateTime.utc_now()})
     :ok
   end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
@@ -197,7 +197,8 @@ defmodule NervesHubWebCore.Accounts do
         where:
           ou.user_id == ^user.id or
             (pu.user_id == ^user.id and
-               pu.role in ^User.role_or_higher(product_role))
+               pu.role in ^User.role_or_higher(product_role)),
+        group_by: o.id
       )
 
     Repo.all(q)

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -293,4 +293,16 @@ defmodule NervesHubWebCore.AccountsTest do
 
     assert result_org.type == :user
   end
+
+  test "get orgs for user by product role returns unique orgs", %{user: user} do
+    {:ok, org1} = Accounts.create_org(user, %{name: "org1"})
+    {:ok, org2} = Accounts.create_org(user, %{name: "org2"})
+
+    Fixtures.product_fixture(user, org1, %{name: "a product a"})
+    Fixtures.product_fixture(user, org1, %{name: "a product b"})
+    Fixtures.product_fixture(user, org2, %{name: "a product c"})
+
+    orgs = Accounts.get_user_orgs_with_product_role(user, :read)
+    assert orgs == Enum.uniq(orgs)
+  end
 end


### PR DESCRIPTION
I missed a group_by. This PR adds it back.  

This was causing the org list to show up with an entry for every product under the role.
<img width="191" alt="Screen Shot 2019-04-15 at 17 53 47" src="https://user-images.githubusercontent.com/1391351/56169586-9fb58d80-5fac-11e9-8729-06ae646e1134.png">
