### PR TITLE
Add fwup progress when device is updating

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -10,6 +10,7 @@ defmodule NervesHubDevice.Presence do
     :connected_at,
     :console_available,
     :firmware_metadata,
+    :fwup_progress,
     :last_communication,
     :rebooting,
     :status,
@@ -62,6 +63,7 @@ defmodule NervesHubDevice.Presence do
     |> case do
       %{update_available: true} = e -> Map.put(e, :status, "update pending")
       %{rebooting: true} = e -> Map.put(e, :status, "rebooting")
+      %{fwup_progress: _progress} = e -> Map.put(e, :status, "updating")
       e -> Map.put(e, :status, "online")
     end
   end

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -37,6 +37,17 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     end
   end
 
+  def handle_in("fwup_progress", %{"value" => percent}, socket) do
+    Presence.update(
+      socket.channel_pid,
+      "devices:#{socket.assigns.device.org_id}",
+      socket.assigns.device.id,
+      %{fwup_progress: percent}
+    )
+
+    {:noreply, socket}
+  end
+
   def handle_in("rebooting", _payload, socket) do
     # Device sends "rebooting" message back to signify ack of the request
     Presence.update(

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -27,15 +27,21 @@
             </a>
           </td>
           <td class="col-2">
-            <%= if is_nil(device.firmware_metadata) do %>
-              unknown
+            <%= if Map.has_key?(device, :fwup_progress) && device.fwup_progress do %>
+              <div class="progress">
+                <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= device.fwup_progress %>%"><%= device.fwup_progress %>%</div>
+              </div>
             <% else %>
-              <p>
-                <strong>Version:</strong> <%= device.firmware_metadata.version %>
-              </p>
-              <p>
-                <strong>UUID:</strong> <%= device.firmware_metadata.uuid %>
-              </p>
+              <%= if is_nil(device.firmware_metadata) do %>
+                unknown
+              <% else %>
+                <p>
+                  <strong>Version:</strong> <%= device.firmware_metadata.version %>
+                </p>
+                <p>
+                  <strong>UUID:</strong> <%= device.firmware_metadata.uuid %>
+                </p>
+              <% end %>
             <% end %>
           </td>
           <td class="col-2 device"><%= device.status %></td>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -18,7 +18,12 @@
       </ul>
 
       <p>
-        <strong>Status: </strong><%= @device_status %>
+        <strong>Status: </strong><%= @device.status %>
+        <%= if Map.has_key?(@device, :fwup_progress) && @device.fwup_progress do %>
+          <div class="progress">
+            <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= @device.fwup_progress %>%"><%= @device.fwup_progress %>%</div>
+          </div>
+        <% end %>
       </p>
 
       <p>
@@ -45,9 +50,9 @@
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
           <%= link "Edit", to: device_path(@socket, :edit, @device), class: "dropdown-item" %>
-          <%= link "Console", to: device_path(@socket, :console, @device), class: "dropdown-item #{unless @console_available, do: "disabled"}" %>
+          <%= link "Console", to: device_path(@socket, :console, @device), class: "dropdown-item #{unless Map.has_key?(@device, :console_available) && @device.console_available, do: "disabled"}" %>
           <div class="dropdown-divider"></div>
-          <button class="dropdown-item" type="button" phx-click="reboot" <%= if @device_status != "online", do: "disabled" %> data-confirm="Are you sure?">Reboot</button>
+          <button class="dropdown-item" type="button" phx-click="reboot" <%= if @device.status == "offline", do: "disabled" %> data-confirm="Are you sure?">Reboot</button>
         </div>
       </div>
     </div>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_show_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_show_test.exs
@@ -59,16 +59,18 @@ defmodule NervesHubWWWWeb.DeviceLiveShowTest do
     end
 
     test "presence_diff with changes", session do
-      payload = %{joins: %{"#{session.device.id}" => %{}}, leaves: %{}}
+      payload = %{joins: %{}, leaves: %{"#{session.device.id}" => %{}}}
+      session = %{device: %{session.device | status: "online"}, user: session.user}
       {:ok, view, html} = mount(Endpoint, Show, session: session)
 
-      assert html =~ "offline"
+      assert html =~ "online"
 
       {:ok, device} =
         Devices.update_device(session.device, %{last_communication: DateTime.utc_now()})
 
       send(view.pid, %Broadcast{event: "presence_diff", payload: payload})
 
+      assert render(view) =~ "offline"
       assert render(view) =~ to_string(device.last_communication)
     end
   end


### PR DESCRIPTION
Requires https://github.com/nerves-hub/nerves_hub/pull/97

Displays a fwup progress based on messages from `nerves_hub` while the device is updating.
Shows progress in `device#show` and `device#index` views.

A good visual check that your deployment is doing what you want and devices are reacting

![fwup_progress](https://user-images.githubusercontent.com/11321326/57240278-452bb200-6feb-11e9-8e29-7bec07b592e9.gif)
