### PR TITLE
Set ex_aws json_codec to use Jason

### DIFF
--- a/apps/nerves_hub_web_core/config/config.exs
+++ b/apps/nerves_hub_web_core/config/config.exs
@@ -12,7 +12,10 @@ config :nerves_hub_web_core, NervesHubWeb.PubSub,
 
 config :ex_aws,
   access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
+  json_codec: Jason,
   secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
   region: System.get_env("AWS_REGION")
+
+config :ex_aws_s3, json_codec: Jason
 
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Firmware uploads are failing because ExAws needs to be told what JSON codec to use for request/response

