### PR TITLE
Navigation update

### DIFF
--- a/apps/nerves_hub_www/assets/css/_navigation.scss
+++ b/apps/nerves_hub_www/assets/css/_navigation.scss
@@ -10,8 +10,12 @@
   margin: auto;
 }
 
-.navitem .dropdown {
-  border-left: 1px solid rgba(255, 255, 255, 0.5);
+.nav-item .dropdown-item.org {
+  font-weight: bold;
+}
+
+.nav-item .dropdown-item.product {
+  padding-left: 40px;
 }
 
 .logo-letter {
@@ -25,5 +29,5 @@
     background-color: whitesmoke;
     border-radius: 50%;
     width: 75px;
-    height: 75px; 
+    height: 75px;
   }

--- a/apps/nerves_hub_www/assets/css/_navigation.scss
+++ b/apps/nerves_hub_www/assets/css/_navigation.scss
@@ -1,13 +1,50 @@
-.navbar-nav {
-  padding-left:50px;
-  padding-right:50px;
+@media (min-width: 480px) and (max-width: 1000px) {
+  .collapse {
+      display: none !important;
+  }
 }
 
-.navbar-brand img {
-  width: 62px;
-  height: 62px;
+nav.navbar {
+  padding: 0;
+  min-height: 70px;
+
+}
+
+.navbar-nav {
+  padding-left:50px;
+}
+
+.navbar-brand {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+  margin-top: 4px;
+  margin-bottom: 4px;
   display: block;
-  margin: auto;
+  img {
+    margin: 2px;
+  }
+}
+
+.circle {
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background-color: #FFF;
+  border-radius: 50%;
+  width: 58px;
+  height: 58px;
+}
+
+.nav-item button {
+  padding-top:0px;
+  padding-bottom:0px;
+}
+
+.nav-item.dropdown.switcher{
+  height: 70px;
+  padding-right: 18px;
+  border-right: 1px solid #555;
+  a {
+    margin-top: 14px;
+  }
 }
 
 .nav-item .dropdown-item.org {
@@ -18,16 +55,21 @@
   padding-left: 40px;
 }
 
+.dropdown-toggle.user-menu::after {
+  display:none;
+}
+
+.dropdown-toggle.user-menu {
+  border-left: 1px solid #555;
+  border-radius: 0px;
+  height: 70px;
+  img {
+    border-radius: 50%;
+    border: 1px solid #FFF;
+  }
+}
+
 .logo-letter {
   color: whitesmoke;
   font-size: 24px;
 }
-
-.circle
-  {
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    background-color: whitesmoke;
-    border-radius: 50%;
-    width: 75px;
-    height: 75px;
-  }

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -20,7 +20,7 @@ defmodule NervesHubWWWWeb.OrgController do
     with {:ok, org} <- Accounts.create_org(user, params) do
       conn
       |> put_flash(:info, "Organization created successfully.")
-      |> redirect(to: org_path(conn, :edit, org))
+      |> NervesHubWWWWeb.SessionController.set_org(%{"org" => to_string(org.id)})
     else
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
@@ -31,6 +31,8 @@ defmodule NervesHubWWWWeb.OrgController do
         %{assigns: %{current_org: %{id: _conn_id} = org, current_limit: limits}} = conn,
         _params
       ) do
+    IO.inspect(conn)
+
     render(
       conn,
       "edit.html",

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -31,8 +31,6 @@ defmodule NervesHubWWWWeb.OrgController do
         %{assigns: %{current_org: %{id: _conn_id} = org, current_limit: limits}} = conn,
         _params
       ) do
-    IO.inspect(conn)
-
     render(
       conn,
       "edit.html",

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -1,15 +1,10 @@
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top shadow">
+<nav class="navbar navbar-expand navbar-dark bg-dark fixed-top shadow">
     <a class="logo navbar-brand circle d-inline-block align-top ml-3" href="<%= logo_href(@conn) %>">
       <img src="/images/logo.svg" />
     </a>
-
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarToggler">
     <%= if logged_in?(@conn) do %>
-      <div class="navbar-nav mr-auto">
-        <li class="nav-item dropdown">
+      <div class="navbar-nav mr-auto flex-grow">
+        <li class="nav-item dropdown switcher">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= @conn.assigns.current_org.name %><%= if product = product(@conn) do %> | <%= product.name %><% end %>
           </a>
@@ -24,12 +19,13 @@
             <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New organization</a>
           </div>
         </li>
+        <li class="divider"></li>
       </div>
-      <div class="navbar-nav mr-3">
+      <div class="navbar-nav">
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Settings
-          </a>
+          <button class="btn btn-default dropdown-toggle user-menu" type="button" id="menu1" data-toggle="dropdown">
+          <img src="<%= gravatar(@conn) %>">
+          </button>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
             <%= if has_org_role?(@conn.assigns.current_org, @conn.assigns.user, :admin) do %>
               <a class="dropdown-item" href="<%= org_path(@conn, :edit, @conn.assigns.current_org)%>">Organization settings</a>
@@ -53,5 +49,4 @@
       <a class="btn btn-outline-success ml-3" href="<%= session_path(@conn, :new)%>">Login</a>
     </div>
   <% end %>
-  </div>
 </nav>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -11,20 +11,19 @@
       <div class="navbar-nav mr-auto">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= @conn.assigns.current_org.name %>
+            <%= @conn.assigns.current_org.name %><%= if product = product(@conn) do %> | <%= product.name %><% end %>
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <%= for org <- user_orgs(@conn) do %>
-              <%= if org.id != @conn.assigns.current_org.id do %>
-              <%= link org.name, class: "dropdown-item", to: session_path(@conn, :set_org, org: org), method: :put%>
-                <% end %>
-        <% end %>
-        <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New organization</a>
+              <%= link org.name, class: "dropdown-item org", to: session_path(@conn, :set_org, org: org), method: :put%>
+              <%= for product <- user_org_products(@conn.assigns.user, org) do %>
+                <%= link product.name, class: "dropdown-item product", to: product_path(@conn, :show, product)%>
+              <% end %>
+              <div class="dropdown-divider"></div>
+            <% end %>
+            <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New organization</a>
           </div>
         </li>
-        <%= for {name, path} <- navigation_links(@conn) do %>
-            <a class="<%= if @conn.request_path == path, do: "active nav-item nav-link", else: "nav-item nav-link" %>" href="<%= path %>"><%= name %></a>
-        <% end %>
       </div>
       <div class="navbar-nav mr-3">
         <li class="nav-item dropdown">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/index.html.eex
@@ -1,9 +1,7 @@
 <%= if @products == [] do %>
 <div class="jumbotron bg-dark">
-  <h1 class="display-4 text-left">Welcome, <%= @conn.assigns.user.username %>!</h1>
-  <p class="lead text-left">NervesHub helps you manage firmware updates for Nerves devices.</p>
+  <p class="lead text-left">The organization <%= @conn.assigns.current_org.name %> doesn't have any products</p>
   <hr class="my-4">
-  <p class="text-left">To get started, add a product by clicking the button below.</p>
   <p class="text-left">
     <a class="btn btn-primary btn-lg" href="<%= product_path(@conn, :new) %>" role="button">Add a Product</a>
   </p>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -6,12 +6,20 @@ defmodule NervesHubWWWWeb.LayoutView do
   alias NervesHubWebCore.Products
   alias NervesHubWebCore.Products.Product
 
+  @gravatar_url "https://secure.gravatar.com/avatar"
+  @gravatar_size 54
+
   def product(%{assigns: %{product: %Product{} = product}}) do
     product
   end
 
   def product(_conn) do
     nil
+  end
+
+  def gravatar(%{assigns: %{user: %{email: email}}}) do
+    hash = :crypto.hash(:md5, String.downcase(email)) |> Base.encode16(case: :lower)
+    "#{@gravatar_url}/#{hash}?s=#{@gravatar_size}"
   end
 
   def user_orgs(%{assigns: %{user: %User{} = user}}) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -3,9 +3,15 @@ defmodule NervesHubWWWWeb.LayoutView do
 
   alias NervesHubWebCore.Accounts
   alias NervesHubWebCore.Accounts.User
+  alias NervesHubWebCore.Products
+  alias NervesHubWebCore.Products.Product
 
-  def navigation_links(conn) do
-    [{"Products", product_path(conn, :index)}]
+  def product(%{assigns: %{product: %Product{} = product}}) do
+    product
+  end
+
+  def product(_conn) do
+    nil
   end
 
   def user_orgs(%{assigns: %{user: %User{} = user}}) do
@@ -13,6 +19,10 @@ defmodule NervesHubWWWWeb.LayoutView do
   end
 
   def user_orgs(_conn), do: []
+
+  def user_org_products(user, org) do
+    Products.get_products_by_user_and_org(user, org)
+  end
 
   def logged_in?(%{assigns: %{user: %User{}}}), do: true
   def logged_in?(_), do: false

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -12,15 +12,9 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
   end
 
   describe "create org" do
-    test "redirects to edit when data is valid", %{conn: conn, current_org: org} do
+    test "redirects to edit when data is valid", %{conn: conn} do
       conn = post(conn, org_path(conn, :create), org: %{name: "An Org"})
-
-      assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) == org_path(conn, :edit, id)
-
-      conn = get(conn, org_path(conn, :edit, id))
-      assert html_response(conn, 200) =~ "Organization settings"
-      assert html_response(conn, 200) =~ org.name
+      assert redirected_to(conn) == product_path(conn, :index)
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
depends on https://github.com/nerves-hub/nerves_hub_web/pull/499
This PR restyles the navigation bar. 

The dropdown on the left lets you switch between organizations and projects. 
<img width="1081" alt="Screen Shot 2019-06-20 at 22 20 35" src="https://user-images.githubusercontent.com/1391351/59893132-e27b5380-93a9-11e9-8ca9-0330ec0a26b1.png">

The dropdown on the right has the org and account settings.
<img width="1081" alt="Screen Shot 2019-06-20 at 22 20 39" src="https://user-images.githubusercontent.com/1391351/59893133-e5764400-93a9-11e9-838b-9d4bde4d875a.png">
