### PR TITLE
Add audit log feed to deployment#show

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
@@ -35,6 +35,18 @@ defmodule NervesHubWWWWeb do
     end
   end
 
+  def live_view do
+    quote do
+      use Phoenix.LiveView
+
+      alias NervesHubWebCore.{Repo, AuditLogs}
+      alias NervesHubWWWWeb.Router.Helpers, as: Routes
+      alias NervesHubWWWWeb.Endpoint
+
+      alias Phoenix.Socket.Broadcast
+    end
+  end
+
   def view do
     quote do
       use Phoenix.View,

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
@@ -103,13 +103,15 @@ defmodule NervesHubWWWWeb.DeploymentController do
     end
   end
 
-  def show(%{assigns: %{current_org: _org, product: product}} = conn, %{"id" => deployment_id}) do
+  def show(%{assigns: %{current_org: _org, product: product, user: user}} = conn, %{
+        "id" => deployment_id
+      }) do
     {:ok, deployment} = Deployments.get_deployment(product, deployment_id)
 
     conn
-    |> render(
-      "show.html",
-      deployment: deployment
+    |> live_render(
+      NervesHubWWWWeb.DeploymentLive.Show,
+      session: %{deployment: deployment, product: product, user: user}
     )
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
@@ -1,0 +1,84 @@
+defmodule NervesHubWWWWeb.DeploymentLive.Show do
+  use NervesHubWWWWeb, :live_view
+
+  alias NervesHubWebCore.Deployments
+
+  def render(assigns) do
+    NervesHubWWWWeb.DeploymentView.render("show.html", assigns)
+  end
+
+  def mount(session, socket) do
+    socket =
+      socket
+      |> assign(:deployment, session.deployment)
+      |> assign(:product, session.product)
+      |> assign(:user, session.user)
+      |> audit_log_assigns()
+
+    {:ok, socket}
+  end
+
+  def handle_event(
+        "delete",
+        _val,
+        %{assigns: %{deployment: deployment, product: product, user: user}} = socket
+      ) do
+    case Deployments.delete_deployment(deployment) do
+      {:ok, _} ->
+        AuditLogs.audit!(user, deployment, :delete, %{id: deployment.id, name: deployment.name})
+
+        socket =
+          socket
+          |> put_flash(:info, "Deployment deleted")
+          |> redirect(to: Routes.product_deployment_path(socket, :index, product))
+
+        {:stop, socket}
+
+      {:error, error} ->
+        {:noreply,
+         put_flash(socket, :error, "Error occurred deleting deployment: #{inspect(error)}")}
+    end
+  end
+
+  def handle_event(
+        "paginate",
+        page_num,
+        %{assigns: %{audit_log_ids: ids, paginate_opts: paginate_opts}} = socket
+      ) do
+    # This LiveView stores an array of all its audit log's ids. On paginate
+    # call, it gets the the index offset based on the page it is currently on
+    # then slices out the number of ids equal to the set page_size starting
+    # at that index. Then we query AuditLogs for only those specific records
+    page_num = String.to_integer(page_num)
+    start_index = (page_num - 1) * paginate_opts.page_size
+    audit_logs = Enum.slice(ids, start_index, paginate_opts.page_size) |> AuditLogs.from_ids()
+
+    socket =
+      socket
+      |> assign(:audit_logs, audit_logs)
+      |> assign(:paginate_opts, %{paginate_opts | page_number: page_num})
+
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "toggle_active",
+        value,
+        %{assigns: %{deployment: deployment, user: user}} = socket
+      ) do
+    {:ok, updated_deployment} = Deployments.update_deployment(deployment, %{is_active: value})
+    AuditLogs.audit!(user, deployment, :update, %{is_active: value})
+    {:noreply, assign(socket, :deployment, updated_deployment)}
+  end
+
+  defp audit_log_assigns(%{assigns: %{deployment: deployment}} = socket) do
+    all_logs = AuditLogs.logs_for_feed(deployment)
+    paginate_opts = %{page_number: 1, page_size: 10}
+
+    socket
+    |> assign(:audit_logs, Enum.slice(all_logs, 0, paginate_opts.page_size))
+    |> assign(:audit_log_ids, Enum.map(all_logs, & &1.id))
+    |> assign(:paginate_opts, paginate_opts)
+    |> assign(:resource_id, deployment.id)
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -1,4 +1,7 @@
-<h1>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-lg-7">
+    <h1>
   Deployment:
   <%= @deployment.name %>
 </h1>
