### PR TITLE
Use human friendly descriptions for audit logs

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
@@ -5,14 +5,34 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
   import EctoEnum
 
   alias NervesHubWebCore.{
+    Accounts.Org,
+    Accounts.User,
     Deployments.Deployment,
+    Devices.Device,
+    Firmwares.Firmware,
     Repo,
     Types.Resource
   }
 
   @primary_key {:id, :binary_id, autogenerate: true}
-  @required_params [:action, :actor_id, :actor_type, :params, :resource_id, :resource_type]
+  @required_params [
+    :action,
+    :actor_id,
+    :actor_type,
+    :description,
+    :params,
+    :resource_id,
+    :resource_type
+  ]
   @optional_params [:changes]
+
+  @identifier_fields %{
+    Device => :identifier,
+    Deployment => :name,
+    Firmware => :uuid,
+    Org => :name,
+    User => :username
+  }
 
   defenum(Action, :action, [:create, :update, :delete])
 
@@ -20,6 +40,7 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
     field(:action, Action)
     field(:actor_id, :id)
     field(:actor_type, Resource)
+    field(:description, :string)
     field(:changes, :map)
     field(:params, :map)
     field(:resource_id, :id)
@@ -29,15 +50,19 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
   end
 
   def build(%actor_type{} = actor, %resource_type{} = resource, action, params) do
+    {description, params} = Map.pop(params, :log_description)
+
     %__MODULE__{
       action: action,
       actor_id: actor.id,
       actor_type: actor_type,
+      description: description,
       resource_id: resource.id,
       resource_type: resource_type,
       params: format_params(actor, resource, action, params)
     }
     |> add_changes(resource)
+    |> create_description(actor, resource)
   end
 
   def changeset(params) do
