### PR TITLE
Adjust line spacing for IEx console

### DIFF
--- a/apps/nerves_hub_www/assets/css/_console.scss
+++ b/apps/nerves_hub_www/assets/css/_console.scss
@@ -7,10 +7,14 @@
   color: white;
   overflow: auto;
   height: 400px;
+  line-height: 1;
+  left: auto;
 }
 
 .console-active-line {
   // Somehow fix the active input line spacing here
+  line-height: 0;
+  text-align: left;
 }
 
 .console-input {

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
@@ -87,8 +87,15 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
     # Lines may come in as a list of characters and/or numbers to represent
     # a string. So call to_string here just to convert before attempting
     # any transposing to HTML which relies on strings.
+    #
+    # Also, IO :put_chars has to explicitly add newline characters for the
+    # terminal to break each line. However, rendering each line in HTML
+    # already formats each "line" as an element, which already gets rendered
+    # on a newline. So we trim any trailing whitespace or newline here to
+    # prevent line bloat.
     line =
       IO.iodata_to_binary(line)
+      |> String.trim_trailing()
       |> AnsiToHTML.generate_phoenix_html(@theme)
 
     new_lines = List.insert_at(lines, -1, line)


### PR DESCRIPTION
I don't know what I'm doing, but this condenses lines closer to better match output
you would see in the terminal. Should make things a little easier to read for now

**Before**
![before](https://user-images.githubusercontent.com/11321326/58280924-fa39ca80-7d5e-11e9-9a1a-ce9f045c294f.png)

**After**
![after](https://user-images.githubusercontent.com/11321326/58293330-48ac9080-7d82-11e9-86bb-ef2b8e7c830f.png)

