### PR TITLE
fix delete_file/1 in Upload.File

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/file.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/file.ex
@@ -24,14 +24,14 @@ defmodule NervesHubWebCore.Firmwares.Upload.File do
 
   @spec delete_file(Firmware.t()) :: :ok
   def delete_file(%{upload_metadata: %{local_path: path}}) do
-    File.rm!(path)
+    # Sometimes fw files may be stored in temporary places that
+    # get cleared on reboots, especially when using this locally.
+    # So if the file doesn't exist, don't attempt to remove
+    if File.exists?(path), do: File.rm!(path), else: :ok
   end
 
-  @spec delete_file(Firmware.t()) ::
-          {:ok, any()}
-          | {:error, any()}
   def delete_file(%{upload_metadata: %{"local_path" => path}}) do
-    File.rm!(path)
+    delete_file(%{upload_metadata: %{local_path: path}})
   end
 
   @spec metadata(Org.id(), String.t()) :: upload_metadata()

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
@@ -106,8 +106,16 @@ defmodule NervesHubWebCore.FirmwaresTest do
     } do
       firmware = Fixtures.firmware_fixture(org_key, product)
       @uploader.delete_file(firmware)
+
+      # Make this path a directory will break delete_firmware/1
+      # cause it to raise
+      File.mkdir(firmware.upload_metadata.local_path)
+
       assert_raise File.Error, fn -> Firmwares.delete_firmware(firmware) end
       assert {:ok, _} = Firmwares.get_firmware(org, firmware.id)
+
+      # Cleanup bogus directory
+      File.rmdir!(firmware.upload_metadata.local_path)
     end
 
     test "delete firmware", %{org: org, org_key: org_key, product: product} do


### PR DESCRIPTION
This just fixes a simple edge case of attempting to delete a firmware file stored locally
that doesn't exist anymore. Really, this only affects running NervesHub locally (or anyone
else who might use this file store instead of S3). In the case of local development, fw
files are stored in tmp locations so a restart could blow it away while the record exists
in the app. Then attempting to delete the record would fail. This just checks if it is there
first before attempting to hard delete