### PR TITLE
500 on invite

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -76,8 +76,7 @@ defmodule NervesHubWWWWeb.AccountController do
   end
 
   def accept_invite(conn, %{"user" => user_params, "token" => token} = _) do
-    clean_params =
-      whitelist(user_params, [:password, :username]) |> IO.inspect(label: "CLEAN PARAMS")
+    clean_params = whitelist(user_params, [:password, :username])
 
     with {:ok, invite} <- Accounts.get_valid_invite(token),
          {:ok, org} <- Accounts.get_org(invite.org_id) do
@@ -85,7 +84,6 @@ defmodule NervesHubWWWWeb.AccountController do
              Accounts.create_user_from_invite(invite, org, clean_params) do
         # Now let everyone in the organization - except the new guy -
         # know about this new user.
-        IO.inspect(new_org_user.user.username, label: "NEWUSER")
         instigator = new_org_user.user.username
 
         email =

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -76,7 +76,8 @@ defmodule NervesHubWWWWeb.AccountController do
   end
 
   def accept_invite(conn, %{"user" => user_params, "token" => token} = _) do
-    clean_params = whitelist(user_params, [:password, :username])
+    clean_params =
+      whitelist(user_params, [:password, :username]) |> IO.inspect(label: "CLEAN PARAMS")
 
     with {:ok, invite} <- Accounts.get_valid_invite(token),
          {:ok, org} <- Accounts.get_org(invite.org_id) do
@@ -84,7 +85,8 @@ defmodule NervesHubWWWWeb.AccountController do
              Accounts.create_user_from_invite(invite, org, clean_params) do
         # Now let everyone in the organization - except the new guy -
         # know about this new user.
-        instigator = conn.assigns.user.username
+        IO.inspect(new_org_user.user.username, label: "NEWUSER")
+        instigator = new_org_user.user.username
 
         email =
           Email.tell_org_user_added(


### PR DESCRIPTION
Fixes #472 

I noticed this issue as well today. Turns out the conn.assigns does not hold the user info at this point, so it was raising. The username is readily available from the params though so it was an easy fix. i didnt have time to research when this might have started happening (or find the commit.) But I suspect if you have Honeybadger or Rollbar, etc hooked up it would be easier to track down by looking for when the `(KeyError) key :user not found in: %{}` errors started coming in.