### PR TITLE
OrgMetric remove bytes_transferred and change bytes_stored to bigint

### DIFF
--- a/apps/nerves_hub_web_core/config/prod.exs
+++ b/apps/nerves_hub_web_core/config/prod.exs
@@ -13,7 +13,7 @@ config :nerves_hub_web_core, NervesHubWebCore.Scheduler,
     ],
     create_org_metrics: [
       schedule: "0 1 * * *",
-      task: {NervesHubWebCore.Accounts, :create_org_metrics, ["01:00:00.000000", [days: -1]]}
+      task: {NervesHubWebCore.Accounts, :create_org_metrics, ["01:00:00.000000"]}
     ]
   ]
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_metric.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_metric.ex
@@ -11,7 +11,6 @@ defmodule NervesHubWebCore.Accounts.OrgMetric do
   @params [
     :org_id,
     :devices,
-    :bytes_transferred,
     :bytes_stored,
     :timestamp
   ]
@@ -20,7 +19,6 @@ defmodule NervesHubWebCore.Accounts.OrgMetric do
     belongs_to(:org, Org)
 
     field(:devices, :integer)
-    field(:bytes_transferred, :integer)
     field(:bytes_stored, :integer)
     field(:timestamp, :utc_datetime)
   end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20190724020853_alter_org_metric.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20190724020853_alter_org_metric.exs
@@ -1,0 +1,10 @@
+defmodule NervesHubWebCore.Repo.Migrations.AlterOrgMetric do
+  use Ecto.Migration
+
+  def change do
+    alter table("org_metrics") do
+      modify :bytes_stored, :bigint
+      remove :bytes_transferred
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -315,28 +315,9 @@ defmodule NervesHubWebCore.AccountsTest do
     setup [:setup_org_metric]
 
     test "create", %{org: org, firmware: firmware} do
-      to = DateTime.utc_now()
-      from = Timex.shift(to, days: -1)
-
-      assert {:ok, org_metric} = Accounts.create_org_metric(org.id, from, to)
+      assert {:ok, org_metric} = Accounts.create_org_metric(org.id, DateTime.utc_now())
       assert org_metric.devices == 1
       assert org_metric.bytes_stored == firmware.size
-      assert org_metric.bytes_transferred == firmware.size
-    end
-
-    test "firmware transfers are limited to run range", %{org: org, firmware: firmware} do
-      to = DateTime.utc_now()
-      from = Timex.shift(to, days: -1)
-
-      # Timestamp precision is seconds. Sleep for about 1
-      :timer.sleep(1100)
-
-      _ = create_firmware_transfer(org, firmware)
-
-      assert {:ok, org_metric} = Accounts.create_org_metric(org.id, from, to)
-      assert org_metric.devices == 1
-      assert org_metric.bytes_stored == firmware.size
-      assert org_metric.bytes_transferred == firmware.size
     end
   end
 


### PR DESCRIPTION
This PR does two things.

First: 

It removes the `bytes_transferred` from the `org_metric` records. This is being removed because it was unreliable. Firmware transfer records are delayed in their delivery and some would be missed in this setup. The purpose of these records is for understanding the counts of storage and devices on a daily basis to be used in billing calculations.

Second:

This increases the field size for `bytes_stored` to fix the following error

```
Task terminating (DBConnection.EncodeError): Postgrex expected an integer in -2147483648..2147483647, got 4820089941. Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly
```