### PR TITLE
Fix device last communication stale update

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -133,7 +133,10 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
   end
 
   def terminate(_reason, %{assigns: %{device: device}}) do
-    Devices.update_device(device, %{last_communication: DateTime.utc_now()})
+    if device = Devices.get_device(device.id) do
+      Devices.update_device(device, %{last_communication: DateTime.utc_now()})
+    end
+
     :ok
   end
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -16,6 +16,7 @@ defmodule NervesHubWebCore.Devices do
 
   @uploader Application.get_env(:nerves_hub_web_core, :firmware_upload)
 
+  def get_device(device_id), do: Repo.get(Device, device_id)
   def get_device!(device_id), do: Repo.get!(Device, device_id)
 
   def get_devices_by_org_id(org_id) do


### PR DESCRIPTION
This PR fixes an error when attempting to update a stale device record. It will occur if a device connects, a modification is made to the device record while it's connected, and then the device disconnects. This modifies the logic to check to ensure the device record still exists, and refetches it to ensure that it is not stale. 