### PR TITLE
Add CA Create/Delete actions

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_certificate_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_certificate_controller.ex
@@ -1,7 +1,13 @@
 defmodule NervesHubWWWWeb.OrgCertificateController do
   use NervesHubWWWWeb, :controller
 
-  alias NervesHubWebCore.Devices
+  alias Ecto.Changeset
+  alias NervesHubWebCore.{Devices, Certificate}
+  alias NervesHubWebCore.Devices.CACertificate
+
+  plug(:validate_role, [org: :delete] when action in [:delete])
+  plug(:validate_role, [org: :write] when action in [:new, :create])
+  plug(:validate_role, [org: :read] when action in [:index])
 
   def index(%{assigns: %{org: org}} = conn, _params) do
     conn
@@ -9,5 +15,63 @@ defmodule NervesHubWWWWeb.OrgCertificateController do
       "index.html",
       certificates: Devices.get_ca_certificates(org)
     )
+  end
+
+  def new(conn, _params) do
+    conn
+    |> render("new.html", changeset: %Changeset{data: %CACertificate{}})
+  end
+
+  def create(
+        %{assigns: %{org: org}} = conn,
+        %{"ca_certificate" => %{"cert" => %{path: upload_path}}} = params
+      ) do
+    with {:ok, cert_pem} <- File.read(upload_path),
+         {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
+         serial <- Certificate.get_serial_number(cert),
+         aki <- Certificate.get_aki(cert),
+         ski <- Certificate.get_ski(cert),
+         {not_before, not_after} <- Certificate.get_validity(cert),
+         params <- %{
+           serial: serial,
+           aki: aki,
+           ski: ski,
+           not_before: not_before,
+           not_after: not_after,
+           der: X509.Certificate.to_der(cert),
+           description: Map.get(params["ca_certificate"], "description")
+         },
+         {:ok, _ca_certificate} <- Devices.create_ca_certificate(org, params) do
+      conn
+      |> put_flash(:info, "Certificate Authority created")
+      |> redirect(to: Routes.org_certificate_path(conn, :index, org.name))
+    else
+      {:error, :not_found} ->
+        conn
+        |> put_flash(:error, "Error decoding certificate")
+        |> redirect(to: Routes.org_certificate_path(conn, :new, org.name))
+
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "Error creating certificate")
+        |> render(
+          "new.html",
+          changeset: changeset
+        )
+    end
+  end
+
+  def delete(%{assigns: %{org: org}} = conn, %{"serial" => serial}) do
+    with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_org_and_serial(org, serial),
+         {:ok, _ca_certificate} <- Devices.delete_ca_certificate(ca_certificate) do
+      conn
+      |> put_flash(:info, "Certificate successfully deleted")
+      |> redirect(to: Routes.org_certificate_path(conn, :index, org.name))
+    else
+      _ ->
+        conn
+        |> put_flash(:error, "Failed to delete certificate. Please try again.")
+        |> redirect(to: Routes.org_certificate_path(conn, :index, org.name))
+    end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -79,6 +79,9 @@ defmodule NervesHubWWWWeb.Router do
       get("/invite", OrgController, :invite)
       post("/invite", OrgController, :send_invite)
       get("/certificates", OrgCertificateController, :index)
+      post("/certificates", OrgCertificateController, :create)
+      get("/certificates/new", OrgCertificateController, :new)
+      delete("/certificates/:serial", OrgCertificateController, :delete)
       get("/users", OrgUserController, :index)
 
       resources("/keys", OrgKeyController)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -2,6 +2,10 @@
   <h1 class="mb-4">
     Certificate Authorities
   </h1>
+  <a class="btn btn-outline-light" href="<%= Routes.org_certificate_path(@conn, :new, @org.name) %>">
+    Add Certificate Authority
+    <div class="button-icon add"></div>
+  </a>
 </div>
 
 <table class="table table-sm table-hover">
@@ -35,6 +39,16 @@
         </td>
         <td>
           <%= cert.not_after %>
+        </td>
+        <td class="actions">
+          <div class="dropdown options">
+            <a class="dropdown-toggle options" href="#" id="<%= cert.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <img src="/images/icons/more.svg" alt="options" />
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+              <%= link "Delete", class: "dropdown-item", to: Routes.org_certificate_path(@conn, :delete, @org.name, cert.serial), method: :delete, data: [confirm: "Are you sure you want to delete this certificate? This can not be undone."] %>
+            </div>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/new.html.eex
@@ -1,0 +1,22 @@
+<h1>New Certificate Authority</h1>
+
+<%= form_for @changeset, Routes.org_certificate_path(@conn, :create, @org.name), [multipart: true], fn f -> %>
+  <div class="form-group">
+    <%= label f, :description, for: "description_input" %>
+    <%= text_input f, :description , class: "form-control", id: "description_input" %>
+    <div class="has-error"><%= error_tag f, :description %></div>
+  </div>
+
+  <label for="cert_input">Upload a Certificate Authority file (.pem)</label>
+
+  <div class="form-group custom-upload-group">
+    <%= label f, :cert, "Click to upload file", class: "custom-upload-label not-selected", for: "cert_input" %>
+    <%= file_input f, :cert, required: true, class: "custom-upload-input hidden", id: "cert_input" %>
+    <div class="has-error"><%= error_tag f, :cert %></div>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <%= link "Back", to: Routes.org_certificate_path(@conn, :index, @org.name), class: "btn btn-outline-light" %>    
+    <%= submit "Create Certificate", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
   use NervesHubWWWWeb.ConnCase.Browser, async: true
 
