### PR TITLE
Support more ANSI in remote console

### DIFF
--- a/apps/nerves_hub_www/assets/css/_console.scss
+++ b/apps/nerves_hub_www/assets/css/_console.scss
@@ -1,0 +1,28 @@
+.console {
+  font-family: monospace;
+  text-align:left;
+  font-size: 16px;
+  padding: 4px;
+  background-color: black;
+  color: white;
+}
+
+.console-active-line {
+}
+
+.console-input {
+  color: inherit;
+  font-family: inherit;
+  width: inherit;
+  border:none;
+  background-image:none;
+  background-color:transparent;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  width: 75%;
+}
+
+.console-input:focus {
+  outline: none;
+}

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -5,6 +5,7 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import '~@fortawesome/fontawesome-free/scss/brands';
 
 @import "audit_log_feed";
+@import "console";
 @import "custom";
 @import "navigation";
 @import "home";

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
@@ -16,7 +16,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
     end
 
     socket
-    |> assign(:active_line, "iex (#{session.username})> ")
+    |> assign(:active_line, "iex(#{session.username})> ")
     |> assign(:device, session.device)
     |> assign(:lines, ["NervesHub IEx Live"])
     |> assign(:username, session.username)
@@ -76,7 +76,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
         %Broadcast{event: "get_line", payload: %{"data" => line}},
         %{assigns: %{username: username}} = socket
       ) do
-    line = String.replace(line, ~r/(iex\()\d+(\))/, "\\1#{username}\\2")
+    line = String.replace(line, ~r/(iex).*(>)/, "\\1(#{username})\\2")
     {:noreply, assign(socket, :active_line, line)}
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.leex
@@ -4,14 +4,14 @@
 <% end %>
 
 <div class="container">
-  <pre style="font-family: monospace; text-align:left; font-size: 16px; padding: 4px; background-color: black; color: white;">
+  <pre class="console">
 
     <%= for line <- @lines do %>
     <p><%= line %></p>
     <% end %>
-    <%= form_for %Plug.Conn{}, "#", [phx_submit: :iex_submit], fn f -> %>
+    <%= form_for %Plug.Conn{}, "#", [phx_submit: :iex_submit, class: "console-active-line"], fn f -> %>
       <%= if @active_line do %>
-        <%= @active_line %><%= text_input f, :iex_input %>
+        <%= @active_line %><%= text_input f, :iex_input, class: "console-input", autofocus: true %>
       <% end %>
     <% end %>
   </pre>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_console_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_console_test.exs
@@ -38,7 +38,7 @@ defmodule NervesHubWWWWeb.DeviceLiveConsoleTest do
     test "iex_submit", session do
       {:ok, view, _html} = mount(Endpoint, Console, session: session)
       input = "Howdy"
-      iex_line = "iex (#{session.username})&gt; #{input}"
+      iex_line = "iex(#{session.username})&gt; #{input}"
 
       assert render_submit(view, :iex_submit, %{iex_input: input}) =~ iex_line
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "ansi_to_html": {:git, "https://github.com/jjcarstens/ansi_to_html", "124aeaa62f44cd0145f77808605148f9edaaa43a", []},
+  "ansi_to_html": {:git, "https://github.com/jjcarstens/ansi_to_html", "7aa02d8c425e92d876616073e26af591c189ef76", []},
   "artificery": {:hex, :artificery, "0.2.6", "f602909757263f7897130cbd006b0e40514a541b148d366ad65b89236b93497a", [:mix], [], "hexpm"},
   "bamboo": {:hex, :bamboo, "1.0.0", "446525f74eb59022ef58bc82f6c91c8e4c5a1469ab42a7f9b37c17262f872ef0", [:mix], [{:hackney, "~> 1.12.1", [hex: :hackney, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "bamboo_smtp": {:hex, :bamboo_smtp, "1.5.0", "ebc4deb64a0ff88d05edc1e5f6fd77aea563cdbeac3fcb277666af96dff309e3", [:mix], [{:bamboo, "~> 1.0.0", [hex: :bamboo, repo: "hexpm", optional: false]}, {:gen_smtp, "~> 0.12.0", [hex: :gen_smtp, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Supports a few more ANSI codes in the remote iex console that were causing crashes (via https://github.com/stephlow/ansi_to_html/pull/2/commits/7aa02d8c425e92d876616073e26af591c189ef76). That change also handles unknown ANSI a little more gracefully so things don't just 💥 

Also updates the console view a bit to make the input field larger and blend in to the "console" background.

The indentation of the command line and some responses are still a little wack...one can only handle so much CSS in one day 😑 

![Screen Shot 2019-05-07 at 4 36 41 PM](https://user-images.githubusercontent.com/11321326/57337539-0aa73f80-70e7-11e9-8e9b-bca060639785.png)