### PR TITLE
Fix fixtures, NervesTeam org name

### DIFF
--- a/apps/nerves_hub_web_core/priv/repo/seeds.exs
+++ b/apps/nerves_hub_web_core/priv/repo/seeds.exs
@@ -53,7 +53,7 @@ defmodule NervesHubWebCore.SeedHelpers do
 
     user = Fixtures.user_fixture(root_user_params)
     [default_user_org | _] = Accounts.get_user_orgs(user)
-    org = Fixtures.org_fixture(user, %{name: "Nerves Team"})
+    org = Fixtures.org_fixture(user, %{name: "NervesTeam"})
     for _ <- 0..2, do: Fixtures.org_key_fixture(org)
     for _ <- 0..2, do: Fixtures.org_key_fixture(default_user_org)
 


### PR DESCRIPTION
The fixtures fail because `Nerves Team` is an invalid Organization name.

Fixes:
```
** (MatchError) no match of right hand side value: {:error, #Ecto.Changeset<action: :insert, changes: %{name: "Nerves Team"}, errors: [name: {"has invalid format", [validation: :format]}], data: #NervesHubWebCore.Accounts.Org<>, valid?: false>}
    (nerves_hub_api 0.1.0) /Users/acrogenesis/Development/valiot/nerves_hub_web/test/support/fixtures.ex:104: NervesHubWebCore.Fixtures.org_fixture/2
    apps/nerves_hub_web_core/priv/repo/seeds.exs:56: NervesHubWebCore.SeedHelpers.nerves_team_seed/1
    (elixir 1.10.4) lib/code.ex:926: Code.require_file/2
    (mix 1.10.4) lib/mix/tasks/run.ex:145: Mix.Tasks.Run.run/5
    (mix 1.10.4) lib/mix/tasks/run.ex:85: Mix.Tasks.Run.run/1
    (mix 1.10.4) lib/mix/task.ex:330: Mix.Task.run_task/3
    (mix 1.10.4) lib/mix/cli.ex:82: Mix.CLI.run_task/2
    (elixir 1.10.4) lib/code.ex:926: Code.require_file/2
make[1]: *** [rebuild-db] Error 1
make: *** [reset-db] Error 2
```