### PR TITLE
Issue #458: Add error handling when deleting firmware with associated deployments

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -41,6 +41,16 @@ defmodule NervesHubAPIWeb.FirmwareController do
     with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
          :ok <- Firmwares.delete_firmware(firmware) do
       send_resp(conn, :no_content, "")
+    else
+      {:error, %Ecto.Changeset{errors: [deployments: _]}} ->
+        send_resp(conn, :conflict, "Firmware has associated deployments")
+
+      {:error, _} ->
+        send_resp(
+          conn,
+          :internal_server_error,
+          "Oops! Something went wrong.  Please try again..."
+        )
     end
   end
 end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/firmware_controller_test.exs
@@ -73,6 +73,20 @@ defmodule NervesHubAPIWeb.FirmwareControllerTest do
 
       assert response(conn, 404)
     end
+
+    test "firmware delete with associated deployment", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      Fixtures.deployment_fixture(org, firmware)
+
+      conn =
+        delete(conn, Routes.firmware_path(conn, :delete, org.name, product.name, firmware.uuid))
+
+      assert response(conn, 409)
+    end
   end
 
   defp create_firmware(%{org: org, product: product}) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -93,11 +93,18 @@ defmodule NervesHubWWWWeb.FirmwareController do
   end
 
   def delete(%{assigns: %{org: org, product: product}} = conn, %{"firmware_uuid" => uuid}) do
-    with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
-         :ok <- Firmwares.delete_firmware(firmware) do
-      conn
-      |> put_flash(:info, "Firmware successfully deleted")
-      |> redirect(to: Routes.firmware_path(conn, :index, org.name, product.name))
+    with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid) do
+      case Firmwares.delete_firmware(firmware) do
+        :ok ->
+          conn
+          |> put_flash(:info, "Firmware successfully deleted")
+          |> redirect(to: Routes.firmware_path(conn, :index, org.name, product.name))
+
+        {:error, %Ecto.Changeset{errors: [deployments: _]}} ->
+          conn
+          |> put_flash(:error, "Firmware has associated deployments")
+          |> redirect(to: Routes.firmware_path(conn, :index, org.name, product.name))
+      end
     end
   end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
@@ -190,6 +190,25 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
       assert redirected_to(conn) == Routes.firmware_path(conn, :index, org.name, product.name)
       assert Firmwares.get_firmware(org, firmware.id) == {:error, :not_found}
     end
+
+    test "error when firmware has associated deployments", %{
+      conn: conn,
+      user: user,
+      org: org
+    } do
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+
+      # Create a deployment from the firmware
+      Fixtures.deployment_fixture(org, firmware)
+
+      conn =
+        delete(conn, Routes.firmware_path(conn, :delete, org.name, product.name, firmware.uuid))
+
+      assert redirected_to(conn) == Routes.firmware_path(conn, :index, org.name, product.name)
+      assert get_flash(conn, :error) =~ "Firmware has associated deployments"
+    end
   end
 
   describe "download firmware" do


### PR DESCRIPTION
Closes #458 

Adds an error flash message when trying to delete a firmware that has associated deployments.