### PR TITLE
fwup: bump to v1.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,8 @@ jobs:
     working_directory: ~/app
     steps:
       - checkout
-      - run: wget https://github.com/fhunleth/fwup/releases/download/v1.3.1/fwup_1.3.1_amd64.deb
-      - run: sudo dpkg -i ./fwup_1.3.1_amd64.deb
+      - run: wget https://github.com/fhunleth/fwup/releases/download/v1.3.2/fwup_1.3.2_amd64.deb
+      - run: sudo dpkg -i ./fwup_1.3.2_amd64.deb
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - restore_cache:

--- a/apps/nerves_hub_api/rel/Dockerfile.build
+++ b/apps/nerves_hub_api/rel/Dockerfile.build
@@ -16,7 +16,7 @@ RUN mix release nerves_hub_api --overwrite
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
 
-RUN apk add 'fwup~=1.3.1' \
+RUN apk add 'fwup~=1.3.2' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
 

--- a/apps/nerves_hub_www/Dockerfile
+++ b/apps/nerves_hub_www/Dockerfile
@@ -4,7 +4,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=en_US.UTF-8 \
   PATH="/app:${PATH}" \
-  FWUP_VERSION=1.3.1 \
+  FWUP_VERSION=1.3.2 \
   DATABASE_URL=postgres://db:db@localhost:5432/db \
   DATABASE_SSL="false" \
   SECRET_KEY_BASE=""

--- a/apps/nerves_hub_www/rel/Dockerfile.build
+++ b/apps/nerves_hub_www/rel/Dockerfile.build
@@ -31,7 +31,7 @@ RUN mix do phx.digest, release nerves_hub_www --overwrite
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
 
-RUN apk add 'fwup~=1.3.1' \
+RUN apk add 'fwup~=1.3.2' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
 


### PR DESCRIPTION
fixes build errors when trying to pull an older version of fwup from apk