@@ -56,6 +81,149 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
     audit_log
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
+  end
+
+  def create_description(%__MODULE__{} = audit_log) do
+    %{actor_type: atype, actor_id: aid, resource_type: rtype, resource_id: rid} = audit_log
+
+    # If the resources don't exist anymore, just build the struct
+    actor = Repo.get(atype, aid) || struct(atype, id: aid)
+    resource = Repo.get(rtype, rid) || struct(rtype, id: rid)
+
+    create_description(audit_log, actor, resource)
+  end
+
+  def create_description(%{description: description} = audit_log, _, _)
+      when not is_nil(description) or not description == "" do
+    # use description that was already provided
+    audit_log
+  end
+
+  def create_description(%{action: action} = audit_log, actor, resource)
+      when action in [:create, :delete] do
+    # i.e.
+    #   user bob created device howdy-1234
+    #   user swanson deleted deployment nunya
+    %{audit_log | description: "#{identifier_for(actor)} #{action}d #{identifier_for(resource)}"}
+  end
+
+  def create_description(
+        %{params: %{send_update_message: true, from: from_str}} = audit_log,
+        %Deployment{} = actor,
+        %Device{} = resource
+      ) do
+    actor = Repo.preload(actor, :firmware)
+
+    description =
+      case from_str do
+        "broadcast" ->
+          "#{identifier_for(actor)} update triggered #{identifier_for(resource)} to update #{
+            identifier_for(actor.firmware)
+          }"
+
+        msg ->
+          "#{identifier_for(resource)} received update for #{identifier_for(actor.firmware)} via #{
+            identifier_for(actor)
+          } after #{msg}"
+      end
+
+    %{audit_log | description: description}
+  end
+
+  def create_description(
+        %{params: %{healthy: false, reason: reason}} = audit_log,
+        %Deployment{} = actor,
+        %Device{} = resource
+      ) do
+    actor = Repo.preload(actor, :firmware)
+
+    description =
+      "#{identifier_for(resource)} marked unhealthy. #{String.capitalize(reason)} for #{
+        identifier_for(actor.firmware)
+      } in #{identifier_for(actor)}"
+
+    %{audit_log | description: description}
+  end
+
+  def create_description(
+        %{params: %{healthy: false, reason: reason}} = audit_log,
+        %Deployment{} = actor,
+        %Deployment{}
+      ) do
+    actor = Repo.preload(actor, :firmware)
+
+    description =
+      "#{identifier_for(actor)} marked unhealthy. #{String.capitalize(reason)} for #{
+        identifier_for(actor.firmware)
+      }"
+
+    %{audit_log | description: description}
+  end
+
+  def create_description(
+        %{params: %{reboot: authorized?}} = audit_log,
+        %User{} = actor,
+        %Device{} = resource
+      ) do
+    reboot_str = if authorized?, do: "triggered reboot", else: "attempted unauthorized reboot"
+    description = "#{identifier_for(actor)} #{reboot_str} on #{identifier_for(resource)}"
+    %{audit_log | description: description}
+  end
+
+  def create_description(
+        %{changes: %{healthy: healthy?}} = audit_log,
+        %User{} = actor,
+        resource
+      ) do
+    health_str = if healthy?, do: "healthy", else: "unhealthy"
+    description = "#{identifier_for(actor)} marked #{identifier_for(resource)} #{health_str}"
+    %{audit_log | description: description}
+  end
+
+  def create_description(
+        %{changes: %{is_active: is_active?}} = audit_log,
+        %User{} = actor,
+        resource
+      ) do
+    active_str = if is_active?, do: "active", else: "inactive"
+    description = "#{identifier_for(actor)} marked #{identifier_for(resource)} #{active_str}"
+    %{audit_log | description: description}
+  end
+
+  def create_description(%{changes: changes} = audit_log, %User{} = actor, resource)
+      when map_size(changes) == 0 do
+    description =
+      "#{identifier_for(actor)} submitted update without changes for #{identifier_for(resource)}"
+
+    %{audit_log | description: description}
+  end
+
+  def create_description(%{changes: changes} = audit_log, %User{} = actor, resource) do
+    changed_fields =
+      Map.keys(changes)
+      |> case do
+        [key] -> "#{to_string(key)} field"
+        [key1, key2] -> "#{key1} and #{key2} fields"
+        [last_key | rem] -> Enum.join(rem, ", ") <> ", and #{last_key} fields"
+      end
+
+    # i.e.
+    #   user Ron changed tags field on device 1234
+    #   user Sam changed tags and description fields on device 1234
+    #   user Julie changed tags, description, and version fields on deployment For Cool Kids
+    description =
+      "#{identifier_for(actor)} changed #{changed_fields} on #{identifier_for(resource)}"
+
+    %{audit_log | description: description}
+  end
+
+  def create_description(audit_log, actor, resource) do
+    desc =
+      "#{identifier_for(actor)} performed unknown #{audit_log.action} on #{
+        identifier_for(resource)
+      }"
+
+    %{audit_log | description: desc}
   end
 
   defp add_changes(
@@ -79,4 +247,20 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
   end
 
   defp format_params(_actor, _resource, _action, params), do: params
+
+  defp identifier_for(%type{} = resource) do
+    simple_type =
+      to_string(type)
+      |> String.downcase()
+      |> String.split(".")
+      |> Enum.at(-1)
+
+    # default to DB id field if target identifier is nil
+    identifier = Map.get(resource, @identifier_fields[type]) || resource.id
+
+    # i.e.
+    #   user ron.swanson
+    #   deployment Awesome Deployment
+    "#{simple_type} #{identifier}"
+  end
 end

--- a/apps/nerves_hub_web_core/priv/repo/add_audit_log_descriptions.exs
+++ b/apps/nerves_hub_web_core/priv/repo/add_audit_log_descriptions.exs
@@ -1,0 +1,42 @@
+alias NervesHubWebCore.{AuditLogs.AuditLog, Repo}
+import Ecto.Query
+import IO.ANSI, only: [default_color: 0, green: 0, red: 0]
+
+Logger.configure(level: :info)
+
+defmodule Helper do
+  def convert_keys(nil), do: %{}
+  def convert_keys(map) do
+    map
+    |> Enum.map(fn {k,v} -> {String.to_atom(k), v} end)
+    |> Map.new
+  end
+end
+
+{success, errors} =
+  from(a in AuditLog, where: is_nil(a.description) or a.description == "")
+  |> Repo.all()
+  |> Enum.reduce({[], []}, fn audit_log, {success, errors} ->
+    # Convert params keys from string to atom
+    params = Helper.convert_keys(audit_log.params)
+
+    # Convert changes keys from string to atom
+    changes = Helper.convert_keys(audit_log.changes)
+
+    with_description = %{audit_log | changes: changes, params: params}
+                       |> AuditLog.create_description()
+
+    AuditLog.changeset(audit_log, Map.from_struct(with_description))
+    |> Repo.update()
+    |> case do
+      {:ok, al} ->
+        IO.write("#{green()}.#{default_color()}")
+        {[al | success], errors}
+      {:error, al} ->
+        IO.write("#{red()}.#{default_color()}")
+        {success, [al | errors]}
+    end
+  end)
+
+IO.puts("\nSuccess: #{green()}#{length(success)}#{default_color()}")
+IO.puts("Error: #{red()}#{length(errors)}#{default_color()}")

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190520202940_add_description_to_audit_logs.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190520202940_add_description_to_audit_logs.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddDescriptionToAuditLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_logs) do
+      add(:description, :string)
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/audit_logs/audit_log_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/audit_logs/audit_log_test.exs
@@ -1,0 +1,251 @@
+defmodule NervesHubWebCore.AuditLogs.AuditLogTest do
+  use NervesHubWebCore.DataCase
+
+  alias NervesHubWebCore.{
+    AuditLogs.AuditLog,
+    Fixtures
+  }
+
+  setup do
+    Fixtures.standard_fixture()
+  end
+
+  describe "build" do
+    test "includes changes if present", %{device: device, user: user} do
+      params = %{tags: ["howdy"]}
+      al = AuditLog.build(user, device, :update, params)
+      assert al.changes == params
+    end
+
+    test "adds firmware_uuid for device update messages", %{
+      deployment: deployment,
+      device: device
+    } do
+      deployment = Repo.preload(deployment, :firmware)
+      al = AuditLog.build(deployment, device, :update, %{send_update_message: true})
+
+      assert al.params.firmware_uuid == deployment.firmware.uuid
+    end
+
+    test "can use supplied description", %{device: device, user: user} do
+      description = "what just happened?!"
+      al = AuditLog.build(user, device, :update, %{log_description: description})
+      assert al.description == description
+      assert al.params == %{}
+    end
+  end
+
+  describe "create_description" do
+    test "default description for create events", context do
+      %{device: device, deployment: deployment, firmware: firmware, org: org, user: user} =
+        context
+
+      al1 = AuditLog.build(user, device, :create, %{})
+      al2 = AuditLog.build(org, device, :create, %{})
+      al3 = AuditLog.build(user, deployment, :create, %{})
+      al4 = AuditLog.build(user, firmware, :create, %{})
+
+      assert al1.description == "user #{user.username} created device #{device.identifier}"
+      assert al2.description == "org #{org.name} created device #{device.identifier}"
+      assert al3.description == "user #{user.username} created deployment #{deployment.name}"
+      assert al4.description == "user #{user.username} created firmware #{firmware.uuid}"
+    end
+
+    test "default description for deleted events", context do
+      %{device: device, deployment: deployment, firmware: firmware, org: org, user: user} =
+        context
+
+      al1 = AuditLog.build(user, device, :delete, %{})
+      al2 = AuditLog.build(org, device, :delete, %{})
+      al3 = AuditLog.build(user, deployment, :delete, %{})
+      al4 = AuditLog.build(user, firmware, :delete, %{})
+
+      assert al1.description == "user #{user.username} deleted device #{device.identifier}"
+      assert al2.description == "org #{org.name} deleted device #{device.identifier}"
+      assert al3.description == "user #{user.username} deleted deployment #{deployment.name}"
+      assert al4.description == "user #{user.username} deleted firmware #{firmware.uuid}"
+    end
+
+    test "marks updates from user without any changes", %{device: device, user: user} do
+      al = AuditLog.build(user, device, :update, %{})
+
+      assert al.description ==
+               "user #{user.username} submitted update without changes for device #{
+                 device.identifier
+               }"
+    end
+
+    test "description when user changes one or more fields on resource", context do
+      %{device: device, user: user} = context
+      one_change = AuditLog.build(user, device, :update, %{tags: ["wat"]})
+      two_changes = AuditLog.build(user, device, :update, %{description: "howdy", tags: ["wat"]})
+
+      many_changes =
+        AuditLog.build(user, device, :update, %{
+          description: "howdy",
+          identifier: "1",
+          tags: ["wat"]
+        })
+
+      assert one_change.description ==
+               "user #{user.username} changed tags field on device #{device.identifier}"
+
+      assert two_changes.description ==
+               "user #{user.username} changed description and tags fields on device #{
+                 device.identifier
+               }"
+
+      assert many_changes.description ==
+               "user #{user.username} changed identifier, tags, and description fields on device #{
+                 device.identifier
+               }"
+    end
+
+    test "description for health changes", context do
+      %{device: device, deployment: deployment, user: user} = context
+
+      al1 = AuditLog.build(user, %{deployment | healthy: false}, :update, %{healthy: true})
+      al2 = AuditLog.build(user, %{deployment | healthy: true}, :update, %{healthy: false})
+      al3 = AuditLog.build(user, %{device | healthy: false}, :update, %{healthy: true})
+      al4 = AuditLog.build(user, %{device | healthy: true}, :update, %{healthy: false})
+
+      assert al1.description ==
+               "user #{user.username} marked deployment #{deployment.name} healthy"
+
+      assert al2.description ==
+               "user #{user.username} marked deployment #{deployment.name} unhealthy"
+
+      assert al3.description == "user #{user.username} marked device #{device.identifier} healthy"
+
+      assert al4.description ==
+               "user #{user.username} marked device #{device.identifier} unhealthy"
+    end
+
+    test "description for active changes", context do
+      %{deployment: deployment, user: user} = context
+
+      al1 = AuditLog.build(user, %{deployment | is_active: false}, :update, %{is_active: true})
+      al2 = AuditLog.build(user, %{deployment | is_active: true}, :update, %{is_active: false})
+
+      assert al1.description ==
+               "user #{user.username} marked deployment #{deployment.name} active"
+
+      assert al2.description ==
+               "user #{user.username} marked deployment #{deployment.name} inactive"
+    end
+
+    test "description for reboot attempts", %{device: device, user: user} do
+      al1 = AuditLog.build(user, device, :update, %{reboot: true})
+      al2 = AuditLog.build(user, device, :update, %{reboot: false})
+
+      assert al1.description ==
+               "user #{user.username} triggered reboot on device #{device.identifier}"
+
+      assert al2.description ==
+               "user #{user.username} attempted unauthorized reboot on device #{device.identifier}"
+    end
+
+    test "description for device updates", context do
+      %{deployment: deployment, device: device, firmware: firmware} = context
+
+      al1 =
+        AuditLog.build(deployment, device, :update, %{
+          send_update_message: true,
+          from: "broadcast"
+        })
+
+      al2 =
+        AuditLog.build(deployment, device, :update, %{
+          send_update_message: true,
+          from: "channel_join"
+        })
+
+      al3 =
+        AuditLog.build(deployment, device, :update, %{
+          send_update_message: true,
+          from: "http_join"
+        })
+
+      assert al1.description ==
+               "deployment #{deployment.name} update triggered device #{device.identifier} to update firmware #{
+                 firmware.uuid
+               }"
+
+      assert al2.description ==
+               "device #{device.identifier} received update for firmware #{firmware.uuid} via deployment #{
+                 deployment.name
+               } after channel_join"
+
+      assert al3.description ==
+               "device #{device.identifier} received update for firmware #{firmware.uuid} via deployment #{
+                 deployment.name
+               } after http_join"
+    end
+
+    test "description for deployment failures", context do
+      %{deployment: deployment, firmware: firmware} = context
+
+      # Deployment failure threshold and rate
+      al1 =
+        AuditLog.build(deployment, deployment, :update, %{
+          healthy: false,
+          reason: "failure threshold met"
+        })
+
+      al2 =
+        AuditLog.build(deployment, deployment, :update, %{
+          healthy: false,
+          reason: "failure rate met"
+        })
+
+      assert al1.description ==
+               "deployment #{deployment.name} marked unhealthy. Failure threshold met for firmware #{
+                 firmware.uuid
+               }"
+
+      assert al2.description ==
+               "deployment #{deployment.name} marked unhealthy. Failure rate met for firmware #{
+                 firmware.uuid
+               }"
+    end
+
+    test "description for device failures", context do
+      %{deployment: deployment, device: device, firmware: firmware} = context
+
+      # Device failure threshold and rate
+      al1 =
+        AuditLog.build(deployment, device, :update, %{
+          healthy: false,
+          reason: "device failure threshold met"
+        })
+
+      al2 =
+        AuditLog.build(deployment, device, :update, %{
+          healthy: false,
+          reason: "device failure rate met"
+        })
+
+      assert al1.description ==
+               "device #{device.identifier} marked unhealthy. Device failure threshold met for firmware #{
+                 firmware.uuid
+               } in deployment #{deployment.name}"
+
+      assert al2.description ==
+               "device #{device.identifier} marked unhealthy. Device failure rate met for firmware #{
+                 firmware.uuid
+               } in deployment #{deployment.name}"
+    end
+
+    test "default description when unmatched or unknown", %{
+      device: device,
+      deployment: deployment
+    } do
+      al = AuditLog.build(deployment, device, :update, %{wat: 1})
+
+      assert al.description ==
+               "deployment #{deployment.name} performed unknown update on device #{
+                 device.identifier
+               }"
+    end
+  end
+end

