### PR TITLE
Fix audit! failures on broadcast

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -118,7 +118,7 @@ defmodule NervesHubWebCore.Devices do
         "device:#{device.id}",
         %Phoenix.Socket.Broadcast{
           event: "update",
-          payload: %{deployment_id: deployment.id, firmware_url: url}
+          payload: %{deploymet: deployment, deployment_id: deployment.id, firmware_url: url}
         }
       )
 


### PR DESCRIPTION
We recently changed update message audits to inject the firmware uuid in it. However,
on a broadcast we were not sending the full deployment struct and so we could not lookup
the firmware (or ensure it was there) to perform the audit. So, this just changes a few
things to send that full struct to the channel, but remove it before sending to the device.

The channel will also do a lazy lookup to search based on deployment id if for some reason
the deployment struct is not in the broadcast payload. Also add a couple regression tests so
this should be backwards compatible (though I didn't find anyone actually using other keys
in the payload besides `firmware_url`)

Resolves [this Rollbar error](https://rollbar.com/nerves-hub/nerves_hub_device/items/2/)