### PR TITLE
Add device connect audit logs.

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -30,7 +30,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
 
   def join("device", params, %{assigns: %{device: device}} = socket) do
     with {:ok, device} <- update_metadata(device, params),
-         {:ok, device} <- Devices.received_communication(device) do
+         {:ok, device} <- Devices.device_connected(device) do
       Phoenix.PubSub.subscribe(NervesHubWeb.PubSub, "device:#{device.id}")
       deployments = Devices.get_eligible_deployments(device)
       join_reply = Devices.resolve_update(device, deployments)

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/plugs/device.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/plugs/device.ex
@@ -17,7 +17,7 @@ defmodule NervesHubDeviceWeb.Plugs.Device do
          {:ok, device} <- Devices.get_device_by_certificate(cert),
          {:ok, metadata} <- Firmwares.metadata_from_conn(conn),
          {:ok, device} <- Devices.update_firmware_metadata(device, metadata),
-         {:ok, device} <- Devices.received_communication(device) do
+         {:ok, device} <- Devices.device_connected(device) do
       assign(conn, :device, device)
     else
       _err ->

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
@@ -221,6 +221,16 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
     %{audit_log | description: description}
   end
 
+  def create_description(
+        %{params: %{last_communication: _}} = audit_log,
+        %Device{} = actor,
+        %Device{}
+      ) do
+    desc = "#{identifier_for(actor)} connected to the server"
+
+    %{audit_log | description: desc}
+  end
+
   def create_description(audit_log, actor, resource) do
     desc =
       "#{identifier_for(actor)} performed unknown #{audit_log.action} on #{

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -286,7 +286,7 @@ defmodule NervesHubWebCore.Devices do
     Repo.delete(ca_certificate)
   end
 
-  def received_communication(device) do
+  def device_connected(device) do
     last_communication = DateTime.utc_now()
 
     AuditLogs.audit!(device, device, :update, %{

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -287,7 +287,13 @@ defmodule NervesHubWebCore.Devices do
   end
 
   def received_communication(device) do
-    update_device(device, %{last_communication: DateTime.utc_now()})
+    last_communication = DateTime.utc_now()
+
+    AuditLogs.audit!(device, device, :update, %{
+      last_communication: last_communication
+    })
+
+    update_device(device, %{last_communication: last_communication})
   end
 
   def update_firmware_metadata(device, nil) do

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHubWebCore.DevicesTest do
 
   alias NervesHubWebCore.{
     Accounts,
+    AuditLogs,
     AuditLogs.AuditLog,
     Fixtures,
     Devices,
@@ -550,5 +551,12 @@ defmodule NervesHubWebCore.DevicesTest do
     end)
 
     assert Devices.failure_threshold_met?(device, deployment)
+  end
+
+  test "received_communication adds audit log", %{device: device} do
+    assert AuditLogs.logs_for(device) == []
+    Devices.received_communication(device)
+    assert [%AuditLog{description: desc}] = AuditLogs.logs_for(device)
+    assert desc =~ "device #{device.identifier} connected to the server"
   end
 end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -553,9 +553,9 @@ defmodule NervesHubWebCore.DevicesTest do
     assert Devices.failure_threshold_met?(device, deployment)
   end
 
-  test "received_communication adds audit log", %{device: device} do
+  test "device_connected adds audit log", %{device: device} do
     assert AuditLogs.logs_for(device) == []
-    Devices.received_communication(device)
+    Devices.device_connected(device)
     assert [%AuditLog{description: desc}] = AuditLogs.logs_for(device)
     assert desc =~ "device #{device.identifier} connected to the server"
   end


### PR DESCRIPTION
Add an audit log record when a device successfully connects to NervesHub