### PR TITLE
Remove dashboard and default to product index

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/dashboard_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/dashboard_controller.ex
@@ -1,8 +1,0 @@
-defmodule NervesHubWWWWeb.DashboardController do
-  use NervesHubWWWWeb, :controller
-
-  def index(conn, _params) do
-    conn
-    |> render("index.html")
-  end
-end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWWWWeb.SessionController do
 
       _ ->
         conn
-        |> redirect(to: dashboard_path(conn, :index))
+        |> redirect(to: product_path(conn, :index))
     end
   end
 
@@ -27,7 +27,7 @@ defmodule NervesHubWWWWeb.SessionController do
         conn
         |> put_session(@session_key, user_id)
         |> put_session("current_org_id", def_org.id)
-        |> redirect(to: dashboard_path(conn, :index))
+        |> redirect(to: product_path(conn, :index))
 
       {:error, :authentication_failed} ->
         conn
@@ -49,10 +49,10 @@ defmodule NervesHubWWWWeb.SessionController do
                   |> Enum.map(fn x -> x.id end)) do
       conn
       |> put_session("current_org_id", org_id)
-      |> redirect(to: dashboard_path(conn, :index))
+      |> redirect(to: product_path(conn, :index))
     else
       conn
-      |> redirect(to: dashboard_path(conn, :index))
+      |> redirect(to: product_path(conn, :index))
     end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -71,8 +71,6 @@ defmodule NervesHubWWWWeb.Router do
 
     put("/set_org", SessionController, :set_org)
 
-    resources("/dashboard", DashboardController, only: [:index])
-
     get("/org/invite", OrgController, :invite)
     post("/org/invite", OrgController, :send_invite)
     get("/org/certificates", OrgCertificateController, :index)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/dashboard/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/dashboard/index.html.eex
@@ -1,9 +1,0 @@
-<div class="jumbotron bg-dark">
-  <h1 class="display-4 text-left">Welcome, <%= @conn.assigns.user.username %>!</h1>
-  <p class="lead text-left">NervesHub helps you manage firmware updates for Nerves devices.</p>
-  <hr class="my-4">
-  <p class="text-left">To get started, add a product by clicking the button below.</p>
-  <p class="text-left">
-    <a class="btn btn-primary btn-lg" href="<%= product_path(@conn, :new) %>" role="button">Add a Product</a>
-  </p>
-</div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
@@ -2,4 +2,4 @@
 
 <%= render "form.html", Map.put(assigns, :action, org_path(@conn, :create)) %>
 
-<span><%= link "Back", to: dashboard_path(@conn, :index) %></span>
+<span><%= link "Back", to: product_path(@conn, :index) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/index.html.eex
@@ -1,3 +1,14 @@
+<%= if @products == [] do %>
+<div class="jumbotron bg-dark">
+  <h1 class="display-4 text-left">Welcome, <%= @conn.assigns.user.username %>!</h1>
+  <p class="lead text-left">NervesHub helps you manage firmware updates for Nerves devices.</p>
+  <hr class="my-4">
+  <p class="text-left">To get started, add a product by clicking the button below.</p>
+  <p class="text-left">
+    <a class="btn btn-primary btn-lg" href="<%= product_path(@conn, :new) %>" role="button">Add a Product</a>
+  </p>
+</div>
+<% else %>
 <div class="row">
   <div class="w-100 shadow nhw_list">
     <div class="header">
@@ -19,3 +30,4 @@
   <div class="col-8">
   </div>
 </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/dashboard_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/dashboard_view.ex
@@ -1,3 +1,0 @@
-defmodule NervesHubWWWWeb.DashboardView do
-  use NervesHubWWWWeb, :view
-end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -28,7 +28,7 @@ defmodule NervesHubWWWWeb.LayoutView do
 
   def logo_href(conn) do
     if logged_in?(conn) do
-      dashboard_path(conn, :index)
+      product_path(conn, :index)
     else
       home_path(conn, :index)
     end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/dashboard_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/dashboard_controller_test.exs
@@ -1,8 +1,0 @@
-defmodule NervesHubWWWWeb.DashboardControllerTest do
-  use NervesHubWWWWeb.ConnCase.Browser
-
-  test "index", %{conn: conn} do
-    conn = get(conn, dashboard_path(conn, :index))
-    assert is_binary(html_response(conn, 200))
-  end
-end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
@@ -35,7 +35,7 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
         )
 
       conn = put(conn, session_path(conn, :set_org, org: org))
-      assert redirected_to(conn) == dashboard_path(conn, :index)
+      assert redirected_to(conn) == product_path(conn, :index)
       assert get_session(conn, "current_org_id") == org.id
     end
   end
@@ -46,7 +46,7 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
 
       result_conn = put(conn, session_path(conn, :set_org, org: new_org))
 
-      assert redirected_to(result_conn) == dashboard_path(result_conn, :index)
+      assert redirected_to(result_conn) == product_path(result_conn, :index)
       assert get_session(result_conn, "current_org_id") == new_org.id
     end
 
@@ -58,7 +58,7 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
       new_org = Fixtures.org_fixture(new_user, %{name: "this org"})
       conn = put(conn, session_path(conn, :set_org, org: new_org))
 
-      assert redirected_to(conn) == dashboard_path(conn, :index)
+      assert redirected_to(conn) == product_path(conn, :index)
       assert get_session(conn, "current_org_id") == org.id
     end
   end


### PR DESCRIPTION
This PR removes the dashboard page and changes the initial page to the product index. The jumbotron from the dashboard will display on the product index if there are no products. Once a product is created, the index shows the product list and you are no longer presented with the "lets get started by creating a new product" screen. 