### PR TITLE
Display organization's users in web interface

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_user_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_user_controller.ex
@@ -1,0 +1,13 @@
+defmodule NervesHubWWWWeb.OrgUserController do
+  use NervesHubWWWWeb, :controller
+
+  alias NervesHubWebCore.Accounts
+
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
+    conn
+    |> render(
+      "index.html",
+      org_users: Accounts.get_org_users(org)
+    )
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -64,6 +64,7 @@ defmodule NervesHubWWWWeb.Router do
     get("/org/invite", OrgController, :invite)
     post("/org/invite", OrgController, :send_invite)
     get("/org/certificates", OrgCertificateController, :index)
+    get("/org/users", OrgUserController, :index)
     resources("/org", OrgController)
 
     resources("/org_keys", OrgKeyController)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -2,8 +2,11 @@
   <%= @org.name %> settings
   <a class="btn btn-lg btn-success pull-right" href="<%= org_certificate_path(@conn, :index)%>">
     Device (CA) Certificates
-  </a>  
+  </a>
   <%= if @org.type != :user do %>
+  <a class="btn btn-lg btn-success pull-right" href="<%= org_user_path(@conn, :index) %>">
+    Users
+  </a>
   <a class="btn btn-lg btn-success pull-right" href="<%= org_path(@conn, :invite) %>">
     Invite user
   </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -1,0 +1,33 @@
+<h2><%= @current_org.name %> Users</h2>
+<div class="row">
+  <div class="w-75 shadow nhw_list">
+    <div class="card">
+      <table id="organization_users" class="table">
+        <thead>
+          <tr class="d-flex">
+            <th class="col-2">User Name</th>
+            <th class="col-3">Email</th>
+            <th class="col-3">Date Added</th>
+            <th class="col-3">Date Updated</th>
+          </tr>
+        </thead>
+        <%= for org_user <- @org_users do %>
+          <tr class="item d-flex">
+            <td class="col-2">
+              <%= org_user.user.username %>
+            </td>
+            <td class="col-3">
+              <%= org_user.user.email %>
+            </td>
+            <td class="col-3">
+              <%= org_user.user.inserted_at %>
+            </td>
+            <td class="col-3">
+              <%= org_user.user.updated_at %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_user_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_user_view.ex
@@ -1,0 +1,3 @@
+defmodule NervesHubWWWWeb.OrgUserView do
+  use NervesHubWWWWeb, :view
+end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
@@ -1,0 +1,20 @@
+defmodule NervesHubWWWWeb.OrgUserControllerTest do
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
+
+  alias NervesHubWebCore.Accounts
+
+  describe "index" do
+    test "lists all users in an organization", %{
+      conn: conn,
+      current_org: org
+    } do
+      org_users = Accounts.get_org_users(org)
+      conn = get(conn, org_user_path(conn, :index))
+      assert html_response(conn, 200) =~ "#{org.name} Users"
+
+      Enum.each(org_users, fn org_user ->
+        assert html_response(conn, 200) =~ org_user.user.username
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Issue: #427

From the Organizations Setttings page select the "Users" button. A list 
of the organization's users is shown on a separate page.

One unit test added.