### PR TITLE
Mark deployments and devices that need attention

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/controllers/device_controller.ex
@@ -1,6 +1,6 @@
 defmodule NervesHubDeviceWeb.DeviceController do
   use NervesHubDeviceWeb, :controller
-  alias NervesHubWebCore.Devices
+  alias NervesHubWebCore.{AuditLogs, Devices}
 
   def me(%{assigns: %{device: device}} = conn, _params) do
     render(conn, "show.json", device: device)
@@ -8,7 +8,15 @@ defmodule NervesHubDeviceWeb.DeviceController do
 
   def update(%{assigns: %{device: device}} = conn, _params) do
     deployments = Devices.get_eligible_deployments(device)
-    join_reply = Devices.resolve_update(device.org, deployments)
+    join_reply = Devices.resolve_update(device, deployments)
+
+    if join_reply.update_available do
+      AuditLogs.audit!(hd(deployments), device, :update, %{
+        from: "http_join",
+        send_update_message: true
+      })
+    end
+
     render(conn, "update.json", reply: join_reply)
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments/deployment.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments/deployment.ex
@@ -12,15 +12,30 @@ defmodule NervesHubWebCore.Deployments.Deployment do
 
   @type t :: %__MODULE__{}
   @required_fields [:firmware_id, :name, :conditions, :is_active, :product_id]
-  @optional_fields []
+  @optional_fields [
+    :device_failure_threshold,
+    :device_failure_rate_seconds,
+    :device_failure_rate_amount,
+    :failure_threshold,
+    :failure_rate_seconds,
+    :failure_rate_amount,
+    :healthy
+  ]
 
   schema "deployments" do
     belongs_to(:firmware, Firmware)
     belongs_to(:product, Product)
 
-    field(:name, :string)
     field(:conditions, :map)
+    field(:device_failure_threshold, :integer, default: 3)
+    field(:device_failure_rate_seconds, :integer, default: 180)
+    field(:device_failure_rate_amount, :integer, default: 5)
+    field(:failure_threshold, :integer, default: 50)
+    field(:failure_rate_seconds, :integer, default: 300)
+    field(:failure_rate_amount, :integer, default: 5)
     field(:is_active, :boolean)
+    field(:name, :string)
+    field(:healthy, :boolean, default: true)
 
     timestamps()
   end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device.ex
@@ -16,6 +16,7 @@ defmodule NervesHubWebCore.Devices.Device do
   @optional_params [
     :last_communication,
     :description,
+    :healthy,
     :tags
   ]
   @required_params [:org_id, :identifier]
@@ -28,6 +29,7 @@ defmodule NervesHubWebCore.Devices.Device do
     field(:identifier, :string)
     field(:description, :string)
     field(:last_communication, :utc_datetime)
+    field(:healthy, :boolean, default: true)
     field(:tags, NervesHubWebCore.Types.Tag)
 
     field(:status, :string, default: "offline", virtual: true)

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20180903215312_unique_deployment_name_product_id.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20180903215312_unique_deployment_name_product_id.exs
@@ -1,19 +1,7 @@
 defmodule NervesHubWebCore.Repo.Migrations.UniqueDeploymentNameProductId do
   use Ecto.Migration
 
-  alias NervesHubWebCore.Repo
-  alias NervesHubWebCore.Deployments.Deployment
-
   def up do
-    deployments = Repo.all(Deployment)
-
-    for deployment <- deployments do
-      deployment
-      |> Repo.preload(:firmware)
-      |> Deployment.changeset(%{})
-      |> Repo.update()
-    end
-
     alter table(:deployments) do
       modify(:product_id, references(:products), null: false)
     end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190429171105_add_rate_and_thresholds_to_deployments.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190429171105_add_rate_and_thresholds_to_deployments.exs
@@ -1,0 +1,17 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddRateAndThresholdsToDeployments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add(:device_failure_threshold, :integer, default: 3)
+      add(:device_failure_rate_seconds, :integer, default: 180)
+      add(:device_failure_rate_amount, :integer, default: 5)
+
+      add(:failure_threshold, :integer, default: 50)
+      add(:failure_rate_seconds, :integer, default: 300)
+      add(:failure_rate_amount, :integer, default: 5)
+
+      add(:healthy, :boolean, default: true)
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190429173128_add_needs_attention_to_devices.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190429173128_add_needs_attention_to_devices.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddNeedsAttentionToDevices do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add(:healthy, :boolean, default: true)
+    end
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -17,6 +17,10 @@
       <td><%= active(@deployment) %>
     </tr>
     <tr>
+      <th>Healthy?</th>
+      <td><%= health_status_icon(@deployment) %>
+    </tr>
+    <tr>
       <th>Version Requirement</th>
       <td><%= version(@deployment) %></td>
     </tr>
