### PR TITLE
Device connection icon looking for wrong word

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -52,10 +52,10 @@
     <p class="flex-row align-items-center tt-c">
       <span><%= @device.status %></span>
       <span class="ml-1">
-        <%= if @device.status != "connected" do %>
+        <%= if @device.status != "online" do %>
           <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
         <% else %>
-          <img src="/images/icons/check.svg" alt="connected" class="table-icon" />
+          <img src="/images/icons/check.svg" alt="online" class="table-icon" />
         <% end %>
       </span>
     </p>


### PR DESCRIPTION
### Why
- Icon for connection status on device show page is not updating when a device is connected

### How
- If statement was looking for wrong term -- updated to check for "online" rather than "connected"