### PR TITLE
Add sorting to devices#index

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -11,6 +11,7 @@ defmodule NervesHubDevice.Presence do
     :console_available,
     :firmware_metadata,
     :rebooting,
+    :status,
     :update_available
   ]
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device.ex
@@ -30,6 +30,8 @@ defmodule NervesHubWebCore.Devices.Device do
     field(:last_communication, :utc_datetime)
     field(:tags, NervesHubWebCore.Types.Tag)
 
+    field(:status, :string, default: "offline", virtual: true)
+
     timestamps()
   end
 

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -129,3 +129,8 @@ main {
 .code-snippet {
   overflow: unset;
 }
+
+.sort-selected {
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -9,19 +9,19 @@ defmodule NervesHubWWWWeb.DeviceController do
   plug(:validate_role, [org: :write] when action in [:new, :create, :edit, :update])
   plug(:validate_role, [org: :read] when action in [:index, :show])
 
-  def index(%{assigns: %{current_org: _org, product: product}} = conn, _params) do
+  def index(%{assigns: %{current_org: org, product: product}} = conn, _params) do
     conn
-    |> render(
-      "index.html",
-      devices: Devices.get_devices(product)
+    |> live_render(
+      NervesHubWWWWeb.DeviceLive.Index,
+      session: %{devices: Devices.get_devices(product), org_id: org.id}
     )
   end
 
   def index(%{assigns: %{current_org: org}} = conn, _params) do
     conn
-    |> render(
-      "index.html",
-      devices: Devices.get_devices(org)
+    |> live_render(
+      NervesHubWWWWeb.DeviceLive.Index,
+      session: %{devices: Devices.get_devices(org), org_id: org.id}
     )
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -1,0 +1,100 @@
+defmodule NervesHubWWWWeb.DeviceLive.Index do
+  use Phoenix.LiveView
+
+  alias NervesHubDevice.Presence
+
+  alias NervesHubWebCore.{Repo, Accounts.AuditLog}
+
+  alias Phoenix.Socket.Broadcast
+
+  def render(assigns) do
+    NervesHubWWWWeb.DeviceView.render("index.html", assigns)
+  end
+
+  def mount(session, socket) do
+    socket =
+      socket
+      |> assign(:devices, assign_statuses(session))
+      |> assign(:current_sort, "identifier")
+      |> assign(:sort_direction, :asc)
+
+    if connected?(socket) do
+      socket.endpoint.subscribe("devices:#{session.org_id}")
+    end
+
+    {:ok, socket}
+  end
+
+  # Handles event of user clicking the same field that is already sorted
+  # For this case, we switch the sorting direction of same field
+  def handle_event("sort", value, %{assigns: %{current_sort: current_sort}} = socket)
+      when value == current_sort do
+    %{devices: devices, sort_direction: sort_direction} = socket.assigns
+
+    # switch sort direction for column because
+    sort_direction = if sort_direction == :desc, do: :asc, else: :desc
+
+    socket =
+      socket
+      |> assign(sort_direction: sort_direction)
+      |> do_sort()
+
+    {:noreply, socket}
+  end
+
+  # User has clicked a new column to sort
+  def handle_event("sort", value, %{assigns: %{devices: devices}} = socket) do
+    socket =
+      socket
+      |> assign(:current_sort, value)
+      |> assign(:sort_direction, :asc)
+      |> do_sort()
+
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        %Broadcast{event: "presence_diff", payload: payload},
+        %{assigns: %{devices: devices}} = socket
+      ) do
+    socket =
+      socket
+      |> assign(:devices, update_statuses(devices, payload))
+      |> case do
+        %{assigns: %{current_sort: "status"}} = socket -> do_sort(socket)
+        socket -> socket
+      end
+
+    {:noreply, socket}
+  end
+
+  defp assign_statuses(%{devices: devices, org_id: org_id}) do
+    presences = Presence.list("devices:#{org_id}")
+
+    for device <- devices do
+      status = get_in(presences, [to_string(device.id), :status]) || "offline"
+      %{device | status: status}
+    end
+  end
+
+  defp do_sort(%{assigns: %{devices: devices, current_sort: current_sort}} = socket) do
+    current_sort = String.to_existing_atom(current_sort)
+    devices = Enum.sort_by(devices, &Map.get(&1, current_sort), sorter(socket))
+    assign(socket, :devices, devices)
+  end
+
+  defp sorter(%{assigns: %{sort_direction: :desc}}), do: &>=/2
+  defp sorter(_), do: &<=/2
+
+  defp update_statuses(devices, %{joins: joins, leaves: leaves}) do
+    for device <- devices do
+      id = to_string(device.id)
+
+      cond do
+        meta = joins[id] -> %{device | status: meta.status}
+        leaves[id] -> %{device | status: "offline"}
+        true -> device
+      end
+    end
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -8,21 +8,21 @@
       </div>
     </div>
     <div class="card">
-    <table id="deployment_listing" class="table">
+    <table id="devices_table" class="table">
       <thead>
         <tr class="d-flex">
-          <th class="col-2">Identifier</th>
+          <%= devices_table_header("Identifier", "identifier", @current_sort, @sort_direction) %>
           <th class="col-2">Firmware Info</th>
-          <th class="col-2">Status</th>
-          <th class="col-2">Last Connection</th>
-          <th class="col-2">Tags</th>
+          <%= devices_table_header("Status", "status", @current_sort, @sort_direction) %>
+          <%= devices_table_header("Last Connection", "last_communication", @current_sort, @sort_direction) %>
+          <%= devices_table_header("Tags", "tags", @current_sort, @sort_direction) %>
           <th class="col-2"></th>
         </tr>
       </thead>
       <%= for device <- @devices do %>
         <tr class="item d-flex">
           <td class="col-2">
-            <a href="<%= device_path(@conn, :show, device.id) %>" class="">
+            <a href="<%= device_path(@socket, :show, device.id) %>" class="">
               <%= device.identifier %>
             </a>
           </td>
@@ -38,7 +38,7 @@
               </p>
             <% end %>
           </td>
-          <td class="col-2 device" data-device-id=<%= "#{device.id}" %>><%= device_status(device) %></td>
+          <td class="col-2 device"><%= device.status %></td>
           <td class="col-2 date-time">
             <%= if is_nil(device.last_communication) do %>
               never
@@ -50,8 +50,8 @@
             <span class="badge"><%= tags_to_string(device) %></span>
           </td>
           <td class="col-2">
-            <%= link "Edit", class: "btn btn-info", to: device_path(@conn, :edit, device) %>
-            <%= link "Delete", class: "btn btn-danger", to: device_path(@conn, :delete, device), method: :delete, data: [confirm: "Are you sure?"]%>
+            <%= link "Edit", class: "btn btn-info", to: device_path(@socket, :edit, device) %>
+            <%= link "Delete", class: "btn btn-danger", to: device_path(@socket, :delete, device), method: :delete, data: [confirm: "Are you sure?"]%>
           </td>
         </tr>
       <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -13,6 +13,21 @@ defmodule NervesHubWWWWeb.DeviceView do
     ]
   end
 
+  def devices_table_header(title, value, current_sort, sort_direction \\ :asc)
+
+  def devices_table_header(title, value, current_sort, sort_direction)
+      when value == current_sort do
+    caret_class = if sort_direction == :asc, do: "up", else: "down"
+
+    content_tag(:th, phx_click: "sort", phx_value: value, class: "col-2 sort-selected") do
+      [title, content_tag(:i, "", class: "fa fa-caret-#{caret_class}")]
+    end
+  end
+
+  def devices_table_header(title, value, _current_sort, _sort_direction) do
+    content_tag(:th, title, phx_click: "sort", phx_value: value, class: "col-2")
+  end
+
   def platform_options do
     [
       "bbb",


### PR DESCRIPTION
resolves #416 

* Changes `devices#index` to use LiveView
* Adds sorting by clicking on the column header
  * Support changing sort direction by clicking the same column
  header to toggle between asc and desc
* Changes `status` to use LiveView from `presence_diff` events
  * adds `status` virtual field to `NervesHubWebCore.Devices.Device` schema

As a bonus, if the view is sorted by `status`, devices changing statuses will live sort as the view gets the change (that is the last part of the gif)

![device_sorting](https://user-images.githubusercontent.com/11321326/56519253-d89ab880-64fe-11e9-8fd9-2b9daf424d1d.gif)
