### PR TITLE
Handle live view mount exceptions

### DIFF
--- a/apps/nerves_hub_api/mix.exs
+++ b/apps/nerves_hub_api/mix.exs
@@ -28,8 +28,11 @@ defmodule NervesHubAPI.Mixfile do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support", Path.expand("../../test/support")]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(env) when env in [:dev, :test],
+    do: ["lib", "test/support", Path.expand("../../test/support")]
+
+  defp elixirc_paths(_),
+    do: ["lib"]
 
   # Specifies your project dependencies.
   #

--- a/apps/nerves_hub_device/mix.exs
+++ b/apps/nerves_hub_device/mix.exs
@@ -37,8 +37,11 @@ defmodule NervesHubDevice.Mixfile do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support", Path.expand("../../test/support")]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(env) when env in [:dev, :test],
+    do: ["lib", "test/support", Path.expand("../../test/support")]
+
+  defp elixirc_paths(_),
+    do: ["lib"]
 
   # Specifies your project dependencies.
   #

--- a/apps/nerves_hub_web_core/mix.exs
+++ b/apps/nerves_hub_web_core/mix.exs
@@ -26,8 +26,11 @@ defmodule NervesHubWebCore.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support", Path.expand("../../test/support")]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(env) when env in [:dev, :test],
+    do: ["lib", "test/support", Path.expand("../../test/support")]
+
+  defp elixirc_paths(_),
+    do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.
   def application do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web.ex
@@ -58,6 +58,25 @@ defmodule NervesHubWWWWeb do
       }
 
       alias Phoenix.Socket.Broadcast
+
+      defp socket_error(socket, error, opts \\ []) do
+        redirect = opts[:redirect_to] || Routes.home_path(socket, :index)
+
+        socket =
+          socket
+          |> put_flash(:info, error)
+          |> redirect(to: redirect)
+
+        {:stop, socket}
+      end
+
+      defp live_view_error(:update) do
+        "The software running on NervesHub was updated to the latest version."
+      end
+
+      defp live_view_error(_) do
+        "An error occurred while loading the view."
+      end
     end
   end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
@@ -25,6 +25,9 @@ defmodule NervesHubWWWWeb.DeploymentLive.Show do
       |> audit_log_assigns()
 
     {:ok, socket}
+  rescue
+    e ->
+      socket_error(socket, live_view_error(e))
   end
 
   # Catch-all to handle when LV sessions change.
@@ -32,12 +35,7 @@ defmodule NervesHubWWWWeb.DeploymentLive.Show do
   # session structure in the module has changed
   # for mount/2
   def mount(_, socket) do
-    socket =
-      socket
-      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
-      |> redirect(to: Routes.home_path(socket, :index))
-
-    {:stop, socket}
+    socket_error(socket, live_view_error(:update))
   end
 
   def handle_event(

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/console.ex
@@ -39,6 +39,9 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
     |> assign(:lines, ["NervesHub IEx Live"])
     |> assign(:user_role, org_user.role)
     |> init_iex()
+  rescue
+    e ->
+      socket_error(socket, live_view_error(e))
   end
 
   # Catch-all to handle when LV sessions change.
@@ -46,12 +49,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Console do
   # session structure in the module has changed
   # for mount/2
   def mount(_, socket) do
-    socket =
-      socket
-      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
-      |> redirect(to: Routes.home_path(socket, :index))
-
-    {:stop, socket}
+    socket_error(socket, live_view_error(:update))
   end
 
   def handle_event("init_console", _value, socket) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/edit.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/edit.ex
@@ -35,6 +35,9 @@ defmodule NervesHubWWWWeb.DeviceLive.Edit do
       |> assign(:changeset, Device.changeset(socket.assigns.device, %{}))
 
     {:ok, socket}
+  rescue
+    e ->
+      socket_error(socket, live_view_error(e))
   end
 
   # Catch-all to handle when LV sessions change.
@@ -42,12 +45,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Edit do
   # session structure in the module has changed
   # for mount/2
   def mount(_, socket) do
-    socket =
-      socket
-      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
-      |> redirect(to: Routes.home_path(socket, :index))
-
-    {:stop, socket}
+    socket_error(socket, live_view_error(:update))
   end
 
   def handle_event("validate", %{"device" => device_params}, socket) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -29,6 +29,9 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
       |> assign(:sort_direction, :asc)
 
     {:ok, socket}
+  rescue
+    e ->
+      socket_error(socket, live_view_error(e))
   end
 
   # Catch-all to handle when LV sessions change.
@@ -36,12 +39,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
   # session structure in the module has changed
   # for mount/2
   def mount(_, socket) do
-    socket =
-      socket
-      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
-      |> redirect(to: Routes.home_path(socket, :index))
-
-    {:stop, socket}
+    socket_error(socket, live_view_error(:update))
   end
 
   # Handles event of user clicking the same field that is already sorted

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
@@ -38,6 +38,9 @@ defmodule NervesHubWWWWeb.DeviceLive.Show do
       |> audit_log_assigns()
 
     {:ok, socket}
+  rescue
+    e ->
+      socket_error(socket, live_view_error(e))
   end
 
   # Catch-all to handle when LV sessions change.
@@ -45,12 +48,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Show do
   # session structure in the module has changed
   # for mount/2
   def mount(_, socket) do
-    socket =
-      socket
-      |> put_flash(:info, "The software running on NervesHub was updated to the latest version")
-      |> redirect(to: Routes.home_path(socket, :index))
-
-    {:stop, socket}
+    socket_error(socket, live_view_error(:update))
   end
 
   def handle_info(

--- a/apps/nerves_hub_www/mix.exs
+++ b/apps/nerves_hub_www/mix.exs
@@ -42,8 +42,11 @@ defmodule NervesHubWWW.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support", Path.expand("../../test/support")]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(env) when env in [:dev, :test],
+    do: ["lib", "test/support", Path.expand("../../test/support")]
+
+  defp elixirc_paths(_),
+    do: ["lib"]
 
   # Specifies your project dependencies.
   #

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule NervesHubUmbrella.MixProject do
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
       aliases: aliases(),
+      elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [
         plt_add_apps: [],
         ignore_warnings: "dialyzer.ignore-warnings"
@@ -73,4 +74,11 @@ defmodule NervesHubUmbrella.MixProject do
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(env) when env in [:dev, :test],
+    do: [Path.expand("test/support")]
+
+  defp elixirc_paths(_),
+    do: ["lib"]
 end


### PR DESCRIPTION
If a product, device, or any other database record that a live view required to mount is deleted, and a page remains open, live view will raise and continue to attempt to mount. This will redirect any exceptions back to the home.