### PR TITLE
Alias route helpers instead of importing

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web.ex
@@ -22,9 +22,10 @@ defmodule NervesHubAPIWeb do
       use Phoenix.Controller, namespace: NervesHubAPIWeb
       import NervesHubWebCore.AuditLogs, only: [audit: 4, audit!: 4]
       import Plug.Conn
-      import NervesHubAPIWeb.Router.Helpers
       import NervesHubAPIWeb.Gettext
       import NervesHubWebCore.RoleValidateHelpers
+
+      alias NervesHubAPIWeb.Router.Helpers, as: Routes
 
       def whitelist(params, keys) do
         keys
@@ -42,10 +43,10 @@ defmodule NervesHubAPIWeb do
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]
-
-      import NervesHubAPIWeb.Router.Helpers
       import NervesHubAPIWeb.ErrorHelpers
       import NervesHubAPIWeb.Gettext
+
+      alias NervesHubAPIWeb.Router.Helpers, as: Routes
     end
   end
 

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/ca_certificate_controller.ex
@@ -41,7 +41,7 @@ defmodule NervesHubAPIWeb.CACertificateController do
       |> put_status(:created)
       |> put_resp_header(
         "location",
-        ca_certificate_path(conn, :show, org.name, ca_certificate.serial)
+        Routes.ca_certificate_path(conn, :show, org.name, ca_certificate.serial)
       )
       |> render("show.json", ca_certificate: ca_certificate)
     else

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
@@ -33,7 +33,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
           |> put_status(:created)
           |> put_resp_header(
             "location",
-            deployment_path(conn, :show, org.name, product.name, deployment.name)
+            Routes.deployment_path(conn, :show, org.name, product.name, deployment.name)
           )
           |> render("show.json", deployment: %{deployment | firmware: firmware})
         end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_controller.ex
@@ -28,7 +28,7 @@ defmodule NervesHubAPIWeb.DeviceController do
       |> put_status(:created)
       |> put_resp_header(
         "location",
-        device_path(conn, :show, org.name, product.name, device.identifier)
+        Routes.device_path(conn, :show, org.name, product.name, device.identifier)
       )
       |> render("show.json", device: device)
     end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -20,7 +20,7 @@ defmodule NervesHubAPIWeb.FirmwareController do
          {:ok, firmware} <- Firmwares.create_firmware(org, filepath, params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", firmware_path(conn, :show, org, product, firmware))
+      |> put_resp_header("location", Routes.firmware_path(conn, :show, org, product, firmware))
       |> render("show.json", firmware: firmware)
     else
       {nil, %{}} -> {:error, :no_firmware_uploaded}

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/org_user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/org_user_controller.ex
@@ -28,7 +28,7 @@ defmodule NervesHubAPIWeb.OrgUserController do
 
       conn
       |> put_status(:created)
-      |> put_resp_header("location", org_user_path(conn, :show, org.name, user.username))
+      |> put_resp_header("location", Routes.org_user_path(conn, :show, org.name, user.username))
       |> render("show.json", org_user: org_user)
     end
   end
@@ -44,7 +44,7 @@ defmodule NervesHubAPIWeb.OrgUserController do
     with {:ok, user} <- Accounts.get_user_by_username(username),
          {:ok, _org_user} <- Accounts.get_org_user(org, user),
          :ok <- Accounts.remove_org_user(org, user) do
-      # Now let everyone in the organization know 
+      # Now let everyone in the organization know
       # that this user has been removed from the organization.
       instigator = conn.assigns.user.username
 

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/product_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/product_controller.ex
@@ -26,7 +26,7 @@ defmodule NervesHubAPIWeb.ProductController do
     with {:ok, product} <- Products.create_product(user, params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", product_path(conn, :show, org.name, product.name))
+      |> put_resp_header("location", Routes.product_path(conn, :show, org.name, product.name))
       |> render("show.json", product: product)
     end
   end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/product_user_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/product_user_controller.ex
@@ -21,7 +21,7 @@ defmodule NervesHubAPIWeb.ProductUserController do
       |> put_status(:created)
       |> put_resp_header(
         "location",
-        product_user_path(conn, :show, org.name, product.name, user.username)
+        Routes.product_user_path(conn, :show, org.name, product.name, user.username)
       )
       |> render("show.json", product_user: product_user)
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
@@ -5,7 +5,7 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
 
   describe "index" do
     test "lists all ca certificates", %{conn: conn, org: org} do
-      conn = get(conn, ca_certificate_path(conn, :index, org.name))
+      conn = get(conn, Routes.ca_certificate_path(conn, :index, org.name))
       assert json_response(conn, 200)["data"] == []
     end
   end
@@ -20,13 +20,13 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
 
       params = %{cert: Base.encode64(ca_cert_pem), description: description}
 
-      conn = post(conn, ca_certificate_path(conn, :create, org.name), params)
+      conn = post(conn, Routes.ca_certificate_path(conn, :create, org.name), params)
       resp_data = json_response(conn, 201)["data"]
       assert %{"serial" => ^serial} = resp_data
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
-      conn = post(conn, ca_certificate_path(conn, :create, org.name), cert: "")
+      conn = post(conn, Routes.ca_certificate_path(conn, :create, org.name), cert: "")
 
       assert json_response(conn, 500)["errors"] != %{}
     end
@@ -36,10 +36,12 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
     setup [:create_ca_certificate]
 
     test "deletes chosen ca_certificate", %{conn: conn, org: org, ca_certificate: ca_certificate} do
-      conn = delete(conn, ca_certificate_path(conn, :delete, org.name, ca_certificate.serial))
+      conn =
+        delete(conn, Routes.ca_certificate_path(conn, :delete, org.name, ca_certificate.serial))
+
       assert response(conn, 204)
 
-      conn = get(conn, ca_certificate_path(conn, :show, org.name, ca_certificate.serial))
+      conn = get(conn, Routes.ca_certificate_path(conn, :show, org.name, ca_certificate.serial))
 
       assert response(conn, 404)
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -5,7 +5,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
 
   describe "index" do
     test "lists all deployments", %{conn: conn, org: org, product: product} do
-      conn = get(conn, deployment_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.deployment_path(conn, :index, org.name, product.name))
       assert json_response(conn, 200)["data"] == []
     end
   end
@@ -38,10 +38,10 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       params: params,
       product: product
     } do
-      conn = post(conn, deployment_path(conn, :create, org.name, product.name), params)
+      conn = post(conn, Routes.deployment_path(conn, :create, org.name, product.name), params)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, deployment_path(conn, :show, org.name, product.name, params.name))
+      conn = get(conn, Routes.deployment_path(conn, :show, org.name, product.name, params.name))
       assert json_response(conn, 200)["data"]["name"] == params.name
     end
 
@@ -52,7 +52,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       product: product,
       user: user
     } do
-      conn = post(conn, deployment_path(conn, :create, org.name, product.name), params)
+      conn = post(conn, Routes.deployment_path(conn, :create, org.name, product.name), params)
       assert json_response(conn, 201)["data"]
 
       [audit_log] = AuditLogs.logs_by(user)
@@ -62,7 +62,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do
-      conn = post(conn, deployment_path(conn, :create, org.name, product.name))
+      conn = post(conn, Routes.deployment_path(conn, :create, org.name, product.name))
       assert json_response(conn, 500)["errors"] != %{}
     end
   end
@@ -76,17 +76,17 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       org: org,
       product: product
     } do
-      path = deployment_path(conn, :update, org.name, product.name, deployment.name)
+      path = Routes.deployment_path(conn, :update, org.name, product.name, deployment.name)
       conn = put(conn, path, deployment: %{"is_active" => true})
       assert %{"is_active" => true} = json_response(conn, 200)["data"]
 
-      path = deployment_path(conn, :show, org.name, product.name, deployment.name)
+      path = Routes.deployment_path(conn, :show, org.name, product.name, deployment.name)
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["is_active"]
     end
 
     test "audits on success", %{conn: conn, deployment: deployment, org: org, product: product} do
-      path = deployment_path(conn, :update, org.name, product.name, deployment.name)
+      path = Routes.deployment_path(conn, :update, org.name, product.name, deployment.name)
       conn = put(conn, path, deployment: %{"is_active" => true})
       assert json_response(conn, 200)["data"]
 
@@ -101,7 +101,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       org: org,
       product: product
     } do
-      path = deployment_path(conn, :update, org.name, product.name, deployment.name)
+      path = Routes.deployment_path(conn, :update, org.name, product.name, deployment.name)
       conn = put(conn, path, deployment: %{is_active: "1234"})
       assert json_response(conn, 422)["errors"] != %{}
     end
@@ -116,10 +116,16 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       product: product,
       deployment: deployment
     } do
-      conn = delete(conn, deployment_path(conn, :delete, org.name, product.name, deployment.name))
+      conn =
+        delete(
+          conn,
+          Routes.deployment_path(conn, :delete, org.name, product.name, deployment.name)
+        )
+
       assert response(conn, 204)
 
-      conn = get(conn, deployment_path(conn, :show, org.name, product.name, deployment.name))
+      conn =
+        get(conn, Routes.deployment_path(conn, :show, org.name, product.name, deployment.name))
 
       assert response(conn, 404)
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_certificate_controller_test.exs
@@ -23,7 +23,7 @@ defmodule NervesHubAPIWeb.DeviceCertificateControllerTest do
       conn =
         get(
           conn,
-          device_certificate_path(conn, :index, org.name, product.name, device.identifier)
+          Routes.device_certificate_path(conn, :index, org.name, product.name, device.identifier)
         )
 
       assert json_response(conn, 200)["data"] == []
@@ -57,7 +57,7 @@ defmodule NervesHubAPIWeb.DeviceCertificateControllerTest do
       conn =
         post(
           conn,
-          device_certificate_path(conn, :sign, org.name, product.name, device.identifier),
+          Routes.device_certificate_path(conn, :sign, org.name, product.name, device.identifier),
           params
         )
 
@@ -80,7 +80,7 @@ defmodule NervesHubAPIWeb.DeviceCertificateControllerTest do
       conn =
         post(
           conn,
-          device_certificate_path(conn, :sign, org.name, product.name, device.identifier),
+          Routes.device_certificate_path(conn, :sign, org.name, product.name, device.identifier),
           csr: ""
         )
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -7,15 +7,15 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       identifier = "api-device-1234"
       device = %{identifier: identifier, description: "test device", tags: ["test"]}
 
-      conn = post(conn, device_path(conn, :create, org.name, product.name), device)
+      conn = post(conn, Routes.device_path(conn, :create, org.name, product.name), device)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, device_path(conn, :show, org.name, product.name, device.identifier))
+      conn = get(conn, Routes.device_path(conn, :show, org.name, product.name, device.identifier))
       assert json_response(conn, 200)["data"]["identifier"] == identifier
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
-      conn = post(conn, key_path(conn, :create, org.name))
+      conn = post(conn, Routes.key_path(conn, :create, org.name))
       assert json_response(conn, 422)["errors"] != %{}
     end
 
@@ -34,7 +34,7 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
 
       device = Fixtures.device_fixture(org, product, firmware)
 
-      conn = get(conn, device_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.device_path(conn, :index, org.name, product.name))
 
       assert json_response(conn, 200)["data"]
 
@@ -61,11 +61,16 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       [to_delete | _] = Devices.get_devices_by_org_id_and_product_id(org.id, product.id)
 
       conn =
-        delete(conn, device_path(conn, :delete, org.name, product.name, to_delete.identifier))
+        delete(
+          conn,
+          Routes.device_path(conn, :delete, org.name, product.name, to_delete.identifier)
+        )
 
       assert response(conn, 204)
 
-      conn = get(conn, device_path(conn, :show, org.name, product.name, to_delete.identifier))
+      conn =
+        get(conn, Routes.device_path(conn, :show, org.name, product.name, to_delete.identifier))
+
       assert response(conn, 404)
     end
 
@@ -87,13 +92,19 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       [to_update | _] = Devices.get_devices_by_org_id_and_product_id(org.id, product.id)
 
       conn =
-        put(conn, device_path(conn, :update, org.name, product.name, to_update.identifier), %{
-          tags: ["a", "b", "c", "d"]
-        })
+        put(
+          conn,
+          Routes.device_path(conn, :update, org.name, product.name, to_update.identifier),
+          %{
+            tags: ["a", "b", "c", "d"]
+          }
+        )
 
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, device_path(conn, :show, org.name, product.name, to_update.identifier))
+      conn =
+        get(conn, Routes.device_path(conn, :show, org.name, product.name, to_update.identifier))
+
       assert json_response(conn, 200)
       assert conn.assigns.device.tags == ["a", "b", "c", "d"]
     end
@@ -127,7 +138,9 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
         |> Base.encode64()
 
       conn =
-        post(conn, device_path(conn, :auth, org.name, product.name), %{"certificate" => cert64})
+        post(conn, Routes.device_path(conn, :auth, org.name, product.name), %{
+          "certificate" => cert64
+        })
 
       assert json_response(conn, 200)["data"]
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
@@ -7,7 +7,7 @@ defmodule NervesHubAPIWeb.FirmwareControllerTest do
 
   describe "index" do
     test "lists all firmwares", %{conn: conn, org: org, product: product} do
-      path = firmware_path(conn, :index, org.name, product.name)
+      path = Routes.firmware_path(conn, :index, org.name, product.name)
       conn = get(conn, path)
       assert json_response(conn, 200)["data"] == []
     end
@@ -26,12 +26,12 @@ defmodule NervesHubAPIWeb.FirmwareControllerTest do
       }
 
       params = %{"firmware" => upload}
-      path = firmware_path(conn, :create, org.name, product.name)
+      path = Routes.firmware_path(conn, :create, org.name, product.name)
       conn = post(conn, path, params)
       assert data = json_response(conn, 201)["data"]
       uuid = data["uuid"]
 
-      conn = get(conn, firmware_path(conn, :show, org.name, product.name, uuid))
+      conn = get(conn, Routes.firmware_path(conn, :show, org.name, product.name, uuid))
       assert json_response(conn, 200)["data"]["uuid"] == uuid
     end
 
@@ -49,13 +49,13 @@ defmodule NervesHubAPIWeb.FirmwareControllerTest do
       }
 
       params = %{"firmware" => upload}
-      path = firmware_path(conn, :create, org.name, product.name)
+      path = Routes.firmware_path(conn, :create, org.name, product.name)
       conn = post(conn, path, params)
       assert json_response(conn, 422)["errors"] != %{}
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do
-      conn = post(conn, firmware_path(conn, :create, org.name, product.name))
+      conn = post(conn, Routes.firmware_path(conn, :create, org.name, product.name))
       assert json_response(conn, 500)["errors"] != %{}
     end
   end
@@ -64,10 +64,12 @@ defmodule NervesHubAPIWeb.FirmwareControllerTest do
     setup [:create_firmware]
 
     test "deletes chosen firmware", %{conn: conn, org: org, product: product, firmware: firmware} do
-      conn = delete(conn, firmware_path(conn, :delete, org.name, product.name, firmware.uuid))
+      conn =
+        delete(conn, Routes.firmware_path(conn, :delete, org.name, product.name, firmware.uuid))
+
       assert response(conn, 204)
 
