### PR TITLE
crowdin: switch to locale_with_underscore

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -27,7 +27,7 @@ files: [
   # where translations live
   # e.g. "/resources/%two_letters_code%/%original_file_name%"
   #
-  "translation" : "/apps/nerves_hub_www/priv/gettext/%two_letters_code%/**/%original_file_name%",
+  "translation" : "/apps/nerves_hub_www/priv/gettext/%locale_with_underscore%/**/%original_file_name%",
 
   #
   # files or directories for ignore
@@ -107,14 +107,31 @@ files: [
   # Often software projects have custom names for locale directories. crowdin-cli allows you to map your own languages to be understandable by Crowdin.
   #
   "languages_mapping" : {
-    "two_letters_code" : {
-        "zh-CN" : "zh_CH",
-        "zh-TW" : "zh_TW",
-        "pt-PT" : "pt_PT",
-        "pt-BR" : "pt_BR",
-        "es-ES" : "es_ES",
-        "sv-SE" : "sv_SE"
-     }
+    "locale_with_underscore" : {
+      "af": "af",
+      "ar": "ar",
+      "ca": "ca",
+      "cs": "cs",
+      "da": "da",
+      "nl": "nl",
+      "fi": "fi",
+      "fr": "fr",
+      "de": "de",
+      "el": "el",
+      "he": "he",
+      "hu": "hu",
+      "it": "it",
+      "ja": "ja",
+      "ko": "ko",
+      "no": "no",
+      "pl": "pl",
+      "ro": "ro",
+      "ru": "ru",
+      "sr": "sr",
+      "tr": "tr",
+      "uk": "uk",
+      "vi": "vi"
+    }
   },
 
   #


### PR DESCRIPTION
The advice from Crowdin is to use locale_with_underscore and manually
put in the exceptions for locales that should just be two letters. This
helps prevent accidents where adding a locale stomps on an existing one.

[skip ci]