### PR TITLE
Org User management

### DIFF
--- a/apps/nerves_hub_www/assets/css/_layout.scss
+++ b/apps/nerves_hub_www/assets/css/_layout.scss
@@ -308,6 +308,10 @@ html {
     padding: 4rem !important;
   }
 
+  .pos-rel {
+    position: relative;
+  }
+
   .x3-grid {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_user_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_user_controller.ex
@@ -2,6 +2,10 @@ defmodule NervesHubWWWWeb.OrgUserController do
   use NervesHubWWWWeb, :controller
 
   alias NervesHubWebCore.Accounts
+  alias NervesHubWebCore.Accounts.{Email, Org}
+  alias NervesHubWebCore.Mailer
+
+  plug(:validate_role, org: :admin)
 
   def index(%{assigns: %{org: org}} = conn, _params) do
     conn
@@ -10,5 +14,59 @@ defmodule NervesHubWWWWeb.OrgUserController do
       org_users: Accounts.get_org_users(org),
       org: org
     )
+  end
+
+  def edit(%{assigns: %{org: org}} = conn, %{"user_id" => user_id}) do
+    {:ok, user} = Accounts.get_user(user_id)
+    {:ok, org_user} = Accounts.get_org_user(org, user)
+
+    conn
+    |> render("edit.html",
+      changeset: Org.change_user_role(org_user, %{}),
+      org_user: org_user
+    )
+  end
+
+  def update(%{assigns: %{org: org}} = conn, %{"user_id" => user_id} = params) do
+    {:ok, user} = Accounts.get_user(user_id)
+    {:ok, org_user} = Accounts.get_org_user(org, user)
+    {:ok, role} = Map.fetch(params["org_user"], "role")
+
+    case Accounts.change_org_user_role(org_user, role) do
+      {:ok, _org_user} ->
+        conn
+        |> put_flash(:info, "Role updated")
+        |> redirect(to: Routes.org_user_path(conn, :index, org.name))
+
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "Error updating role")
+        |> render(
+          "edit.html",
+          changeset: changeset,
+          org_user: org_user
+        )
+    end
+  end
+
+  def delete(%{assigns: %{org: org, user: current_user}} = conn, %{"user_id" => user_id}) do
+    {:ok, user} = Accounts.get_user(user_id)
+
+    case Accounts.remove_org_user(org, user) do
+      :ok ->
+        instigator = current_user.username
+
+        Email.tell_org_user_removed(org, Accounts.get_org_users(org), instigator, user)
+        |> Mailer.deliver_later()
+
+        conn
+        |> put_flash(:info, "User removed")
+        |> redirect(to: Routes.org_user_path(conn, :index, org.name))
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "Could not remove user")
+        |> redirect(to: Routes.org_user_path(conn, :index, org.name))
+    end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/org_user.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/plugs/org_user.ex
@@ -1,0 +1,25 @@
+defmodule NervesHubWWWWeb.Plugs.OrgUser do
+  use NervesHubWWWWeb, :plug
+
+  alias NervesHubWebCore.Accounts
+
+  def init(opts) do
+    opts
+  end
+
+  def call(%{assigns: %{org: org}, params: %{"user_id" => user_id}} = conn, _opts) do
+    with {:ok, user} <- Accounts.get_user(user_id),
+         {:ok, org_user} <- Accounts.get_org_user(org, user) do
+      conn
+      |> assign(:org_user, org_user)
+    else
+      _error ->
+        conn
+        |> put_status(:not_found)
+        |> put_layout(false)
+        |> put_view(NervesHubWWWWeb.ErrorView)
+        |> render("404.html")
+        |> halt
+    end
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -83,6 +83,9 @@ defmodule NervesHubWWWWeb.Router do
       get("/certificates/new", OrgCertificateController, :new)
       delete("/certificates/:serial", OrgCertificateController, :delete)
       get("/users", OrgUserController, :index)
+      get("/users/:user_id", OrgUserController, :edit)
+      put("/users/:user_id", OrgUserController, :update)
+      delete("/users/:user_id", OrgUserController, :delete)
 
       resources("/keys", OrgKeyController)
     end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
@@ -2,8 +2,10 @@
 <%= form_for @conn, Routes.deployment_path(@conn, :new, @org.name, @product.name), [method: :get, as: :deployment], fn f -> %>
   <div class="form-group">
     <label for="firmware_id">Firmware</label>
