### PR TITLE
Remove the create user certificate button

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -1,4 +1,4 @@
-<h2>Account Certificates <span><%= button "", class: "btn btn-success fa fa-plus", title: "Create New Account Certificate", to: account_certificate_path(@conn, :new), method: :get %></span></h2>
+<h2>Account Certificates</h2>
 <div class="row">
   <div class="w-100 shadow nhw_list">
     <div class="card">


### PR DESCRIPTION
User of button causes an internal server error. See issue #437 for 
making user cert creation work.