-      conn = get(conn, firmware_path(conn, :show, org.name, product.name, firmware.uuid))
+      conn = get(conn, Routes.firmware_path(conn, :show, org.name, product.name, firmware.uuid))
 
       assert response(conn, 404)
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/key_controller_test.exs
@@ -7,14 +7,14 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
 
   describe "index" do
     test "lists all keys", %{conn: conn, org: org} do
-      conn = get(conn, key_path(conn, :index, org.name))
+      conn = get(conn, Routes.key_path(conn, :index, org.name))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "index roles" do
     test "error: missing org read", %{conn2: conn, org: org} do
-      conn = get(conn, key_path(conn, :index, org.name))
+      conn = get(conn, Routes.key_path(conn, :index, org.name))
       assert json_response(conn, 403)["status"] != ""
     end
   end
@@ -26,15 +26,15 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
       pub_key = Fwup.get_public_key(name)
       key = %{name: name, key: pub_key, org_id: org.id}
 
-      conn = post(conn, key_path(conn, :create, org.name), key)
+      conn = post(conn, Routes.key_path(conn, :create, org.name), key)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, key_path(conn, :show, org.name, key.name))
+      conn = get(conn, Routes.key_path(conn, :show, org.name, key.name))
       assert json_response(conn, 200)["data"]["name"] == name
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
-      conn = post(conn, key_path(conn, :create, org.name))
+      conn = post(conn, Routes.key_path(conn, :create, org.name))
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -48,10 +48,10 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
       pub_key = Fwup.get_public_key(name)
       key = %{name: name, key: pub_key, org_id: org.id}
 
-      conn = post(conn, key_path(conn, :create, org.name), key)
+      conn = post(conn, Routes.key_path(conn, :create, org.name), key)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, key_path(conn, :show, org.name, key.name))
+      conn = get(conn, Routes.key_path(conn, :show, org.name, key.name))
       assert json_response(conn, 200)["data"]["name"] == name
     end
 
@@ -62,7 +62,7 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
       pub_key = Fwup.get_public_key(name)
       key = %{name: name, key: pub_key, org_id: org.id}
 
-      conn = post(conn, key_path(conn, :create, org.name), key)
+      conn = post(conn, Routes.key_path(conn, :create, org.name), key)
       assert json_response(conn, 403)["status"] != ""
     end
   end
@@ -71,10 +71,10 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
     setup [:create_key]
 
     test "deletes chosen key", %{conn: conn, org: org, key: key} do
-      conn = delete(conn, key_path(conn, :delete, org.name, key.name))
+      conn = delete(conn, Routes.key_path(conn, :delete, org.name, key.name))
       assert response(conn, 204)
 
-      conn = get(conn, key_path(conn, :show, org.name, key.name))
+      conn = get(conn, Routes.key_path(conn, :show, org.name, key.name))
 
       assert response(conn, 404)
     end
@@ -85,19 +85,19 @@ defmodule NervesHubAPIWeb.KeyControllerTest do
 
     test "ok: org delete", %{user2: user, conn2: conn, org: org, key: key} do
       Accounts.add_org_user(org, user, %{role: :delete})
-      conn = delete(conn, key_path(conn, :delete, org.name, key.name))
+      conn = delete(conn, Routes.key_path(conn, :delete, org.name, key.name))
       assert response(conn, 204)
     end
 
     test "error: org write", %{user2: user, conn2: conn, org: org, key: key} do
       Accounts.add_org_user(org, user, %{role: :write})
-      conn = delete(conn, key_path(conn, :delete, org.name, key.name))
+      conn = delete(conn, Routes.key_path(conn, :delete, org.name, key.name))
       assert json_response(conn, 403)["status"] != ""
     end
 
     test "error: org read", %{user2: user, conn2: conn, org: org, key: key} do
       Accounts.add_org_user(org, user, %{role: :read})
-      conn = delete(conn, key_path(conn, :delete, org.name, key.name))
+      conn = delete(conn, Routes.key_path(conn, :delete, org.name, key.name))
       assert json_response(conn, 403)["status"] != ""
     end
   end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/org_user_controller_test.exs
@@ -12,7 +12,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
 
   describe "index" do
     test "lists all org_users", %{conn: conn, org: org, user: user} do
-      conn = get(conn, org_user_path(conn, :index, org.name))
+      conn = get(conn, Routes.org_user_path(conn, :index, org.name))
 
       assert json_response(conn, 200)["data"] ==
                [%{"email" => user.email, "role" => "admin", "username" => user.username}]
@@ -25,7 +25,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
         Accounts.add_org_user(org, user, %{role: @role})
-        conn = get(conn, org_user_path(conn, :index, org.name))
+        conn = get(conn, Routes.org_user_path(conn, :index, org.name))
         assert json_response(conn, 403)["status"] != ""
       end
     end
@@ -34,10 +34,10 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
   describe "add org_users" do
     test "renders org_user when data is valid", %{conn: conn, org: org, user2: user2} do
       org_user = %{"username" => user2.username, "role" => "write"}
-      conn = post(conn, org_user_path(conn, :add, org.name), org_user)
+      conn = post(conn, Routes.org_user_path(conn, :add, org.name), org_user)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, org_user_path(conn, :show, org.name, user2.username))
+      conn = get(conn, Routes.org_user_path(conn, :show, org.name, user2.username))
       assert json_response(conn, 200)["data"]["username"] == user2.username
 
       # An email should have been sent
@@ -50,7 +50,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
 
     test "renders errors when data is invalid", %{conn: conn, org: org, user2: user2} do
       org_user = %{"username" => user2.username, "role" => "bogus"}
-      conn = post(conn, org_user_path(conn, :add, org.name), org_user)
+      conn = post(conn, Routes.org_user_path(conn, :add, org.name), org_user)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -62,7 +62,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
         Accounts.add_org_user(org, user, %{role: @role})
         org_user = %{"username" => "1234", "role" => "admin"}
-        conn = post(conn, org_user_path(conn, :add, org.name), org_user)
+        conn = post(conn, Routes.org_user_path(conn, :add, org.name), org_user)
         assert json_response(conn, 403)["status"] != ""
       end
     end
@@ -72,7 +72,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
     setup [:create_org_user]
 
     test "remove existing user", %{conn: conn, org: org, user2: user} do
-      conn = delete(conn, org_user_path(conn, :remove, org.name, user.username))
+      conn = delete(conn, Routes.org_user_path(conn, :remove, org.name, user.username))
       assert response(conn, 204)
 
       # An email should have been sent
@@ -82,7 +82,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
         subject: "[NervesHub] User #{instigator} removed #{user.username} from #{org.name}"
       )
 
-      conn = get(conn, org_user_path(conn, :show, org.name, user.username))
+      conn = get(conn, Routes.org_user_path(conn, :show, org.name, user.username))
       assert response(conn, 404)
     end
   end
@@ -93,7 +93,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
         Accounts.add_org_user(org, user, %{role: @role})
-        conn = delete(conn, org_user_path(conn, :remove, org.name, "1234"))
+        conn = delete(conn, Routes.org_user_path(conn, :remove, org.name, "1234"))
         assert json_response(conn, 403)["status"] != ""
       end
     end
@@ -103,11 +103,12 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
     setup [:create_org_user]
 
     test "renders org_user when data is valid", %{conn: conn, org: org, user2: user} do
-      conn = put(conn, org_user_path(conn, :update, org.name, user.username), role: "write")
+      conn =
+        put(conn, Routes.org_user_path(conn, :update, org.name, user.username), role: "write")
 
       assert json_response(conn, 200)["data"]["role"] == "write"
 
-      path = org_user_path(conn, :show, org.name, user.username)
+      path = Routes.org_user_path(conn, :show, org.name, user.username)
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["role"] == "write"
     end
@@ -119,7 +120,10 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
         Accounts.add_org_user(org, user, %{role: @role})
-        conn = put(conn, org_user_path(conn, :update, org.name, user.username), role: "write")
+
+        conn =
+          put(conn, Routes.org_user_path(conn, :update, org.name, user.username), role: "write")
+
         assert json_response(conn, 403)["status"] != ""
       end
     end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
@@ -11,14 +11,14 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
 
   describe "index" do
     test "lists all products", %{conn: conn, org: org} do
-      conn = get(conn, product_path(conn, :index, org.name))
+      conn = get(conn, Routes.product_path(conn, :index, org.name))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
   describe "index roles" do
     test "error: missing org read", %{conn2: conn, org: org} do
-      conn = get(conn, product_path(conn, :index, org.name))
+      conn = get(conn, Routes.product_path(conn, :index, org.name))
       assert json_response(conn, 403)["status"] != ""
     end
   end
@@ -28,15 +28,15 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
       name = "test"
       product = %{name: name}
 
-      conn = post(conn, product_path(conn, :create, org.name), product)
+      conn = post(conn, Routes.product_path(conn, :create, org.name), product)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, product_path(conn, :show, org.name, product.name))
+      conn = get(conn, Routes.product_path(conn, :show, org.name, product.name))
       assert json_response(conn, 200)["data"]["name"] == name
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
-      conn = post(conn, product_path(conn, :create, org.name))
+      conn = post(conn, Routes.product_path(conn, :create, org.name))
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -48,10 +48,10 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
 
       Accounts.add_org_user(org, user, %{role: :write})
 
-      conn = post(conn, product_path(conn, :create, org.name), product)
+      conn = post(conn, Routes.product_path(conn, :create, org.name), product)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, product_path(conn, :show, org.name, product.name))
+      conn = get(conn, Routes.product_path(conn, :show, org.name, product.name))
       assert json_response(conn, 200)["data"]["name"] == name
     end
 
@@ -61,7 +61,7 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
 
       Accounts.add_org_user(org, user, %{role: :read})
 
-      conn = post(conn, product_path(conn, :create, org.name), product)
+      conn = post(conn, Routes.product_path(conn, :create, org.name), product)
       assert json_response(conn, 403)["status"] != ""
     end
   end
@@ -70,10 +70,10 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
     setup [:create_product]
 
     test "deletes chosen product", %{conn: conn, org: org, product: product} do
-      conn = delete(conn, product_path(conn, :delete, org.name, product.name))
+      conn = delete(conn, Routes.product_path(conn, :delete, org.name, product.name))
       assert response(conn, 204)
 
-      conn = get(conn, product_path(conn, :show, org.name, product.name))
+      conn = get(conn, Routes.product_path(conn, :show, org.name, product.name))
 
       assert response(conn, 403)
     end
@@ -85,10 +85,10 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
     test "ok: org delete", %{user2: user, conn2: conn, org: org, product: product} do
       Accounts.add_org_user(org, user, %{role: :delete})
 
-      conn = delete(conn, product_path(conn, :delete, org.name, product.name))
+      conn = delete(conn, Routes.product_path(conn, :delete, org.name, product.name))
       assert response(conn, 204)
 
-      conn = get(conn, product_path(conn, :show, org.name, product.name))
+      conn = get(conn, Routes.product_path(conn, :show, org.name, product.name))
 
       assert response(conn, 403)
     end
@@ -96,14 +96,14 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
     test "error: org delete", %{user2: user, conn2: conn, org: org, product: product} do
       Accounts.add_org_user(org, user, %{role: :read})
 
-      conn = delete(conn, product_path(conn, :delete, org.name, product.name))
+      conn = delete(conn, Routes.product_path(conn, :delete, org.name, product.name))
       assert json_response(conn, 403)["status"] != ""
     end
 
     test "error: org read", %{user2: user, conn2: conn, org: org, product: product} do
       Accounts.add_org_user(org, user, %{role: :read})
 
-      conn = delete(conn, product_path(conn, :delete, org.name, product.name))
+      conn = delete(conn, Routes.product_path(conn, :delete, org.name, product.name))
       assert json_response(conn, 403)["status"] != ""
     end
   end
@@ -113,11 +113,13 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
 
     test "renders deployment when data is valid", %{conn: conn, org: org, product: product} do
       conn =
-        put(conn, product_path(conn, :update, org.name, product.name), product: %{"name" => "new"})
+        put(conn, Routes.product_path(conn, :update, org.name, product.name),
+          product: %{"name" => "new"}
+        )
 
       assert %{"name" => "new"} = json_response(conn, 200)["data"]
 
-      path = product_path(conn, :show, org.name, "new")
+      path = Routes.product_path(conn, :show, org.name, "new")
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["name"] == "new"
     end
@@ -131,11 +133,13 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
       Products.add_product_user(product, user, %{role: :admin})
 
       conn =
-        put(conn, product_path(conn, :update, org.name, product.name), product: %{"name" => "new"})
+        put(conn, Routes.product_path(conn, :update, org.name, product.name),
+          product: %{"name" => "new"}
+        )
 
       assert %{"name" => "new"} = json_response(conn, 200)["data"]
 
-      path = product_path(conn, :show, org.name, "new")
+      path = Routes.product_path(conn, :show, org.name, "new")
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["name"] == "new"
     end
@@ -143,7 +147,7 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
     test "error: org read", %{user2: user, conn2: conn, org: org, product: product} do
       Accounts.add_org_user(org, user, %{role: :read})
 
-      conn = delete(conn, product_path(conn, :delete, org.name, product.name))
+      conn = delete(conn, Routes.product_path(conn, :delete, org.name, product.name))
       assert json_response(conn, 403)["status"] != ""
     end
   end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_user_controller_test.exs
@@ -15,7 +15,7 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
 
   describe "index" do
     test "lists all product_users", %{conn: conn, org: org, user: user, product: product} do
-      conn = get(conn, product_user_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.product_user_path(conn, :index, org.name, product.name))
 
       assert json_response(conn, 200)["data"] ==
                [%{"email" => user.email, "role" => "admin", "username" => user.username}]
@@ -28,7 +28,7 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
 
       test "error: product #{@role}", %{conn2: conn, org: org, user2: user, product: product} do
         Products.add_product_user(product, user, %{role: @role})
-        conn = get(conn, product_user_path(conn, :index, org.name, product.name))
+        conn = get(conn, Routes.product_user_path(conn, :index, org.name, product.name))
         assert json_response(conn, 403)["status"] != ""
       end
     end
@@ -42,10 +42,15 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
       product: product
     } do
       product_user = %{"username" => user2.username, "role" => "write"}
-      conn = post(conn, product_user_path(conn, :add, org.name, product.name), product_user)
+
+      conn =
+        post(conn, Routes.product_user_path(conn, :add, org.name, product.name), product_user)
+
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, product_user_path(conn, :show, org.name, product.name, user2.username))
+      conn =
+        get(conn, Routes.product_user_path(conn, :show, org.name, product.name, user2.username))
+
       assert json_response(conn, 200)["data"]["username"] == user2.username
     end
 
@@ -56,7 +61,10 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
       product: product
     } do
       product_user = %{"username" => user2.username, "role" => "bogus"}
-      conn = post(conn, product_user_path(conn, :add, org.name, product.name), product_user)
+
+      conn =
+        post(conn, Routes.product_user_path(conn, :add, org.name, product.name), product_user)
+
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -68,7 +76,10 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user, product: product} do
         Products.add_product_user(product, user, %{role: @role})
         product_user = %{"username" => user.username, "role" => "write"}
-        conn = post(conn, product_user_path(conn, :add, org.name, product.name), product_user)
+
+        conn =
+          post(conn, Routes.product_user_path(conn, :add, org.name, product.name), product_user)
+
         assert json_response(conn, 403)["status"] != ""
       end
     end
