### PR TITLE
Make from_email customizable

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
@@ -87,7 +87,7 @@ defmodule NervesHubWebCore.Accounts.Email do
   end
 
   defp from_address do
-    email = Application.fetch_env!(:nerves_hub_web_core, :nerves_hub_from_email)
+    email = Application.fetch_env!(:nerves_hub_web_core, :from_email)
     {"NervesHub", email}
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
@@ -3,7 +3,8 @@ defmodule NervesHubWebCore.Accounts.Email do
 
   alias NervesHubWebCore.Accounts.{Invite, Org, User, OrgUser}
 
-  @from {"NervesHub", "no-reply@nerves-hub.org"}
+  @from_email Application.fetch_env!(:nerves_hub_web_core, :from_email)
+  @from {"NervesHub", @from_email}
 
   def invite(%Invite{} = invite, %Org{} = org) do
     new_email()

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/email.ex
@@ -3,12 +3,9 @@ defmodule NervesHubWebCore.Accounts.Email do
 
   alias NervesHubWebCore.Accounts.{Invite, Org, User, OrgUser}
 
-  @from_email Application.fetch_env!(:nerves_hub_web_core, :from_email)
-  @from {"NervesHub", @from_email}
-
   def invite(%Invite{} = invite, %Org{} = org) do
     new_email()
-    |> from(@from)
+    |> from(from_address())
     |> to(invite.email)
     |> subject("[NervesHub] Hi from NervesHub!")
     |> put_layout({NervesHubWebCore.EmailView, :layout})
@@ -18,7 +15,7 @@ defmodule NervesHubWebCore.Accounts.Email do
   def forgot_password(%User{email: email, password_reset_token: token} = user)
       when is_binary(token) do
     new_email()
-    |> from(@from)
+    |> from(from_address())
     |> to(email)
     |> subject("[NervesHub] Reset NervesHub Password")
     |> put_layout({NervesHubWebCore.EmailView, :layout})
@@ -27,7 +24,7 @@ defmodule NervesHubWebCore.Accounts.Email do
 
   def org_user_created(email, %Org{} = org) do
     new_email()
-    |> from(@from)
+    |> from(from_address())
     |> to(email)
     |> subject("[NervesHub] Welcome to #{org.name}")
     |> put_layout({NervesHubWebCore.EmailView, :layout})
@@ -52,9 +49,9 @@ defmodule NervesHubWebCore.Accounts.Email do
       end
 
     new_email()
-    |> from(@from)
+    |> from(from_address())
     |> subject(email_subject)
-    |> to(@from)
+    |> to(from_address())
     |> bcc(org_users_emails)
     |> put_layout({NervesHubWebCore.EmailView, :layout})
     |> render("tell_org_user_added.html", user: new_user, org: org)
@@ -69,9 +66,9 @@ defmodule NervesHubWebCore.Accounts.Email do
     org_users_emails = generate_org_users_emails(org_users)
 
     new_email()
-    |> from(@from)
+    |> from(from_address())
     |> subject("[NervesHub] User #{instigator} removed #{user_removed.username} from #{org.name}")
-    |> to(@from)
+    |> to(from_address())
     |> bcc(org_users_emails)
     |> put_layout({NervesHubWebCore.EmailView, :layout})
     |> render("tell_org_user_removed.html", instigator: instigator, user: user_removed, org: org)
@@ -87,5 +84,10 @@ defmodule NervesHubWebCore.Accounts.Email do
         [email | acc]
       end
     )
+  end
+
+  defp from_address do
+    email = Application.fetch_env!(:nerves_hub_web_core, :nerves_hub_from_email)
+    {"NervesHub", email}
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
 #
 config :nerves_hub_web_core,
   ecto_repos: [NervesHubWebCore.Repo],
-  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
+  nerves_hub_from_email: System.get_env("NERVES_HUB_FROM_EMAIL", "no-reply@nerves-hub.org"),
   host: host
 
 config :nerves_hub_web_core, NervesHubWeb.PubSub,

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
 #
 config :nerves_hub_web_core,
   ecto_repos: [NervesHubWebCore.Repo],
-  nerves_hub_from_email: System.get_env("NERVES_HUB_FROM_EMAIL", "no-reply@nerves-hub.org"),
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
   host: host
 
 config :nerves_hub_web_core, NervesHubWeb.PubSub,

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,6 +55,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
 #
 config :nerves_hub_web_core,
   ecto_repos: [NervesHubWebCore.Repo],
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
   host: host
 
 config :nerves_hub_web_core, NervesHubWeb.PubSub,


### PR DESCRIPTION
Why:

* Private/Custom instances may need a custom from email that is validatable

This change addresses the need by:

* Getting from_email from env vars
* Provide a default value if not from_email is set