### PR TITLE
Fix error broadcasting update message

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -118,7 +118,7 @@ defmodule NervesHubWebCore.Devices do
         "device:#{device.id}",
         %Phoenix.Socket.Broadcast{
           event: "update",
-          payload: %{deploymet: deployment, deployment_id: deployment.id, firmware_url: url}
+          payload: %{deployment: deployment, deployment_id: deployment.id, firmware_url: url}
         }
       )
 


### PR DESCRIPTION
I guess I can't spell :man_facepalming:

So, this spells `deployment` key correct in the broadcast message to update a device. Also adds
a test in to make sure it gets broadcasted as expected.