### PR TITLE
pool_size & prepare Repo options dynamic configuration added

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
@@ -4,11 +4,25 @@ defmodule NervesHubWebCore.Repo do
     adapter: Ecto.Adapters.Postgres
 
   @doc """
-  Dynamically loads the repository url from the
-  DATABASE_URL environment variable.
+  Dynamically loads the following parameters with environment variables:
+    url <= DATABASE_URL
+    pool_size <= DATABASE_POOL_SIZE
+    prepare <= DATABASE_PREPARED_STATEMENT
   """
   def init(_, opts) do
-    {:ok, Keyword.put(opts, :url, System.get_env("DATABASE_URL"))}
+    config = 
+      with  url <- System.get_env("DATABASE_URL"),
+            pool_size <- System.get_env("DATABASE_POOL_SIZE") || "20",
+            pool_size_int <- String.to_integer(pool_size),
+            prepared_statements <- System.get_env("DATABASE_PREPARED_STATEMENT") || "named",
+            prepared_statements_atom <- String.to_existing_atom(prepared_statements) do
+        opts
+        |> Keyword.put(:url, url)
+        |> Keyword.put(:pool_size, pool_size_int)
+        |> Keyword.put(:prepare, prepared_statements_atom)
+      end
+
+    {:ok, config}
   end
 
   def reload(%module{id: id}), do: get(module, id)


### PR DESCRIPTION
Why:
- It seems that pool_size parameter (NervesHubWebCore.Repo) is hardcoded.
- It is not possible to disable prepared statements in Ecto (runtime). 

How:
- init/2 function (at repo.ex), handles the enviroment variables just as url.