### PR TITLE
Fix elixir 1.8.1 deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: nerveshub/docker-build:alpine-3.8
+    - image: nerveshub/docker-build:alpine-3.9
   working_directory: ~/repo
 
 remote_docker: &remote_docker

--- a/apps/nerves_hub_api/rel/Dockerfile.build
+++ b/apps/nerves_hub_api/rel/Dockerfile.build
@@ -1,5 +1,6 @@
+ARG ELIXIR_VERSION=1.8.1
 # Elixir build container
-FROM bitwalker/alpine-elixir:1.8.1 as builder
+FROM bitwalker/alpine-elixir:${ELIXIR_VERSION} as builder
 
 ENV MIX_ENV=prod
 
@@ -13,7 +14,7 @@ RUN mix deps.clean --all && mix deps.get
 RUN mix release --env=$MIX_ENV --name=nerves_hub_api
 
 # Release Container
-FROM nerveshub/runtime:alpine-3.8 as release
+FROM nerveshub/runtime:alpine-3.9 as release
 
 RUN apk add 'fwup~=1.3.0' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \

--- a/apps/nerves_hub_device/rel/Dockerfile.build
+++ b/apps/nerves_hub_device/rel/Dockerfile.build
@@ -1,5 +1,6 @@
+ARG ELIXIR_VERSION=1.8.1
 # Elixir build container
-FROM bitwalker/alpine-elixir:1.8.1 as builder
+FROM bitwalker/alpine-elixir:${ELIXIR_VERSION} as builder
 
 ENV MIX_ENV=prod
 
@@ -13,7 +14,7 @@ RUN mix deps.clean --all && mix deps.get
 RUN mix release --env=$MIX_ENV --name=nerves_hub_device
 
 # Release Container
-FROM nerveshub/runtime:alpine-3.8 as release
+FROM nerveshub/runtime:alpine-3.9 as release
 
 EXPOSE 443
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/audit_log_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/audit_log_view.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubWWWWeb.AuditLogView do
   use NervesHubWWWWeb, :view
 
-  import NervesHubWWWWeb.LayoutView, only: [pagination_links: 1, pagination_links: 2]
+  import NervesHubWWWWeb.LayoutView, only: [pagination_links: 2]
 
   def actor_link(%{actor_id: id, actor_type: type}, current_id) do
     link_to_resource(type, id, current_id, "audit-log-actor")
@@ -36,7 +36,7 @@ defmodule NervesHubWWWWeb.AuditLogView do
     |> Enum.at(-1)
   end
 
-  defp link_to_resource(type, id, current_id, class \\ "") do
+  defp link_to_resource(type, id, current_id, class) do
     simple_type = feed_type(type)
 
     if id == current_id do
@@ -52,12 +52,12 @@ defmodule NervesHubWWWWeb.AuditLogView do
     "/products"
   end
 
-  def path_for("firmware", id) do
+  def path_for("firmware", _id) do
     # TODO: handle product id lookup
     "/products"
   end
 
-  def path_for("user", id) do
+  def path_for("user", _id) do
     # TODO: Add route for user#show instead of settings
     ""
   end

--- a/apps/nerves_hub_www/rel/Dockerfile.build
+++ b/apps/nerves_hub_www/rel/Dockerfile.build
@@ -29,7 +29,7 @@ COPY --from=assets /build/apps/nerves_hub_www/priv/static apps/nerves_hub_www/pr
 RUN mix do phx.digest, release --env=$MIX_ENV --name=nerves_hub_www
 
 # Release Container
-FROM nerveshub/runtime:alpine-3.8 as release
+FROM nerveshub/runtime:alpine-3.9 as release
 
 RUN apk add 'fwup~=1.3.0' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \


### PR DESCRIPTION
This updates the runtime container to 3.9 to match the build containers. Tested by executing the migration from the last failed deployment successfully. This also cleans up compiler warnings.