@@ -43,6 +47,10 @@
 </a>
 
 <a class="btn btn-primary mr-3" phx-click="toggle_active" phx-value=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
+
+<%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
+  <%= submit "Mark #{if @deployment.healthy, do: "Unhealthy", else: "Healthy"}", class: "btn btn-primary mr-3" %>
+<% end %>
 
 <%= form_for %Plug.Conn{}, "#", [phx_submit: "delete"], fn _f -> %>
   <%= submit "Delete Deployment", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -27,6 +27,10 @@
       </p>
 
       <p>
+        <strong>Healthy?: </strong><%= health_status_icon(@device) %>
+      </p>
+
+      <p>
         <strong>Last Connection:</strong>
         <%= if is_nil(@device.last_communication) do %>
           never
@@ -49,8 +53,11 @@
           Actions
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-          <%= link "Edit", to: device_path(@socket, :edit, @device), class: "dropdown-item" %>
           <%= link "Console", to: device_path(@socket, :console, @device), class: "dropdown-item #{unless Map.has_key?(@device, :console_available) && @device.console_available, do: "disabled"}" %>
+          <%= link "Edit", to: device_path(@socket, :edit, @device), class: "dropdown-item" %>
+          <%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
+            <%= submit "Mark #{if @device.healthy, do: "Unhealthy", else: "Healthy"}", class: "dropdown-item" %>
+          <% end %>
           <div class="dropdown-divider"></div>
           <button class="dropdown-item" type="button" phx-click="reboot" <%= if @device.status == "offline", do: "disabled" %> data-confirm="Are you sure?">Reboot</button>
         </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
@@ -4,6 +4,8 @@ defmodule NervesHubWWWWeb.DeploymentView do
   alias NervesHubWebCore.Firmwares.Firmware
   alias NervesHubWebCore.Deployments.Deployment
 
+  import NervesHubWWWWeb.LayoutView, only: [health_status_icon: 1]
+
   def firmware_dropdown_options(firmwares) do
     firmwares
     |> Enum.map(&[value: &1.id, key: firmware_display_name(&1)])

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -2,6 +2,8 @@ defmodule NervesHubWWWWeb.DeviceView do
   use NervesHubWWWWeb, :view
   alias NervesHubDevice.Presence
 
+  import NervesHubWWWWeb.LayoutView, only: [health_status_icon: 1]
+
   def architecture_options do
     [
       "aarch64",

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -38,6 +38,18 @@ defmodule NervesHubWWWWeb.LayoutView do
     Accounts.has_org_role?(org, user, role)
   end
 
+  def health_status_icon(%{healthy: healthy?}) do
+    {icon, color} = if healthy?, do: {"check-circle", "green"}, else: {"times-circle", "red"}
+    content_tag(:i, "", class: "fas fa-#{icon}", style: "color:#{color}")
+  end
+
+  def health_status_icon(_) do
+    content_tag(:i, "",
+      class: "fas fa-question-circle",
+      title: "Don't know how to tell health status"
+    )
+  end
+
   def permit_uninvited_signups do
     Application.get_env(:nerves_hub_www, NervesHubWWWWeb.AccountController)[:allow_signups]
   end


### PR DESCRIPTION
First attempt at https://github.com/nerves-hub/nerves_hub_web/issues/418 and https://github.com/nerves-hub/nerves_hub_web/issues/419

* Adds new fields to `Deployment` schema
  * :device_failure_threshold
  * :device_failure_rate_seconds
  * :device_failure_rate_amount
  * :failure_threshold
  * :failure_rate_seconds
  * :failure_rate_amount
  * :healthy
* Adds `healthy` bool to `Device` schema

The new `deployment` fields are to calculate a failure rate and failure threshold at both device and deployment levels.
The `failure rate` == X number of device update failures within Y seconds
The `failure threshold` is total number of devices in a `healthy == false` state that are permitted. Devices get in a `healthy == false` state when they attempt to update from the same deployment and exceed the `device_failure_threshold` (total number of times its allowed to attempt to update) or `device_failure_rate` (X attempted updates in Y seconds)

This is a good start, but not perfect. It will help cover some cases to get the ball rolling. But I would consider it a little inaccurate since to make some of these assertions we're relying on looking up device updates in the audit log with `send_update_message: true` in order to say "that device is attempting the same up multiple times and is probably failing 🤔". I went with this route because we mostly tell devices to update via a broadcast with no feedback from the device, but it can probably be approved.

Next step will be to get some feedback from devices about its attempts or connections to try some stronger asserts _first_ on what is breaking before checking loose audit events to see what might be going on.