### PR TITLE
Removes extra delete button

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -37,10 +37,6 @@
       <span class="button-icon edit"></span>
       <span class="action-text">Edit</span>
     <% end %>
-    <%= link class: "btn btn-outline-light", to: Routes.device_path(@socket, :delete, @org.name, @product.name, @device.identifier), method: :delete, data: [confirm: "Are you sure?"] do %>
-      <span class="button-icon left-icon delete"></span>
-      <span>Delete</span>
-    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
Removes an extra delete button on the device show page.

![Screen Shot 2020-10-02 at 2 20 23 PM](https://user-images.githubusercontent.com/333595/94961525-6a5f7100-04ba-11eb-8c4c-dd0e8a8ef29e.png)
