### PR TITLE
Allow ANSI \e[22m in console output

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
   alias NervesHubDevice.Presence
   alias Phoenix.Socket.Broadcast
 
-  @theme AnsiToHTML.Theme.new(container: :none)
+  @theme AnsiToHTML.Theme.new(container: :none, "\e[22m": {:text, []})
 
   def render(assigns) do
     NervesHubWWWWeb.DeviceView.render("console.html", assigns)


### PR DESCRIPTION
Some messaages from remote iex session come in with an escape of `\e[22m` and it would
break the rendering. This parameter is [`Normal color or intensity`](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters) so I think just ignoring it and defaulting to the HTML coloring is fine.

Also resolves [this rollbar error](https://rollbar.com/nerves-hub/nerves_hub_www/items/1)