### PR TITLE
Fix live view deployment activate button

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/deployment_live/show.ex
@@ -84,7 +84,7 @@ defmodule NervesHubWWWWeb.DeploymentLive.Show do
 
   def handle_event(
         "toggle_active",
-        value,
+        %{"isactive" => value},
         %{assigns: %{deployment: deployment, user: user}} = socket
       ) do
     {:ok, updated_deployment} = Deployments.update_deployment(deployment, %{is_active: value})

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -62,7 +62,7 @@
   Edit Deployment
 </a>
 
-<a class="btn btn-primary mr-3" phx-click="toggle_active" phx-value=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
+<a class="btn btn-primary mr-3" phx-click="toggle_active" phx-value-isactive=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
 
 <%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
   <%= submit "Mark #{if @deployment.healthy, do: "Unhealthy", else: "Healthy"}", class: "btn btn-primary mr-3" %>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/deployment_live_show_test.exs
@@ -17,7 +17,7 @@ defmodule NervesHubWWWWeb.DeploymentLiveShowTest do
 
       before_audit_count = AuditLogs.logs_for(deployment) |> length
 
-      assert render_click(view, :toggle_active, "true") =~ "Make Inactive"
+      assert render_click(view, :toggle_active, %{"isactive" => "true"}) =~ "Make Inactive"
 
       # assert_broadcast("reboot", %{})
 
@@ -36,7 +36,7 @@ defmodule NervesHubWWWWeb.DeploymentLiveShowTest do
 
       before_audit_count = AuditLogs.logs_for(deployment) |> length
 
-      assert render_click(view, :toggle_active, "false") =~ "Make Active"
+      assert render_click(view, :toggle_active, %{"isactive" => "false"}) =~ "Make Active"
 
       # assert_broadcast("reboot", %{})
 


### PR DESCRIPTION
Phoenix live view was updated and the behavior of `phx-value` changed to `phx-value-<var>`. This updates the show page on deployments to fix the activate / deactivate button.