### PR TITLE
Send firmware metadata to device in update message

### DIFF
--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/websocket_test.exs
@@ -146,7 +146,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
       {:ok, socket} = Socket.start_link(@ssl_socket_config)
       wait_for_socket(socket)
       {:ok, reply, _channel} = Channel.join(socket, "device")
-      assert %{"update_available" => true, "firmware_url" => _} = reply
+      assert %{"update_available" => true, "firmware_url" => _, "firmware_meta" => %{}} = reply
 
       device =
         Device
@@ -195,7 +195,7 @@ defmodule NervesHubDeviceWeb.WebsocketTest do
       assert_receive(
         %Phoenix.Socket.Broadcast{
           event: "update",
-          payload: %{firmware_url: _f_url}
+          payload: %{firmware_url: _f_url, firmware_meta: %{}}
         },
         1000
       )

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/deployments/deployments_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/deployments/deployments_test.exs
@@ -2,7 +2,7 @@ defmodule NervesHubWebCore.DeploymentsTest do
   use NervesHubWebCore.DataCase, async: false
   use Phoenix.ChannelTest
 
-  alias NervesHubWebCore.{AuditLogs.AuditLog, Deployments, Fixtures}
+  alias NervesHubWebCore.{AuditLogs.AuditLog, Deployments, Fixtures, Firmwares}
   alias Ecto.Changeset
 
   setup do
@@ -125,8 +125,10 @@ defmodule NervesHubWebCore.DeploymentsTest do
         |> elem(1)
         |> Deployments.update_deployment(%{is_active: true})
 
+      {:ok, meta} = Firmwares.metadata_from_firmware(new_firmware)
+
       assert [^device] = Deployments.fetch_relevant_devices(deployment)
-      assert_broadcast("update", %{firmware_url: _f_url}, 500)
+      assert_broadcast("update", %{firmware_url: _f_url, firmware_meta: ^meta}, 500)
     end
 
     test "does not update incorrect devices", %{
@@ -165,7 +167,9 @@ defmodule NervesHubWebCore.DeploymentsTest do
           |> elem(1)
           |> Deployments.update_deployment(%{is_active: true})
 
-        refute_broadcast("update", %{firmware_url: _f_url})
+        {:ok, meta} = Firmwares.metadata_from_firmware(new_firmware)
+
+        refute_broadcast("update", %{firmware_url: _f_url, firmware_meta: ^meta})
       end
     end
 
@@ -197,7 +201,9 @@ defmodule NervesHubWebCore.DeploymentsTest do
         |> elem(1)
         |> Deployments.update_deployment(%{is_active: true, healthy: false})
 
-      refute_broadcast("update", %{firmware_url: _f_url})
+      {:ok, meta} = Firmwares.metadata_from_firmware(new_firmware)
+
+      refute_broadcast("update", %{firmware_url: _f_url, firmware_meta: ^meta})
     end
 
     test "does not update devices if device in unhealthy state", %{
@@ -233,7 +239,9 @@ defmodule NervesHubWebCore.DeploymentsTest do
         |> elem(1)
         |> Deployments.update_deployment(%{is_active: true})
 
-      refute_broadcast("update", %{firmware_url: _f_url})
+      {:ok, meta} = Firmwares.metadata_from_firmware(new_firmware)
+
+      refute_broadcast("update", %{firmware_url: _f_url, firmware_meta: ^meta})
     end
 
     test "failure_threshold_met?", %{

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -500,7 +500,8 @@ defmodule NervesHubWebCore.DevicesTest do
         %{
           deployment: ^deployment,
           deployment_id: ^deployment_id,
-          firmware_url: _
+          firmware_url: _,
+          firmware_meta: %{}
         }
       )
     end
@@ -525,9 +526,10 @@ defmodule NervesHubWebCore.DevicesTest do
       firmware: firmware
     } do
       result = Devices.resolve_update(device, deployment)
-
+      {:ok, meta} = Firmwares.metadata_from_firmware(firmware)
       assert result.update_available
       assert result.firmware_url =~ firmware.uuid
+      assert result.firmware_meta.uuid == meta.uuid
     end
   end
 


### PR DESCRIPTION
When sending an update to a device, pass all firmware metadata. This information is useful to present when determining if the client should choose to apply the update.