-  alias NervesHubWebCore.Fixtures
+  alias NervesHubWebCore.{Certificate, Devices, Fixtures}
 
   describe "index" do
     test "lists all appropriate device(ca) certificates", %{
@@ -15,6 +15,87 @@ defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
       assert html_response(conn, 200) =~ "Certificate Authorities"
       assert html_response(conn, 200) =~ db1_cert.serial
       assert html_response(conn, 200) =~ db2_cert.serial
+    end
+  end
+
+  describe "new" do
+    test "renders form", %{conn: conn, org: org} do
+      conn = get(conn, Routes.org_certificate_path(conn, :new, org.name))
+      assert html_response(conn, 200) =~ "New Certificate Authority"
+    end
+  end
+
+  describe "create" do
+    test "CA is created on success", %{conn: conn, org: org} do
+      ca_file_path = Fixtures.device_certificate_authority_file()
+      {:ok, ca} = File.read!(ca_file_path) |> X509.Certificate.from_pem()
+      serial = Certificate.get_serial_number(ca)
+      description = "My ca"
+
+      upload = %Plug.Upload{
+        path: ca_file_path
+      }
+
+      params = %{ca_certificate: %{cert: upload, description: description}}
+
+      conn = post(conn, Routes.org_certificate_path(conn, :create, org.name), params)
+      assert redirected_to(conn) == Routes.org_certificate_path(conn, :index, org.name)
+
+      assert {:ok, %{description: ^description, serial: ^serial}} =
+               Devices.get_ca_certificate_by_serial(serial)
+    end
+
+    test "renders errors when cert is invalid", %{conn: conn, org: org} do
+      bad_ca_file_path = Fixtures.bad_device_certificate_authority_file()
+
+      upload = %Plug.Upload{
+        path: bad_ca_file_path
+      }
+
+      params = %{ca_certificate: %{cert: upload}}
+
+      conn = post(conn, Routes.org_certificate_path(conn, :create, org.name), params)
+      assert redirected_to(conn) == Routes.org_certificate_path(conn, :new, org.name)
+      conn = get(conn, Routes.org_certificate_path(conn, :new, org.name))
+      assert html_response(conn, 200) =~ "Error decoding certificate"
+    end
+
+    test "renders errors when params are invalid", %{conn: conn, org: org} do
+      ca_file_path = Fixtures.device_certificate_authority_file()
+      {:ok, ca} = File.read!(ca_file_path) |> X509.Certificate.from_pem()
+      serial = Certificate.get_serial_number(ca)
+      description = 123
+
+      upload = %Plug.Upload{
+        path: ca_file_path
+      }
+
+      params = %{ca_certificate: %{cert: upload, description: description}}
+
+      conn = post(conn, Routes.org_certificate_path(conn, :create, org.name), params)
+      assert html_response(conn, 200) =~ "Error creating certificate"
+
+      assert {:error, :not_found} = Devices.get_ca_certificate_by_serial(serial)
+    end
+  end
+
+  describe "delete certificate authority" do
+    test "deletes chosen resource", %{
+      conn: conn,
+      org: org
+    } do
+      %{db_cert: ca} = Fixtures.ca_certificate_fixture(org)
+
+      conn =
+        delete(
+          conn,
+          Routes.org_certificate_path(conn, :delete, org.name, ca.serial)
+        )
+
+      assert redirected_to(conn) == Routes.org_certificate_path(conn, :index, org.name)
+
+      assert Devices.get_ca_certificate_by_serial(ca.serial) ==
+               {:error, :not_found}
     end
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -71,6 +71,7 @@ defmodule NervesHubWebCore.Fixtures do
       not_before: not_before,
       not_after: not_after
     }
+
     %{cert: cert, key: key, params: params}
   end
 
@@ -93,8 +94,8 @@ defmodule NervesHubWebCore.Fixtures do
       org_id: org_id,
       firmware_uuid: firmware_uuid,
       remote_ip: "192.0.2.3",
-      bytes_sent: 300000,
-      bytes_total: 32184752,
+      bytes_sent: 300_000,
+      bytes_total: 32_184_752,
       timestamp: DateTime.utc_now()
     }
   end
@@ -197,6 +198,7 @@ defmodule NervesHubWebCore.Fixtures do
     params =
       firmware_transfer_params(org_id, firmware_uuid)
       |> Map.merge(params)
+
     Firmwares.create_firmware_transfer(params)
   end
 
@@ -221,6 +223,7 @@ defmodule NervesHubWebCore.Fixtures do
         params \\ %{}
       ) do
     {:ok, metadata} = Firmwares.metadata_from_firmware(firmware)
+
     {:ok, device} =
       %{
         org_id: org.id,
@@ -241,11 +244,23 @@ defmodule NervesHubWebCore.Fixtures do
     |> File.read!()
   end
 
+  def device_certificate_authority_file() do
+    path()
+    |> Path.join("ssl/device-root-ca.pem")
+  end
+
+  def bad_device_certificate_authority_file() do
+    path()
+    |> Path.join("ssl/device-root-ca-key.pem")
+  end
+
   def device_certificate_fixture(_, _ \\ nil)
+
   def device_certificate_fixture(%Devices.Device{} = device, nil) do
     cert = device_certificate_pem() |> X509.Certificate.from_pem!()
     device_certificate_fixture(device, cert)
   end
+
   def device_certificate_fixture(%Devices.Device{} = device, cert) do
     serial = Certificate.get_serial_number(cert)
     {not_before, not_after} = Certificate.get_validity(cert)


### PR DESCRIPTION
Why:

* Users may want to create/delete CAs from the UI

This change addresses the need by:

* Adding actions to the router for WWW
* Adding an action for a new screen
* Adding actions for creating/delete CAs
* Add some helpers to fixtures to easily access CA files.
* Adding tests