### PR TITLE
Support remote iex lines that are lists

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
@@ -84,7 +84,13 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
         %Broadcast{event: "put_chars", payload: %{"data" => line}},
         %{assigns: %{lines: lines}} = socket
       ) do
-    line = AnsiToHTML.generate_phoenix_html(line, @theme)
+    # Lines may come in as a list of characters and/or numbers to represent
+    # a string. So call to_string here just to convert before attempting
+    # any transposing to HTML which relies on strings.
+    line =
+      IO.iodata_to_binary(line)
+      |> AnsiToHTML.generate_phoenix_html(@theme)
+
     new_lines = List.insert_at(lines, -1, line)
     {:noreply, assign(socket, :lines, new_lines)}
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_console_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_console_test.exs
@@ -72,6 +72,19 @@ defmodule NervesHubWWWWeb.DeviceLiveConsoleTest do
       assert render(view) =~ "Howdy"
     end
 
+    test "put_chars with binary list", %{session: session} do
+      list_line = [72, 111, 119, 100, 121, 32, 'Partner']
+
+      {:ok, view, html} = mount(Endpoint, Console, session: session)
+
+      refute html =~ "Howdy Partner"
+
+      msg = %Broadcast{event: "put_chars", payload: %{"data" => list_line}}
+      send(view.pid, msg)
+
+      assert render(view) =~ "Howdy Partner"
+    end
+
     test "get_line", %{current_user: user, session: session} do
       {:ok, view, html} = mount(Endpoint, Console, session: session)
 


### PR DESCRIPTION
A recent change in https://github.com/nerves-hub/nerves_hub/pull/102 added support to handle
io_requests requiring a function to be run to format the data. In some cases, that ends up
being a list of characters or numbers (representing a character) that would break the console
session because to regex is used to generate the ANSI HTML and it couldn't handle the list.

So this just calls ~~`to_string/1`~~ `IO.iodata_to_binary/1` on data that comes in from the device before attempting to convert
to HTML and display.