### PR TITLE
Deployment health views

### DIFF
--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -135,3 +135,9 @@ main {
   text-decoration-line: underline;
   text-decoration-style: dotted;
 }
+
+.help-icon {
+  font-size: 10px;
+  position: relative;
+  bottom: 1em;
+}

--- a/apps/nerves_hub_www/assets/js/app.js
+++ b/apps/nerves_hub_www/assets/js/app.js
@@ -1,5 +1,6 @@
 import 'phoenix_html'
 import 'bootstrap'
+import $ from 'jquery'
 import LiveSocket from 'phoenix_live_view'
 let dates = require('./dates')
 
@@ -8,4 +9,8 @@ liveSocket.connect()
 
 document.querySelectorAll('.date-time').forEach(d => {
   d.innerHTML = dates.formatDateTime(d.innerHTML)
+})
+
+$(function() {
+  $('[data-toggle="help-tooltip"]').tooltip()
 })

--- a/apps/nerves_hub_www/assets/yarn.lock
+++ b/apps/nerves_hub_www/assets/yarn.lock
@@ -3622,9 +3622,9 @@ jest@^24.0.0:
     jest-cli "^24.0.0"
 
 jquery@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.0"

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
@@ -133,10 +133,23 @@ defmodule NervesHubWWWWeb.DeploymentController do
         %{assigns: %{product: product, user: user}} = conn,
         %{"id" => deployment_id, "deployment" => deployment_params}
       ) do
+    allowed_fields = [
+      :conditions,
+      :device_failure_rate_amount,
+      :device_failure_rate_seconds,
+      :device_failure_threshold,
+      :failure_rate_amount,
+      :failure_rate_seconds,
+      :failure_threshold,
+      :firmware_id,
+      :name,
+      :is_active
+    ]
+
     params =
       deployment_params
       |> inject_conditions_map()
-      |> whitelist([:name, :conditions, :firmware_id, :is_active])
+      |> whitelist(allowed_fields)
 
     {:ok, deployment} = Deployments.get_deployment(product, deployment_id)
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.eex
@@ -67,5 +67,55 @@
     <div class="has-error"><%= error_tag f, :tags %></div>
   </div>
 
+  <div class="form-group">
+    <label for="failure_rate_input">Failure Threshold</label>
+    <%= help_icon(help_message_for(:failure_threshold)) %>
+    <%= number_input f, :failure_threshold,
+      class: "form-control-sm",
+      id: "failure_threshold"
+    %>
+    <div class="has-error"><%= error_tag f, :failure_threshold %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="failure_rate_input">Failure Rate</label>
+    <%= help_icon(help_message_for(:failure_rate)) %>
+    <%= number_input f, :failure_rate_amount,
+      class: "form-control-sm",
+      id: "failure_rate_amount"
+    %>
+    device failures per
+    <%= number_input f, :failure_rate_seconds,
+      class: "form-control-sm",
+      id: "failure_rate_input"
+    %> seconds
+    <div class="has-error invalid-tooltip"><%= error_tag f, :failure_rate_seconds %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="failure_rate_input">Device Failure Threshold</label>
+    <%= help_icon(help_message_for(:device_failure_threshold)) %>
+    <%= number_input f, :device_failure_threshold,
+      class: "form-control-sm",
+      id: "device_failure_threshold"
+    %>
+    <div class="has-error"><%= error_tag f, :device_failure_threshold %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="device_failure_rate_input">Device Failure Rate</label>
+    <%= help_icon(help_message_for(:device_failure_rate)) %>
+    <%= number_input f, :device_failure_rate_amount,
+      class: "form-control-sm",
+      id: "device_failure_rate_amount"
+    %>
+    failures per
+    <%= number_input f, :device_failure_rate_seconds,
+      class: "form-control-sm",
+      id: "device_failure_rate_input"
+    %> seconds
+    <div class="has-error"><%= error_tag f, :device_failure_rate_seconds %></div>
+  </div>
+
   <%= submit "Update Deployment", class: "btn btn-primary" %>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -38,6 +38,22 @@
       <th>Firmware Info</th>
       <td><%= firmware_summary(@deployment.firmware) %></td>
     </tr>
