### PR TITLE
Adds description to ca_certificate.json render function

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/ca_certificate_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/ca_certificate_view.ex
@@ -14,7 +14,8 @@ defmodule NervesHubAPIWeb.CACertificateView do
     %{
       serial: ca_certificate.serial,
       not_before: ca_certificate.not_before,
-      not_after: ca_certificate.not_after
+      not_after: ca_certificate.not_after,
+      description: ca_certificate.description
     }
   end
 end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/ca_certificate_controller_test.exs
@@ -23,6 +23,7 @@ defmodule NervesHubAPIWeb.CACertificateControllerTest do
       conn = post(conn, Routes.ca_certificate_path(conn, :create, org.name), params)
       resp_data = json_response(conn, 201)["data"]
       assert %{"serial" => ^serial} = resp_data
+      assert %{"description" => ^description} = resp_data
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org} do


### PR DESCRIPTION
connects to #660 
connects to nerves-hub/nerves_hub_user_api#22 
Seems like this was in place already just not a part of the response. 🤷‍♂️ 