### PR TITLE
Scope device controller actions to product role

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -5,9 +5,9 @@ defmodule NervesHubAPIWeb.DeviceController do
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:create, :update])
-  plug(:validate_role, [org: :read] when action in [:index, :show, :auth])
+  plug(:validate_role, [product: :delete] when action in [:delete])
+  plug(:validate_role, [product: :write] when action in [:create, :update])
+  plug(:validate_role, [product: :read] when action in [:index, :show, :auth])
 
   def index(%{assigns: %{org: org, product: product}} = conn, _params) do
     conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -5,9 +5,9 @@ defmodule NervesHubWWWWeb.DeviceController do
   alias NervesHubWebCore.Devices.Device
   alias Ecto.Changeset
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:new, :create])
-  plug(:validate_role, [org: :read] when action in [:index])
+  plug(:validate_role, [product: :delete] when action in [:delete])
+  plug(:validate_role, [product: :write] when action in [:new, :create])
+  plug(:validate_role, [product: :read] when action in [:index])
 
   def index(%{assigns: %{current_org: org, product: product}} = conn, _params) do
     conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -19,12 +19,8 @@ defmodule NervesHubWWWWeb.Router do
     plug(NervesHubWWWWeb.Plugs.FetchOrg)
   end
 
-  pipeline :org_read do
-    plug(NervesHubWebCore.RoleValidateHelpers, org: :read)
-  end
-
-  pipeline :org_write do
-    plug(NervesHubWebCore.RoleValidateHelpers, org: :write)
+  pipeline :product_write do
+    plug(NervesHubWebCore.RoleValidateHelpers, product: :write)
   end
 
   pipeline :product_level do
@@ -110,7 +106,7 @@ defmodule NervesHubWWWWeb.Router do
   # let's be explicit here and pipe through role checks before
   # attempting to mount the LiveView session.
   scope "/", NervesHubWWWWeb do
-    pipe_through([:browser, :logged_in, :org_write])
+    pipe_through([:browser, :logged_in, :product_level, :product_write])
 
     live("/products/:product_id/devices/:id/edit", DeviceLive.Edit,
       as: :product_device,
@@ -119,7 +115,7 @@ defmodule NervesHubWWWWeb.Router do
   end
 
   scope "/", NervesHubWWWWeb do
-    pipe_through([:browser, :logged_in, :org_read])
+    pipe_through([:browser, :logged_in, :product_level, :product_read])
 
     live("/products/:product_id/devices/:id", DeviceLive.Show,
       as: :product_device,


### PR DESCRIPTION
Scopes `device` controller actions to validate the product role instead of the org