### PR TITLE
Check for equal or higher Org role before Product role

### DIFF
--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/role_validate_helpers_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/role_validate_helpers_test.exs
@@ -1,0 +1,66 @@
+defmodule NervesHubWebCore.RoleValidateHelpersTest do
+  use NervesHubWebCore.DataCase, async: true
+  use Plug.Test
+
+  alias NervesHubWebCore.Fixtures
+  alias NervesHubWebCore.Accounts
+  alias NervesHubWebCore.RoleValidateHelpers, as: Validator
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+
+    conn =
+      conn(:get, "/")
+      |> assign(:user, user)
+      |> assign(:org, org)
+      |> assign(:product, product)
+
+    %{conn: conn, user: user, org: org, product: product}
+  end
+
+  test "org creator has admin role", %{conn: conn} do
+    refute Validator.validate_role(conn, org: :admin).halted
+  end
+
+  test "org role", %{conn: conn} do
+    user = Fixtures.user_fixture()
+
+    conn =
+      conn
+      |> Plug.Conn.assign(:user, user)
+      |> Validator.validate_role(org: :admin)
+
+    assert conn.halted
+  end
+
+  test "product creator has admin role", %{conn: conn} do
+    refute Validator.validate_role(conn, product: :admin).halted
+  end
+
+  test "product role", %{conn: conn} do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user, %{name: "product-role-test"})
+    product = Fixtures.product_fixture(user, org)
+
+    conn =
+      conn
+      |> Plug.Conn.assign(:product, product)
+      |> Validator.validate_role(product: :admin)
+
+    assert conn.halted
+  end
+
+  test "check account role before product role", %{conn: conn, org: org} do
+    user = Fixtures.user_fixture()
+    Accounts.add_org_user(org, user, %{role: :admin})
+
+    conn =
+      conn
+      |> Plug.Conn.assign(:user, user)
+      |> Validator.validate_role(product: :admin)
+
+    refute conn.halted
+  end
+end


### PR DESCRIPTION
This PR allows a user with an equal or higher `OrgUser` role to have implicit permission when a `ProductUser` role is required. For example. Viewing a product requires a `product: :read` role but users with an `org: :read` role or higher such as [`:admin, :delete, :write`] will also work.