### PR TITLE
Fix layout_view_tests due to missing mocks

### DIFF
--- a/apps/nerves_hub_www/test/nerves_hub_www_web/views/layout_view_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/views/layout_view_test.exs
@@ -1,5 +1,6 @@
 defmodule NervesHubWWWWeb.LayoutViewTest do
   use ExUnit.Case
+  use DefaultMocks
   use NervesHubWWWWeb.ConnCase, async: true
 
   import NervesHubWWWWeb.LayoutView,


### PR DESCRIPTION
Fixes broken test:
```
1) test org_device_limit/1 a string representation of total devices and device limit is returned (NervesHubWWWWeb.LayoutViewTest)
     apps/nerves_hub_www/test/nerves_hub_www_web/views/layout_view_test.exs:30
     ** (Mox.UnexpectedCallError) no expectation defined for NervesHubWebCore.PatcherMock.patchable?/1 in process #PID<0.2035.0> with args ["/var/folders/nx/_3hhhmld02jd5ft2_4p4h55m0000gn/T/signed-1551.fw"]
     code: %{org: org, device: _} = Fixtures.standard_fixture()
     stacktrace:
       (mox 0.5.2) lib/mox.ex:693: Mox.__dispatch__/4
       (nerves_hub_web_core 0.1.0) lib/nerves_hub_web_core/firmwares.ex:439: NervesHubWebCore.Firmwares.build_firmware_params/3
       (nerves_hub_web_core 0.1.0) lib/nerves_hub_web_core/firmwares.ex:109: anonymous fn/4 in NervesHubWebCore.Firmwares.create_firmware/4
       (ecto_sql 3.4.1) lib/ecto/adapters/sql.ex:894: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
       (db_connection 2.2.1) lib/db_connection.ex:1427: DBConnection.run_transaction/4
       (nerves_hub_api 0.1.0) /Users/jschneck/dev/nerves-hub/nerves_hub_web/test/support/fixtures.ex:193: NervesHubWebCore.Fixtures.firmware_fixture/3
       (nerves_hub_api 0.1.0) /Users/jschneck/dev/nerves-hub/nerves_hub_web/test/support/fixtures.ex:296: NervesHubWebCore.Fixtures.standard_fixture/0
       test/nerves_hub_www_web/views/layout_view_test.exs:31: (test)
```