### PR TITLE
Fix connections for devices with trusted certificates

### DIFF
--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -119,9 +119,10 @@ defmodule NervesHubWebCore.Fixtures do
     org_key
   end
 
-  def ca_certificate_fixture(%Accounts.Org{} = org) do
+  def ca_certificate_fixture(%Accounts.Org{} = org, opts \\ []) do
+    opts = Keyword.merge([template: :root_ca], opts)
     ca_key = X509.PrivateKey.new_ec(:secp256r1)
-    ca = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", template: :root_ca)
+    ca = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", opts)
 
     {not_before, not_after} = NervesHubWebCore.Certificate.get_validity(ca)
 


### PR DESCRIPTION
This fixes the SSL verify_fun to support allowing certificates from devices with expired ca's. The CA cert needs to remain in the database even after it has expired for this to work.