### PR TITLE
Fix delta updates failing

### DIFF
--- a/apps/nerves_hub_api/rel/Dockerfile.build
+++ b/apps/nerves_hub_api/rel/Dockerfile.build
@@ -4,7 +4,7 @@ FROM bitwalker/alpine-elixir:${ELIXIR_VERSION} as builder
 
 ENV MIX_ENV=prod
 
-RUN apk --no-cache add make gcc musl-dev xdelta3 zip unzip
+RUN apk --no-cache add make gcc musl-dev
 RUN mix local.hex --force && mix local.rebar --force
 RUN mkdir /build
 ADD . /build
@@ -19,6 +19,8 @@ FROM nerveshub/runtime:alpine-3.9 as release
 RUN apk add 'fwup~=1.8.1' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
+
+RUN apk --no-cache add xdelta3 zip unzip
 
 EXPOSE 443
 

--- a/apps/nerves_hub_device/rel/Dockerfile.build
+++ b/apps/nerves_hub_device/rel/Dockerfile.build
@@ -4,7 +4,7 @@ FROM bitwalker/alpine-elixir:${ELIXIR_VERSION} as builder
 
 ENV MIX_ENV=prod
 
-RUN apk --no-cache add make gcc musl-dev xdelta3 zip unzip
+RUN apk --no-cache add make gcc musl-dev
 RUN mix local.hex --force && mix local.rebar --force
 RUN mkdir /build
 ADD . /build
@@ -15,6 +15,12 @@ RUN mix release nerves_hub_device  --overwrite
 
 # Release Container
 FROM nerveshub/runtime:alpine-3.9 as release
+
+RUN apk add 'fwup~=1.8.1' \
+  --repository http://nl.alpinelinux.org/alpine/edge/community/ \
+  --no-cache
+
+RUN apk --no-cache add xdelta3 zip unzip
 
 EXPOSE 443
 

--- a/apps/nerves_hub_web_core/mix.exs
+++ b/apps/nerves_hub_web_core/mix.exs
@@ -37,7 +37,7 @@ defmodule NervesHubWebCore.MixProject do
   def application do
     [
       mod: {NervesHubWebCore.Application, []},
-      extra_applications: [:logger, :jason],
+      extra_applications: [:logger, :jason, :inets],
       start_phases: [{:start_workers, []}]
     ]
   end

--- a/apps/nerves_hub_www/rel/Dockerfile.build
+++ b/apps/nerves_hub_www/rel/Dockerfile.build
@@ -18,7 +18,7 @@ FROM bitwalker/alpine-elixir:${ELIXIR_VERSION} as builder
 
 ENV MIX_ENV=prod
 
-RUN apk --no-cache add make gcc musl-dev xdelta3 zip unzip
+RUN apk --no-cache add make gcc musl-dev
 RUN mix local.hex --force && mix local.rebar --force
 RUN mkdir /build
 ADD . /build
@@ -34,6 +34,8 @@ FROM nerveshub/runtime:alpine-3.9 as release
 RUN apk add 'fwup~=1.8.1' \
   --repository http://nl.alpinelinux.org/alpine/edge/community/ \
   --no-cache
+
+RUN apk --no-cache add xdelta3 zip unzip
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
What:

* Delta updates were failing for a number or reasons:

1. The `inets` application wasn't available
2. The `xdelta3` executable wasn't available

How:

* Add `inets` to extra_applications
* Make sure delta update executables are installed so they'll be accessible