### PR TITLE
Add support for uploading trusted device certs

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_certificate_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/device_certificate_controller.ex
@@ -5,8 +5,9 @@ defmodule NervesHubAPIWeb.DeviceCertificateController do
 
   action_fallback(NervesHubAPIWeb.FallbackController)
 
-  plug(:validate_role, [org: :write] when action in [:sign])
-  plug(:validate_role, [org: :read] when action in [:index])
+  plug(:validate_role, [org: :delete] when action in [:delete])
+  plug(:validate_role, [org: :write] when action in [:sign, :create])
+  plug(:validate_role, [org: :read] when action in [:index, :show])
 
   def index(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier}) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do
@@ -15,9 +16,51 @@ defmodule NervesHubAPIWeb.DeviceCertificateController do
     end
   end
 
-  def sign(%{assigns: %{org: org}} = conn, %{"csr" => csr, "device_identifier" => identifier}) do
-    with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
-         {:ok, %{"cert" => cert_pem}} <- CertificateAuthority.sign_device_csr(csr),
+  def show(%{assigns: %{device: device}} = conn, %{"serial" => serial}) do
+    with {:ok, device_certificate} <-
+           Devices.get_device_certificate_by_device_and_serial(device, serial) do
+      render(conn, "show.json", device_certificate: device_certificate)
+    end
+  end
+
+  def create(%{assigns: %{org: org, product: product, device: device}} = conn, %{"cert" => cert64}) do
+    with {:ok, cert_pem} <- Base.decode64(cert64),
+         {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
+         serial <- Certificate.get_serial_number(cert),
+         aki <- Certificate.get_aki(cert),
+         ski <- Certificate.get_ski(cert),
+         {not_before, not_after} <- Certificate.get_validity(cert),
+         params <- %{
+           serial: serial,
+           aki: aki,
+           ski: ski,
+           not_before: not_before,
+           not_after: not_after,
+           der: X509.Certificate.to_der(cert)
+         },
+         {:ok, device_certificate} <- Devices.create_device_certificate(device, params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header(
+        "location",
+        Routes.device_certificate_path(
+          conn,
+          :show,
+          org.name,
+          product.name,
+          device.identifier,
+          device_certificate.serial
+        )
+      )
+      |> render("show.json", device_certificate: device_certificate)
+    else
+      {:error, :not_found} -> {:error, "error decoding certificate"}
+      e -> e
+    end
+  end
+
+  def sign(%{assigns: %{device: device}} = conn, %{"csr" => csr}) do
+    with {:ok, %{"cert" => cert_pem}} <- CertificateAuthority.sign_device_csr(csr),
          {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
          serial <- Certificate.get_serial_number(cert),
          aki <- Certificate.get_aki(cert),
@@ -32,6 +75,14 @@ defmodule NervesHubAPIWeb.DeviceCertificateController do
          },
          {:ok, _db_cert} <- Devices.create_device_certificate(device, params) do
       render(conn, "cert.json", cert: cert_pem, device_certificate: cert_pem)
+    end
+  end
+
+  def delete(%{assigns: %{device: device}} = conn, %{"serial" => serial}) do
+    with {:ok, device_certificate} <-
+           Devices.get_device_certificate_by_device_and_serial(device, serial),
+         {:ok, _device_certificate} <- Devices.delete_device_certificate(device_certificate) do
+      send_resp(conn, :no_content, "")
     end
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/device.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/plugs/device.ex
@@ -1,0 +1,23 @@
+defmodule NervesHubAPIWeb.Plugs.Device do
+  import Plug.Conn
+
+  alias NervesHubWebCore.Devices
+
+  def init(opts) do
+    opts
+  end
+
+  def call(%{params: %{"device_identifier" => device_identifier}} = conn, _opts) do
+    case Devices.get_device_by_identifier(conn.assigns.org, device_identifier) do
+      {:ok, device} ->
+        conn
+        |> assign(:device, device)
+
+      _ ->
+        conn
+        |> put_resp_header("content-type", "application/json")
+        |> send_resp(403, Jason.encode!(%{status: "Invalid device: #{device_identifier}"}))
+        |> halt()
+    end
+  end
+end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -17,6 +17,10 @@ defmodule NervesHubAPIWeb.Router do
     plug(NervesHubAPIWeb.Plugs.Product)
   end
 
+  pipeline :device do
+    plug(NervesHubAPIWeb.Plugs.Device)
+  end
+
   scope "/users", NervesHubAPIWeb do
     pipe_through(:api)
 
@@ -94,13 +98,17 @@ defmodule NervesHubAPIWeb.Router do
               post("/auth", DeviceController, :auth)
 
               scope "/:device_identifier" do
+                pipe_through(:device)
                 get("/", DeviceController, :show)
                 delete("/", DeviceController, :delete)
                 put("/", DeviceController, :update)
 
                 scope "/certificates" do
                   get("/", DeviceCertificateController, :index)
+                  get("/:serial", DeviceCertificateController, :show)
+                  post("/", DeviceCertificateController, :create)
                   post("/sign", DeviceCertificateController, :sign)
+                  delete("/:serial", DeviceCertificateController, :delete)
                 end
               end
             end

--- a/apps/nerves_hub_api/rel/Dockerfile.build
+++ b/apps/nerves_hub_api/rel/Dockerfile.build
@@ -16,7 +16,7 @@ RUN mix release nerves_hub_api --overwrite
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
 
-RUN apk add 'fwup~=1.8.0' \
+RUN apk add 'fwup~=1.8.1' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
 

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -78,7 +78,7 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       conn =
         get(conn, Routes.device_path(conn, :show, org.name, product.name, to_delete.identifier))
 
-      assert response(conn, 404)
+      assert json_response(conn, 403)["status"] != ""
     end
 
     test "renders error when using deprecated api", %{conn: conn, org: org} do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -224,10 +224,37 @@ defmodule NervesHubWebCore.Devices do
     end
   end
 
+  @spec get_device_certificate_by_device_and_serial(Device.t(), binary) ::
+          {:ok, DeviceCertificate.t()} | {:error, any()}
+  def get_device_certificate_by_device_and_serial(%Device{id: device_id}, serial) do
+    query =
+      from(
+        dc in DeviceCertificate,
+        where: dc.serial == ^serial and dc.device_id == ^device_id
+      )
+
+    query
+    |> Repo.one()
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      device_certificate ->
+        {:ok, device_certificate}
+    end
+  end
+
   def update_device_certificate(%DeviceCertificate{} = certificate, params) do
     certificate
     |> DeviceCertificate.update_changeset(params)
     |> Repo.update()
+  end
+
+  @spec delete_device_certificate(DeviceCertificate.t()) ::
+          {:ok, DeviceCertificate.t()}
+          | {:error, Changeset.t()}
+  def delete_device_certificate(%DeviceCertificate{} = device_certificate) do
+    Repo.delete(device_certificate)
   end
 
   @spec create_ca_certificate(Org.t(), any()) ::

--- a/apps/nerves_hub_www/rel/Dockerfile.build
+++ b/apps/nerves_hub_www/rel/Dockerfile.build
@@ -31,7 +31,7 @@ RUN mix do phx.digest, release nerves_hub_www --overwrite
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
 
-RUN apk add 'fwup~=1.8.0' \
+RUN apk add 'fwup~=1.8.1' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -235,11 +235,15 @@ defmodule NervesHubWebCore.Fixtures do
     device
   end
 
+  def device_certificate_pem() do
+    path()
+    |> Path.join("ssl/device-1234-cert.pem")
+    |> File.read!()
+  end
+
   def device_certificate_fixture(_, _ \\ nil)
   def device_certificate_fixture(%Devices.Device{} = device, nil) do
-    cert_file = Path.join(path(), "ssl/device-1234-cert.pem")
-    {:ok, cert_pem} = File.read(cert_file)
-    {:ok, cert} = X509.Certificate.from_pem(cert_pem)
+    cert = device_certificate_pem() |> X509.Certificate.from_pem!()
     device_certificate_fixture(device, cert)
   end
   def device_certificate_fixture(%Devices.Device{} = device, cert) do


### PR DESCRIPTION
When using pre-signed crypto auth chips such as the ATECC608A-TNGTLS, trusted device certificates are often provided from the supplier. These need to be uploaded to the server to allow them to connect and authenticate.

This adds the following endpoints to the API:

/org/product/device/certificate/create
/org/product/device/certificate/show
/org/product/device/certificate/delete