### PR TITLE
Only show instigator when available

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
@@ -43,13 +43,20 @@ defmodule NervesHubWebCore.Accounts.Email do
       generate_org_users_emails(org_users)
       |> Enum.filter(fn email -> email != new_user.email end)
 
+    email_subject =
+      if instigator do
+        "[NervesHub] User #{instigator} added #{new_user.username} to #{org.name}"
+      else
+        "[NervesHub] User #{new_user.username} added to #{org.name}"
+      end
+
     new_email()
     |> from(@from)
-    |> subject("[NervesHub] User #{instigator} added #{new_user.username} to #{org.name}")
+    |> subject(email_subject)
     |> to(@from)
     |> bcc(org_users_emails)
     |> put_layout({NervesHubWebCore.EmailView, :layout})
-    |> render("tell_org_user_added.html", instigator: instigator, user: new_user, org: org)
+    |> render("tell_org_user_added.html", user: new_user, org: org)
   end
 
   @doc """

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -84,7 +84,14 @@ defmodule NervesHubWWWWeb.AccountController do
              Accounts.create_user_from_invite(invite, org, clean_params) do
         # Now let everyone in the organization - except the new guy -
         # know about this new user.
-        instigator = new_org_user.user.username
+
+        # TODO: Fix this - We don't have the instigating user in the conn
+        # anymore, and the new user is not always the instigator.
+        instigator =
+          case conn.assigns do
+            %{user: %{username: username}} -> username
+            _ -> nil
+          end
 
         email =
           Email.tell_org_user_added(


### PR DESCRIPTION
So turns out https://github.com/nerves-hub/nerves_hub_web/pull/574 had a little more complications. The fix was actually using the new user as the instigator of the invite, but that's not always the situation.

So this shims things a bit to fix the tests and put us back in a good state. We should circle back and decide if we care to have the user add instigator in the email to everyone. And if so, how to better handle it