### PR TITLE
Add ability to list Device (CA) Certificates

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_certificate_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_certificate_controller.ex
@@ -1,0 +1,13 @@
+defmodule NervesHubWWWWeb.OrgCertificateController do
+  use NervesHubWWWWeb, :controller
+
+  alias NervesHubWebCore.Devices
+
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
+    conn
+    |> render(
+      "index.html",
+      certificates: Devices.get_ca_certificates(org)
+    )
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -63,6 +63,7 @@ defmodule NervesHubWWWWeb.Router do
 
     get("/org/invite", OrgController, :invite)
     post("/org/invite", OrgController, :send_invite)
+    get("/org/certificates", OrgCertificateController, :index)
     resources("/org", OrgController)
 
     resources("/org_keys", OrgKeyController)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
@@ -1,5 +1,5 @@
 <h1>
-  Edit Account
+  <%= @user.username %> User Settings 
   <a class="btn btn-lg btn-success pull-right" href="<%= account_certificate_path(@conn, :index)%>">
     User Certificates
   </a>
@@ -32,4 +32,3 @@
 
   <%= submit "Update", class: "btn btn-primary" %>
 <% end %>
-

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -1,4 +1,4 @@
-<h2><%= @user.username %> User Certificates <span><%= button "", class: "btn btn-success fa fa-plus", title: "Create New Account Certificate", to: account_certificate_path(@conn, :new), method: :get %></span></h2>
+<h2><%= @user.username %> User Certificates </h2>
 <div class="row">
   <div class="w-100 shadow nhw_list">
     <div class="card">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -1,5 +1,8 @@
 <h1>
-  <%= @org.name %> settings
+  <%= @org.name %> Organization Settings
+  <a class="btn btn-lg btn-success pull-right" href="<%= org_certificate_path(@conn, :index)%>">
+    Device (CA) Certificates
+  </a>
   <%= if @org.type != :user do %>
   <a class="btn btn-lg btn-success pull-right" href="<%= org_path(@conn, :invite) %>">
     Invite user

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -1,8 +1,8 @@
-<h2><%= @user.username %> User Certificates <span><%= button "", class: "btn btn-success fa fa-plus", title: "Create New Account Certificate", to: account_certificate_path(@conn, :new), method: :get %></span></h2>
+<h2><%= @current_org.name %> Device (CA) Certificates <span><%= button "", class: "btn btn-success fa fa-plus", title: "Create New Account Certificate", to: account_certificate_path(@conn, :new), method: :get %></span></h2>
 <div class="row">
   <div class="w-100 shadow nhw_list">
     <div class="card">
-      <table id="account_certificates" class="table">
+      <table id="organization_certificates" class="table">
         <thead>
           <tr class="d-flex">
             <th class="col-2">Description</th>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_certificate.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_certificate.ex
@@ -1,0 +1,3 @@
+defmodule NervesHubWWWWeb.OrgCertificateView do
+  use NervesHubWWWWeb, :view
+end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
@@ -25,7 +25,7 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
       Fixtures.user_certificate_fixture(other_user, %{description: "baz", serial: "anotherserial"})
 
       conn = get(conn, account_certificate_path(conn, :index))
-      assert html_response(conn, 200) =~ "Account Certificates"
+      assert html_response(conn, 200) =~ "User Certificates"
       assert html_response(conn, 200) =~ account_certificate_path(conn, :delete, foo_cert)
       assert html_response(conn, 200) =~ account_certificate_path(conn, :delete, bar_cert)
       refute html_response(conn, 200) =~ "baz"

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -59,7 +59,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn: conn
     } do
       conn = get(conn, account_path(conn, :edit))
-      assert html_response(conn, 200) =~ "Edit Account"
+      assert html_response(conn, 200) =~ "Organization settings"
       assert html_response(conn, 200) =~ account_certificate_path(conn, :index)
       assert html_response(conn, 200) =~ "type=\"password\""
     end


### PR DESCRIPTION
Issue #348

Added button to Organization Settings page to take you to a list of 
Device (CA) cerftificates. Shown in the same format as User 
Certificates.
Took the liberty to change the User and Organization Settings page to 
display what type of page one is on - organization or user. For example 
the User Settings page now says: "<username> User Settings". Updated 
relevant unit tests.

Note issue will be created to make the "New" and "Delete" buttons on the Device (CA) Certificates page operational.

Also, removed new button from User Certificates page. New user certificates should only be created from the CLI.