### PR TITLE
Add catch-all for LiveView mounts

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
@@ -27,6 +27,19 @@ defmodule NervesHubWWWWeb.DeploymentLive.Show do
     {:ok, socket}
   end
 
+  # Catch-all to handle when LV sessions change.
+  # Typically this is after a deploy when the
+  # session structure in the module has changed
+  # for mount/2
+  def mount(_, socket) do
+    socket =
+      socket
+      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
+      |> redirect(to: Routes.home_path(socket, :index))
+
+    {:stop, socket}
+  end
+
   def handle_event(
         "delete",
         _val,

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
@@ -41,6 +41,19 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
     |> init_iex()
   end
 
+  # Catch-all to handle when LV sessions change.
+  # Typically this is after a deploy when the
+  # session structure in the module has changed
+  # for mount/2
+  def mount(_, socket) do
+    socket =
+      socket
+      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
+      |> redirect(to: Routes.home_path(socket, :index))
+
+    {:stop, socket}
+  end
+
   def handle_event("init_console", _value, socket) do
     socket.endpoint.broadcast_from!(self(), console_topic(socket), "init", %{})
     {:noreply, socket}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/edit.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/edit.ex
@@ -37,6 +37,19 @@ defmodule NervesHubWWWWeb.DeviceLive.Edit do
     {:ok, socket}
   end
 
+  # Catch-all to handle when LV sessions change.
+  # Typically this is after a deploy when the
+  # session structure in the module has changed
+  # for mount/2
+  def mount(_, socket) do
+    socket =
+      socket
+      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
+      |> redirect(to: Routes.home_path(socket, :index))
+
+    {:stop, socket}
+  end
+
   def handle_event("validate", %{"device" => device_params}, socket) do
     changeset =
       socket.assigns.device

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -31,6 +31,19 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
     {:ok, socket}
   end
 
+  # Catch-all to handle when LV sessions change.
+  # Typically this is after a deploy when the
+  # session structure in the module has changed
+  # for mount/2
+  def mount(_, socket) do
+    socket =
+      socket
+      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
+      |> redirect(to: Routes.home_path(socket, :index))
+
+    {:stop, socket}
+  end
+
   # Handles event of user clicking the same field that is already sorted
   # For this case, we switch the sorting direction of same field
   def handle_event("sort", value, %{assigns: %{current_sort: current_sort}} = socket)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
@@ -40,6 +40,19 @@ defmodule NervesHubWWWWeb.DeviceLive.Show do
     {:ok, socket}
   end
 
+  # Catch-all to handle when LV sessions change.
+  # Typically this is after a deploy when the
+  # session structure in the module has changed
+  # for mount/2
+  def mount(_, socket) do
+    socket =
+      socket
+      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
+      |> redirect(to: Routes.home_path(socket, :index))
+
+    {:stop, socket}
+  end
+
   def handle_info(
         %Broadcast{event: "presence_diff", payload: payload},
         %{assigns: %{device: device}} = socket

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
@@ -17,6 +17,11 @@ defmodule NervesHubWWWWeb.DeploymentLiveShowTest do
     [session: session]
   end
 
+  test "redirects on mount with unrecognized session structure" do
+    home_path = Routes.home_path(Endpoint, :index)
+    assert {:error, %{redirect: ^home_path}} = mount(Endpoint, Show, session: "wat?! who der?!")
+  end
+
   describe "handle_event" do
     test "toggle active", %{fixture: %{deployment: deployment}, session: session} do
       {:ok, view, _html} = mount(Endpoint, Show, session: session)

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_console_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_console_test.exs
@@ -45,6 +45,13 @@ defmodule NervesHubWWWWeb.DeviceLiveConsoleTest do
       path = Routes.device_path(Endpoint, :show, org.name, product.name, device.identifier)
       assert somewhere == path
     end
+
+    test "redirects on mount with unrecognized session structure" do
+      home_path = Routes.home_path(Endpoint, :index)
+
+      assert {:error, %{redirect: ^home_path}} =
+               mount(Endpoint, Console, session: "wat?! who der?!")
+    end
   end
 
   describe "handle_event" do

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_edit_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_edit_test.exs
@@ -18,6 +18,11 @@ defmodule NervesHubWWWWeb.DeviceLiveEditTest do
     [session: session]
   end
 
+  test "redirects on mount with unrecognized session structure" do
+    home_path = Routes.home_path(Endpoint, :index)
+    assert {:error, %{redirect: ^home_path}} = mount(Endpoint, Edit, session: "wat?! who der?!")
+  end
+
   describe "validate" do
     test "valid tags allow submit", %{session: session} do
       params = %{"device" => %{tags: "new,tags"}}

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_show_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_show_test.exs
@@ -22,6 +22,11 @@ defmodule NervesHubWWWWeb.DeviceLiveShowTest do
     [session: session]
   end
 
+  test "redirects on mount with unrecognized session structure" do
+    home_path = Routes.home_path(Endpoint, :index)
+    assert {:error, %{redirect: ^home_path}} = mount(Endpoint, Show, session: "wat?! who der?!")
+  end
+
   describe "handle_event" do
     test "reboot allowed", %{fixture: %{device: device}, session: session} do
       {:ok, view, _html} = mount(Endpoint, Show, session: session)


### PR DESCRIPTION
When we change anything about the session structure of a LiveView, it causes tons of rollbar errors after deployment because any existing browser tabs/windows are trying to reuse the old session structure which no longer has a matching `mount/2` clause for it.

So, this adds a catch-all to redirect to the home path if that apps.