### PR TITLE
Fix FirmwareTransfer ingress

### DIFF
--- a/apps/nerves_hub_web_core/config/prod.exs
+++ b/apps/nerves_hub_web_core/config/prod.exs
@@ -10,10 +10,10 @@ config :nerves_hub_web_core, NervesHubWebCore.Scheduler,
       schedule: "*/15 * * * *",
       task: {NervesHubWebCore.Firmwares.GC, :run, []}
     ],
-    # digest_firmware_transfers: [
-    #   schedule: "*/30 * * * *",
-    #   task: {NervesHubWebCore.Firmwares.Transfer.S3Ingress, :run, []}
-    # ],
+    digest_firmware_transfers: [
+      schedule: "*/30 * * * *",
+      task: {NervesHubWebCore.Firmwares.Transfer.S3Ingress, :run, []}
+    ],
     create_org_metrics: [
       schedule: "0 1 * * *",
       task: {NervesHubWebCore.Accounts, :create_org_metrics, ["01:00:00.000000", [days: -1]]}


### PR DESCRIPTION
The module was compiling in application env values that were coming from the target container runtime and were not available at build time. This moves those to runtime checks.