### PR TITLE
Fix deleting device from UI

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -7,6 +7,18 @@ defmodule NervesHubWWWWeb.DeviceController do
 
   plug(:validate_role, [org: :delete] when action in [:delete])
   plug(:validate_role, [org: :write] when action in [:new, :create])
+  plug(:validate_role, [org: :read] when action in [:index])
+
+  def index(%{assigns: %{current_org: org}} = conn, _params) do
+    conn
+    |> live_render(
+      NervesHubWWWWeb.DeviceLive.Index,
+      # We need to pass csrf_token here so that we can use
+      # the delete button from the index.
+      # see https://github.com/phoenixframework/phoenix_live_view/issues/111
+      session: %{org_id: org.id, csrf_token: get_csrf_token()}
+    )
+  end
 
   def new(%{assigns: %{current_org: _org}} = conn, _params) do
     conn
@@ -23,7 +35,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     |> case do
       {:ok, _device} ->
         conn
-        |> redirect(to: device_path(conn, NervesHubWWWWeb.DeviceLive.Index))
+        |> redirect(to: device_path(conn, :index))
 
       {:error, changeset} ->
         conn
@@ -39,6 +51,6 @@ defmodule NervesHubWWWWeb.DeviceController do
 
     conn
     |> put_flash(:info, "device deleted successfully.")
-    |> redirect(to: device_path(conn, NervesHubWWWWeb.DeviceLive.Index))
+    |> redirect(to: device_path(conn, :index))
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -11,7 +11,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
     NervesHubWWWWeb.DeviceView.render("index.html", assigns)
   end
 
-  def mount(%{current_org_id: org_id}, socket) do
+  def mount(%{org_id: org_id, csrf_token: csrf_token}, socket) do
     if connected?(socket) do
       socket.endpoint.subscribe("devices:#{org_id}")
     end
@@ -20,6 +20,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
       socket
       |> assign(:devices, assign_statuses(org_id))
       |> assign(:current_sort, "identifier")
+      |> assign(:csrf_token, csrf_token)
       |> assign(:sort_direction, :asc)
 
     {:ok, socket}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -91,7 +91,7 @@ defmodule NervesHubWWWWeb.Router do
     post("/account/certificates/create", AccountCertificateController, :create)
     get("/account/certificates/:id/download", AccountCertificateController, :download)
 
-    resources("/devices", DeviceController, only: [:create, :delete, :new])
+    resources("/devices", DeviceController, only: [:index, :create, :delete, :new])
 
     resources "/products", ProductController, except: [:edit, :update] do
       pipe_through(:product_level)
@@ -121,8 +121,6 @@ defmodule NervesHubWWWWeb.Router do
 
   scope "/", NervesHubWWWWeb do
     pipe_through([:browser, :logged_in, :org_read])
-
-    live("/devices", DeviceLive.Index, as: :device, session: [:current_org_id])
 
     live("/devices/:id", DeviceLive.Show,
       as: :device,

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -57,7 +57,7 @@
           </td>
           <td class="col-2">
             <%= link "Edit", class: "btn btn-info", to: device_path(@socket, DeviceLive.Edit, device) %>
-            <%= link "Delete", class: "btn btn-danger", to: device_path(@socket, :delete, device), method: :delete, data: [confirm: "Are you sure?"]%>
+            <%= link "Delete", class: "btn btn-danger", to: device_path(@socket, :delete, device), method: :delete, data: [confirm: "Are you sure?", csrf: @csrf_token] %>
           </td>
         </tr>
       <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
@@ -22,5 +22,5 @@
   </div>
 
   <%= submit "Create", class: "btn btn-large btn-primary" %>
-  <a class="btn btn-secondary" href="<%= device_path(@conn, DeviceLive.Index) %>">Cancel</a>
+  <a class="btn btn-secondary" href="<%= device_path(@conn, :index) %>">Cancel</a>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -47,7 +47,7 @@
       </p>
 
       <div class="dropdown dropright">
-        <%= link "Back", to: device_path(@socket, DeviceLive.Index), class: "btn btn-secondary"%>
+        <%= link "Back", to: device_path(@socket, :index), class: "btn btn-secondary"%>
 
         <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Actions

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/show.html.eex
@@ -13,7 +13,7 @@
   <a class="btn btn-lg btn-primary pull-right" href="<%= product_firmware_path(@conn, :index, @product.id) %>">
  View Firmware
   </a>
-  <a class="btn btn-lg btn-primary pull-right" href="<%= device_path(@conn, DeviceLive.Index) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= device_path(@conn, :index) %>">
  View Devices
   </a>
   <a class="btn btn-lg btn-primary pull-right" href="<%= product_deployment_path(@conn, :index, @product) %>">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -8,7 +8,7 @@ defmodule NervesHubWWWWeb.LayoutView do
     if has_org_role?(org, user, :read) do
       [
         {"Products", product_path(conn, :index)},
-        {"All Devices", device_path(conn, DeviceLive.Index)}
+        {"All Devices", device_path(conn, :index)}
       ]
     else
       [

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -24,10 +24,10 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       # check that we end up in the right place
       create_conn = post(conn, device_path(conn, :create), device: device_params)
 
-      assert redirected_to(create_conn, 302) =~ device_path(conn, DeviceLive.Index)
+      assert redirected_to(create_conn, 302) =~ device_path(conn, :index)
 
       # check that the proper creation side effects took place
-      conn = get(conn, device_path(conn, DeviceLive.Index))
+      conn = get(conn, device_path(conn, :index))
       assert html_response(conn, 200) =~ device_params.identifier
     end
   end
@@ -36,7 +36,7 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
     test "deletes chosen device", %{conn: conn, current_org: org} do
       [to_delete | _] = Devices.get_devices(org)
       conn = delete(conn, device_path(conn, :delete, to_delete))
-      assert redirected_to(conn) == device_path(conn, DeviceLive.Index)
+      assert redirected_to(conn) == device_path(conn, :index)
 
       conn = get(conn, device_path(conn, DeviceLive.Show, to_delete))
       assert html_response(conn, 302)


### PR DESCRIPTION
Attempting to delete a device from the UI would error because LiveView handles CSRF token a little different and it would not match the token expected for `device#delete` endpoint in the device controller.

So this adjusts that to handle the LiveView session for DeviceLive.Index a little differently by going back to the original idea of forwarding from the controller and passing the needed csrf token.

This can probably be adjusted if needed once https://github.com/phoenixframework/phoenix_live_view/issues/111 is resolved.