### PR TITLE
Toggle file upload endpoint using config.

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -1,5 +1,4 @@
 defmodule NervesHubWWWWeb.Endpoint do
-  @env Mix.env()
   use Phoenix.Endpoint, otp_app: :nerves_hub_www
 
   socket("/live", Phoenix.LiveView.Socket)
@@ -16,14 +15,14 @@ defmodule NervesHubWWWWeb.Endpoint do
     only: ~w(css fonts images js favicon.ico robots.txt)
   )
 
-  # This should only be enabled if using NervesHubWebCore.Firmwares.Upload.File
-  if @env in [:dev, :test] do
-    @file_config Application.get_env(:nerves_hub_web_core, NervesHubWebCore.Firmwares.Upload.File)
+  file_upload_config =
+    Application.get_env(:nerves_hub_web_core, NervesHubWebCore.Firmwares.Upload.File, [])
 
+  if Keyword.get(file_upload_config, :enabled, false) do
     plug(
       Plug.Static,
-      at: @file_config[:public_path],
-      from: @file_config[:local_path]
+      at: file_upload_config[:public_path],
+      from: file_upload_config[:local_path]
     )
   end
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -57,6 +57,7 @@ config :nerves_hub_web_core,
   scheme: web_scheme
 
 config :nerves_hub_web_core, NervesHubWebCore.Firmwares.Upload.File,
+  enabled: true,
   local_path: Path.join(System.tmp_dir(), "firmware"),
   public_path: "/firmware"
 


### PR DESCRIPTION
This allows using the file store as an alternative to S3 on platforms that are not on AWS.