### PR TITLE
Update fwup to 1.3.1

### DIFF
--- a/apps/nerves_hub_api/rel/Dockerfile.build
+++ b/apps/nerves_hub_api/rel/Dockerfile.build
@@ -16,7 +16,7 @@ RUN mix release --env=$MIX_ENV --name=nerves_hub_api
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
 
-RUN apk add 'fwup~=1.3.0' \
+RUN apk add 'fwup~=1.3.1' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
 

--- a/apps/nerves_hub_www/Dockerfile
+++ b/apps/nerves_hub_www/Dockerfile
@@ -4,7 +4,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=en_US.UTF-8 \
   PATH="/app:${PATH}" \
-  FWUP_VERSION=1.3.0 \
+  FWUP_VERSION=1.3.1 \
   DATABASE_URL=postgres://db:db@localhost:5432/db \
   DATABASE_SSL="false" \
   SECRET_KEY_BASE=""

--- a/apps/nerves_hub_www/rel/Dockerfile.build
+++ b/apps/nerves_hub_www/rel/Dockerfile.build
@@ -31,7 +31,7 @@ RUN mix do phx.digest, release --env=$MIX_ENV --name=nerves_hub_www
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
 
-RUN apk add 'fwup~=1.3.0' \
+RUN apk add 'fwup~=1.3.1' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
 


### PR DESCRIPTION
This is needed to build prod containers. I guess there is an issue with pulling previous version from the community apk repo.