### PR TITLE
Add more logging to Firmware Transfer ingress

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/transfer/s3_ingress.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/transfer/s3_ingress.ex
@@ -101,7 +101,8 @@ defmodule NervesHubWebCore.Firmwares.Transfer.S3Ingress do
      }}
   end
 
-  def decode_record(_) do
+  def decode_record(record) do
+    Logger.error(fn -> "Invalid FirmwareTransfer record #{inspect(record)}" end)
     {:error, :invalid_transfer_record}
   end
 


### PR DESCRIPTION
I am trying to debug issues with digesting the server access logs. There doesn't seem to be anything in the error logs that is useful, so I am adding this additional logger error to see if we are throwing away unmatched messages and why.