### PR TITLE
Add status_update to device channel 

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/presence.ex
@@ -67,6 +67,7 @@ defmodule NervesHubDevice.Presence do
     Enum.reduce(metas, %{}, &Map.merge(&1, &2))
     |> Map.take(@allowed_fields)
     |> case do
+      %{status: _status} = e -> e
       %{update_available: true} = e -> Map.put(e, :status, "update pending")
       %{rebooting: true} = e -> Map.put(e, :status, "rebooting")
       %{fwup_progress: _progress} = e -> Map.put(e, :status, "updating")

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -65,6 +65,17 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     {:noreply, socket}
   end
 
+  def handle_in("status_update", %{"status" => status}, socket) do
+    Presence.update(
+      socket.channel_pid,
+      "product:#{socket.assigns.device.product_id}:devices",
+      socket.assigns.device.id,
+      %{status: status}
+    )
+
+    {:noreply, socket}
+  end
+
   def handle_in("rebooting", _payload, socket) do
     # Device sends "rebooting" message back to signify ack of the request
     Presence.update(


### PR DESCRIPTION
https://github.com/nerves-hub/nerves_hub/pull/109 adds ability for the device to assert more about what's happening on it and set a status. Since its already storing for itself, I thought it might be nice to send it here for the web to display also.