### PR TITLE
Return products for orgs where a user has a comparable org role

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products.ex
@@ -8,7 +8,7 @@ defmodule NervesHubWebCore.Products do
   alias Ecto.Multi
   alias NervesHubWebCore.Repo
   alias NervesHubWebCore.Products.{Product, ProductUser}
-  alias NervesHubWebCore.Accounts.{User, Org}
+  alias NervesHubWebCore.Accounts.{User, Org, OrgUser}
 
   def get_products_by_user_and_org(%User{id: user_id}, %Org{id: org_id}) do
     query =
@@ -16,10 +16,13 @@ defmodule NervesHubWebCore.Products do
         p in Product,
         join: pu in ProductUser,
         on: p.id == pu.product_id,
+        full_join: ou in OrgUser,
+        on: p.org_id == ou.org_id,
         where:
           p.org_id == ^org_id and
-            pu.user_id == ^user_id and
-            pu.role in ^User.role_or_higher(:read)
+            ((ou.user_id == ^user_id and ou.role in ^User.role_or_higher(:read)) or
+               (pu.user_id == ^user_id and pu.role in ^User.role_or_higher(:read))),
+        group_by: p.id
       )
 
     query

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/products/products_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/products/products_test.exs
@@ -2,7 +2,7 @@ defmodule NervesHubWebCore.ProductsTest do
   use NervesHubWebCore.DataCase, async: true
 
   alias NervesHubWebCore.Fixtures
-  alias NervesHubWebCore.Products
+  alias NervesHubWebCore.{Products, Accounts}
 
   describe "products" do
     alias NervesHubWebCore.Products.Product
@@ -85,6 +85,15 @@ defmodule NervesHubWebCore.ProductsTest do
 
     test "Unable to remove last user from org", %{product: product, user: user} do
       assert {:error, :last_user} = Products.remove_product_user(product, user)
+    end
+
+    test "List products from an org where the user has a comparable org role", %{
+      org: org,
+      product: product
+    } do
+      user = Fixtures.user_fixture()
+      Accounts.add_org_user(org, user, %{role: :read})
+      assert [^product] = Products.get_products_by_user_and_org(user, org)
     end
   end
 end


### PR DESCRIPTION
Viewing products require a `product: :read` role. This alters the logic to first check if the user has a comparable `org: :read` role for the organization. If so, they should be able to see all products in the org.

Fixes https://github.com/nerves-hub/nerves_hub_web/issues/390