### PR TITLE
Restrict organization names

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/org_user_controller_test.exs
@@ -6,7 +6,7 @@ defmodule NervesHubAPIWeb.OrgUserControllerTest do
   alias NervesHubWebCore.Accounts
 
   setup context do
-    org = Fixtures.org_fixture(context.user, %{name: "api test"})
+    org = Fixtures.org_fixture(context.user, %{name: "api_test"})
     Map.put(context, :org, org)
   end
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
@@ -5,7 +5,7 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
   alias NervesHubWebCore.{Accounts, Products}
 
   setup context do
-    org = Fixtures.org_fixture(context.user, %{name: "api test"})
+    org = Fixtures.org_fixture(context.user, %{name: "api_test"})
     Map.put(context, :org, org)
   end
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_user_controller_test.exs
@@ -5,7 +5,7 @@ defmodule NervesHubAPIWeb.ProductUserControllerTest do
   alias NervesHubWebCore.Products
 
   setup context do
-    org = Fixtures.org_fixture(context.user, %{name: "api test"})
+    org = Fixtures.org_fixture(context.user, %{name: "api_test"})
     product = Fixtures.product_fixture(context.user, org, %{name: "api"})
 
     context

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
@@ -231,7 +231,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
 
   describe "Custom CA Signers" do
     test "vaild certificate can connect", %{user: user} do
-      org = Fixtures.org_fixture(user, %{name: "custom ca test"})
+      org = Fixtures.org_fixture(user, %{name: "custom_ca_test"})
       {device, _firmware} = device_fixture(user, %{identifier: @valid_serial}, org)
 
       %{cert: ca, key: ca_key} = Fixtures.ca_certificate_fixture(org)
@@ -275,7 +275,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
     end
 
     test "vaild certificate expired signer can connect", %{user: user} do
-      org = Fixtures.org_fixture(user, %{name: "custom ca test"})
+      org = Fixtures.org_fixture(user, %{name: "custom_ca_test"})
       {device, _firmware} = device_fixture(user, %{identifier: @valid_serial}, org)
 
       not_before = Timex.now() |> Timex.shift(days: -1)
@@ -331,7 +331,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
     end
 
     test "ca signer last used is updated", %{user: user} do
-      org = Fixtures.org_fixture(user, %{name: "ca cert is updated"})
+      org = Fixtures.org_fixture(user, %{name: "ca_cert_is_updated"})
 
       {device, _firmware} = device_fixture(user, %{identifier: @valid_serial}, org)
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org.ex
@@ -42,6 +42,7 @@ defmodule NervesHubWebCore.Accounts.Org do
     |> cast(params, @params)
     |> validate_required(@params)
     |> unique_constraint(:name)
+    |> validate_format(:name, ~r/^[A-Za-z0-9-_]+$/)
   end
 
   def add_user(struct, params) do

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -29,6 +29,11 @@ defmodule NervesHubWebCore.AccountsTest do
     assert {:error, %Changeset{}} = Accounts.create_org(user, @required_org_params)
   end
 
+  test "create_org with invalid characters", %{user: user} do
+    assert {:error, %Changeset{}} = Accounts.create_org(user, %{name: "Org with space"})
+    assert {:error, %Changeset{}} = Accounts.create_org(user, %{name: "Org with %"})
+  end
+
   test "create_org_limits with defaults", %{user: user} do
     {:ok, %Org{} = result_org} = Accounts.create_org(user, @required_org_params)
     limits = Accounts.get_org_limit_by_org_id(result_org.id)

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -68,7 +68,7 @@ defmodule NervesHubWebCore.AccountsTest do
 
   test "create_org with user" do
     user = Fixtures.user_fixture()
-    {:ok, %Org{} = org1} = Accounts.create_org(user, %{name: "An Org"})
+    {:ok, %Org{} = org1} = Accounts.create_org(user, %{name: "An_Org"})
     assert org1 in Accounts.get_user_orgs(user)
   end
 
@@ -283,7 +283,7 @@ defmodule NervesHubWebCore.AccountsTest do
     first_id = org.id
     org_key = Fixtures.org_key_fixture(org)
 
