### PR TITLE
Display Device (CA) Certificates

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_certificate_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_certificate_controller.ex
@@ -1,0 +1,13 @@
+defmodule NervesHubWWWWeb.OrgCertificateController do
+  use NervesHubWWWWeb, :controller
+
+  alias NervesHubWebCore.Devices
+
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
+    conn
+    |> render(
+      "index.html",
+      certificates: Devices.get_ca_certificates(org)
+    )
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -63,6 +63,7 @@ defmodule NervesHubWWWWeb.Router do
 
     get("/org/invite", OrgController, :invite)
     post("/org/invite", OrgController, :send_invite)
+    get("/org/certificates", OrgCertificateController, :index)
     resources("/org", OrgController)
 
     resources("/org_keys", OrgKeyController)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -1,5 +1,8 @@
 <h1>
   <%= @org.name %> settings
+  <a class="btn btn-lg btn-success pull-right" href="<%= org_certificate_path(@conn, :index)%>">
+    Device (CA) Certificates
+  </a>  
   <%= if @org.type != :user do %>
   <a class="btn btn-lg btn-success pull-right" href="<%= org_path(@conn, :invite) %>">
     Invite user

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -1,0 +1,37 @@
+<h2><%= @current_org.name %> Device (CA) Certificates</h2>
+<div class="row">
+  <div class="w-100 shadow nhw_list">
+    <div class="card">
+      <table id="organization_certificates" class="table">
+        <thead>
+          <tr class="d-flex">
+            <th class="col-2">Description</th>
+            <th class="col-2">Serial</th>
+            <th class="col-2">Last Used</th>
+            <th class="col-2">Not Before</th>
+            <th class="col-2">Not After</th>
+          </tr>
+        </thead>
+        <%= for cert <- @certificates do %>
+          <tr class="item d-flex">
+            <td class="col-2">
+              <%= cert.description %>
+            </td>
+            <td class="col-2">
+              <%= cert.serial %>
+            </td>
+            <td class="col-2 date-time">
+              <%= cert.last_used %>
+            </td>
+            <td class="col-2 date-time">
+              <%= cert.not_before %>
+            </td>
+            <td class="col-2 date-time">
+              <%= cert.not_after %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_certificate.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_certificate.ex
@@ -1,0 +1,3 @@
+defmodule NervesHubWWWWeb.OrgCertificateView do
+  use NervesHubWWWWeb, :view
+end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
@@ -1,0 +1,20 @@
+defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
+
+  alias NervesHubWebCore.Fixtures
+
+  describe "index" do
+    test "lists all appropriate device(ca) certificates", %{
+      conn: conn,
+      current_org: org
+    } do
+      %{db_cert: db1_cert} = Fixtures.ca_certificate_fixture(org)
+      %{db_cert: db2_cert} = Fixtures.ca_certificate_fixture(org)
+
+      conn = get(conn, org_certificate_path(conn, :index))
+      assert html_response(conn, 200) =~ "#{org.name} Device (CA) Certificates"
+      assert html_response(conn, 200) =~ db1_cert.serial
+      assert html_response(conn, 200) =~ db2_cert.serial
+    end
+  end
+end


### PR DESCRIPTION
Issue #348 

Device (CA) certificates are displayed on their own page. The page can be reached from the Organization Settings page via the button "Device (CA) Certificates.

No adding or deleting of these certificates are available from this page

Unit test added (only :index) 