@@ -78,10 +89,17 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
     setup [:create_product_user]
 
     test "remove existing user", %{conn: conn, org: org, user2: user, product: product} do
-      conn = delete(conn, product_user_path(conn, :remove, org.name, product.name, user.username))
+      conn =
+        delete(
+          conn,
+          Routes.product_user_path(conn, :remove, org.name, product.name, user.username)
+        )
+
       assert response(conn, 204)
 
-      conn = get(conn, product_user_path(conn, :show, org.name, product.name, user.username))
+      conn =
+        get(conn, Routes.product_user_path(conn, :show, org.name, product.name, user.username))
+
       assert response(conn, 404)
     end
   end
@@ -92,7 +110,10 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user, product: product} do
         Products.add_product_user(product, user, %{role: @role})
-        conn = delete(conn, product_user_path(conn, :remove, org.name, product.name, "1234"))
+
+        conn =
+          delete(conn, Routes.product_user_path(conn, :remove, org.name, product.name, "1234"))
+
         assert json_response(conn, 403)["status"] != ""
       end
     end
@@ -108,13 +129,13 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
       product: product
     } do
       conn =
-        put(conn, product_user_path(conn, :update, org.name, product.name, user.username),
+        put(conn, Routes.product_user_path(conn, :update, org.name, product.name, user.username),
           role: "write"
         )
 
       assert json_response(conn, 200)["data"]["role"] == "write"
 
-      path = product_user_path(conn, :show, org.name, product.name, user.username)
+      path = Routes.product_user_path(conn, :show, org.name, product.name, user.username)
       conn = get(conn, path)
       assert json_response(conn, 200)["data"]["role"] == "write"
     end
@@ -128,7 +149,9 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
         Products.add_product_user(product, user, %{role: @role})
 
         conn =
-          put(conn, product_user_path(conn, :update, org.name, product.name, user.username),
+          put(
+            conn,
+            Routes.product_user_path(conn, :update, org.name, product.name, user.username),
             role: "write"
           )
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -6,7 +6,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
   alias NervesHubWebCore.Accounts
 
   test "me", %{conn: conn, user: user} do
-    conn = get(conn, user_path(conn, :me))
+    conn = get(conn, Routes.user_path(conn, :me))
 
     assert json_response(conn, 200)["data"] == %{
              "username" => user.username,
@@ -17,7 +17,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
   test "register new account" do
     conn = build_conn()
     body = %{username: "api_test", password: "12345678", email: "new_test@test.com"}
-    conn = post(conn, user_path(conn, :register), body)
+    conn = post(conn, Routes.user_path(conn, :register), body)
 
     assert json_response(conn, 200)["data"] == %{
              "username" => body.username,
@@ -36,7 +36,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
       })
 
     conn = build_conn()
-    conn = post(conn, user_path(conn, :auth), %{email: user.email, password: password})
+    conn = post(conn, Routes.user_path(conn, :auth), %{email: user.email, password: password})
 
     assert json_response(conn, 200)["data"] == %{
              "username" => user.username,
@@ -62,7 +62,7 @@ defmodule NervesHubAPIWeb.UserControllerTest do
 
     conn = build_conn()
 
-    conn = post(conn, user_path(conn, :sign), params)
+    conn = post(conn, Routes.user_path(conn, :sign), params)
     resp_data = json_response(conn, 200)["data"]
     assert %{"cert" => cert} = resp_data
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/nerves_hub_api_web_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/nerves_hub_api_web_test.exs
@@ -5,13 +5,13 @@ defmodule NervesHubAPIWebTest do
 
   test "conn missing certificate is rejected" do
     conn = Phoenix.ConnTest.build_conn()
-    conn = get(conn, user_path(conn, :me))
+    conn = get(conn, Routes.user_path(conn, :me))
     assert json_response(conn, 403)["status"] == "forbidden"
   end
 
   test "user certificate last used is updated", %{conn: conn, user: user} do
     [%{last_used: last_used}] = Accounts.get_user_certificates(user)
-    get(conn, user_path(conn, :me))
+    get(conn, Routes.user_path(conn, :me))
     [%{last_used: updated_last_used}] = Accounts.get_user_certificates(user)
     assert last_used != updated_last_used
   end

--- a/apps/nerves_hub_api/test/support/conn_case.ex
+++ b/apps/nerves_hub_api/test/support/conn_case.ex
@@ -20,8 +20,9 @@ defmodule NervesHubAPIWeb.ConnCase do
     quote do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
-      import NervesHubAPIWeb.Router.Helpers
       import NervesHubAPIWeb.ConnCase, only: [build_auth_conn: 1, peer_data: 1]
+
+      alias NervesHubAPIWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing
       @endpoint NervesHubAPIWeb.Endpoint

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web.ex
@@ -21,8 +21,9 @@ defmodule NervesHubDeviceWeb do
     quote do
       use Phoenix.Controller, namespace: NervesHubDeviceWeb
       import Plug.Conn
-      import NervesHubDeviceWeb.Router.Helpers
       import NervesHubDeviceWeb.Gettext
+
+      alias NervesHubDeviceWeb.Router.Helpers, as: Routes
     end
   end
 
@@ -35,9 +36,10 @@ defmodule NervesHubDeviceWeb do
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]
 
-      import NervesHubDeviceWeb.Router.Helpers
       import NervesHubDeviceWeb.ErrorHelpers
       import NervesHubDeviceWeb.Gettext
+
+      alias NervesHubDeviceWeb.Router.Helpers, as: Routes
 
       def render("error.json", %{error: error}) do
         %{

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/controllers/device_controller_test.exs
@@ -4,7 +4,7 @@ defmodule NervesHubDeviceWeb.DeviceControllerTest do
 
   describe "device" do
     test "identify a device", %{conn: conn, device: device} do
-      conn = get(conn, device_path(conn, :me))
+      conn = get(conn, Routes.device_path(conn, :me))
       assert json_response(conn, 200)["data"]["identifier"] == device.identifier
     end
 
@@ -15,7 +15,7 @@ defmodule NervesHubDeviceWeb.DeviceControllerTest do
       product: product
     } do
       # Make sure there is no update available
-      conn = get(conn, device_path(conn, :update))
+      conn = get(conn, Routes.device_path(conn, :update))
       assert json_response(conn, 200)["data"]["update_available"] == false
 
       # Create a new firmware and active deployment for the device
@@ -24,13 +24,13 @@ defmodule NervesHubDeviceWeb.DeviceControllerTest do
       {:ok, _} = Deployments.update_deployment(deployment, params)
 
       # Should be an update available now.
-      conn = get(conn, device_path(conn, :update))
+      conn = get(conn, Routes.device_path(conn, :update))
       assert json_response(conn, 200)["data"]["update_available"]
     end
 
     test "last used is updated", %{conn: conn, device: device} do
       [%{last_used: last_used}] = Devices.get_device_certificates(device)
-      get(conn, device_path(conn, :me))
+      get(conn, Routes.device_path(conn, :me))
       [%{last_used: updated_last_used}] = Devices.get_device_certificates(device)
       assert last_used != updated_last_used
     end

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/plugs/device_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/plugs/device_test.exs
@@ -16,7 +16,7 @@ defmodule NervesHubDeviceWeb.Plugs.DeviceTest do
     assert plug_call_conn.status == 403
     refute plug_call_conn.assigns[:device]
 
-    get_conn = get(conn, device_path(conn, :me))
+    get_conn = get(conn, Routes.device_path(conn, :me))
     assert json_response(get_conn, 403)["status"] == "forbidden"
   end
 
@@ -30,7 +30,7 @@ defmodule NervesHubDeviceWeb.Plugs.DeviceTest do
     refute plug_call_conn.status == 403
     assert plug_call_conn.assigns[:device]
 
-    get_conn = get(conn, device_path(conn, :me))
+    get_conn = get(conn, Routes.device_path(conn, :me))
     assert json_response(get_conn, 200)
   end
 
@@ -50,7 +50,7 @@ defmodule NervesHubDeviceWeb.Plugs.DeviceTest do
     refute plug_call_conn.status == 403
     assert plug_call_conn.assigns[:device]
 
-    get_conn = get(conn, device_path(conn, :me))
+    get_conn = get(conn, Routes.device_path(conn, :me))
     assert json_response(get_conn, 200)
   end
 
@@ -98,7 +98,7 @@ defmodule NervesHubDeviceWeb.Plugs.DeviceTest do
     device = plug_call_conn.assigns[:device]
     assert device
 
-    get_conn = get(conn, device_path(conn, :me))
+    get_conn = get(conn, Routes.device_path(conn, :me))
     assert json_response(get_conn, 200)
   end
 end

--- a/apps/nerves_hub_device/test/support/conn_case.ex
+++ b/apps/nerves_hub_device/test/support/conn_case.ex
@@ -20,7 +20,8 @@ defmodule NervesHubDeviceWeb.ConnCase do
     quote do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
-      import NervesHubDeviceWeb.Router.Helpers
+
+      alias NervesHubDeviceWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing
       @endpoint NervesHubDeviceWeb.Endpoint

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments.ex
@@ -43,28 +43,6 @@ defmodule NervesHubWebCore.Deployments do
 
   def get_deployment!(deployment_id), do: Repo.get!(Deployment, deployment_id)
 
-  def get_deployment_by_product_name(product_name, deployment_name) do
-    from(
-      d in Deployment,
-      join: f in Firmware,
-      on: f.id == d.firmware_id,
-      join: p in Product,
-      on: p.id == f.product_id,
-      where: d.name == ^deployment_name,
-      where: p.name == ^product_name
-    )
-    |> Deployment.with_firmware()
-    |> Deployment.with_product()
-    |> Repo.one()
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      deployment ->
-        {:ok, deployment}
-    end
-  end
-
   @spec get_deployment_by_name(Product.t(), String.t()) ::
           {:ok, Deployment.t()} | {:error, :not_found}
   def get_deployment_by_name(%Product{id: product_id}, deployment_name) do
@@ -72,8 +50,7 @@ defmodule NervesHubWebCore.Deployments do
       d in Deployment,
       where: d.name == ^deployment_name,
       join: f in assoc(d, :firmware),
-      where: f.product_id == ^product_id,
-      preload: [{:firmware, :product}]
+      where: f.product_id == ^product_id
     )
     |> Deployment.with_firmware()
     |> Deployment.with_product()

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -71,21 +71,6 @@ defmodule NervesHubWebCore.Devices do
     end
   end
 
-  def get_device_by_org_name(org_name, device_id) do
-    from(
-      d in Device,
-      join: o in Org,
-      on: o.id == d.org_id,
-      where: o.name == ^org_name,
-      where: d.id == ^device_id
-    )
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      device -> {:ok, device}
-    end
-  end
-
   def get_device_by_org!(%Org{id: org_id}, device_id) do
     device_by_org_query(org_id, device_id)
     |> Repo.one!()

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
@@ -27,12 +27,14 @@ defmodule NervesHubWWWWeb do
   def controller do
     quote do
       use Phoenix.Controller, namespace: NervesHubWWWWeb
+
       import NervesHubWebCore.AuditLogs, only: [audit: 4, audit!: 4]
       import Plug.Conn
-      import NervesHubWWWWeb.Router.Helpers
       import NervesHubWWWWeb.Gettext
       import Phoenix.LiveView.Controller, only: [live_render: 3]
       import NervesHubWebCore.RoleValidateHelpers
+
+      alias NervesHubWWWWeb.Router.Helpers, as: Routes
 
       def whitelist(params, keys) do
         keys
@@ -71,7 +73,6 @@ defmodule NervesHubWWWWeb do
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML
 
-      import NervesHubWWWWeb.Router.Helpers
       import NervesHubWWWWeb.ErrorHelpers
       import NervesHubWWWWeb.Gettext
 
@@ -89,9 +90,10 @@ defmodule NervesHubWWWWeb do
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]
 
-      import NervesHubWWWWeb.Router.Helpers
       import NervesHubWWWWeb.ErrorHelpers
       import NervesHubWWWWeb.Gettext