+    <tr>
+      <th>Failure Rate <%= help_icon(help_message_for(:failure_rate)) %></th>
+      <td><%= @deployment.failure_rate_amount %> device failures per <%= @deployment.failure_rate_seconds %> seconds</td>
+    </tr>
+    <tr>
+      <th>Failure Threshold <%= help_icon(help_message_for(:failure_threshold)) %></th>
+      <td><%= @deployment.failure_threshold %></td>
+    </tr>
+    <tr>
+      <th>Device Failure Rate <%= help_icon(help_message_for(:device_failure_rate)) %></th>
+      <td><%= @deployment.device_failure_rate_amount %> failures per <%= @deployment.device_failure_rate_seconds %> seconds</td>
+    </tr>
+    <tr>
+      <th>Device Failure Threshold <%= help_icon(help_message_for(:device_failure_threshold)) %></th>
+      <td><%= @deployment.device_failure_threshold %></td>
+    </tr>
   </tbody>
 </table>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWWWWeb.DeploymentView do
   alias NervesHubWebCore.Firmwares.Firmware
   alias NervesHubWebCore.Deployments.Deployment
 
-  import NervesHubWWWWeb.LayoutView, only: [health_status_icon: 1]
+  import NervesHubWWWWeb.LayoutView, only: [health_status_icon: 1, help_icon: 1]
 
   def firmware_dropdown_options(firmwares) do
     firmwares
@@ -32,6 +32,22 @@ defmodule NervesHubWWWWeb.DeploymentView do
     case f.version do
       nil -> "--"
       version -> "#{version}"
+    end
+  end
+
+  def help_message_for(field) do
+    case field do
+      :failure_threshold ->
+        "Maximum number of target devices from this deployment that can be in an unhealthy state before marking the deployment unhealthy"
+
+      :failure_rate ->
+        "Maximum number of device install failures from this deployment within X seconds before being marked unhealthy"
+
+      :device_failure_rate ->
+        "Maximum number of device failures within X seconds a device can have for this deployment before being marked unhealthy"
+
+      :device_failure_threshold ->
+        "Maximum number of install attempts and/or failures a device can have for this deployment before being marked unhealthy"
     end
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -50,6 +50,14 @@ defmodule NervesHubWWWWeb.LayoutView do
     )
   end
 
+  def help_icon(message, placement \\ :top) do
+    content_tag(:i, "",
+      class: "help-icon far fa-question-circle",
+      data: [toggle: "help-tooltip", placement: placement],
+      title: message
+    )
+  end
+
   def permit_uninvited_signups do
     Application.get_env(:nerves_hub_www, NervesHubWWWWeb.AccountController)[:allow_signups]
   end


### PR DESCRIPTION
~~This is branched off of #455 that I forgot to put in, but that PR was already big enough so I decided to keep it separate.~~

~~Until #455 is merged, you'll want to just look at [this diff](https://github.com/nerves-hub/nerves_hub_web/compare/deployment_protections...deployment_health_views) for changes~~
Rebased 🎉 ☝️ 

Update deployment views
 * Updates `deployment#show` to display failure rates and thresholds
 * Updates `deployment#edit` to allow changing failure rates and thresholds
 * adds help icons with tooltips about failure rates and thresholds

![Screen Shot 2019-05-07 at 9 11 51 AM](https://user-images.githubusercontent.com/11321326/57312074-13c5eb80-70aa-11e9-9ef5-98bcf9d4c86f.png)
![Screen Shot 2019-05-07 at 9 12 10 AM](https://user-images.githubusercontent.com/11321326/57312076-13c5eb80-70aa-11e9-9560-a2295e830329.png)
![Screen Shot 2019-05-07 at 9 12 21 AM](https://user-images.githubusercontent.com/11321326/57312078-145e8200-70aa-11e9-8f5f-c4377e0c32db.png)
