### PR TITLE
move firmware deletion error message into context

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -42,8 +42,8 @@ defmodule NervesHubAPIWeb.FirmwareController do
          :ok <- Firmwares.delete_firmware(firmware) do
       send_resp(conn, :no_content, "")
     else
-      {:error, %Ecto.Changeset{errors: [deployments: _]}} ->
-        send_resp(conn, :conflict, "Firmware has associated deployments")
+      {:error, %Ecto.Changeset{errors: [deployments: {reason, _}]}} ->
+        send_resp(conn, :conflict, reason)
 
       {:error, _} ->
         send_resp(

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
@@ -77,7 +77,7 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
   def delete_changeset(%Firmware{} = firmware, params) do
     firmware
     |> cast(params, @required_params ++ @optional_params)
-    |> foreign_key_constraint(:deployments, name: :deployments_firmware_id_fkey)
+    |> no_assoc_constraint(:deployments, message: "Firmware has associated deployments")
   end
 
   defp validate_limits(%Ecto.Changeset{changes: %{org_id: org_id}} = cs) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -97,8 +97,8 @@ defmodule NervesHubWWWWeb.FirmwareController do
          :ok <- Firmwares.delete_firmware(firmware) do
       put_flash(conn, :info, "Firmware successfully deleted")
     else
-      {:error, %Ecto.Changeset{errors: [deployments: _]}} ->
-        put_flash(conn, :error, "Firmware has associated deployments")
+      {:error, %Ecto.Changeset{errors: [deployments: {reason, _}]}} ->
+        put_flash(conn, :error, reason)
 
       {:error, _} ->
         put_flash(conn, :error, "Oops! Something went wrong.  Please try again...")


### PR DESCRIPTION
* Fix duplication of error message when deleting firmware that has an associated deployment
  * Move error message from `NervesHubWWWWeb.FirmwareController` and `NervesHubAPIWeb.FirmwareController` into `NervesHubWebCore.Firmwares.Firmware`
context to remove the need to update the error message in multiple places.