### PR TITLE
Clean up S3 ingress firmware transfer return case

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/transfer/s3_ingress.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/transfer/s3_ingress.ex
@@ -34,9 +34,6 @@ defmodule NervesHubWebCore.Firmwares.Transfer.S3Ingress do
                 {:ok, _transfer} ->
                   errors
 
-                {:error, %{errors: [remote_ip: {"record already exists", _}]}} ->
-                  errors
-
                 {:error, error} ->
                   Logger.error(fn -> "Error inserting transfer: #{inspect(error)}" end)
                   [error | errors]


### PR DESCRIPTION
This return type was removed in https://github.com/nerves-hub/nerves_hub_web/pull/495