### PR TITLE
Add daily org metrics

### DIFF
--- a/apps/nerves_hub_web_core/config/prod.exs
+++ b/apps/nerves_hub_web_core/config/prod.exs
@@ -13,6 +13,10 @@ config :nerves_hub_web_core, NervesHubWebCore.Scheduler,
     digest_firmware_transfers: [
       schedule: "*/30 * * * *",
       task: {NervesHubWebCore.Firmwares.Transfer.S3Ingress, :run, []}
+    ],
+    create_org_metrics: [
+      schedule: "0 1 * * *",
+      task: {NervesHubWebCore.Accounts, :create_org_metrics, ["01:00:00.000000", [days: -1]]}
     ]
   ]
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_metric.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_metric.ex
@@ -1,0 +1,34 @@
+defmodule NervesHubWebCore.Accounts.OrgMetric do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHubWebCore.Accounts.Org
+
+  @type t :: %__MODULE__{}
+  @primary_key {:id, :binary_id, autogenerate: true}
+
+  @params [
+    :org_id,
+    :devices,
+    :bytes_transferred,
+    :bytes_stored,
+    :timestamp
+  ]
+
+  schema "org_metrics" do
+    belongs_to(:org, Org)
+
+    field(:devices, :integer)
+    field(:bytes_transferred, :integer)
+    field(:bytes_stored, :integer)
+    field(:timestamp, :utc_datetime)
+  end
+
+  def changeset(%__MODULE__{} = org_metric, params) do
+    org_metric
+    |> cast(params, @params)
+    |> validate_required(@params)
+    |> foreign_key_constraint(:org_id, name: :firmware_transfers_org_id_fkey)
+  end
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -38,6 +38,17 @@ defmodule NervesHubWebCore.Devices do
     |> Repo.all()
   end
 
+  def get_device_count_by_org_id(org_id) do
+    q =
+      from(
+        d in Device,
+        where: d.org_id == ^org_id,
+        select: count(d)
+      )
+
+    Repo.one!(q)
+  end
+
   defp device_by_org_query(org_id, device_id) do
     from(
       d in Device,

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -40,6 +40,18 @@ defmodule NervesHubWebCore.Firmwares do
     end
   end
 
+  @spec get_firmware_by_org_id(non_neg_integer()) :: [Firmware.t()]
+  def get_firmware_by_org_id(org_id) do
+    q =
+      from(
+        f in Firmware,
+        join: p in assoc(f, :product),
+        where: p.org_id == ^org_id
+      )
+
+    Repo.all(q)
+  end
+
   @spec get_firmware_by_product_and_version(Org.t(), String.t(), String.t()) ::
           {:ok, Firmware.t()}
           | {:error, :not_found}
@@ -275,6 +287,19 @@ defmodule NervesHubWebCore.Firmwares do
     %FirmwareTransfer{}
     |> FirmwareTransfer.changeset(params)
     |> Repo.insert()
+  end
+
+  def get_firmware_transfers_by_org_id_between_dates(org_id, from_datetime, to_datetime) do
+    q =
+      from(
+        ft in FirmwareTransfer,
+        where:
+          ft.org_id == ^org_id and
+            ft.timestamp >= ^from_datetime and
+            ft.timestamp <= ^to_datetime
+      )
+
+    Repo.all(q)
   end
 
   # Private functions

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_transfer.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_transfer.ex
@@ -32,9 +32,5 @@ defmodule NervesHubWebCore.Firmwares.FirmwareTransfer do
     |> cast(params, @params)
     |> validate_required(@params)
     |> foreign_key_constraint(:org_id, name: :firmware_transfers_org_id_fkey)
-    |> unique_constraint(:remote_ip,
-      name: :firmware_transfers_unique_index,
-      message: "record already exists"
-    )
   end
 end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190618162113_add_org_metrics.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190618162113_add_org_metrics.exs
@@ -1,0 +1,16 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddOrgMetrics do
+  use Ecto.Migration
+
+  def change do
+    create table(:org_metrics, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:org_id, references(:orgs, null: false))
+      add(:devices, :integer, null: false)
+      add(:bytes_transferred, :integer, null: false)
+      add(:bytes_stored, :integer, null: false)
+      add(:timestamp, :utc_datetime, null: false)
+    end
+
+    create(index(:org_metrics, [:org_id]))
+  end
+end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190618200916_remove_firmware_transfer_unique_index.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190618200916_remove_firmware_transfer_unique_index.exs
@@ -1,0 +1,7 @@
+defmodule NervesHubWebCore.Repo.Migrations.RemoveFirmwareTransferUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop(index(:firmware_transfers, [:unique]))
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
@@ -304,12 +304,6 @@ defmodule NervesHubWebCore.FirmwaresTest do
       assert {:ok, _transfer} = Fixtures.firmware_transfer_fixture(org.id, "12345")
     end
 
-    test "cannot create same record twice", %{user: user} do
-      org = Fixtures.org_fixture(user, %{name: "transfer-dup"})
-      assert {:ok, _transfer} = Fixtures.firmware_transfer_fixture(org.id, "12345")
-      assert {:error, _error} = Fixtures.firmware_transfer_fixture(org.id, "12345")
-    end
-
     test "cannot create records for orgs that do not exist" do
       assert {:error, _} = Fixtures.firmware_transfer_fixture(9_999_999_999, "12345")
     end


### PR DESCRIPTION
This PR creates a new model `OrgMetric` which is to be used for storing usage metrics. The model tracks the following information:
  
  * `devices`: total number of device records
  * `bytes_transferred`: Total number of bytes transferred deploying firmware
  * `bytes_stored`: Total number of bytes storing firmware on S3

A record is created for each org, each day. The intention for surfacing this data is to render current / previous usage numbers to the user and for billing.