### PR TITLE
Add from email to release config

### DIFF
--- a/apps/nerves_hub_api/config/release.exs
+++ b/apps/nerves_hub_api/config/release.exs
@@ -28,6 +28,9 @@ else
   config :rollbax, enabled: false
 end
 
+config :nerves_hub_web_core,
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
+
 config :nerves_hub_web_core, NervesHubWebCore.Firmwares.Upload.S3,
   bucket: System.fetch_env!("S3_BUCKET_NAME")
 

--- a/apps/nerves_hub_device/config/release.exs
+++ b/apps/nerves_hub_device/config/release.exs
@@ -28,6 +28,9 @@ else
   config :rollbax, enabled: false
 end
 
+config :nerves_hub_web_core,
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
+
 config :nerves_hub_web_core, NervesHubWebCore.Firmwares.Upload.S3,
   bucket: System.fetch_env!("S3_BUCKET_NAME")
 

--- a/apps/nerves_hub_www/config/release.exs
+++ b/apps/nerves_hub_www/config/release.exs
@@ -52,6 +52,7 @@ config :nerves_hub_web_core, NervesHubWebCore.Mailer,
 
 config :nerves_hub_web_core,
   host: host,
-  port: port
+  port: port,
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
 
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint, url: [host: host, port: port]


### PR DESCRIPTION
@mobileoverlord it turns out we did need to configuration in the release.exs files because, as you described, the config.exs is already compiled when the env variables are injected into the docker build process. I left config.exs file as is, since it is still useful for regular development.