-    <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
-    <div class="select-icon"></div>
+    <div class="pos-rel">
+      <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
+      <div class="select-icon"></div>
+    </div>
     <div class="has-error"><%= error_tag f, :firmware_id %></div>
   </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
@@ -18,11 +18,13 @@
       <span class="tooltip-info"></span>
       <span class="tooltip-text">User role can be changed from the command line</span>
     </label>
-    <select class="form-control" disabled id="role_input">
-      <option value="Admin">Admin</option>
-      <option value="Basic">Basic</option>
-    </select>
-    <div class="select-icon"></div>
+    <div class="pos-rel">
+      <select class="form-control" disabled id="role_input">
+        <option value="Admin">Admin</option>
+        <option value="Basic">Basic</option>
+      </select>
+      <div class="select-icon"></div>
+    </div>
   </div>
 
   <div class="button-submit-wrapper">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/edit.html.eex
@@ -7,8 +7,10 @@
     <label for="role_input" class="tooltip-label h3 mb-1">
       <span>Role</span>
     </label>
-    <%= select f, :role, role_options(), class: "form-control", id: "role_input" %>    
-    <div class="select-icon"></div>
+    <div class="pos-rel">
+      <%= select f, :role, role_options(), class: "form-control", id: "role_input" %>
+      <div class="select-icon"></div>
+    </div>
     <div class="has-error"><%= error_tag f, :role %></div>
   </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/edit.html.eex
@@ -1,0 +1,19 @@
+<h1>
+  Edit User Role
+</h1>
+
+<%= form_for @changeset, Routes.org_user_path(@conn, :update, @org.name, @org_user.user_id), fn f -> %>
+  <div class="form-group">
+    <label for="role_input" class="tooltip-label h3 mb-1">
+      <span>Role</span>
+    </label>
+    <%= select f, :role, role_options(), class: "form-control", id: "role_input" %>    
+    <div class="select-icon"></div>
+    <div class="has-error"><%= error_tag f, :role %></div>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <a class="btn btn-outline-light" href="<%= Routes.org_user_path(@conn, :index, @org.name) %>">Cancel</a>
+    <%= submit "Update", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -38,6 +38,20 @@
         <td class="date-time">
           <%= org_user.user.inserted_at %>
         </td>
+        <%= if org_user.user.id != assigns.user.id do %>
+          <td class="actions">
+            <div class="dropdown options">
+              <a class="dropdown-toggle options" href="#" id="<%= org_user.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <img src="/images/icons/more.svg" alt="options" />
+              </a>
+              <div class="dropdown-menu dropdown-menu-right">
+                <%= link "edit", class: "dropdown-item", to: Routes.org_user_path(@conn, :edit, @org.name, org_user.user_id) %>
+                <div class="dropdown-divider"></div>
+                <%= link "Delete", class: "dropdown-item", to: Routes.org_user_path(@conn, :delete, @org.name, org_user.user_id), method: :delete, data: [confirm: "Are you sure you want to remove this user? This can not be undone."] %>
+              </div>
+            </div>
+          </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_user_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_user_view.ex
@@ -1,3 +1,15 @@
 defmodule NervesHubWWWWeb.OrgUserView do
   use NervesHubWWWWeb, :view
+
+  alias NervesHubWebCore.Accounts.User
+
+  def role_options() do
+    User.Role.__enum_map__() |> Enum.map(fn opt -> {format_option(opt), opt} end)
+  end
+
+  defp format_option(opt) do
+    opt
+    |> to_string()
+    |> String.capitalize()
+  end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_user_controller_test.exs
@@ -1,7 +1,13 @@
 defmodule NervesHubWWWWeb.OrgUserControllerTest do
   use NervesHubWWWWeb.ConnCase.Browser, async: true
+  use Bamboo.Test
 
