### PR TITLE
Add org_id to Firmware, Deployment, DeviceCertificate, AuditLog

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/deployment_controller.ex
@@ -10,7 +10,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
   plug(:validate_role, [product: :write] when action in [:create, :update])
   plug(:validate_role, [product: :read] when action in [:index, :show])
 
-  @whitelist_fields [:name, :firmware_id, :conditions, :is_active]
+  @whitelist_fields [:name, :org_id, :firmware_id, :conditions, :is_active]
 
   def index(%{assigns: %{product: product}} = conn, _params) do
     deployments = Deployments.get_deployments_by_product(product.id)
@@ -25,6 +25,7 @@ defmodule NervesHubAPIWeb.DeploymentController do
       uuid ->
         with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
              params <- Map.put(params, "firmware_id", firmware.id),
+             params <- Map.put(params, "org_id", org.id),
              params <- whitelist(params, @whitelist_fields),
              {:ok, deployment} <- Deployments.create_deployment(params) do
           audit!(user, deployment, :create, params)

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -17,6 +17,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
 
       params = %{
         name: "test",
+        org_id: context.org.id,
         firmware: firmware.uuid,
         firmware_id: firmware.id,
         conditions: %{
@@ -26,10 +27,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
         is_active: false
       }
 
-      context
-      |> Map.put(:org_key, org_key)
-      |> Map.put(:firmware, firmware)
-      |> Map.put(:params, params)
+      [params: params, firmware: firmware, org_key: org_key]
     end
 
     test "renders deployment when data is valid", %{
@@ -134,7 +132,7 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
   defp create_deployment(%{org: org, product: product}) do
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    deployment = Fixtures.deployment_fixture(firmware)
+    deployment = Fixtures.deployment_fixture(org, firmware)
     {:ok, %{deployment: deployment}}
   end
 end

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
@@ -53,7 +53,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
         version: "0.0.1"
       })
 
-    Fixtures.deployment_fixture(firmware)
+    Fixtures.deployment_fixture(org, firmware)
 
     params = Enum.into(device_params, %{tags: ["beta", "beta-edge"]})
 
@@ -134,7 +134,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
           version: "0.0.2"
         })
 
