### PR TITLE
Issue #582 - add user invite link to org users page

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_user_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_user_controller.ex
@@ -7,7 +7,8 @@ defmodule NervesHubWWWWeb.OrgUserController do
     conn
     |> render(
       "index.html",
-      org_users: Accounts.get_org_users(org)
+      org_users: Accounts.get_org_users(org),
+      org: org
     )
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -4,6 +4,14 @@
       User Roles
     </h2>
   </div>
+  <%= if @org.type != :user do %>
+  <div class="col-3 mr-auto table-head-link">
+    <a href="<%= Routes.org_path(@conn, :invite, @org.name) %>">
+      <span class="fa fa-plus fa-fw mr-3"></span>
+      <span class="text">Invite user</span>
+    </a>
+  </div>
+  <% end %>
 </div>
 <div class="row">
   <table class="table table-sm table-hover">

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
@@ -16,5 +16,15 @@ defmodule NervesHubWWWWeb.OrgUserControllerTest do
         assert html_response(conn, 200) =~ org_user.user.username
       end)
     end
+
+    test "user is able to invite users to org", %{conn: conn, org: org} do
+      conn = get(conn, Routes.org_user_path(conn, :index, org.name))
+      assert html_response(conn, 200) =~ "Invite user"
+    end
+
+    test "user is unable to invite users to user org", %{conn: conn, user: user} do
+      conn = get(conn, Routes.org_user_path(conn, :index, user.username))
+      refute html_response(conn, 200) =~ "Invite user"
+    end
   end
 end


### PR DESCRIPTION
* Add "Invite user" link to an organization's users page when the organization is not the current user

closes #582 