### PR TITLE
Fixes ISE when the default org name is invalid

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -14,15 +14,25 @@ defmodule NervesHubAPIWeb.UserControllerTest do
            }
   end
 
-  test "register new account" do
-    conn = build_conn()
-    body = %{username: "api_test", password: "12345678", email: "new_test@test.com"}
-    conn = post(conn, Routes.user_path(conn, :register), body)
+  describe "register new account" do
+    test "register new account" do
+      conn = build_conn()
+      body = %{username: "api_test", password: "12345678", email: "new_test@test.com"}
+      conn = post(conn, Routes.user_path(conn, :register), body)
 
-    assert json_response(conn, 200)["data"] == %{
-             "username" => body.username,
-             "email" => body.email
-           }
+      assert json_response(conn, 200)["data"] == %{
+               "username" => body.username,
+               "email" => body.email
+             }
+    end
+
+    test "shows an error when username/org doesn't conform to ~r/^[A-Za-z0-9-_]" do
+      conn = build_conn()
+      body = %{username: "api.test", password: "12345678", email: "new_test@test.com"}
+      conn = post(conn, Routes.user_path(conn, :register), body)
+
+      assert json_response(conn, 422) == %{"errors" => %{"username" => ["invalid character(s) in username"]}}
+    end
   end
 
   test "authenticate existing accounts" do

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/user_controller_test.exs
@@ -31,7 +31,9 @@ defmodule NervesHubAPIWeb.UserControllerTest do
       body = %{username: "api.test", password: "12345678", email: "new_test@test.com"}
       conn = post(conn, Routes.user_path(conn, :register), body)
 
-      assert json_response(conn, 422) == %{"errors" => %{"username" => ["invalid character(s) in username"]}}
+      assert json_response(conn, 422) == %{
+               "errors" => %{"username" => ["invalid character(s) in username"]}
+             }
     end
   end
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/user.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/user.ex
@@ -71,7 +71,7 @@ defmodule NervesHubWebCore.Accounts.User do
   end
 
   defp validate_username(%Changeset{changes: %{username: username}} = changeset) do
-    case Regex.match?(~r/^[A-Z,a-z,\d,\-,.,_,~]*$/, username) do
+    case Regex.match?(~r/^[A-Za-z0-9-_]+$/, username) do
       true -> changeset
       false -> add_error(changeset, :username, "invalid character(s) in username")
     end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/user_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/user_test.exs
@@ -4,18 +4,19 @@ defmodule NervesHubWebCore.Accounts.UserTest do
   alias NervesHubWebCore.Accounts.User
 
   test "changeset/2 - validates username" do
-    invalid_chars = ~w(! $ * \( \) + ; / ? : @ = & " < > # % { } | \ ^ [ ] \s`)
+    invalid_chars = ~w(! $ . ~ * \( \) + ; / ? : @ = & " < > # % { } | \ ^ [ ] \s`)
 
     Enum.each(invalid_chars, fn char ->
       %Changeset{errors: errors} =
         User.creation_changeset(%NervesHubWebCore.Accounts.User{}, %{username: "username#{char}"})
 
+        IO.inspect(errors)
       assert {"invalid character(s) in username", []} = errors[:username]
     end)
 
     %Changeset{errors: errors} =
       User.creation_changeset(%NervesHubWebCore.Accounts.User{}, %{
-        username: "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~"
+        username: "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
       })
 
     assert is_nil(errors[:username])

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/user_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/user_test.exs
@@ -10,7 +10,6 @@ defmodule NervesHubWebCore.Accounts.UserTest do
       %Changeset{errors: errors} =
         User.creation_changeset(%NervesHubWebCore.Accounts.User{}, %{username: "username#{char}"})
 
-        IO.inspect(errors)
       assert {"invalid character(s) in username", []} = errors[:username]
     end)
 


### PR DESCRIPTION
I tried to sign up as `brian.berlin` and I got a 500 error. My fix applies the same validation on orgs name that is being done to the users username. I wonder though if there are usernames in other production environments that will end up having trouble editing their account. I guess that depends on how long the bug has been around.

Other options might be to remove characters not allowed by the org name from the username before saving. Or maybe use the orgs name validation on users username.