### PR TITLE
Use Firmwares.delete_firmware/1 when garbage collecting

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/gc.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/gc.ex
@@ -1,14 +1,13 @@
 defmodule NervesHubWebCore.Firmwares.GC do
   require Logger
 
-  alias NervesHubWebCore.Repo
   alias NervesHubWebCore.Firmwares
 
   def run() do
     Firmwares.get_firmware_by_expired_ttl()
     |> Enum.each(fn firmware ->
-      case Repo.delete(firmware) do
-        {:ok, _firmware} ->
+      case Firmwares.delete_firmware(firmware) do
+        :ok ->
           Logger.debug("Garbage collected firmware #{firmware.uuid}")
 
         {:error, reason} ->


### PR DESCRIPTION
Fixes an issue where the database record would be cleaned up but the files would not be deleted.