### PR TITLE
allow spaces to delimit in tag field

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/types.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/types.ex
@@ -10,18 +10,14 @@ defmodule NervesHubWebCore.Types do
 
     def cast(tags) when is_bitstring(tags) do
       tags
-      |> String.split(",", trim: true)
+      |> String.split([" ", ","], trim: true)
       |> Stream.map(&String.trim/1)
       |> Enum.reject(&(byte_size(&1) == 0))
       |> cast()
     end
 
     def cast(tags) when is_list(tags) do
-      if Enum.any?(tags, &(32 in to_charlist(&1))) do
-        {:error, message: "tags cannot contain spaces"}
-      else
-        Ecto.Type.cast(type(), tags)
-      end
+      Ecto.Type.cast(type(), tags)
     end
 
     def cast(_tag), do: :error

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/types_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/types_test.exs
@@ -37,4 +37,24 @@ defmodule NervesHubWebCore.TypesTest do
       assert Types.Resource.load(to_string(AuditLog)) == {:ok, AuditLog}
     end
   end
+
+  describe "tag" do
+    test "type" do
+      assert Types.Tag.type() == {:array, :string}
+    end
+
+    test "cast" do
+      # Valid cast
+      assert Types.Tag.cast("foo, bar") == {:ok, ["foo", "bar"]}
+      assert Types.Tag.cast("foo, bar baz") == {:ok, ["foo", "bar", "baz"]}
+
+      assert Types.Tag.cast("dont forget to like and subscribe") ==
+               {:ok, ["dont", "forget", "to", "like", "and", "subscribe"]}
+
+      assert Types.Tag.cast(["foo", "bar"]) == {:ok, ["foo", "bar"]}
+
+      # Invalid cast
+      assert Types.Tag.cast(:some_atom) == :error
+    end
+  end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
@@ -15,7 +15,7 @@
 
 <%= form_for @changeset, "#", [phx_change: :validate, phx_submit: :save], fn f -> %>
   <div class="form-group">
-    <label for="tags"><strong>Tags</strong> <i>(comma delimited)<i/></label>
+    <label for="tags"><strong>Tags</strong> <i>(separated by spaces or commas)<i/></label>
     <%= text_input f, :tags, class: "form-control", id: "tags", value: tags_to_string(@changeset) %>
     <div class="has-error"><%= error_tag f, :tags %></div>
   </div>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_edit_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_edit_test.exs
@@ -21,7 +21,7 @@ defmodule NervesHubWWWWeb.DeviceLiveEditTest do
     end
 
     test "invalid tags prevent submit", %{conn: conn, fixture: fixture} do
-      params = %{"device" => %{tags: "this is one invalid tag"}}
+      params = %{"device" => %{tags: " "}}
 
       {:ok, view, _html} = live(conn, device_path(fixture, :edit))
 
@@ -30,7 +30,7 @@ defmodule NervesHubWWWWeb.DeviceLiveEditTest do
       error_text = Floki.find(html, "span.help-block") |> Floki.text()
 
       assert button_disabled == "disabled"
-      assert error_text == "tags cannot contain spaces"
+      assert error_text == "should have at least 1 item(s)"
     end
   end
 


### PR DESCRIPTION
Hi @jjcarstens et al,
I noticed tags were not allowed to be delimited by spaces. It seems they were also not allowed to contain spaces, so I whipped up this PR (i hope you dont mind not discussing it with you first) to support space and/or comma delimited lists in tags. 
If there is some other reason not to support this or if you just dont like it, feel free to close it.