+
+      alias NervesHubWWWWeb.Router.Helpers, as: Routes
 
       def render("error.json", %{error: error}) do
         %{

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_certificate_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_certificate_controller.ex
@@ -55,7 +55,7 @@ defmodule NervesHubWWWWeb.AccountCertificateController do
 
       conn
       |> redirect(
-        to: account_certificate_path(conn, :show, user.username, db_cert, file: archive)
+        to: Routes.account_certificate_path(conn, :show, user.username, db_cert, file: archive)
       )
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -73,7 +73,7 @@ defmodule NervesHubWWWWeb.AccountCertificateController do
 
     conn
     |> put_flash(:info, "Certificate deleted successfully.")
-    |> redirect(to: account_certificate_path(conn, :index, user.username))
+    |> redirect(to: Routes.account_certificate_path(conn, :index, user.username))
   end
 
   # Thanks to Hex for lending us this chunk of code.

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -49,7 +49,7 @@ defmodule NervesHubWWWWeb.AccountController do
       {:ok, user} ->
         conn
         |> put_flash(:info, "Account updated")
-        |> redirect(to: account_path(conn, :edit, user.username))
+        |> redirect(to: Routes.account_path(conn, :edit, user.username))
 
       {:error, changeset} ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/deployment_controller.ex
@@ -44,7 +44,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
       {:error, :not_found} ->
         conn
         |> put_flash(:error, "Invalid firmware selected")
-        |> redirect(to: deployment_path(conn, :new, org.name, product.name))
+        |> redirect(to: Routes.deployment_path(conn, :new, org.name, product.name))
     end
   end
 
@@ -54,7 +54,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
     if Enum.empty?(firmwares) do
       conn
       |> put_flash(:error, "You must upload a firmware version before creating a deployment")
-      |> redirect(to: firmware_path(conn, :upload, org.name, product.name))
+      |> redirect(to: Routes.firmware_path(conn, :upload, org.name, product.name))
     else
       conn
       |> render("select-firmware.html", firmwares: firmwares)
@@ -84,14 +84,14 @@ defmodule NervesHubWWWWeb.DeploymentController do
       {:error, :not_found} ->
         conn
         |> put_flash(:error, "Invalid firmware selected")
-        |> redirect(to: deployment_path(conn, :new, org.name, product.name))
+        |> redirect(to: Routes.deployment_path(conn, :new, org.name, product.name))
 
       {_, {:ok, deployment}} ->
         audit!(user, deployment, :create, params)
 
         conn
         |> put_flash(:info, "Deployment created")
-        |> redirect(to: deployment_path(conn, :index, org.name, product.name))
+        |> redirect(to: Routes.deployment_path(conn, :index, org.name, product.name))
 
       {firmware, {:error, changeset}} ->
         conn
@@ -162,7 +162,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
         |> put_flash(:info, "Deployment updated")
         |> redirect(
           to:
-            deployment_path(
+            Routes.deployment_path(
               conn,
               :show,
               org.name,
@@ -187,7 +187,7 @@ defmodule NervesHubWWWWeb.DeploymentController do
 
     conn
     |> put_flash(:info, "Deployment successfully deleted")
-    |> redirect(to: deployment_path(conn, :index, org.name, product.name))
+    |> redirect(to: Routes.deployment_path(conn, :index, org.name, product.name))
   end
 
   @doc """

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -38,7 +38,7 @@ defmodule NervesHubWWWWeb.DeviceController do
     |> case do
       {:ok, _device} ->
         conn
-        |> redirect(to: device_path(conn, :index, org.name, product.name))
+        |> redirect(to: Routes.device_path(conn, :index, org.name, product.name))
 
       {:error, changeset} ->
         conn
@@ -77,7 +77,7 @@ defmodule NervesHubWWWWeb.DeviceController do
 
     conn
     |> put_flash(:info, "device deleted successfully.")
-    |> redirect(to: device_path(conn, :index, org.name, product.name))
+    |> redirect(to: Routes.device_path(conn, :index, org.name, product.name))
   end
 
   def console(

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -27,7 +27,7 @@ defmodule NervesHubWWWWeb.FirmwareController do
       {:ok, _firmware} ->
         conn
         |> put_flash(:info, "Firmware uploaded")
-        |> redirect(to: firmware_path(conn, :index, org.name, product.name))
+        |> redirect(to: Routes.firmware_path(conn, :index, org.name, product.name))
 
       {:error, :no_public_keys} ->
         render_error(
@@ -97,7 +97,7 @@ defmodule NervesHubWWWWeb.FirmwareController do
          :ok <- Firmwares.delete_firmware(firmware) do
       conn
       |> put_flash(:info, "Firmware successfully deleted")
-      |> redirect(to: firmware_path(conn, :index, org.name, product.name))
+      |> redirect(to: Routes.firmware_path(conn, :index, org.name, product.name))
     end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -20,7 +20,7 @@ defmodule NervesHubWWWWeb.OrgController do
     with {:ok, org} <- Accounts.create_org(user, params) do
       conn
       |> put_flash(:info, "Organization created successfully.")
-      |> redirect(to: product_path(conn, :index, org.name))
+      |> redirect(to: Routes.product_path(conn, :index, org.name))
     else
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
@@ -45,7 +45,7 @@ defmodule NervesHubWWWWeb.OrgController do
       {:ok, org} ->
         conn
         |> put_flash(:info, "Organization Updated")
-        |> redirect(to: org_path(conn, :edit, org.name))
+        |> redirect(to: Routes.org_path(conn, :edit, org.name))
 
       {:error, changeset} ->
         render(
@@ -73,7 +73,7 @@ defmodule NervesHubWWWWeb.OrgController do
 
         conn
         |> put_flash(:info, "User has been invited")
-        |> redirect(to: org_path(conn, :edit, org.name))
+        |> redirect(to: Routes.org_path(conn, :edit, org.name))
 
       {:ok, %OrgUser{}} ->
         Email.org_user_created(invite_params["email"], org)
@@ -81,7 +81,7 @@ defmodule NervesHubWWWWeb.OrgController do
 
         conn
         |> put_flash(:info, "User has been added to #{org.name}")
-        |> redirect(to: org_path(conn, :edit, org.name))
+        |> redirect(to: Routes.org_path(conn, :edit, org.name))
 
       {:error, changeset} ->
         render(conn, "invite.html",

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_key_controller.ex
@@ -23,12 +23,12 @@ defmodule NervesHubWWWWeb.OrgKeyController do
       {:ok, _org_key} ->
         conn
         |> put_flash(:info, "Organization key created successfully.")
-        |> redirect(to: org_path(conn, :edit, org.name))
+        |> redirect(to: Routes.org_path(conn, :edit, org.name))
 
       {:error, %Ecto.Changeset{}} ->
         conn
         |> put_flash(:error, "Failed to create key -- it must have a unique name and value")
-        |> redirect(to: org_path(conn, :edit, org.name))
+        |> redirect(to: Routes.org_path(conn, :edit, org.name))
     end
   end
 
@@ -56,7 +56,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
       {:ok, _org_key} ->
         conn
         |> put_flash(:info, "Organization key updated successfully.")
-        |> redirect(to: org_path(conn, :edit, org.name))
+        |> redirect(to: Routes.org_path(conn, :edit, org.name))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", org_key: org_key, changeset: changeset)
@@ -69,7 +69,7 @@ defmodule NervesHubWWWWeb.OrgKeyController do
     with {:ok, _org_key} <- Accounts.delete_org_key(org_key) do
       conn
       |> put_flash(:info, "Organization key deleted successfully.")
-      |> redirect(to: org_path(conn, :edit, org.name))
+      |> redirect(to: Routes.org_path(conn, :edit, org.name))
     else
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", org_key: org_key, changeset: changeset)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/password_reset_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/password_reset_controller.ex
@@ -34,7 +34,7 @@ defmodule NervesHubWWWWeb.PasswordResetController do
 
         conn
         |> put_flash(:info, "Please check your email in order to reset your password.")
-        |> redirect(to: session_path(conn, :new))
+        |> redirect(to: Routes.session_path(conn, :new))
 
       _ ->
         conn
@@ -61,7 +61,7 @@ defmodule NervesHubWWWWeb.PasswordResetController do
           :warning,
           "We're sorry, your password reset link is expired. Please try again."
         )
-        |> redirect(to: session_path(conn, :new))
+        |> redirect(to: Routes.session_path(conn, :new))
     end
   end
 
@@ -72,7 +72,7 @@ defmodule NervesHubWWWWeb.PasswordResetController do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "Password reset successfully. Please log in.")
-        |> redirect(to: session_path(conn, :new))
+        |> redirect(to: Routes.session_path(conn, :new))
 
       {:error, :not_found} ->
         conn
@@ -80,7 +80,7 @@ defmodule NervesHubWWWWeb.PasswordResetController do
           :warning,
           "We're sorry, your password reset link is expired or incorrect. Please try again."
         )
-        |> redirect(to: session_path(conn, :new))
+        |> redirect(to: Routes.session_path(conn, :new))
 
       {:error, %Changeset{} = changeset} ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/product_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/product_controller.ex
@@ -28,7 +28,7 @@ defmodule NervesHubWWWWeb.ProductController do
       {:ok, product} ->
         conn
         |> put_flash(:info, "Product created successfully.")
-        |> redirect(to: product_path(conn, :show, org.name, product.name))
+        |> redirect(to: Routes.product_path(conn, :show, org.name, product.name))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
@@ -53,7 +53,7 @@ defmodule NervesHubWWWWeb.ProductController do
       {:ok, product} ->
         conn
         |> put_flash(:info, "Product updated successfully.")
-        |> redirect(to: product_path(conn, :show, org.name, product.name))
+        |> redirect(to: Routes.product_path(conn, :show, org.name, product.name))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", product: product, changeset: changeset)
@@ -65,6 +65,6 @@ defmodule NervesHubWWWWeb.ProductController do
 
     conn
     |> put_flash(:info, "Product deleted successfully.")
-    |> redirect(to: product_path(conn, :index, org.name))
+    |> redirect(to: Routes.product_path(conn, :index, org.name))
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/session_controller.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWWWWeb.SessionController do
       user_id ->
         case Accounts.get_user(user_id) do
           {:ok, user} ->
-            redirect(conn, to: product_path(conn, :index, user.username))
+            redirect(conn, to: Routes.product_path(conn, :index, user.username))
 
           _ ->
             render(conn, "new.html")
@@ -30,12 +30,12 @@ defmodule NervesHubWWWWeb.SessionController do
       {:ok, user} ->
         conn
         |> put_session(@session_key, user.id)
-        |> redirect(to: product_path(conn, :index, user.username))
+        |> redirect(to: Routes.product_path(conn, :index, user.username))
 
       {:error, :authentication_failed} ->
         conn
         |> put_flash(:error, "Login Failed")
-        |> redirect(to: session_path(conn, :new))
+        |> redirect(to: Routes.session_path(conn, :new))
     end
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
@@ -1,11 +1,11 @@
 <h1>
   Edit Account
-  <a class="btn btn-lg btn-success pull-right" href="<%= account_certificate_path(@conn, :index, @user.username)%>">
+  <a class="btn btn-lg btn-success pull-right" href="<%= Routes.account_certificate_path(@conn, :index, @user.username)%>">
     User Certificates
   </a>
 </h1>
 
-<%= form_for @changeset, account_path(@conn, :update, @user.username), fn f -> %>
+<%= form_for @changeset, Routes.account_path(@conn, :update, @user.username), fn f -> %>
   <div class="form-group">
     <label for="username_input">Username</label>
     <%= text_input f, :username, class: "form-control", id: "username_input" %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
@@ -2,7 +2,7 @@
   <%= gettext "You will be added to the %{organization_name} org", organization_name: @org.name %>
 </p>
 
-<%= form_for @changeset, account_path(@conn, :accept_invite, @token), [as: :user, method: "post"], fn f -> %>
+<%= form_for @changeset, Routes.account_path(@conn, :accept_invite, @token), [as: :user, method: "post"], fn f -> %>
   <p>
     <label>
       Username:

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/new.html.eex
@@ -1,5 +1,5 @@
 <div class="modal-content shadow">
-  <%= form_for @changeset, account_path(@conn, :create), [as: :user], fn f -> %>
+  <%= form_for @changeset, Routes.account_path(@conn, :create), [as: :user], fn f -> %>
     <div class="modal-header panel-title rounded-top">
       Create an Account
     </div>
@@ -24,7 +24,7 @@
     </div>
     <div class="modal-footer">
       <div class="col-4">
-        <a class="btn btn-secondary" href="<%= home_path(@conn, :index) %>">
+        <a class="btn btn-secondary" href="<%= Routes.home_path(@conn, :index) %>">
           Cancel
         </a>
       </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -31,7 +31,7 @@
               <%= cert.not_after %>
             </td>
             <td class="col-2">
-              <center><%= link "Delete", class: "btn btn-danger", to: account_certificate_path(@conn, :delete, @user.username, cert), method: :delete, data: [confirm: "Are you sure?"]%></center>
+              <center><%= link "Delete", class: "btn btn-danger", to: Routes.account_certificate_path(@conn, :delete, @user.username, cert), method: :delete, data: [confirm: "Are you sure?"]%></center>
             </td>
           </tr>
         <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/new.html.eex
@@ -2,7 +2,7 @@
   <h1>Generate an Account Certificate</h1>
 </div>
 
-<%= form_for @changeset, account_certificate_path(@conn, :create, @user.username), fn f -> %>
+<%= form_for @changeset, Routes.account_certificate_path(@conn, :create, @user.username), fn f -> %>
 
   <div class="form-group">
     <label for="description">Description</label>
@@ -11,5 +11,5 @@
   </div>
 
   <%= submit "Create", class: "btn btn-large btn-primary" %>
-  <a class="btn btn-secondary" href="<%= account_certificate_path(@conn, :index, @user.username) %>">Cancel</a>
+  <a class="btn btn-secondary" href="<%= Routes.account_certificate_path(@conn, :index, @user.username) %>">Cancel</a>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/show.html.eex
@@ -4,7 +4,7 @@
 </p>
 
 <%= if not is_nil(@file) do %>
-<a href="<%= account_certificate_path(@conn, :download, @user.username, @user_certificate, file: @file) %>" class="btn btn-primary">Download Certificates</a>
+<a href="<%= Routes.account_certificate_path(@conn, :download, @user.username, @user_certificate, file: @file) %>" class="btn btn-primary">Download Certificates</a>
 <% end %>
 <BR/>
-<a href="<%= account_certificate_path(@conn, :index, @user.username) %>" class="btn btn-secondary">Back</a>
+<a href="<%= Routes.account_certificate_path(@conn, :index, @user.username) %>" class="btn btn-secondary">Back</a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.eex
@@ -1,6 +1,6 @@
 <h1>Edit deployment</h1>
 
-<%= form_for @changeset, deployment_path(@conn, :update, @org.name, @product.name, @deployment.name), [as: :deployment], fn f -> %>
+<%= form_for @changeset, Routes.deployment_path(@conn, :update, @org.name, @product.name, @deployment.name), [as: :deployment], fn f -> %>
   <h3 class="h3">Firmware Details</h3>
 
   <table class="table" style="width: auto">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.eex
@@ -7,7 +7,7 @@
           Deployments for <strong><%= @product.name %></strong>
         </div>
         <div class="col-4 text-right">
-          <a href="<%= deployment_path(@conn, :new, @org.name, @product.name)%>">
+          <a href="<%= Routes.deployment_path(@conn, :new, @org.name, @product.name)%>">
             <span class="fa fa-plus-circle">
           </a>
         </div>
@@ -34,7 +34,7 @@
               <%= if deployment.is_active, do: "Active", else: "Inactive" %>
             </span>
           </td>
-          <td class="col-1"><a class="btn btn-sm btn-secondary" href="<%= deployment_path(@conn, :show, @org.name, @product.name, deployment.name) %>">Details</a></td>
+          <td class="col-1"><a class="btn btn-sm btn-secondary" href="<%= Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name) %>">Details</a></td>
         </tr>
       <% end %>
     </table>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.eex
@@ -1,5 +1,5 @@
 <div class="modal-content shadow">
-  <%= form_for @changeset, deployment_path(@conn, :create, @org.name, @product.name), [as: :deployment], fn f -> %>
+  <%= form_for @changeset, Routes.deployment_path(@conn, :create, @org.name, @product.name), [as: :deployment], fn f -> %>
     <div class="modal-header panel-title rounded-top">
       Create Deployment for <strong><%= firmware_summary(@firmware) %></strong>
     </div>
@@ -39,7 +39,7 @@
     </div>
     <div class="modal-footer">
       <div class="col-4">
-        <a class="btn btn-secondary" href="<%= deployment_path(@conn, :index, @org.name, @product.name) %>">
+        <a class="btn btn-secondary" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">
           Cancel
         </a>
       </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
@@ -1,5 +1,5 @@
 <div class="modal-content shadow">
-  <%= form_for @conn, deployment_path(@conn, :new, @org.name, @product.name), [method: :get, as: :deployment], fn f -> %>
+  <%= form_for @conn, Routes.deployment_path(@conn, :new, @org.name, @product.name), [method: :get, as: :deployment], fn f -> %>
     <div class="modal-header panel-title rounded-top">
       Select Firmware for New Deployment
     </div>
@@ -12,7 +12,7 @@
     </div>
     <div class="modal-footer">
       <div class="col-4">
-        <a class="btn btn-secondary" href="<%= deployment_path(@conn, :index, @org.name, @product.name) %>">
+        <a class="btn btn-secondary" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">
           Cancel
         </a>
       </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -58,7 +58,7 @@
 </table>
 
 <div class="row">
-<a class="btn btn-primary mr-3" href="<%= deployment_path(@socket, :edit, @org.name, @product.name, @deployment.name) %>">
+<a class="btn btn-primary mr-3" href="<%= Routes.deployment_path(@socket, :edit, @org.name, @product.name, @deployment.name) %>">
   Edit Deployment
 </a>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
@@ -22,7 +22,7 @@
 
   <%= submit "Update Tags", class: "btn btn-primary", disabled: @changeset.errors != [] %>
 
-  <a class="btn btn-secondary" href=<%= device_path(@socket, :show, @org.name, @product.name, @device.identifier) %>>
+  <a class="btn btn-secondary" href=<%= Routes.device_path(@socket, :show, @org.name, @product.name, @device.identifier) %>>
     Cancel
   </a>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -22,7 +22,7 @@
       <%= for device <- @devices do %>
         <tr class="item d-flex">
           <td class="col-2">
-            <a href="<%= device_path(@socket, :show, @org.name, @product.name, device.identifier) %>" class="">
+            <a href="<%= Routes.device_path(@socket, :show, @org.name, @product.name, device.identifier) %>" class="">
               <%= device.identifier %>
             </a>
           </td>
@@ -56,8 +56,8 @@
             <span class="badge"><%= tags_to_string(device) %></span>
           </td>
           <td class="col-2">
-            <%= link "Edit", class: "btn btn-info", to: device_path(@socket, :edit, @org.name, @product.name, device.identifier) %>
-            <%= link "Delete", class: "btn btn-danger", to: device_path(@socket, :delete, @org.name, @product.name, device.identifier), method: :delete, data: [confirm: "Are you sure?", csrf: @csrf_token] %>
+            <%= link "Edit", class: "btn btn-info", to: Routes.device_path(@socket, :edit, @org.name, @product.name, device.identifier) %>
+            <%= link "Delete", class: "btn btn-danger", to: Routes.device_path(@socket, :delete, @org.name, @product.name, device.identifier), method: :delete, data: [confirm: "Are you sure?", csrf: @csrf_token] %>
           </td>
         </tr>
       <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
@@ -2,7 +2,7 @@
   <h1>Create a Device</h1>
 </div>
 
-<%= form_for @changeset, device_path(@conn, :create, @org.name, @product.name), fn f -> %>
+<%= form_for @changeset, Routes.device_path(@conn, :create, @org.name, @product.name), fn f -> %>
   <div class="form-group">
     <label for="identifier">Identifier</label>
     <%= text_input f, :identifier, class: "form-control", id: "identifier" %>
@@ -22,5 +22,5 @@
   </div>
 
   <%= submit "Create", class: "btn btn-large btn-primary" %>
-  <a class="btn btn-secondary" href="<%= device_path(@conn, :index, @org.name, @product.name) %>">Cancel</a>
+  <a class="btn btn-secondary" href="<%= Routes.device_path(@conn, :index, @org.name, @product.name) %>">Cancel</a>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -47,14 +47,14 @@
       </p>
 
       <div class="dropdown dropright">
-        <%= link "Back", to: device_path(@socket, :index, @org.name, @product.name), class: "btn btn-secondary"%>
+        <%= link "Back", to: Routes.device_path(@socket, :index, @org.name, @product.name), class: "btn btn-secondary"%>
 
         <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           Actions
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-          <%= link "Console", to: device_path(@socket, :console, @org.name, @product.name, @device.identifier), class: "dropdown-item #{unless Map.has_key?(@device, :console_available) && @device.console_available, do: "disabled"}" %>
-          <%= link "Edit", to: device_path(@socket, :edit, @org.name, @product.name, @device.identifier), class: "dropdown-item" %>
+          <%= link "Console", to: Routes.device_path(@socket, :console, @org.name, @product.name, @device.identifier), class: "dropdown-item #{unless Map.has_key?(@device, :console_available) && @device.console_available, do: "disabled"}" %>
+          <%= link "Edit", to: Routes.device_path(@socket, :edit, @org.name, @product.name, @device.identifier), class: "dropdown-item" %>
           <%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
             <%= submit "Mark #{if @device.healthy, do: "Unhealthy", else: "Healthy"}", class: "dropdown-item" %>
           <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -1,7 +1,7 @@
 <h1>
   Firmware
 
-  <a class="btn btn-lg btn-primary pull-right" href="<%= firmware_path(@conn, :upload, @org.name, @product.name) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= Routes.firmware_path(@conn, :upload, @org.name, @product.name) %>">
     Upload Firmware
   </a>
 </h1>
@@ -34,9 +34,9 @@
       <td><%= firmware.author %></td>
       <td><%= format_signed(firmware, @org) %></td>
       <td><pre class="pre-scrollable"><%= firmware.misc %></pre></td>
-      <td><%= link("Download", to: firmware_path(@conn, :download, @org.name, @product.name, firmware.id)) %></td>
+      <td><%= link("Download", to: Routes.firmware_path(@conn, :download, @org.name, @product.name, firmware.id)) %></td>
       <td>
-        <%= form_for @conn, firmware_path(@conn, :delete, @org.name, @product.name, firmware.id), [method: :delete], fn _ -> %>
+        <%= form_for @conn, Routes.firmware_path(@conn, :delete, @org.name, @product.name, firmware.id), [method: :delete], fn _ -> %>
           <%= submit "Delete Firmware", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this firmware? This can not be undone.')" %>
         <% end %>
       </td>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/upload.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/upload.html.eex
@@ -1,5 +1,5 @@
 <div class="modal-content shadow">
-  <%= form_for @changeset, firmware_path(@conn, :do_upload, @org.name, @product.name), [multipart: true], fn f -> %>
+  <%= form_for @changeset, Routes.firmware_path(@conn, :do_upload, @org.name, @product.name), [multipart: true], fn f -> %>
     <div class="modal-header panel-title rounded-top">
       Upload firmware for <strong><%= @product.name %></strong>
     </div>
@@ -12,7 +12,7 @@
     </div>
     <div class="modal-footer">
       <div class="col-4">
-        <a class="btn btn-secondary" href="<%= product_path(@conn, :index, @org.name) %>">
+        <a class="btn btn-secondary" href="<%= Routes.product_path(@conn, :index, @org.name) %>">
           Cancel
         </a>
       </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
@@ -6,8 +6,8 @@
         NervesHub
       </h6>
       <a href="https://github.com/nerves-hub">Source code</a>
-      <a href="<%= nerves_key_path(@conn, :index) %>">NervesKey</a>
-      <a href="<%= sponsor_path(@conn, :index) %>">Sponsors</a>
+      <a href="<%= Routes.nerves_key_path(@conn, :index) %>">NervesKey</a>
+      <a href="<%= Routes.sponsor_path(@conn, :index) %>">Sponsors</a>
     </div>
     <div class="p-2 bd-highlight">
       <h6 class="text-dark logo-font">
@@ -21,9 +21,9 @@
       <h6 class="text-dark logo-font">
         Terms and Conditions
       </h6>
-      <a href="<%= policy_path(@conn, :coc) %>">Code of Conduct</a>
-      <a href="<%= policy_path(@conn, :tos) %>">Terms of Service</a>
-      <a href="<%= policy_path(@conn, :privacy) %>">Privacy Policy</a>
+      <a href="<%= Routes.policy_path(@conn, :coc) %>">Code of Conduct</a>
+      <a href="<%= Routes.policy_path(@conn, :tos) %>">Terms of Service</a>
+      <a href="<%= Routes.policy_path(@conn, :privacy) %>">Privacy Policy</a>
     </div>
   </div>
 </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -10,13 +10,13 @@
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <%= for org <- user_orgs(@conn) do %>
-              <%= link org.name, class: "dropdown-item org", to: org_path(@conn, :edit, org.name) %>
+              <%= link org.name, class: "dropdown-item org", to: Routes.org_path(@conn, :edit, org.name) %>
               <%= for product <- user_org_products(@conn.assigns.user, org) do %>
-                <%= link product.name, class: "dropdown-item product", to: product_path(@conn, :show, org.name, product.name) %>
+                <%= link product.name, class: "dropdown-item product", to: Routes.product_path(@conn, :show, org.name, product.name) %>
               <% end %>
               <div class="dropdown-divider"></div>
             <% end %>
-            <a class="dropdown-item" href="<%= org_path(@conn, :new) %>">New organization</a>
+            <a class="dropdown-item" href="<%= Routes.org_path(@conn, :new) %>">New organization</a>
           </div>
         </li>
         <li class="divider"></li>
@@ -27,9 +27,9 @@
           <img src="<%= gravatar(@conn) %>">
           </button>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
-            <a class="dropdown-item" href="<%= account_path(@conn, :edit, @conn.assigns.user.username)%>">User settings</a>
+            <a class="dropdown-item" href="<%= Routes.account_path(@conn, :edit, @conn.assigns.user.username)%>">User settings</a>
             <div class="dropdown-divider"></div>
-            <a class="dropdown-item" href="<%= session_path(@conn, :delete)%>">Logout</a>
+            <a class="dropdown-item" href="<%= Routes.session_path(@conn, :delete)%>">Logout</a>
           </div>
         </li>
       </div>
@@ -39,11 +39,11 @@
     </div>
     <div class="navbar-nav mr-3">
       <%= if permit_uninvited_signups() do %>
-        <a class="btn btn-outline-primary ml-3" href="<%= account_path(@conn, :new) %>">
+        <a class="btn btn-outline-primary ml-3" href="<%= Routes.account_path(@conn, :new) %>">
           Create Account
         </a>
       <% end %>
-      <a class="btn btn-outline-success ml-3" href="<%= session_path(@conn, :new)%>">Login</a>
+      <a class="btn btn-outline-success ml-3" href="<%= Routes.session_path(@conn, :new)%>">Login</a>
     </div>
   <% end %>
 </nav>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
@@ -8,7 +8,7 @@
     <meta name="author" content="">
 
     <title>NervesHub</title>
-    <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+    <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
 
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"></script>
@@ -57,6 +57,6 @@
       window.userToken = "<%= assigns[:user_token] %>"
       window.orgId = "<%= assigns[:org] && Map.get(assigns[:org], :id) %>"
     </script>
-    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
+    <script src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -1,13 +1,13 @@
 <h1>
   <%= @org.name %> settings
-  <a class="btn btn-lg btn-success pull-right" href="<%= org_certificate_path(@conn, :index, @org.name)%>">
+  <a class="btn btn-lg btn-success pull-right" href="<%= Routes.org_certificate_path(@conn, :index, @org.name)%>">
     Device (CA) Certificates
   </a>
   <%= if @org.type != :user do %>
-  <a class="btn btn-lg btn-success pull-right" href="<%= org_user_path(@conn, :index, @org.name) %>">
+  <a class="btn btn-lg btn-success pull-right" href="<%= Routes.org_user_path(@conn, :index, @org.name) %>">
     Users
   </a>
-  <a class="btn btn-lg btn-success pull-right" href="<%= org_path(@conn, :invite, @org.name) %>">
+  <a class="btn btn-lg btn-success pull-right" href="<%= Routes.org_path(@conn, :invite, @org.name) %>">
     Invite user
   </a>
   <% end %>
@@ -44,7 +44,7 @@
     </div>
 
     <div class="panel-body">
-        <%= form_for @org_changeset, org_path(@conn, :update, @org.name), fn f -> %>
+        <%= form_for @org_changeset, Routes.org_path(@conn, :update, @org.name), fn f -> %>
           <div class="form-group">
             <label for="name_input">Name</label>
             <%= text_input f, :name, class: "form-control", id: "name_input" %>
@@ -63,7 +63,7 @@
   </div>
 
   <div class="panel-body">
-    <%= form_for @org_key_changeset, org_key_path(@conn, :create, @org.name), fn f -> %>
+    <%= form_for @org_key_changeset, Routes.org_key_path(@conn, :create, @org.name), fn f -> %>
       <div class="form-group">
         <label for="key_name_input">Name</label>
         <%= text_input f, :name, class: "form-control", id: "key_name_input" %>
@@ -101,8 +101,8 @@
         </td>
         <td><%= key.key %></td>
         <td class="text-right">
-          <%= link "Edit", to: org_key_path(@conn, :edit, @org.name, key), class: "btn btn-primary" %>
-          <%= link "Delete", to: org_key_path(@conn, :delete, @org.name, key), class: "btn btn-danger", method: :delete, data: [confirm: "Are you sure?"]  %>
+          <%= link "Edit", to: Routes.org_key_path(@conn, :edit, @org.name, key), class: "btn btn-primary" %>
+          <%= link "Delete", to: Routes.org_key_path(@conn, :delete, @org.name, key), class: "btn btn-danger", method: :delete, data: [confirm: "Are you sure?"]  %>
         </td>
       <% end %>
     <% else %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
@@ -6,7 +6,7 @@
   <p>Enter the email address of the user you would like to invite to <%= @org.name %>.</p>
   <p><strong>Invites expire in 48 hours.</strong></p>
 
-  <%= form_for @changeset, org_path(@conn, :send_invite, @org.name), fn f -> %>
+  <%= form_for @changeset, Routes.org_path(@conn, :send_invite, @org.name), fn f -> %>
     <div class="form-group">
       <label for="email_input">Email</label>
       <%= email_input f, :email, class: "form-control", id: "email_input", value: assigns[:email] %>
@@ -15,6 +15,6 @@
     </div>
 
     <%= submit "Send Invite", class: "btn btn-success" %>
-    <a class="btn btn-secondary" href="<%= org_path(@conn, :edit, @org.name) %>">Cancel</a>
+    <a class="btn btn-secondary" href="<%= Routes.org_path(@conn, :edit, @org.name) %>">Cancel</a>
   <% end %>
 </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
@@ -1,5 +1,5 @@
 <h2>New organization</h2>
 
-<%= render "form.html", Map.put(assigns, :action, org_path(@conn, :create)) %>
+<%= render "form.html", Map.put(assigns, :action, Routes.org_path(@conn, :create)) %>
 
-<span><%= link "Back", to: product_path(@conn, :index, @user.username) %></span>
+<span><%= link "Back", to: Routes.product_path(@conn, :index, @user.username) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/edit.html.eex
@@ -1,5 +1,5 @@
 <h2>Edit organization key</h2>
 
-<%= render "form.html", Map.put(assigns, :action, org_key_path(@conn, :update, @org.name, @org_key)) %>
+<%= render "form.html", Map.put(assigns, :action, Routes.org_key_path(@conn, :update, @org.name, @org_key)) %>
 
-<span><%= link "Back", to: org_key_path(@conn, :index, @org.name) %></span>
+<span><%= link "Back", to: Routes.org_key_path(@conn, :index, @org.name) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/index.html.eex
@@ -12,13 +12,13 @@
     <tr>
 
       <td>
-        <%= link "Show", to: org_key_path(@conn, :show, @org.name, org_keys) %>
-        <%= link "Edit", to: org_key_path(@conn, :edit, @org.name, org_keys) %>
-        <%= link "Delete", to: org_key_path(@conn, :delete, @org.name, org_keys), method: :delete, data: [confirm: "Are you sure?"] %>
+        <%= link "Show", to: Routes.org_key_path(@conn, :show, @org.name, org_keys) %>
+        <%= link "Edit", to: Routes.org_key_path(@conn, :edit, @org.name, org_keys) %>
+        <%= link "Delete", to: Routes.org_key_path(@conn, :delete, @org.name, org_keys), method: :delete, data: [confirm: "Are you sure?"] %>
       </td>
     </tr>
 <% end %>
   </tbody>
 </table>
 
-<span><%= link "New organization keys", to: org_key_path(@conn, :new, @org.name) %></span>
+<span><%= link "New organization keys", to: Routes.org_key_path(@conn, :new, @org.name) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/new.html.eex
@@ -1,5 +1,5 @@
 <h2>New organization keys</h2>
 
-<%= render "form.html", Map.put(assigns, :action, org_key_path(@conn, :create, @org.name)) %>
+<%= render "form.html", Map.put(assigns, :action, Routes.org_key_path(@conn, :create, @org.name)) %>
 
-<span><%= link "Back", to: org_key_path(@conn, :index, @org.name) %></span>
+<span><%= link "Back", to: Routes.org_key_path(@conn, :index, @org.name) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/show.html.eex
@@ -4,5 +4,5 @@
 
 </ul>
 
-<span><%= link "Edit", to: org_key_path(@conn, :edit, @org.name, @org_key) %></span>
-<span><%= link "Back", to: org_key_path(@conn, :index, @org.name) %></span>
+<span><%= link "Edit", to: Routes.org_key_path(@conn, :edit, @org.name, @org_key) %></span>
+<span><%= link "Back", to: Routes.org_key_path(@conn, :index, @org.name) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/password_reset/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/password_reset/new.html.eex
@@ -2,7 +2,7 @@
   <h1>Reset Password</h1>
 </div>
 
-<%= form_for @changeset, password_reset_path(@conn, :create), fn f -> %>
+<%= form_for @changeset, Routes.password_reset_path(@conn, :create), fn f -> %>
   <div class="form-group">
     <label for="email">Email</label>
     <%= email_input f, :email, class: "form-control", id: "email" %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/password_reset/new_password_form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/password_reset/new_password_form.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @changeset, password_reset_path(@conn, :reset, @token), fn f -> %>
+<%= form_for @changeset, Routes.password_reset_path(@conn, :reset, @token), fn f -> %>
   <p>
     <label>
       New Password:

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/_listing.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/_listing.html.eex
@@ -2,18 +2,18 @@
   <li class="list-group-item">
     <div class="row">
       <div class="col-8">
-        <a href="<%= product_path(@conn, :show, @org.name, product.name) %>">
+        <a href="<%= Routes.product_path(@conn, :show, @org.name, product.name) %>">
           <%= product.name %>
         </a>
       </div>
       <div class="col-4 text-right">
-        <a href="<%= firmware_path(@conn, :index, @org.name, product.name) %>" title="Firmware">
+        <a href="<%= Routes.firmware_path(@conn, :index, @org.name, product.name) %>" title="Firmware">
           <span class="fa fa-box">
         </a>
-        <a href="<%= deployment_path(@conn, :index, @org.name, product.name) %>" title="Deployments">
+        <a href="<%= Routes.deployment_path(@conn, :index, @org.name, product.name) %>" title="Deployments">
           <span class="fa fa-boxes">
         </a>
-        <%= link raw("<span class='fa fa-trash-alt'></span>"), to: product_path(@conn, :delete, @org.name, product.name), method: :delete,  title: "Delete!", data: [confirm: "Really?"] %>
+        <%= link raw("<span class='fa fa-trash-alt'></span>"), to: Routes.product_path(@conn, :delete, @org.name, product.name), method: :delete,  title: "Delete!", data: [confirm: "Really?"] %>
       </div>
     </div>
   </li>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/index.html.eex
@@ -3,7 +3,7 @@
   <p class="lead text-left">The organization <%= @org.name %> doesn't have any products</p>
   <hr class="my-4">
   <p class="text-left">
-    <a class="btn btn-primary btn-lg" href="<%= product_path(@conn, :new, @org.name) %>" role="button">Add a Product</a>
+    <a class="btn btn-primary btn-lg" href="<%= Routes.product_path(@conn, :new, @org.name) %>" role="button">Add a Product</a>
   </p>
 </div>
 <% else %>
@@ -15,7 +15,7 @@
           All Products
         </div>
         <div class="col-4 text-right">
-          <a href="<%= product_path(@conn, :new, @org.name)%>">
+          <a href="<%= Routes.product_path(@conn, :new, @org.name)%>">
             <span class="fa fa-plus-circle">
           </a>
         </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/new.html.eex
@@ -1,5 +1,5 @@
 <div class="modal-content shadow">
-  <%= form_for @changeset, product_path(@conn, :create, @org.name), fn f -> %>
+  <%= form_for @changeset, Routes.product_path(@conn, :create, @org.name), fn f -> %>
     <div class="modal-header panel-title rounded-top">
       Create a Product
     </div>
@@ -16,7 +16,7 @@
     </div>
     <div class="modal-footer">
       <div class="col-4">
-        <a class="btn btn-secondary" href="<%= product_path(@conn, :index, @org.name) %>">
+        <a class="btn btn-secondary" href="<%= Routes.product_path(@conn, :index, @org.name) %>">
           Cancel
         </a>
       </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/show.html.eex
@@ -1,5 +1,5 @@
 <h2>Show Product
-  <a class="btn btn-lg btn-primary pull-right" href="<%= device_path(@conn, :new, @org.name, @product.name) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= Routes.device_path(@conn, :new, @org.name, @product.name) %>">
     Add Device
   </a>
 </h2>
@@ -10,15 +10,15 @@
     <%= @product.name %>
   </li>
 
-  <a class="btn btn-lg btn-primary pull-right" href="<%= firmware_path(@conn, :index, @org.name, @product.name) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= Routes.firmware_path(@conn, :index, @org.name, @product.name) %>">
  View Firmware
   </a>
-  <a class="btn btn-lg btn-primary pull-right" href="<%= device_path(@conn, :index, @org.name, @product.name) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= Routes.device_path(@conn, :index, @org.name, @product.name) %>">
  View Devices
   </a>
-  <a class="btn btn-lg btn-primary pull-right" href="<%= deployment_path(@conn, :index, @org.name, @product.name) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">
  View Deployments
   </a>
 </ul>
 
-<span><%= link "Back", to: product_path(@conn, :index, @org.name) %></span>
+<span><%= link "Back", to: Routes.product_path(@conn, :index, @org.name) %></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/session/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/session/new.html.eex
@@ -1,5 +1,5 @@
 <div class="modal-content shadow">
-  <%= form_for @conn, session_path(@conn, :create), [as: :login],fn f -> %>
+  <%= form_for @conn, Routes.session_path(@conn, :create), [as: :login],fn f -> %>
     <div class="modal-header panel-title rounded-top">
       Log in to your NervesHub account
     </div>
@@ -18,12 +18,12 @@
     </div>
     <div class="modal-footer">
       <div class="col-4">
-        <a class="btn btn-secondary" href="<%= home_path(@conn, :index) %>">
+        <a class="btn btn-secondary" href="<%= Routes.home_path(@conn, :index) %>">
           Cancel
         </a>
       </div>
       <div class="col-8 text-right">
-        <a class="btn" href="<%= password_reset_path(@conn, :new) %>">
+        <a class="btn" href="<%= Routes.password_reset_path(@conn, :new) %>">
           Forgot Password
         </a>
         <%= submit "Login", class: "btn btn-primary" %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/sponsor/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/sponsor/index.html.eex
@@ -2,21 +2,21 @@
 
 <div class="row mb-5">
     <a href="https://www.smartrent.com/" class="mx-auto">
-    <%= img_tag(static_path(@conn, "/images/sponsors/smartrent.svg"), style: "height:50px") %>
+    <%= img_tag(Routes.static_path(@conn, "/images/sponsors/smartrent.svg"), style: "height:50px") %>
     </a>
 </div>
 <div class="row mb-5">
     <a href="https://www.verypossible.com/services/iot-development" class="mx-auto">
-    <%= img_tag(static_path(@conn, "/images/sponsors/very_logo.svg"), style: "height:80px") %>
+    <%= img_tag(Routes.static_path(@conn, "/images/sponsors/very_logo.svg"), style: "height:80px") %>
     </a>
 </div>
 <div class="row mb-5">
     <a href="https://www.letote.com/careers" class="mx-auto">
-      <%= img_tag(static_path(@conn, "/images/sponsors/letote.svg"), style: "height:50px") %>
+      <%= img_tag(Routes.static_path(@conn, "/images/sponsors/letote.svg"), style: "height:50px") %>
     </a>
 </div>
 <div class="row mb-5">
     <a href="https://www.alliedcomponentworks.com" class="mx-auto">
-      <%= img_tag(static_path(@conn, "/images/sponsors/acw.svg"), style: "height:100px") %>
+      <%= img_tag(Routes.static_path(@conn, "/images/sponsors/acw.svg"), style: "height:100px") %>
     </a>
 </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -37,9 +37,9 @@ defmodule NervesHubWWWWeb.LayoutView do
 
   def logo_href(conn) do
     if logged_in?(conn) do
-      product_path(conn, :index, conn.assigns.user.username)
+      Routes.product_path(conn, :index, conn.assigns.user.username)
     else
-      home_path(conn, :index)
+      Routes.home_path(conn, :index)
     end
   end
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_certificate_controller_test.exs
@@ -24,14 +24,14 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
 
       Fixtures.user_certificate_fixture(other_user, %{description: "baz", serial: "anotherserial"})
 
-      conn = get(conn, account_certificate_path(conn, :index, user.username))
+      conn = get(conn, Routes.account_certificate_path(conn, :index, user.username))
       assert html_response(conn, 200) =~ "Account Certificates"
 
       assert html_response(conn, 200) =~
-               account_certificate_path(conn, :delete, user.username, foo_cert)
+               Routes.account_certificate_path(conn, :delete, user.username, foo_cert)
 
       assert html_response(conn, 200) =~
-               account_certificate_path(conn, :delete, user.username, bar_cert)
+               Routes.account_certificate_path(conn, :delete, user.username, bar_cert)
 
       refute html_response(conn, 200) =~ "baz"
     end
@@ -39,7 +39,7 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
 
   describe "new certificate" do
     test "renders form", %{conn: conn, user: user} do
-      conn = get(conn, account_certificate_path(conn, :new, user.username))
+      conn = get(conn, Routes.account_certificate_path(conn, :new, user.username))
       assert html_response(conn, 200) =~ "Generate an Account Certificate"
     end
   end
@@ -50,14 +50,16 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
       %{params: params} = Fixtures.user_certificate_params(user, @create_attrs)
 
       conn =
-        post(conn, account_certificate_path(conn, :create, user.username),
+        post(conn, Routes.account_certificate_path(conn, :create, user.username),
           user_certificate: params
         )
 
       assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) =~ account_certificate_path(conn, :show, user.username, id)
 
-      conn = get(conn, account_certificate_path(conn, :show, user.username, id))
+      assert redirected_to(conn) =~
+               Routes.account_certificate_path(conn, :show, user.username, id)
+
+      conn = get(conn, Routes.account_certificate_path(conn, :show, user.username, id))
       assert html_response(conn, 200) =~ "User Certificate"
     end
   end
@@ -66,11 +68,11 @@ defmodule NervesHubWWWWeb.AccountCertificateControllerTest do
     test "deletes chosen certificate", %{conn: conn, user: user} do
       Fixtures.user_certificate_fixture(user, %{description: "foo", serial: "abc123"})
       assert [cert | _] = Accounts.get_user_certificates(user)
-      conn = delete(conn, account_certificate_path(conn, :delete, user.username, cert))
-      assert redirected_to(conn) == account_certificate_path(conn, :index, user.username)
+      conn = delete(conn, Routes.account_certificate_path(conn, :delete, user.username, cert))
+      assert redirected_to(conn) == Routes.account_certificate_path(conn, :index, user.username)
 
       assert_error_sent(404, fn ->
-        get(conn, account_certificate_path(conn, :show, user.username, cert))
+        get(conn, Routes.account_certificate_path(conn, :show, user.username, cert))
       end)
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -8,7 +8,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
     test "renders account creation form", %{
       conn: conn
     } do
-      conn = get(conn, account_path(conn, :new))
+      conn = get(conn, Routes.account_path(conn, :new))
       assert html_response(conn, 200) =~ "Create an Account"
     end
   end
@@ -19,7 +19,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
     } do
       {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, conn.assigns.org)
 
-      conn = get(conn, account_path(conn, :invite, invite.token))
+      conn = get(conn, Routes.account_path(conn, :invite, invite.token))
 
       assert html_response(conn, 200) =~
                "You will be added to the #{conn.assigns.org.name} org"
@@ -36,7 +36,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn =
         post(
           conn,
-          account_path(conn, :accept_invite, invite.token, %{
+          Routes.account_path(conn, :accept_invite, invite.token, %{
             "user" => %{
               "username" => "MyName",
               "email" => "not_joe@example.com",
@@ -65,9 +65,12 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn: conn,
       user: user
     } do
-      conn = get(conn, account_path(conn, :edit, user.username))
+      conn = get(conn, Routes.account_path(conn, :edit, user.username))
       assert html_response(conn, 200) =~ "Edit Account"
-      assert html_response(conn, 200) =~ account_certificate_path(conn, :index, user.username)
+
+      assert html_response(conn, 200) =~
+               Routes.account_certificate_path(conn, :index, user.username)
+
       assert html_response(conn, 200) =~ "type=\"password\""
     end
   end
@@ -80,7 +83,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn =
         conn
         |> put(
-          account_path(conn, :update, user.username, %{
+          Routes.account_path(conn, :update, user.username, %{
             "user" => %{
               "username" => "MyNewestName",
               "password" => "foobarbaz",
@@ -89,7 +92,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
           })
         )
 
-      assert html_response(conn, 302) =~ account_path(conn, :edit, "MyNewestName")
+      assert html_response(conn, 302) =~ Routes.account_path(conn, :edit, "MyNewestName")
 
       updated_user = Accounts.get_user(user.id) |> elem(1)
 
@@ -103,7 +106,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn =
         conn
         |> put(
-          account_path(conn, :update, user.username, %{
+          Routes.account_path(conn, :update, user.username, %{
             "user" => %{
               "username" => "MyNewestName",
               "password" => "12345678",
@@ -122,7 +125,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn =
         conn
         |> put(
-          account_path(conn, :update, user.username, %{
+          Routes.account_path(conn, :update, user.username, %{
             "user" => %{
               "username" => "MyNewestName",
               "password" => "12345678",
@@ -142,7 +145,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn =
         post(
           conn,
-          account_path(conn, :create, %{
+          Routes.account_path(conn, :create, %{
             "user" => %{
               "username" => "MyName",
               "email" => "joe@example.com",
@@ -160,7 +163,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn =
         post(
           conn,
-          account_path(conn, :create, %{
+          Routes.account_path(conn, :create, %{
             "user" => %{
               "username" => "MyName",
               "org_name" => "a Org",

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -7,7 +7,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
     test "lists all deployments", %{conn: conn, user: user, org: org} do
       product = Fixtures.product_fixture(user, org)
 
-      conn = get(conn, deployment_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.deployment_path(conn, :index, org.name, product.name))
       assert html_response(conn, 200) =~ "Deployments"
     end
   end
@@ -25,24 +25,26 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       conn =
         get(
           conn,
-          deployment_path(conn, :new, org.name, product.name),
+          Routes.deployment_path(conn, :new, org.name, product.name),
           deployment: %{firmware_id: firmware.id}
         )
 
       assert html_response(conn, 200) =~ "Create Deployment"
 
-      assert html_response(conn, 200) =~ deployment_path(conn, :create, org.name, product.name)
+      assert html_response(conn, 200) =~
+               Routes.deployment_path(conn, :create, org.name, product.name)
     end
 
     test "redirects with invalid firmware", %{conn: conn, user: user, org: org} do
       product = Fixtures.product_fixture(user, org)
 
       conn =
-        get(conn, deployment_path(conn, :new, org.name, product.name),
+        get(conn, Routes.deployment_path(conn, :new, org.name, product.name),
           deployment: %{firmware_id: -1}
         )
 
-      assert redirected_to(conn, 302) =~ deployment_path(conn, :new, org.name, product.name)
+      assert redirected_to(conn, 302) =~
+               Routes.deployment_path(conn, :new, org.name, product.name)
     end
 
     test "renders select firmware when no firmware_id is passed", %{
@@ -53,10 +55,12 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
     } do
       product = Fixtures.product_fixture(user, org)
       Fixtures.firmware_fixture(org_key, product)
-      conn = get(conn, deployment_path(conn, :new, org.name, product.name))
+      conn = get(conn, Routes.deployment_path(conn, :new, org.name, product.name))
 
       assert html_response(conn, 200) =~ "Select Firmware for New Deployment"
-      assert html_response(conn, 200) =~ deployment_path(conn, :create, org.name, product.name)
+
+      assert html_response(conn, 200) =~
+               Routes.deployment_path(conn, :create, org.name, product.name)
     end
 
     test "redirects to firmware upload firmware_id is passed and no firmwares are found" do
@@ -69,9 +73,10 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
         |> Map.put(:assigns, %{org: org})
         |> init_test_session(%{"auth_user_id" => user.id})
 
-      conn = get(conn, deployment_path(conn, :new, org.name, product.name))
+      conn = get(conn, Routes.deployment_path(conn, :new, org.name, product.name))
 
-      assert redirected_to(conn, 302) =~ firmware_path(conn, :upload, org.name, product.name)
+      assert redirected_to(conn, 302) =~
+               Routes.firmware_path(conn, :upload, org.name, product.name)
     end
   end
 
@@ -102,15 +107,15 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       create_conn =
         post(
           conn,
-          deployment_path(conn, :create, org.name, product.name),
+          Routes.deployment_path(conn, :create, org.name, product.name),
           deployment: deployment_params
         )
 
       assert redirected_to(create_conn, 302) =~
-               deployment_path(create_conn, :index, org.name, product.name)
+               Routes.deployment_path(create_conn, :index, org.name, product.name)
 
       # check that the proper creation side effects took place
-      conn = get(conn, deployment_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.deployment_path(conn, :index, org.name, product.name))
       assert html_response(conn, 200) =~ deployment_params.name
       assert html_response(conn, 200) =~ "Inactive"
       assert html_response(conn, 200) =~ firmware.version
@@ -130,11 +135,11 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       create_conn =
         post(
           conn,
-          deployment_path(conn, :create, org.name, product.name),
+          Routes.deployment_path(conn, :create, org.name, product.name),
           deployment: deployment_params
         )
 
-      redirect_path = deployment_path(create_conn, :index, org.name, product.name)
+      redirect_path = Routes.deployment_path(create_conn, :index, org.name, product.name)
 
       assert redirected_to(create_conn, 302) =~ redirect_path
 
@@ -160,11 +165,13 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       firmware = Fixtures.firmware_fixture(org_key, product)
       deployment = Fixtures.deployment_fixture(firmware)
 
-      conn = get(conn, deployment_path(conn, :edit, org.name, product.name, deployment.name))
+      conn =
+        get(conn, Routes.deployment_path(conn, :edit, org.name, product.name, deployment.name))
+
       assert html_response(conn, 200) =~ "Edit"
 
       assert html_response(conn, 200) =~
-               deployment_path(conn, :update, org.name, product.name, deployment.name)
+               Routes.deployment_path(conn, :update, org.name, product.name, deployment.name)
     end
   end
 
@@ -182,7 +189,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       conn =
         put(
           conn,
-          deployment_path(conn, :update, org.name, product.name, deployment.name),
+          Routes.deployment_path(conn, :update, org.name, product.name, deployment.name),
           deployment: %{
             "version" => "4.3.2",
             "tags" => "new, tags, now",
@@ -194,7 +201,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       {:ok, reloaded_deployment} = Deployments.get_deployment(product, deployment.id)
 
       assert redirected_to(conn, 302) =~
-               deployment_path(conn, :show, org.name, product.name, deployment.name)
+               Routes.deployment_path(conn, :show, org.name, product.name, deployment.name)
 
       assert reloaded_deployment.name == "not original"
       assert reloaded_deployment.conditions["version"] == "4.3.2"
@@ -209,11 +216,11 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       update_conn =
         put(
           conn,
-          deployment_path(conn, :update, org.name, product.name, deployment.name),
+          Routes.deployment_path(conn, :update, org.name, product.name, deployment.name),
           deployment: params
         )
 
-      redirect_path = deployment_path(update_conn, :index, org.name, product.name)
+      redirect_path = Routes.deployment_path(update_conn, :index, org.name, product.name)
 
       assert redirected_to(update_conn, 302) =~ redirect_path
 
@@ -238,8 +245,13 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       firmware = Fixtures.firmware_fixture(org_key, product)
       deployment = Fixtures.deployment_fixture(firmware)
 
-      conn = delete(conn, deployment_path(conn, :delete, org.name, product.name, deployment.name))
-      assert redirected_to(conn) == deployment_path(conn, :index, org.name, product.name)
+      conn =
+        delete(
+          conn,
+          Routes.deployment_path(conn, :delete, org.name, product.name, deployment.name)
+        )
+
+      assert redirected_to(conn) == Routes.deployment_path(conn, :index, org.name, product.name)
       assert Deployments.get_deployment(product, deployment.id) == {:error, :not_found}
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -10,7 +10,7 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
 
   describe "new device" do
     test "renders form with valid request params", %{conn: conn, org: org, product: product} do
-      new_conn = get(conn, device_path(conn, :new, org.name, product.name))
+      new_conn = get(conn, Routes.device_path(conn, :new, org.name, product.name))
 
       assert html_response(new_conn, 200) =~ "Create a Device"
     end
@@ -29,12 +29,15 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
 
       # check that we end up in the right place
       create_conn =
-        post(conn, device_path(conn, :create, org.name, product.name), device: device_params)
+        post(conn, Routes.device_path(conn, :create, org.name, product.name),
+          device: device_params
+        )
 
-      assert redirected_to(create_conn, 302) =~ device_path(conn, :index, org.name, product.name)
+      assert redirected_to(create_conn, 302) =~
+               Routes.device_path(conn, :index, org.name, product.name)
 
       # check that the proper creation side effects took place
-      conn = get(conn, device_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.device_path(conn, :index, org.name, product.name))
       assert html_response(conn, 200) =~ device_params.identifier
     end
   end
@@ -48,11 +51,16 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       [to_delete | _] = Devices.get_devices_by_org_id_and_product_id(org.id, product.id)
 
       conn =
-        delete(conn, device_path(conn, :delete, org.name, product.name, to_delete.identifier))
+        delete(
+          conn,
+          Routes.device_path(conn, :delete, org.name, product.name, to_delete.identifier)
+        )
 
-      assert redirected_to(conn) == device_path(conn, :index, org.name, product.name)
+      assert redirected_to(conn) == Routes.device_path(conn, :index, org.name, product.name)
 
-      conn = get(conn, device_path(conn, :show, org.name, product.name, to_delete.identifier))
+      conn =
+        get(conn, Routes.device_path(conn, :show, org.name, product.name, to_delete.identifier))
+
       assert html_response(conn, 404)
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
@@ -10,9 +10,11 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
     test "lists all firmwares", %{conn: conn, user: user, org: org} do
       product = Fixtures.product_fixture(user, org)
 
-      conn = get(conn, firmware_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.firmware_path(conn, :index, org.name, product.name))
       assert html_response(conn, 200) =~ "Firmware"
-      assert html_response(conn, 200) =~ firmware_path(conn, :upload, org.name, product.name)
+
+      assert html_response(conn, 200) =~
+               Routes.firmware_path(conn, :upload, org.name, product.name)
     end
   end
 
@@ -23,10 +25,12 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
       org: org
     } do
       product = Fixtures.product_fixture(user, org)
-      conn = get(conn, firmware_path(conn, :upload, org.name, product.name))
+      conn = get(conn, Routes.firmware_path(conn, :upload, org.name, product.name))
 
       assert html_response(conn, 200) =~ "Upload Firmware"
-      assert html_response(conn, 200) =~ firmware_path(conn, :do_upload, org.name, product.name)
+
+      assert html_response(conn, 200) =~
+               Routes.firmware_path(conn, :do_upload, org.name, product.name)
     end
   end
 
@@ -50,15 +54,15 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
 
       # check that we end up in the right place
       create_conn =
-        post(conn, firmware_path(conn, :upload, org.name, product.name), %{
+        post(conn, Routes.firmware_path(conn, :upload, org.name, product.name), %{
           "firmware" => %{"file" => upload}
         })
 
       assert redirected_to(create_conn, 302) =~
-               firmware_path(conn, :index, org.name, product.name)
+               Routes.firmware_path(conn, :index, org.name, product.name)
 
       # check that the proper creation side effects took place
-      conn = get(conn, firmware_path(conn, :index, org.name, product.name))
+      conn = get(conn, Routes.firmware_path(conn, :index, org.name, product.name))
       # starter is the product for the test firmware
       assert html_response(conn, 200) =~ product_name
     end
@@ -83,7 +87,7 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
 
       # check for the error message
       conn =
-        post(conn, firmware_path(conn, :upload, org.name, product.name), %{
+        post(conn, Routes.firmware_path(conn, :upload, org.name, product.name), %{
           "firmware" => %{"file" => upload}
         })
 
@@ -110,7 +114,7 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
 
       # check for the error message
       conn =
-        post(conn, firmware_path(conn, :upload, org.name, product.name), %{
+        post(conn, Routes.firmware_path(conn, :upload, org.name, product.name), %{
           "firmware" => %{"file" => upload}
         })
 
@@ -136,7 +140,7 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
 
       # check for the error message
       conn =
-        post(conn, firmware_path(conn, :upload, org.name, product.name), %{
+        post(conn, Routes.firmware_path(conn, :upload, org.name, product.name), %{
           "firmware" => %{"file" => upload}
         })
 
@@ -162,7 +166,7 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
 
       # check for the error message
       conn =
-        post(conn, firmware_path(conn, :upload, org.name, product.name), %{
+        post(conn, Routes.firmware_path(conn, :upload, org.name, product.name), %{
           "firmware" => %{"file" => upload}
         })
 
@@ -180,8 +184,10 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
       org_key = Fixtures.org_key_fixture(org)
       firmware = Fixtures.firmware_fixture(org_key, product)
 
-      conn = delete(conn, firmware_path(conn, :delete, org.name, product.name, firmware.uuid))
-      assert redirected_to(conn) == firmware_path(conn, :index, org.name, product.name)
+      conn =
+        delete(conn, Routes.firmware_path(conn, :delete, org.name, product.name, firmware.uuid))
+
+      assert redirected_to(conn) == Routes.firmware_path(conn, :index, org.name, product.name)
       assert Firmwares.get_firmware(org, firmware.id) == {:error, :not_found}
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/nerves_key_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/nerves_key_controller_test.exs
@@ -4,7 +4,7 @@ defmodule NervesHubWWWWeb.NervesKeyControllerTest do
   test "renders nerves_key", %{
     conn: conn
   } do
-    conn = get(conn, nerves_key_path(conn, :index))
+    conn = get(conn, Routes.nerves_key_path(conn, :index))
     assert html_response(conn, 302) =~ "https://github.com/nerves-hub/nerves_key"
   end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
@@ -11,7 +11,7 @@ defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
       %{db_cert: db1_cert} = Fixtures.ca_certificate_fixture(org)
       %{db_cert: db2_cert} = Fixtures.ca_certificate_fixture(org)
 
-      conn = get(conn, org_certificate_path(conn, :index, org.name))
+      conn = get(conn, Routes.org_certificate_path(conn, :index, org.name))
       assert html_response(conn, 200) =~ "#{org.name} Device (CA) Certificates"
       assert html_response(conn, 200) =~ db1_cert.serial
       assert html_response(conn, 200) =~ db2_cert.serial

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -5,33 +5,33 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
   describe "new org" do
     test "renders form", %{conn: conn} do
-      conn = get(conn, org_path(conn, :new))
+      conn = get(conn, Routes.org_path(conn, :new))
       assert html_response(conn, 200) =~ "New organization"
     end
   end
 
   describe "create org" do
     test "redirects to edit when data is valid", %{conn: conn} do
-      conn = post(conn, org_path(conn, :create), org: %{name: "An Org"})
-      assert redirected_to(conn) == product_path(conn, :index, "An Org")
+      conn = post(conn, Routes.org_path(conn, :create), org: %{name: "An Org"})
+      assert redirected_to(conn) == Routes.product_path(conn, :index, "An Org")
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, org_path(conn, :create), org: %{})
+      conn = post(conn, Routes.org_path(conn, :create), org: %{})
       assert html_response(conn, 200) =~ "New organization"
     end
   end
 
   describe "edit org" do
     test "renders form for editing org on conn", %{conn: conn, org: org} do
-      conn = get(conn, org_path(conn, :edit, org.name))
+      conn = get(conn, Routes.org_path(conn, :edit, org.name))
       assert html_response(conn, 200)
     end
 
     test "does not render form for org not on conn", %{conn: conn} do
       user = Fixtures.user_fixture(%{name: "secret-user"})
       new_org = Fixtures.org_fixture(user, %{name: "Secret Org Name"})
-      conn = get(conn, org_path(conn, :edit, new_org.name))
+      conn = get(conn, Routes.org_path(conn, :edit, new_org.name))
       assert html_response(conn, 404)
     end
   end
@@ -41,7 +41,8 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
       user = Fixtures.user_fixture(%{email: "new@org.com"})
       new_org = Fixtures.org_fixture(user, %{name: "Secret Org Name"})
 
-      conn = put(conn, org_path(conn, :update, new_org.name), org: %{name: "Nefarious Name"})
+      conn =
+        put(conn, Routes.org_path(conn, :update, new_org.name), org: %{name: "Nefarious Name"})
 
       assert html_response(conn, 404)
 
@@ -50,22 +51,22 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
         |> Map.put(:assigns, %{org: new_org})
         |> init_test_session(%{"auth_user_id" => user.id})
 
-      updated_conn = get(new_conn, org_path(conn, :edit, new_org.name))
+      updated_conn = get(new_conn, Routes.org_path(conn, :edit, new_org.name))
 
       refute html_response(updated_conn, 200) =~ "Nefarious Name"
     end
 
     test "redirects when data is valid", %{conn: conn, org: org} do
-      conn = put(conn, org_path(conn, :update, org.name), org: %{name: "new name"})
+      conn = put(conn, Routes.org_path(conn, :update, org.name), org: %{name: "new name"})
 
-      assert redirected_to(conn) == org_path(conn, :edit, "new name")
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, "new name")
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
       conn =
         put(
           conn,
-          org_path(conn, :update, org.name),
+          Routes.org_path(conn, :update, org.name),
           org: %{name: ""}
         )
 
@@ -77,9 +78,11 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
   describe "send invite" do
     test "sends invite when user does not exist", %{conn: conn, org: org} do
       conn =
-        post(conn, org_path(conn, :send_invite, org.name), invite: %{email: "nunya@bid.ness"})
+        post(conn, Routes.org_path(conn, :send_invite, org.name),
+          invite: %{email: "nunya@bid.ness"}
+        )
 
-      assert redirected_to(conn) == org_path(conn, :edit, org.name)
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, org.name)
 
       redirected_conn = get(conn, redirected_to(conn))
 
@@ -88,9 +91,11 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
     test "creates OrgUser when user already exists", %{conn: conn, org: org} do
       user = Fixtures.user_fixture(%{email: "who@der.com"})
-      conn = post(conn, org_path(conn, :send_invite, org.name), invite: %{email: user.email})
 
-      assert redirected_to(conn) == org_path(conn, :edit, org.name)
+      conn =
+        post(conn, Routes.org_path(conn, :send_invite, org.name), invite: %{email: user.email})
+
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, org.name)
 
       redirected_conn = get(conn, redirected_to(conn))
 
@@ -102,7 +107,8 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
       org: org,
       user: user
     } do
-      conn = post(conn, org_path(conn, :send_invite, org.name), invite: %{email: user.email})
+      conn =
+        post(conn, Routes.org_path(conn, :send_invite, org.name), invite: %{email: user.email})
 
       assert html_response(conn, 200) =~ user.email
       assert html_response(conn, 200) =~ "is already member"

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_key_controller_test.exs
@@ -8,14 +8,14 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
 
   describe "index" do
     test "lists all org_keys", %{conn: conn, org: org} do
-      conn = get(conn, org_key_path(conn, :index, org.name))
+      conn = get(conn, Routes.org_key_path(conn, :index, org.name))
       assert html_response(conn, 200) =~ "Listing organization keys"
     end
   end
 
   describe "new org_keys" do
     test "renders form", %{conn: conn, org: org} do
-      conn = get(conn, org_key_path(conn, :new, org.name))
+      conn = get(conn, Routes.org_key_path(conn, :new, org.name))
       assert html_response(conn, 200) =~ "New organization keys"
     end
   end
@@ -23,24 +23,24 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
   describe "create org_keys" do
     test "redirects to show when data is valid", %{conn: conn, org: org} do
       params = %{name: "foobarbazbangpow", key: "a key"}
-      conn = post(conn, org_key_path(conn, :create, org.name), org_key: params)
+      conn = post(conn, Routes.org_key_path(conn, :create, org.name), org_key: params)
 
-      assert redirected_to(conn) == org_path(conn, :edit, org.name)
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, org.name)
 
-      conn = get(conn, org_path(conn, :edit, org.name))
+      conn = get(conn, Routes.org_path(conn, :edit, org.name))
       assert html_response(conn, 200) =~ params.name
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
-      conn = post(conn, org_key_path(conn, :create, org.name), org_key: @invalid_attrs)
-      assert redirected_to(conn) == org_path(conn, :edit, org.name)
+      conn = post(conn, Routes.org_key_path(conn, :create, org.name), org_key: @invalid_attrs)
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, org.name)
     end
   end
 
   describe "edit org_keys" do
     test "renders form for editing chosen org_keys", %{conn: conn, org: org} do
       org_key = Fixtures.org_key_fixture(org)
-      conn = get(conn, org_key_path(conn, :edit, org.name, org_key))
+      conn = get(conn, Routes.org_key_path(conn, :edit, org.name, org_key))
       assert html_response(conn, 200) =~ "Edit organization key"
     end
   end
@@ -48,11 +48,13 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
   describe "update org_key" do
     test "redirects when data is valid", %{conn: conn, org: org} do
       org_key = Fixtures.org_key_fixture(org)
-      conn = put(conn, org_key_path(conn, :update, org.name, org_key), org_key: @update_attrs)
 
-      assert redirected_to(conn) == org_path(conn, :edit, org.name)
+      conn =
+        put(conn, Routes.org_key_path(conn, :update, org.name, org_key), org_key: @update_attrs)
 
-      conn = get(conn, org_key_path(conn, :show, org.name, org_key))
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, org.name)
+
+      conn = get(conn, Routes.org_key_path(conn, :show, org.name, org_key))
       assert html_response(conn, 200)
     end
 
@@ -62,7 +64,7 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
       conn =
         put(
           conn,
-          org_key_path(conn, :update, org.name, org_key),
+          Routes.org_key_path(conn, :update, org.name, org_key),
           org_key: @invalid_attrs
         )
 
@@ -74,11 +76,11 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
     test "deletes chosen org_key", %{conn: conn, org: org} do
       org_key = Fixtures.org_key_fixture(org)
 
-      conn = delete(conn, org_key_path(conn, :delete, org.name, org_key))
-      assert redirected_to(conn) == org_path(conn, :edit, org.name)
+      conn = delete(conn, Routes.org_key_path(conn, :delete, org.name, org_key))
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, org.name)
 
       assert_error_sent(404, fn ->
-        get(conn, org_key_path(conn, :show, org.name, org_key))
+        get(conn, Routes.org_key_path(conn, :show, org.name, org_key))
       end)
     end
 
@@ -92,7 +94,7 @@ defmodule NervesHubWWWWeb.OrgKeyControllerTest do
       product = Fixtures.product_fixture(user, org)
       Fixtures.firmware_fixture(org_key, product)
 
-      conn = delete(conn, org_key_path(conn, :delete, org.name, org_key))
+      conn = delete(conn, Routes.org_key_path(conn, :delete, org.name, org_key))
       assert html_response(conn, 200) =~ "Key is in use."
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
@@ -9,7 +9,7 @@ defmodule NervesHubWWWWeb.OrgUserControllerTest do
       org: org
     } do
       org_users = Accounts.get_org_users(org)
-      conn = get(conn, org_user_path(conn, :index, org.name))
+      conn = get(conn, Routes.org_user_path(conn, :index, org.name))
       assert html_response(conn, 200) =~ "#{org.name} Users"
 
       Enum.each(org_users, fn org_user ->

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/password_reset_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/password_reset_controller_test.exs
@@ -7,7 +7,7 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
 
   describe "new password_reset" do
     test "renders form", %{conn: conn} do
-      conn = get(conn, password_reset_path(conn, :new))
+      conn = get(conn, Routes.password_reset_path(conn, :new))
       assert html_response(conn, 200) =~ "Reset Password"
     end
   end
@@ -18,9 +18,9 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
     test "with valid params", %{conn: conn, user: user} do
       params = %{"password_reset" => %{"email" => user.email}}
 
-      reset_conn = post(conn, password_reset_path(conn, :create), params)
+      reset_conn = post(conn, Routes.password_reset_path(conn, :create), params)
 
-      assert redirected_to(reset_conn) == session_path(reset_conn, :new)
+      assert redirected_to(reset_conn) == Routes.session_path(reset_conn, :new)
 
       {:ok, updated_user} = Accounts.get_user(user.id)
       assert_delivered_email(NervesHubWWW.Accounts.Email.forgot_password(updated_user))
@@ -29,7 +29,7 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
     test "with invalid params", %{conn: conn} do
       params = %{}
 
-      reset_conn = post(conn, password_reset_path(conn, :create), params)
+      reset_conn = post(conn, Routes.password_reset_path(conn, :create), params)
       assert html_response(reset_conn, 200) =~ "You must enter an email address."
     end
   end
@@ -41,9 +41,13 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
       params = %{"user" => %{"email" => user.email}}
 
       reset_conn =
-        get(conn, password_reset_path(conn, :new_password_form, "not a good token"), params)
+        get(
+          conn,
+          Routes.password_reset_path(conn, :new_password_form, "not a good token"),
+          params
+        )
 
-      assert redirected_to(reset_conn) == session_path(reset_conn, :new)
+      assert redirected_to(reset_conn) == Routes.session_path(reset_conn, :new)
     end
 
     test "new_password_form with valid token", %{conn: conn, user: user} do
@@ -54,7 +58,7 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
         |> elem(1)
         |> Map.get(:password_reset_token)
 
-      reset_conn = get(conn, password_reset_path(conn, :new_password_form, token), params)
+      reset_conn = get(conn, Routes.password_reset_path(conn, :new_password_form, token), params)
 
       assert html_response(reset_conn, 200) =~ "New Password:"
     end
@@ -69,8 +73,8 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
         |> elem(1)
         |> Map.get(:password_reset_token)
 
-      reset_conn = put(conn, password_reset_path(conn, :reset, token), params)
-      assert redirected_to(reset_conn) == session_path(reset_conn, :new)
+      reset_conn = put(conn, Routes.password_reset_path(conn, :reset, token), params)
+      assert redirected_to(reset_conn) == Routes.session_path(reset_conn, :new)
 
       # enforce side effect
       {:ok, updated_user} = Accounts.get_user(user.id)
@@ -78,7 +82,7 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
 
       # check token is expired
       second_params = %{"user" => %{"password" => "newer password"}}
-      put(conn, password_reset_path(conn, :reset, token), second_params)
+      put(conn, Routes.password_reset_path(conn, :reset, token), second_params)
       {:ok, second_updated_user} = Accounts.get_user(user.id)
       assert second_updated_user.password_hash == updated_user.password_hash
     end
@@ -91,7 +95,7 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
         |> elem(1)
         |> Map.get(:password_reset_token)
 
-      reset_conn = put(conn, password_reset_path(conn, :reset, token), params)
+      reset_conn = put(conn, Routes.password_reset_path(conn, :reset, token), params)
       assert html_response(reset_conn, 200) =~ "You must provide a new password."
 
       # enforce side effect
@@ -104,8 +108,8 @@ defmodule NervesHubWWWWeb.PasswordResetControllerTest do
 
       bad_token = Ecto.UUID.bingenerate()
 
-      reset_conn = put(conn, password_reset_path(conn, :reset, bad_token), params)
-      assert redirected_to(reset_conn) == session_path(reset_conn, :new)
+      reset_conn = put(conn, Routes.password_reset_path(conn, :reset, bad_token), params)
+      assert redirected_to(reset_conn) == Routes.session_path(reset_conn, :new)
 
       # enforce side effect
       {:ok, updated_user} = Accounts.get_user(user.id)

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/policy_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/policy_controller_test.exs
@@ -5,21 +5,21 @@ defmodule NervesHubWWWWeb.PolicyControllerTest do
     test "renders terms of service", %{
       conn: conn
     } do
-      conn = get(conn, policy_path(conn, :tos))
+      conn = get(conn, Routes.policy_path(conn, :tos))
       assert html_response(conn, 200) =~ "Terms of Service"
     end
 
     test "renders code of conduct", %{
       conn: conn
     } do
-      conn = get(conn, policy_path(conn, :coc))
+      conn = get(conn, Routes.policy_path(conn, :coc))
       assert html_response(conn, 200) =~ "Code of Conduct"
     end
 
     test "renders privacy policy", %{
       conn: conn
     } do
-      conn = get(conn, policy_path(conn, :privacy))
+      conn = get(conn, Routes.policy_path(conn, :privacy))
       assert html_response(conn, 200) =~ "Privacy Policy"
     end
   end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
@@ -8,14 +8,14 @@ defmodule NervesHubWWWWeb.ProductControllerTest do
 
   describe "index" do
     test "lists all products", %{conn: conn, org: org} do
-      conn = get(conn, product_path(conn, :index, org.name))
+      conn = get(conn, Routes.product_path(conn, :index, org.name))
       assert html_response(conn, 200) =~ "All Products"
     end
   end
 
   describe "new product" do
     test "renders form", %{conn: conn, org: org} do
-      conn = get(conn, product_path(conn, :new, org.name))
+      conn = get(conn, Routes.product_path(conn, :new, org.name))
       assert html_response(conn, 200) =~ "Create a Product"
     end
   end
@@ -23,18 +23,18 @@ defmodule NervesHubWWWWeb.ProductControllerTest do
   describe "create product" do
     test "redirects to show when data is valid", %{conn: conn, org: org} do
       params = @create_attrs
-      conn = post(conn, product_path(conn, :create, org.name), product: params)
+      conn = post(conn, Routes.product_path(conn, :create, org.name), product: params)
       assert %{product_name: product_name} = redirected_params(conn)
-      assert redirected_to(conn) == product_path(conn, :show, org.name, params.name)
+      assert redirected_to(conn) == Routes.product_path(conn, :show, org.name, params.name)
 
-      conn = get(conn, product_path(conn, :show, org.name, params.name))
+      conn = get(conn, Routes.product_path(conn, :show, org.name, params.name))
       assert html_response(conn, 200) =~ "Show Product"
       assert html_response(conn, 200) =~ org.name
-      assert html_response(conn, 200) =~ firmware_path(conn, :index, org.name, params.name)
+      assert html_response(conn, 200) =~ Routes.firmware_path(conn, :index, org.name, params.name)
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do
-      conn = post(conn, product_path(conn, :create, org.name), product: @invalid_attrs)
+      conn = post(conn, Routes.product_path(conn, :create, org.name), product: @invalid_attrs)
       assert html_response(conn, 200) =~ "Create a Product"
     end
   end
@@ -43,9 +43,9 @@ defmodule NervesHubWWWWeb.ProductControllerTest do
     setup [:create_product]
 
     test "deletes chosen product", %{conn: conn, org: org, product: product} do
-      path = product_path(conn, :delete, org.name, product.name)
+      path = Routes.product_path(conn, :delete, org.name, product.name)
       conn = delete(conn, path)
-      assert redirected_to(conn) == product_path(conn, :index, org.name)
+      assert redirected_to(conn) == Routes.product_path(conn, :index, org.name)
       conn = get(conn, path)
       assert html_response(conn, 404)
     end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
@@ -18,7 +18,7 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
   describe "new session" do
     test "renders form" do
       conn = build_conn()
-      conn = get(conn, session_path(conn, :new))
+      conn = get(conn, Routes.session_path(conn, :new))
       assert html_response(conn, 200) =~ "Log in to your NervesHub account"
     end
   end
@@ -30,11 +30,11 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
       conn =
         post(
           conn,
-          session_path(conn, :create),
+          Routes.session_path(conn, :create),
           login: %{email: user.email, password: user.password}
         )
 
-      assert redirected_to(conn) == product_path(conn, :index, user.username)
+      assert redirected_to(conn) == Routes.product_path(conn, :index, user.username)
     end
   end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/sponsor_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/sponsor_controller_test.exs
@@ -4,7 +4,7 @@ defmodule NervesHubWWWWeb.SponsorControllerTest do
   test "renders sponsors", %{
     conn: conn
   } do
-    conn = get(conn, sponsor_path(conn, :index))
+    conn = get(conn, Routes.sponsor_path(conn, :index))
     assert html_response(conn, 200) =~ "Sponsors"
   end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
@@ -58,7 +58,7 @@ defmodule NervesHubWWWWeb.DeploymentLiveShowTest do
     } do
       {:ok, view, _html} = mount(Endpoint, Show, session: session)
 
-      path = deployment_path(Endpoint, :index, org.name, product.name)
+      path = Routes.deployment_path(Endpoint, :index, org.name, product.name)
 
       assert_redirect(view, ^path, fn ->
         assert render_submit(view, :delete)

--- a/apps/nerves_hub_www/test/support/conn_case.ex
+++ b/apps/nerves_hub_www/test/support/conn_case.ex
@@ -19,7 +19,7 @@ defmodule NervesHubWWWWeb.ConnCase do
     quote do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
-      import NervesHubWWWWeb.Router.Helpers
+      alias NervesHubWWWWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing
       @endpoint NervesHubWWWWeb.Endpoint


### PR DESCRIPTION
New phoenix projects advocate aliasing the route helpers instead of importing them into views and controller. This PR updates the project to follow the new structure.