### PR TITLE
Do not send email on create account

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -13,25 +13,16 @@ defmodule NervesHubWWWWeb.AccountController do
     render(conn, "new.html", changeset: %Changeset{data: %User{}})
   end
 
+  @doc """
+  This action is triggered by a "Create Account" UI request. There is no
+  organization involved save the one created for the user.
+  """
   def create(conn, %{"user" => user_params}) do
     user_params
     |> whitelist([:password, :username, :email])
     |> Accounts.create_user()
     |> case do
-      {:ok, new_user} ->
-        org = conn.assigns.current_org
-        # Now let everyone in the organization - except the new guy -
-        # know about this new user.
-        instigator = conn.assigns.user.username
-
-        Email.tell_org_user_added(
-          org,
-          Accounts.get_org_users(org),
-          instigator,
-          new_user
-        )
-        |> Mailer.deliver_later()
-
+      {:ok, _new_user} ->
         redirect(conn, to: "/")
 
       {:error, changeset} ->


### PR DESCRIPTION
In anticipation of web UI registration, this fixes a bug whereby an 
email is *not* sent to an organization's users; the only user is the one 
just registered.

This bug was introduced with the PR for Issue #403 because of not understanding the difference between "create account" and accepting an invitiation.