### PR TITLE
OrgUser fixes

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/org_user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/org_user_controller.ex
@@ -33,6 +33,7 @@ defmodule NervesHubAPIWeb.OrgUserController do
 
   def remove(%{assigns: %{org: org}} = conn, %{"username" => username}) do
     with {:ok, user} <- Accounts.get_user_by_username(username),
+         {:ok, _org_user} <- Accounts.get_org_user(org, user),
          :ok <- Accounts.remove_org_user(org, user) do
       send_resp(conn, :no_content, "")
     end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
@@ -117,7 +117,8 @@ defmodule NervesHubWebCore.Accounts do
     end
   end
 
-  def remove_org_user(%Org{type: :user}, %User{}), do: {:error, :user_org}
+  def remove_org_user(%Org{type: :user, name: name}, %User{username: name}),
+    do: {:error, :user_org}
 
   def remove_org_user(%Org{} = org, %User{} = user) do
     count = Repo.aggregate(Ecto.assoc(org, :org_users), :count, :id)

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -280,6 +280,11 @@ defmodule NervesHubWebCore.AccountsTest do
     assert {:ok, %Org{type: :group}} = Accounts.create_org(user, %{name: "group-org"})
   end
 
+  test "cannot remove user from their own org", %{user: user} do
+    {:ok, org} = Accounts.get_org_by_name_and_user(user.username, user)
+    assert {:error, _} = Accounts.remove_org_user(org, user)
+  end
+
   test "create_user sets default org to type user" do
     params = %{
       username: "user_with_org",


### PR DESCRIPTION
This fixes up a couple things that were found when designing the CLI around the OrgUser API.

* Removing a user from an org that was `type: :user` resulted in an error. This updates the code to prevent a user from being removed from their own user org.
* Return a not found error when trying to remove a user from an org who is not an OrgUser