### PR TITLE
Allow deployment state in API requests/response

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/deployment_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/deployment_view.ex
@@ -14,6 +14,7 @@ defmodule NervesHubAPIWeb.DeploymentView do
     %{
       name: deployment.name,
       is_active: deployment.is_active,
+      state: if(deployment.is_active, do: "on", else: "off"),
       firmware_uuid: deployment.firmware.uuid,
       conditions: deployment.conditions
     }

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/deployment_controller_test.exs
@@ -83,6 +83,23 @@ defmodule NervesHubAPIWeb.DeploymentControllerTest do
       assert json_response(conn, 200)["data"]["is_active"]
     end
 
+    test "can use state to set is_active", %{
+      conn: conn,
+      deployment: deployment,
+      org: org,
+      product: product
+    } do
+      path = Routes.deployment_path(conn, :update, org.name, product.name, deployment.name)
+      refute deployment.is_active
+      conn = put(conn, path, deployment: %{"state" => "on"})
+      assert %{"is_active" => true, "state" => "on"} = json_response(conn, 200)["data"]
+
+      path = Routes.deployment_path(conn, :show, org.name, product.name, deployment.name)
+      conn = get(conn, path)
+      assert json_response(conn, 200)["data"]["is_active"]
+      assert json_response(conn, 200)["data"]["state"] == "on"
+    end
+
     test "audits on success", %{conn: conn, deployment: deployment, org: org, product: product} do
       path = Routes.deployment_path(conn, :update, org.name, product.name, deployment.name)
       conn = put(conn, path, deployment: %{"is_active" => true})


### PR DESCRIPTION
Part of https://github.com/nerves-hub/nerves_hub_web/issues/641

From discussion in #639 

Deployments now display a `state` value of `on/off` string in the UI. This adds that to the API response and allows updating a deployment state as well so that changes can also be reflected in the CLI