@@ -35,16 +38,23 @@
 </table>
 
 <div class="row">
-<a class="btn btn-primary mr-3" href="<%= product_deployment_path(@conn, :edit, @product.id, @deployment) %>">
+<a class="btn btn-primary mr-3" href="<%= product_deployment_path(@socket, :edit, @product.id, @deployment) %>">
   Edit Deployment
 </a>
 
-<%= form_for @conn, product_deployment_path(@conn, :update, @product.id, @deployment), [as: :deployment, method: "put"], fn f -> %>
-  <%= hidden_input f, :is_active, id: "is_active_input", value: !@deployment.is_active %>
-  <%= submit "Make #{opposite_status(@deployment)}", class: "btn btn-primary mr-3" %>
-<% end %>
+<a class="btn btn-primary mr-3" phx-click="toggle_active" phx-value=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
 
-<%= form_for @conn, product_deployment_path(@conn, :delete, @product.id, @deployment), [method: :delete], fn _ -> %>
+<%= form_for %Plug.Conn{}, "#", [phx_submit: "delete"], fn f -> %>
   <%= submit "Delete Deployment", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>
 <% end %>
 </div>
+    </div>
+    <div class="col-lg-5">
+      <%= render(NervesHubWWWWeb.AuditLogView, "_audit_log_feed.html", assigns) %>
+    </div>
+  </div>
+</div>
+
+
+
+

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
@@ -1,0 +1,69 @@
+defmodule NervesHubWWWWeb.DeploymentLiveShowTest do
+  use NervesHubWWWWeb.ConnCase.Browser, async: false
+
+  alias NervesHubWebCore.{AuditLogs, Repo}
+  alias NervesHubWWWWeb.{DeploymentLive.Show, Endpoint}
+
+  setup %{fixture: fixture} do
+    [
+      deployment: Repo.preload(fixture.deployment, :firmware),
+      product: fixture.product,
+      user: fixture.user
+    ]
+  end
+
+  describe "handle_event" do
+    test "toggle active", session do
+      {:ok, view, _html} = mount(Endpoint, Show, session: session)
+
+      before_audit_count = AuditLogs.logs_for(session.deployment) |> length
+
+      assert render_click(view, :toggle_active, "true") =~ "Make Inactive"
+      # assert_broadcast("reboot", %{})
+
+      deployment = Repo.reload(session.deployment)
+
+      assert deployment.is_active == true
+
+      after_audit_count = AuditLogs.logs_for(session.deployment) |> length
+
+      assert after_audit_count == before_audit_count + 1
+    end
+
+    test "toggle inactive", session do
+      {:ok, view, _html} = mount(Endpoint, Show, session: session)
+
+      before_audit_count = AuditLogs.logs_for(session.deployment) |> length
+
+      assert render_click(view, :toggle_active, "false") =~ "Make Active"
+      # assert_broadcast("reboot", %{})
+
+      deployment = Repo.reload(session.deployment)
+
+      assert deployment.is_active == false
+
+      after_audit_count = AuditLogs.logs_for(session.deployment) |> length
+
+      assert after_audit_count == before_audit_count + 1
+    end
+
+    test "delete", session do
+      {:ok, view, _html} = mount(Endpoint, Show, session: session)
+
+      products_path = "/products/#{session.product.id}/deployments"
+
+      assert_redirect(view, ^products_path, fn ->
+        assert render_submit(view, :delete)
+      end)
+
+      [audit_log | _tail] = AuditLogs.logs_for(session.deployment)
+
+      assert audit_log.action == :delete
+
+      assert audit_log.params == %{
+               "id" => session.deployment.id,
+               "name" => session.deployment.name
+             }
+    end
+  end
+end


### PR DESCRIPTION
Basically the same as #444 

* Changes `deployment#show` page to use LiveView
  * Adds audit log feed in view
  * audits toggling deployment active/inactive
  * audits deleting the deployment

![image](https://user-images.githubusercontent.com/11321326/56461321-069cc300-636e-11e9-8409-0ca7ef7f23f3.png)