--- a/apps/nerves_hub_www/assets/css/_audit_log_feed.scss
+++ b/apps/nerves_hub_www/assets/css/_audit_log_feed.scss
@@ -3,8 +3,10 @@
 }
 
 .audit-log-time {
+  color: rgb(149, 156, 166);
   font-size: 12px;
   font-style: italic;
+  margin-top: 5px;
 }
 
 .audit-log-actor {
@@ -29,4 +31,37 @@
 #audit-log-feed {
   height: 500px;
   overflow: auto;
+}
+
+.audit-log-item {
+  padding-bottom: 20px;
+  padding-left: 20px;
+  margin-left: 20px;
+  border-left-width: 1px;
+  border-left-style: solid;
+  border-left-color: rgb(223, 227, 232);
+  position: relative;
+  line-height: 1.3em;
+  cursor: pointer;
+}
+
+.audit-log-feed-icon {
+  background-color: rgb(79, 75, 71);
+  border: 3px solid rgb(232, 96, 48);
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
+  border-bottom-left-radius: 10px;
+  width: 10px;
+  height: 10px;
+  position: absolute;
+  top: 5px;
+  left: -5px;
+}
+
+.audit-log-date {
+  margin-top: 5px;
+  font-family: ProximaNovaRegularItalic, Helvetica, Arial, sans-serif;
+  color: rgb(149, 156, 166);
+  font-size: 11px;
 }

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
@@ -1,22 +1,11 @@
 <h4>Audit Logs</h4>
 <div id="audit-log-feed">
