### PR TITLE
Add an index to audit_logs params->firmware_uuid

### DIFF
--- a/apps/nerves_hub_web_core/priv/repo/migrations/20200425222430_add_metadata_index_to_audit_logs.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20200425222430_add_metadata_index_to_audit_logs.exs
@@ -1,0 +1,11 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddMetadataIndexToAuditLogs do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE INDEX audit_param_firmware_uuid ON audit_logs((params->'firmware_uuid'));")
+  end
+
+  def down do
+    execute("DROP INDEX audit_param_firmware_uuid")
+  end
+end


### PR DESCRIPTION
There are some log running queries that take place on the audit logs table from using jsonb values in the where part. I think this could help them along. 