### PR TITLE
Don't capitalize org and product in navigation

### DIFF
--- a/apps/nerves_hub_www/assets/css/_navigation.scss
+++ b/apps/nerves_hub_www/assets/css/_navigation.scss
@@ -56,7 +56,6 @@ nav.navbar {
   align-items: center;
   padding: 1.5rem;
   font-weight: bold;
-  text-transform: capitalize;
 
   &:hover {
     color: white;
@@ -104,7 +103,6 @@ nav.navbar {
     font-size: 18px;
     font-weight: 700;
     color: white;
-    text-transform: capitalize;
     min-width: 340px;
   }
 


### PR DESCRIPTION
New UI asserts capitalization on orgs and products in the navigation menu. However, if I name my org lowercased with other characters, I'd like to see that in the nav as well instead of having my names reformatted for me in views.

Super nit - what do you think?

/cc @Mrjaco12 @coryjewell 

### Old
<img width="695" alt="image" src="https://user-images.githubusercontent.com/11321326/93358023-39b2e280-f7fe-11ea-9806-4fba933ba6c0.png">

### New
<img width="700" alt="image" src="https://user-images.githubusercontent.com/11321326/93357910-138d4280-f7fe-11ea-87cf-7d11099e2ca2.png">
