### PR TITLE
Fix device#index fwup progress

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -95,7 +95,11 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
           # slightly inaccurate to set here, but only by a minuscule amount
           # and saves DB calls and broadcasts
           disconnect_time = DateTime.truncate(DateTime.utc_now(), :second)
-          %{device | last_communication: disconnect_time, status: "offline", fwup_progress: nil}
+
+          device
+          |> Map.put(:last_communication, disconnect_time)
+          |> Map.put(:status, "offline")
+          |> Map.put(:fwup_progress, nil)
 
         true ->
           device

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
@@ -137,12 +137,11 @@ defmodule NervesHubWWWWeb.DeviceLive.Show do
         # and saves DB calls and broadcasts
         disconnect_time = DateTime.truncate(DateTime.utc_now(), :second)
 
-        device =
-          device
-          |> Map.put(:console_available, false)
-          |> Map.put(:fwup_progress, nil)
-          |> Map.put(:last_communication, disconnect_time)
-          |> Map.put(:status, "offline")
+        device
+        |> Map.put(:console_available, false)
+        |> Map.put(:fwup_progress, nil)
+        |> Map.put(:last_communication, disconnect_time)
+        |> Map.put(:status, "offline")
 
       true ->
         device


### PR DESCRIPTION
I forgot to change the `devices#index` to use `Map.put` to update the device with `:fwup_progress` instead of using the update syntax `%{ | }`. So there are a few cases where this would error out if the device has not gotten a fwup message or anything.

(the other route would be to add these as virtual fields on the device, but was opting for this simple change to keep device schema cleaner for now)