-      Fixtures.deployment_fixture(firmware2, %{
+      Fixtures.deployment_fixture(org, firmware2, %{
         name: "a different name",
         conditions: %{
           "version" => ">=0.0.1",
@@ -176,7 +176,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
         )
 
       deployment =
-        Fixtures.deployment_fixture(firmware, %{
+        Fixtures.deployment_fixture(device.org, firmware, %{
           name: "a different name",
           conditions: %{
             "version" => ">=0.0.1",

--- a/apps/nerves_hub_device/test/support/conn_case.ex
+++ b/apps/nerves_hub_device/test/support/conn_case.ex
@@ -45,7 +45,7 @@ defmodule NervesHubDeviceWeb.ConnCase do
     %{cert: cert, db_cert: device_cert} = Fixtures.device_certificate_fixture(device)
 
     deployment =
-      Fixtures.deployment_fixture(firmware, %{
+      Fixtures.deployment_fixture(org, firmware, %{
         conditions: %{"tags" => device.tags, "version" => ""}
       })
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
@@ -22,7 +22,8 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
     :description,
     :params,
     :resource_id,
-    :resource_type
+    :resource_type,
+    :org_id
   ]
   @optional_params [:changes]
 
@@ -37,6 +38,8 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
   defenum(Action, :action, [:create, :update, :delete])
 
   schema "audit_logs" do
+    belongs_to(:org, Org)
+
     field(:action, Action)
     field(:actor_id, :id)
     field(:actor_type, Resource)
@@ -59,6 +62,7 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
       description: description,
       resource_id: resource.id,
       resource_type: resource_type,
+      org_id: resource.org_id,
       params: format_params(actor, resource, action, params)
     }
     |> add_changes(resource)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments/deployment.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments/deployment.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWebCore.Deployments.Deployment do
   import Ecto.Changeset
   import Ecto.Query
 
+  alias NervesHubWebCore.Accounts.Org
   alias NervesHubWebCore.Firmwares.Firmware
   alias NervesHubWebCore.Products.Product
   alias NervesHubWebCore.Repo
@@ -11,7 +12,7 @@ defmodule NervesHubWebCore.Deployments.Deployment do
   alias __MODULE__
 
   @type t :: %__MODULE__{}
-  @required_fields [:firmware_id, :name, :conditions, :is_active, :product_id]
+  @required_fields [:org_id, :firmware_id, :name, :conditions, :is_active, :product_id]
   @optional_fields [
     :device_failure_threshold,
     :device_failure_rate_seconds,
@@ -25,6 +26,7 @@ defmodule NervesHubWebCore.Deployments.Deployment do
   schema "deployments" do
     belongs_to(:firmware, Firmware)
     belongs_to(:product, Product)
+    belongs_to(:org, Org)
 
     field(:conditions, :map)
     field(:device_failure_threshold, :integer, default: 3)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -162,6 +162,8 @@ defmodule NervesHubWebCore.Devices do
           {:ok, DeviceCertificate.t()}
           | {:error, Changeset.t()}
   def create_device_certificate(%Device{} = device, params) do
+    params = Map.put(params, :org_id, device.org_id)
+
     device
     |> Ecto.build_assoc(:device_certificates)
     |> DeviceCertificate.changeset(params)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device_certificate.ex
@@ -2,11 +2,13 @@ defmodule NervesHubWebCore.Devices.DeviceCertificate do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias NervesHubWebCore.Accounts.Org
   alias NervesHubWebCore.Devices.{Device, DeviceCertificate}
 
   @type t :: %__MODULE__{}
 
   @required_params [
+    :org_id,
     :device_id,
     :serial,
     :aki,
@@ -20,6 +22,7 @@ defmodule NervesHubWebCore.Devices.DeviceCertificate do
 
   schema "device_certificates" do
     belongs_to(:device, Device)
+    belongs_to(:org, Org)
 
     field(:serial, :string)
     field(:aki, :binary)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
   import Ecto.Query
 
   alias NervesHubWebCore.Accounts
+  alias NervesHubWebCore.Accounts.Org
   alias NervesHubWebCore.Accounts.OrgKey
   alias NervesHubWebCore.Deployments.Deployment
   alias NervesHubWebCore.Products.Product
@@ -22,6 +23,7 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
     :vcs_identifier
   ]
   @required_params [
+    :org_id,
     :architecture,
     :platform,
     :product_id,
@@ -31,11 +33,9 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
     :version,
     :size
   ]
-  @virtual_params [
-    :org_id
-  ]
 
   schema "firmwares" do
+    belongs_to(:org, Org)
     belongs_to(:product, Product)
     belongs_to(:org_key, OrgKey)
     has_many(:deployments, Deployment)
@@ -45,7 +45,6 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
     field(:description, :string)
     field(:size, :integer)
     field(:misc, :string)
-    field(:org_id, :integer, virtual: true)
     field(:platform, :string)
     field(:ttl, :integer)
     field(:ttl_until, :utc_datetime)
@@ -59,8 +58,8 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
 
   def create_changeset(%Firmware{} = firmware, params) do
     firmware
-    |> cast(params, @required_params ++ @virtual_params ++ @optional_params)
-    |> validate_required(@required_params ++ @virtual_params)
+    |> cast(params, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
     |> validate_limits()
     |> unique_constraint(:uuid, name: :firmwares_product_id_uuid_index)
     |> foreign_key_constraint(:deployments, name: :deployments_firmware_id_fkey)

--- a/apps/nerves_hub_web_core/priv/repo/add_org_id.exs
+++ b/apps/nerves_hub_web_core/priv/repo/add_org_id.exs
@@ -1,0 +1,99 @@
+alias NervesHubWebCore.Repo
+alias NervesHubWebCore.Firmwares.Firmware
+alias NervesHubWebCore.Devices.DeviceCertificate
+alias NervesHubWebCore.Deployments.Deployment
+alias NervesHubWebCore.AuditLogs.AuditLog
+
+import Ecto.Query
+import IO.ANSI, only: [default_color: 0, green: 0, red: 0]
+
+Logger.configure(level: :info)
+
+{success, errors} =
+  from(f in Firmware, where: is_nil(f.org_id), preload: [:org_key])
+  |> Repo.all()
+  |> Enum.reduce({[], []}, fn firmware, {success, errors} ->
+    Firmware.update_changeset(firmware, %{org_id: firmware.org_key.org_id})
+    |> Repo.update()
+    |> case do
+      {:ok, firmware} ->
+        IO.write("#{green()}.#{default_color()}")
+        {[firmware | success], errors}
+      {:error, firmware} ->
+        IO.write("#{red()}.#{default_color()}")
+        {success, [firmware | errors]}
+    end
+  end)
+
+IO.puts "\n"
+IO.puts("Firmware Success: #{green()}#{length(success)}#{default_color()}")
+IO.puts("Firmware Errors: #{red()}#{length(errors)}#{default_color()}")
+IO.puts "\n"
+
+{success, errors} =
+  from(dc in DeviceCertificate, where: is_nil(dc.org_id), preload: [:device])
+  |> Repo.all()
+  |> Enum.reduce({[], []}, fn device_certificate, {success, errors} ->
+    DeviceCertificate.changeset(device_certificate, %{org_id: device_certificate.device.org_id})
+    |> Repo.update()
+    |> case do
+      {:ok, device_certificate} ->
+        IO.write("#{green()}.#{default_color()}")
+        {[device_certificate | success], errors}
+      {:error, device_certificate} ->
+        IO.write("#{red()}.#{default_color()}")
+        {success, [device_certificate | errors]}
+    end
+  end)
+
+IO.puts "\n"
+IO.puts("DeviceCert Success: #{green()}#{length(success)}#{default_color()}")
+IO.puts("DeviceCert Errors: #{red()}#{length(errors)}#{default_color()}")
+IO.puts "\n"
+
+{success, errors} =
+  from(d in Deployment, where: is_nil(d.org_id), preload: [:product])
+  |> Repo.all()
+  |> Enum.reduce({[], []}, fn deployment, {success, errors} ->
+    Deployment.creation_changeset(deployment, %{org_id: deployment.product.org_id})
+    |> Repo.update()
+    |> case do
+      {:ok, deployment} ->
+        IO.write("#{green()}.#{default_color()}")
+        {[deployment | success], errors}
+      {:error, deployment} ->
+        IO.write("#{red()}.#{default_color()}")
+        {success, [deployment | errors]}
+    end
+  end)
+
+IO.puts "\n"
+IO.puts("Deployment Success: #{green()}#{length(success)}#{default_color()}")
+IO.puts("Deployment Errors: #{red()}#{length(errors)}#{default_color()}")
+IO.puts "\n"
+
+{success, errors} =
+  from(al in AuditLog, where: is_nil(al.org_id))
+  |> Repo.all()
+  |> Enum.reduce({[], []}, fn audit_log, {success, errors} ->
+    case Repo.get(audit_log.resource_type, audit_log.resource_id) do
+      nil ->
+        {[audit_log | success], errors}
+      %{org_id: org_id} ->
+        AuditLog.changeset(audit_log, %{org_id: org_id})
+      |> Repo.update()
+      |> case do
+        {:ok, audit_log} ->
+          IO.write("#{green()}.#{default_color()}")
+          {[audit_log | success], errors}
+        {:error, audit_log} ->
+          IO.write("#{red()}.#{default_color()}")
+          {success, [audit_log | errors]}
+      end
+    end
+  end)
+
+IO.puts "\n"
+IO.puts("AuditLog Success: #{green()}#{length(success)}#{default_color()}")
+IO.puts("AuditLog Errors: #{red()}#{length(errors)}#{default_color()}")
+IO.puts "\n"

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20191002190115_add_org_id_to_models.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20191002190115_add_org_id_to_models.exs
@@ -1,0 +1,21 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddOrgIdToModels do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_logs) do
+      add :org_id, references(:orgs, on_delete: :nothing, null: true)
+    end
+
+    alter table(:deployments) do
+      add :org_id, references(:orgs, on_delete: :nothing, null: true)
+    end
+
+    alter table(:firmwares) do
+      add :org_id, references(:orgs, on_delete: :nothing, null: true)
+    end
+
+    alter table(:device_certificates) do
+      add :org_id, references(:orgs, on_delete: :nothing, null: true)
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/priv/repo/seeds.exs
+++ b/apps/nerves_hub_web_core/priv/repo/seeds.exs
@@ -39,7 +39,7 @@ defmodule NervesHubWebCore.SeedHelpers do
 
     firmwares = firmwares |> List.to_tuple()
 
-    Fixtures.deployment_fixture(firmwares |> elem(2), %{
+    Fixtures.deployment_fixture(org_with_keys_and_users, firmwares |> elem(2), %{
       conditions: %{"version" => "< 1.0.0", "tags" => ["beta"]}
     })
 

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/deployments/deployments_test.exs
@@ -11,14 +11,14 @@ defmodule NervesHubWebCore.DeploymentsTest do
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    deployment = Fixtures.deployment_fixture(firmware)
+    deployment = Fixtures.deployment_fixture(org, firmware)
 
     user2 = Fixtures.user_fixture(%{username: "user2", email: "user2@test.com"})
     org2 = Fixtures.org_fixture(user2, %{name: "org2"})
     product2 = Fixtures.product_fixture(user2, org2)
     org_key2 = Fixtures.org_key_fixture(org2)
     firmware2 = Fixtures.firmware_fixture(org_key2, product2)
-    deployment2 = Fixtures.deployment_fixture(firmware2)
+    deployment2 = Fixtures.deployment_fixture(org2, firmware2)
 
     {:ok,
      %{
@@ -37,9 +37,11 @@ defmodule NervesHubWebCore.DeploymentsTest do
 
   describe "create deployment" do
     test "create_deployment with valid parameters", %{
+      org: org,
       firmware: firmware
     } do
       params = %{
+        org_id: org.id,
         firmware_id: firmware.id,
         name: "a different name",
         conditions: %{
@@ -57,11 +59,13 @@ defmodule NervesHubWebCore.DeploymentsTest do
     end
 
     test "deployments have unique names wrt product", %{
+      org: org,
       firmware: firmware,
       deployment: existing_deployment
     } do
       params = %{
         name: existing_deployment.name,
+        org_id: org.id,
         firmware_id: firmware.id,
         conditions: %{
           "version" => "< 1.0.0",
@@ -104,6 +108,7 @@ defmodule NervesHubWebCore.DeploymentsTest do
 
       params = %{
         firmware_id: new_firmware.id,
+        org_id: org.id,
         name: "my deployment",
         conditions: %{
           "version" => "< 1.0.1",
@@ -142,6 +147,7 @@ defmodule NervesHubWebCore.DeploymentsTest do
         new_firmware = Fixtures.firmware_fixture(org_key, product, f_params)
 
         params = %{
+          org_id: org.id,
           firmware_id: new_firmware.id,
           name: "my deployment #{d_params.identifier}",
           conditions: %{
@@ -173,6 +179,7 @@ defmodule NervesHubWebCore.DeploymentsTest do
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.1"})
 
       params = %{
+        org_id: org.id,
         firmware_id: new_firmware.id,
         name: "my deployment",
         conditions: %{
@@ -209,6 +216,7 @@ defmodule NervesHubWebCore.DeploymentsTest do
 
       params = %{
         firmware_id: new_firmware.id,
+        org_id: org.id,
         name: "my deployment",
         conditions: %{
           "version" => "< 1.0.1",
@@ -247,6 +255,7 @@ defmodule NervesHubWebCore.DeploymentsTest do
 
       params = %{
         firmware_id: new_firmware.id,
+        org_id: org.id,
         name: "my deployment",
         conditions: %{
           "version" => "< 1.0.1",

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -20,7 +20,7 @@ defmodule NervesHubWebCore.DevicesTest do
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    deployment = Fixtures.deployment_fixture(firmware)
+    deployment = Fixtures.deployment_fixture(org, firmware)
     device = Fixtures.device_fixture(org, product, firmware)
     Fixtures.device_certificate_fixture(device)
 
@@ -334,6 +334,7 @@ defmodule NervesHubWebCore.DevicesTest do
     new_firmware = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.1"})
 
     params = %{
+      org_id: org.id,
       firmware_id: new_firmware.id,
       name: "my deployment",
       conditions: %{
@@ -374,6 +375,7 @@ defmodule NervesHubWebCore.DevicesTest do
       new_firmware = Fixtures.firmware_fixture(org_key, product, f_params)
 
       params = %{
+        org_id: org.id,
         firmware_id: new_firmware.id,
         name: "my deployment #{d_params.identifier}",
         conditions: %{
@@ -402,7 +404,7 @@ defmodule NervesHubWebCore.DevicesTest do
     product: product
   } do
     old_deployment =
-      Fixtures.deployment_fixture(firmware, %{
+      Fixtures.deployment_fixture(org, firmware, %{
         name: "a different name",
         conditions: %{"tags" => ["beta", "beta-edge"], "version" => ""}
       })
@@ -421,6 +423,7 @@ defmodule NervesHubWebCore.DevicesTest do
     firmware2 = Fixtures.firmware_fixture(org_key, product2)
 
     params = %{
+      org_id: org.id,
       firmware_id: firmware2.id,
       name: "my deployment",
       conditions: %{

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
@@ -20,7 +20,7 @@ defmodule NervesHubWebCore.FirmwaresTest do
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    deployment = Fixtures.deployment_fixture(firmware)
+    deployment = Fixtures.deployment_fixture(org, firmware)
     device = Fixtures.device_fixture(org, product, firmware)
 
     {:ok,
@@ -127,13 +127,14 @@ defmodule NervesHubWebCore.FirmwaresTest do
   end
 
   test "cannot delete firmware when it is referenced by deployment", %{
+    org: org,
     org_key: org_key,
     product: product
   } do
     firmware = Fixtures.firmware_fixture(org_key, product)
     assert File.exists?(firmware.upload_metadata[:local_path])
 
-    Fixtures.deployment_fixture(firmware, %{name: "a deployment"})
+    Fixtures.deployment_fixture(org, firmware, %{name: "a deployment"})
 
     assert {:error, %Changeset{}} = Firmwares.delete_firmware(firmware)
   end
@@ -236,6 +237,7 @@ defmodule NervesHubWebCore.FirmwaresTest do
       firmware = Fixtures.firmware_fixture(org_key, product)
 
       params = %{
+        org_id: org.id,
         firmware_id: firmware.id,
         name: "firmware ttl",
         conditions: %{
@@ -261,6 +263,7 @@ defmodule NervesHubWebCore.FirmwaresTest do
       firmware = Fixtures.firmware_fixture(org_key, product)
 
       params = %{
+        org_id: org.id,
         firmware_id: firmware.id,
         name: "firmware ttl",
         conditions: %{

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/endpoint.ex
@@ -32,8 +32,7 @@ defmodule NervesHubWWWWeb.Endpoint do
     socket(
       "/phoenix/live_reload/socket",
       Phoenix.LiveReloader.Socket,
-      websocket: true,
-      long_polling: true
+      websocket: true
     )
 
     plug(Phoenix.LiveReloader)

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -163,7 +163,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
     } do
       product = Fixtures.product_fixture(user, org)
       firmware = Fixtures.firmware_fixture(org_key, product)
-      deployment = Fixtures.deployment_fixture(firmware)
+      deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =
         get(conn, Routes.deployment_path(conn, :edit, org.name, product.name, deployment.name))
@@ -184,7 +184,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
     } do
       product = Fixtures.product_fixture(user, org)
       firmware = Fixtures.firmware_fixture(org_key, product)
-      deployment = Fixtures.deployment_fixture(firmware)
+      deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =
         put(
@@ -243,7 +243,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
     } do
       product = Fixtures.product_fixture(user, org)
       firmware = Fixtures.firmware_fixture(org_key, product)
-      deployment = Fixtures.deployment_fixture(firmware)
+      deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =
         delete(

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -200,11 +200,12 @@ defmodule NervesHubWebCore.Fixtures do
   end
 
   def deployment_fixture(
+        %Org{} = org,
         %Firmwares.Firmware{} = firmware,
         params \\ %{}
       ) do
     {:ok, deployment} =
-      %{firmware_id: firmware.id}
+      %{org_id: org.id, firmware_id: firmware.id}
       |> Enum.into(params)
       |> Enum.into(@deployment_params)
       |> Deployments.create_deployment()
@@ -258,7 +259,7 @@ defmodule NervesHubWebCore.Fixtures do
     product = product_fixture(user, org, %{name: "Hop"})
     org_key = org_key_fixture(org)
     firmware = firmware_fixture(org_key, product)
-    deployment = deployment_fixture(firmware)
+    deployment = deployment_fixture(org, firmware)
     device = device_fixture(org, product, firmware)
     %{db_cert: device_certificate} = device_certificate_fixture(device)
 
@@ -281,7 +282,7 @@ defmodule NervesHubWebCore.Fixtures do
 
     org_key = org_key_fixture(org)
     firmware = firmware_fixture(org_key, product)
-    deployment = deployment_fixture(firmware)
+    deployment = deployment_fixture(org, firmware)
     device = device_fixture(org, product, firmware, %{tags: ["beta", "beta-edge"]})
     %{db_cert: device_certificate} = device_certificate_fixture(device)
 
@@ -303,7 +304,7 @@ defmodule NervesHubWebCore.Fixtures do
     product = product_fixture(user, org, %{name: "Smart Rent Thing"})
     org_key = org_key_fixture(org)
     firmware = firmware_fixture(org_key, product)
-    deployment = deployment_fixture(firmware)
+    deployment = deployment_fixture(org, firmware)
     device = device_fixture(org, product, firmware, %{identifier: "smartrent_1234"})
     %{db_cert: device_certificate} = device_certificate_fixture(device)
 


### PR DESCRIPTION
This PR adds org_id to firmwares, device_certificates, deployments, and audit_logs. This reference is being added so it is easy to get to when creating audit logs on resources of these types. 