### PR TITLE
Email all on add remove user

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/org_user_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule NervesHubAPIWeb.OrgUserControllerTest do
   use NervesHubAPIWeb.ConnCase, async: true
+  use Bamboo.Test
 
   alias NervesHubWebCore.Fixtures
   alias NervesHubWebCore.Accounts
@@ -38,6 +39,13 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
 
       conn = get(conn, org_user_path(conn, :show, org.name, user2.username))
       assert json_response(conn, 200)["data"]["username"] == user2.username
+
+      # An email should have been sent
+      instigator = conn.assigns.user.username
+
+      assert_email_delivered_with(
+        subject: "[NervesHub] User #{instigator} added #{user2.username} to #{org.name}"
+      )
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org, user2: user2} do
@@ -66,6 +74,13 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
     test "remove existing user", %{conn: conn, org: org, user2: user} do
       conn = delete(conn, org_user_path(conn, :remove, org.name, user.username))
       assert response(conn, 204)
+
+      # An email should have been sent
+      instigator = conn.assigns.user.username
+
+      assert_email_delivered_with(
+        subject: "[NervesHub] User #{instigator} removed #{user.username} from #{org.name}"
+      )
 
       conn = get(conn, org_user_path(conn, :show, org.name, user.username))
       assert response(conn, 404)

--- a/apps/nerves_hub_www/lib/nerves_hub_www/accounts/email.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www/accounts/email.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubWWW.Accounts.Email do
   use Bamboo.Phoenix, view: NervesHubWWWWeb.EmailView
 
-  alias NervesHubWebCore.Accounts.{Invite, Org, User}
+  alias NervesHubWebCore.Accounts.{Invite, Org, User, OrgUser}
 
   @from {"NervesHub", "no-reply@nerves-hub.org"}
 
@@ -31,5 +31,53 @@ defmodule NervesHubWWW.Accounts.Email do
     |> subject("[NervesHub] Welcome to #{org.name}")
     |> put_layout({NervesHubWWWWeb.LayoutView, :email})
     |> render("org_user_created.html", org: org)
+  end
+
+  @doc """
+  Create an email that announces the addition of a new user. The email is sent
+  to each of the organization's users - except the new user. The email addresses
+  are specified via BCC. The instigator is the user who initiated the addition of the user.
+  """
+  def tell_org_user_added(%Org{} = org, org_users, instigator, %User{} = new_user) do
+    org_users_emails =
+      generate_org_users_emails(org_users)
+      |> Enum.filter(fn email -> email != new_user.email end)
+
+    new_email()
+    |> from(@from)
+    |> subject("[NervesHub] User #{instigator} added #{new_user.username} to #{org.name}")
+    |> to(@from)
+    |> bcc(org_users_emails)
+    |> put_layout({NervesHubWWWWeb.LayoutView, :email})
+    |> render("tell_org_user_added.html", instigator: instigator, user: new_user, org: org)
+  end
+
+  @doc """
+  Create an email that announces the removal of a user. The email is
+  sent to all of the the organization's users. The email addresses are specified via BCC.
+  The instigator is the user who initiated the removal of the user.
+  """
+  def tell_org_user_removed(%Org{} = org, org_users, instigator, %User{} = user_removed) do
+    org_users_emails = generate_org_users_emails(org_users)
+
+    new_email()
+    |> from(@from)
+    |> subject("[NervesHub] User #{instigator} removed #{user_removed.username} from #{org.name}")
+    |> to(@from)
+    |> bcc(org_users_emails)
+    |> put_layout({NervesHubWWWWeb.LayoutView, :email})
+    |> render("tell_org_user_removed.html", instigator: instigator, user: user_removed, org: org)
+  end
+
+  defp generate_org_users_emails(org_users) do
+    # NB:Note there is a check for nil email addresses. This can
+    # occur during testing and, in any event, causes the Bamboo emailer to crash
+    org_users
+    |> Enum.reduce(
+      [],
+      fn %OrgUser{user: %User{email: email}}, acc when email != nil ->
+        [email | acc]
+      end
+    )
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/tell_org_user_added.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/tell_org_user_added.html.eex
@@ -1,0 +1,3 @@
+<p>Hi!</p>
+<p>Welcome <%= @user.username %> to our <%= @org.name %> organization!
+<%= raw(closing()) %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/tell_org_user_removed.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/email/tell_org_user_removed.html.eex
@@ -1,0 +1,3 @@
+<p>Hello,</p>
+<p>The user <%= @user.username %> is no longer with our <%= @org.name %> organization.
+<%= raw(closing()) %>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule NervesHubWWWWeb.AccountControllerTest do
   use NervesHubWWWWeb.ConnCase.Browser, async: true
+  use Bamboo.Test
 
   alias NervesHubWebCore.Accounts
 
@@ -29,7 +30,8 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
     test "accepts submitted invitation", %{
       conn: conn
     } do
-      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, conn.assigns.current_org)
+      org = conn.assigns.current_org
+      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, org)
 
       conn =
         post(
@@ -49,8 +51,12 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
                "info" => "Account successfully created, login below"
              }
 
-      assert {:ok, %Accounts.User{username: "MyName"}} =
-               Accounts.get_user_by_email("joe@example.com")
+      # An email should have been sent
+      instigator = conn.assigns.user.username
+
+      assert_email_delivered_with(
+        subject: "[NervesHub] User #{instigator} added MyName to #{org.name}"
+      )
     end
   end
 


### PR DESCRIPTION
Issue #403 

When a user is added or removed from an organization, either by an API call or (in the future) via the the web UI, an email is sent to all other users in that organization notifying them of this action. The subject line includes the username of the initiator of the action.

Unit tests added.