-  alias NervesHubWebCore.Accounts
+  alias NervesHubWebCore.{Accounts, Fixtures}
+
+  setup context do
+    user = Fixtures.user_fixture(%{username: context.user.username <> "0"})
+    Map.put(context, :user2, user)
+  end
 
   describe "index" do
     test "lists all users in an organization", %{
@@ -26,5 +32,73 @@ defmodule NervesHubWWWWeb.OrgUserControllerTest do
       conn = get(conn, Routes.org_user_path(conn, :index, user.username))
       refute html_response(conn, 200) =~ "Add New User"
     end
+  end
+
+  describe "update org_user role" do
+    setup [:create_org_user]
+
+    test "updates role and redirects", %{conn: conn, org: org, user2: user} do
+      conn =
+        put(conn, Routes.org_user_path(conn, :update, org.name, user.id), %{
+          org_user: %{role: "write"}
+        })
+
+      assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
+
+      conn = get(conn, Routes.org_user_path(conn, :index, org.name))
+      assert html_response(conn, 200) =~ "Role updated"
+      assert html_response(conn, 200) =~ "write"
+    end
+
+    test "shows error", %{conn: conn, org: org, user2: user} do
+      conn =
+        put(conn, Routes.org_user_path(conn, :update, org.name, user.id), %{
+          org_user: %{role: "invalid role"}
+        })
+
+      assert html_response(conn, 200) =~ "Error updating role"
+      assert html_response(conn, 200) =~ "is invalid"
+    end
+  end
+
+  describe "delete valid user" do
+    setup [:create_org_user]
+
+    test "removes existing user", %{conn: conn, org: org, user2: user} do
+      conn = delete(conn, Routes.org_user_path(conn, :delete, org.name, user.id))
+      assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
+
+      # An email should have been sent
+      instigator = conn.assigns.user.username
+
+      assert_email_delivered_with(
+        subject: "[NervesHub] User #{instigator} removed #{user.username} from #{org.name}"
+      )
+
+      assert {:error, :not_found} = Accounts.get_org_user(org, user)
+
+      conn = get(conn, Routes.org_user_path(conn, :index, org.name))
+      assert html_response(conn, 200) =~ "User removed"
+    end
+  end
+
+  describe "delete invalid user" do
+    test "fails to remove existing user", %{conn: conn, org: org, user: user} do
+      {:ok, org_user} = Accounts.get_org_user(org, user)
+      conn = delete(conn, Routes.org_user_path(conn, :delete, org.name, user.id))
+      assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
+
+      assert_no_emails_delivered()
+
+      assert {:ok, ^org_user} = Accounts.get_org_user(org, user)
+
+      conn = get(conn, Routes.org_user_path(conn, :index, org.name))
+      assert html_response(conn, 200) =~ "Could not remove user"
+    end
+  end
+
+  defp create_org_user(%{user2: user, org: org}) do
+    {:ok, org_user} = Accounts.add_org_user(org, user, %{role: :admin})
+    {:ok, %{org_user: org_user}}
   end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/plugs/org_user_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/plugs/org_user_test.exs
@@ -1,0 +1,40 @@
+defmodule NervesHubWWWWeb.Plugs.OrgUserTest do
+  use NervesHubWWWWeb.ConnCase.Browser, async: true
+  use Plug.Test
+
+  alias NervesHubWebCore.{Accounts, Fixtures}
+
+  setup context do
+    {:ok, org_user} = Accounts.get_org_user(context.org, context.user)
+    Map.put(context, :org_user, org_user)
+  end
+
+  test "org_user is set when found", %{conn: conn, org_user: org_user} do
+    conn =
+      conn
+      |> Map.put(:params, %{"user_id" => org_user.user_id})
+      |> NervesHubWWWWeb.Plugs.OrgUser.call([])
+
+    assert conn.assigns.org_user == org_user
+  end
+
+  test "404 is rendered user is not found", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:params, %{"user_id" => 000})
+      |> NervesHubWWWWeb.Plugs.OrgUser.call([])
+
+    assert html_response(conn, 404) =~ "not found"
+  end
+
+  test "404 is rendered when org_user is not found", %{conn: conn, user: user} do
+    user2 = Fixtures.user_fixture(%{username: user.username <> "0"})
+
+    conn =
+      conn
+      |> Map.put(:params, %{"user_id" => user2.id})
+      |> NervesHubWWWWeb.Plugs.OrgUser.call([])
+
+    assert html_response(conn, 404) =~ "not found"
+  end
+end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/views/org_user_view_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/views/org_user_view_test.exs
@@ -1,0 +1,16 @@
+defmodule NervesHubWWWWeb.OrgUserViewTest do
+  use NervesHubWWWWeb.ConnCase, async: true
+
+  alias NervesHubWWWWeb.OrgUserView
+
+  describe "role_options/0" do
+    test "a list of formatted tuples is returned" do
+      assert OrgUserView.role_options() == [
+               {"Admin", :admin},
+               {"Delete", :delete},
+               {"Write", :write},
+               {"Read", :read}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
Why:

* Admins may need to remove users or change user roles

This change addresses the need by:

* Added an edit template
* Added actions/routes for edit, update, delete
* Add a view helper to get role options
* Only show action menu for users that aren't the current user
* Add tests for each action and the new OrgUserView function