-    other_org = Fixtures.org_fixture(user, %{name: "another org"})
+    other_org = Fixtures.org_fixture(user, %{name: "another_org"})
 
     assert {:ok, %OrgKey{org_id: ^first_id}} =
              Accounts.update_org_key(org_key, %{org_id: other_org.id})

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -59,7 +59,7 @@ defmodule NervesHubWebCore.DevicesTest do
   end
 
   test "org cannot have too many devices", %{user: user} do
-    org = Fixtures.org_fixture(user, %{name: "an org with no devices"})
+    org = Fixtures.org_fixture(user, %{name: "an_org_with_no_devices"})
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)
@@ -88,7 +88,7 @@ defmodule NervesHubWebCore.DevicesTest do
   end
 
   test "org device count limit can be raised", %{user: user} do
-    org = Fixtures.org_fixture(user, %{name: "an org with no devices"})
+    org = Fixtures.org_fixture(user, %{name: "an_org_with_no_devices"})
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org)
     firmware = Fixtures.firmware_fixture(org_key, product)

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -65,7 +65,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
 
     test "redirects to firmware upload firmware_id is passed and no firmwares are found" do
       user = Fixtures.user_fixture(%{email: "new@org.com"})
-      org = Fixtures.org_fixture(user, %{name: "empty org"})
+      org = Fixtures.org_fixture(user, %{name: "empty_org"})
       product = Fixtures.product_fixture(user, org)
 
       conn =

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -12,8 +12,8 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
   describe "create org" do
     test "redirects to edit when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.org_path(conn, :create), org: %{name: "An Org"})
-      assert redirected_to(conn) == Routes.product_path(conn, :index, "An Org")
+      conn = post(conn, Routes.org_path(conn, :create), org: %{name: "An_Org"})
+      assert redirected_to(conn) == Routes.product_path(conn, :index, "An_Org")
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -30,7 +30,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
     test "does not render form for org not on conn", %{conn: conn} do
       user = Fixtures.user_fixture(%{name: "secret-user"})
-      new_org = Fixtures.org_fixture(user, %{name: "Secret Org Name"})
+      new_org = Fixtures.org_fixture(user, %{name: "Secret_Org_Name"})
       conn = get(conn, Routes.org_path(conn, :edit, new_org.name))
       assert html_response(conn, 404)
     end
@@ -39,10 +39,10 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
   describe "update org" do
     test "cannot update wrong org", %{conn: conn} do
       user = Fixtures.user_fixture(%{email: "new@org.com"})
-      new_org = Fixtures.org_fixture(user, %{name: "Secret Org Name"})
+      new_org = Fixtures.org_fixture(user, %{name: "Secret_Org_Name"})
 
       conn =
-        put(conn, Routes.org_path(conn, :update, new_org.name), org: %{name: "Nefarious Name"})
+        put(conn, Routes.org_path(conn, :update, new_org.name), org: %{name: "Nefarious_Name"})
 
       assert html_response(conn, 404)
 
@@ -53,13 +53,13 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
       updated_conn = get(new_conn, Routes.org_path(conn, :edit, new_org.name))
 
-      refute html_response(updated_conn, 200) =~ "Nefarious Name"
+      refute html_response(updated_conn, 200) =~ "Nefarious_Name"
     end
 
     test "redirects when data is valid", %{conn: conn, org: org} do
-      conn = put(conn, Routes.org_path(conn, :update, org.name), org: %{name: "new name"})
+      conn = put(conn, Routes.org_path(conn, :update, org.name), org: %{name: "new_name"})
 
-      assert redirected_to(conn) == Routes.org_path(conn, :edit, "new name")
+      assert redirected_to(conn) == Routes.org_path(conn, :edit, "new_name")
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/session_controller_test.exs
@@ -11,7 +11,7 @@ defmodule NervesHubWWWWeb.SessionControllerTest do
         password: "password"
       })
 
-    org = Fixtures.org_fixture(user, %{name: "my test org 1"})
+    org = Fixtures.org_fixture(user, %{name: "my_test_org_1"})
     {:ok, %{user: user, org: org}}
   end
 


### PR DESCRIPTION
It seems the nerves_hub cli cannot deal with spaces, so I added a bit of validation for that. It's way more restricting than just spaces though `~r/^[A-Za-z0-9-_]+$`. If that's to restricted feel free to adjust the regex.