### PR TITLE
Hard set device websocket messages to use V2 serializer

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/endpoint.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/endpoint.ex
@@ -5,7 +5,9 @@ defmodule NervesHubDeviceWeb.Endpoint do
     "/socket",
     NervesHubDeviceWeb.UserSocket,
     websocket: [
-      connect_info: [:peer_data, :x_headers]
+      connect_info: [:peer_data, :x_headers],
+      # Force all websocket messages to go through V2 serializer
+      serializer: [{Phoenix.Socket.V2.JSONSerializer, ">= 1.0.0"}]
     ]
   )
 


### PR DESCRIPTION
Based on the [`Phoenix.Socket` docs](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/socket.ex#L92-L95), I assumed all websocket messages used the `Phoenix.Socket.V2.JSONSerializer`. But from some recent experiements have learned
this is not the case and the statement in the docs refers to the `phoenix.js` socket lib setting `vsn=2.0.0` for you in the connect params.

We've recently documented the websocket API which conforms to this V2 structure, so this just sets that in place to force all messages to use V2.JSONSerializer without the extra requirement of setting `vsn=2.0.0` in the connect params and removes the need to document both versions.