### PR TITLE
Return device firmware metadata

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/device_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/device_view.ex
@@ -20,7 +20,8 @@ defmodule NervesHubAPIWeb.DeviceView do
       version: version(device),
       status: device_status(device),
       last_communication: last_communication(device),
-      description: device.description
+      description: device.description,
+      firmware_metadata: device.firmware_metadata
     }
   end
 


### PR DESCRIPTION
Return a device's firmware metadata on an API request.

This change is necessary to support https://github.com/nerves-hub/nerves_hub_cli/issues/102