### PR TITLE
Send CTL-L when loading the console page

### DIFF
--- a/apps/nerves_hub_www/assets/js/console.js
+++ b/apps/nerves_hub_www/assets/js/console.js
@@ -29,6 +29,8 @@ export default class IEx {
       .join()
       .receive('ok', () => {
         console.log('JOINED')
+        // Push CTL-L to refresh form line
+        channel.push('dn', { data: '\f' })
       })
       .receive('error', () => {
         console.log('ERROR')


### PR DESCRIPTION
This will refresh the line to make it appear on the page rather than have a blank black console screen