-  <%= for audit_log <- @audit_logs do %>
-    <div class="">
-      <div data-toggle="collapse" data-target='#<%= String.replace(audit_log.id, ~r/\d/, "") %>' aria-expanded="true">
-        <div class="card-header">
-          <%= audit_log_icon(audit_log) %>
-          <span class="audit-log-actor"><%= actor_link(audit_log, assigns[:resource_id]) %></span>
-          <i class="fas fa-long-arrow-alt-right"></i>
-          <span class="audit-log-resource"><%= resource_link(audit_log, assigns[:resource_id]) %></span>
-          <span class="audit-log-time"><%= audit_log.inserted_at %></span>
-        </div>
-      </div>
 
-      <div id='<%= String.replace(audit_log.id, ~r/\d/, "") %>' class="collapse" aria-labelledby="headingOne" data-parent="#audit-log-feed">
-        <div class="card-body">
-          <%= audit_log_info(audit_log) %>
-        </div>
-      </div>
+  <%= for audit_log <- @audit_logs do %>
+    <div class="audit-log-item" id='<%= audit_log.id %>' title='<%= inspect(audit_log.changes) %>'>
+      <div class="audit-log-feed-icon"></div>
+      <%= audit_log.description %>
+      <div class="audit-log-time"><%= audit_log.inserted_at %></div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Changes the audit log feed to use a more easily understandable phrase about what event occurred
that was audited instead of icons with a click-to-expand behavior. This description is generated
when creating the audit log and stored in the record.

Also changes it to look more like a feed (i guess?)

Includes a script in `apps/nerves_hub_web_core/priv/repo/migrations/20190520202940_add_description_to_audit_logs.exs` to be run after the new field is added via migration.

![Screen Shot 2019-05-21 at 3 01 43 PM](https://user-images.githubusercontent.com/11321326/58130926-8b336900-7bda-11e9-9616-e8e352552b84.png)
