### PR TITLE
Temporarily disable delta updates

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -346,13 +346,17 @@ defmodule NervesHubWebCore.Firmwares do
           {:ok, String.t()}
           | {:error, :failure}
 
-  def get_firmware_url(source, target, fwup_version) when is_binary(fwup_version) do
-    if Version.match?(fwup_version, @min_fwup_patchable_version) do
-      do_get_firmware_url(source, target)
-    else
-      @uploader.download_file(target)
-    end
-  end
+  ##
+  # TODO: Put this check back in once delta updates has been fixed
+  # Until then, skip attempting any patches for now ¬
+  #
+  # def get_firmware_url(source, target, fwup_version) when is_binary(fwup_version) do
+  #   if Version.match?(fwup_version, @min_fwup_patchable_version) do
+  #     do_get_firmware_url(source, target)
+  #   else
+  #     @uploader.download_file(target)
+  #   end
+  # end
 
   def get_firmware_url(_source, target, _fwup_version), do: @uploader.download_file(target)
 

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
@@ -404,6 +404,7 @@ defmodule NervesHubWebCore.FirmwaresTest do
       assert {:ok, url} = Firmwares.get_firmware_url(source, target, "1.5.999")
     end
 
+    @tag :skip
     test "returns patch download_file when one exists", %{
       firmware: source,
       org_key: org_key,
@@ -420,6 +421,7 @@ defmodule NervesHubWebCore.FirmwaresTest do
       assert {:ok, url} = Firmwares.get_firmware_url(source, target, @valid_fwup_version)
     end
 
+    @tag :skip
     test "returns download_file for a new patch", %{
       firmware: source,
       org_key: org_key,

--- a/apps/nerves_hub_web_core/test/test_helper.exs
+++ b/apps/nerves_hub_web_core/test/test_helper.exs
@@ -1,6 +1,6 @@
 Logger.remove_backend(:console)
 Code.compiler_options(ignore_module_conflict: true)
 
-ExUnit.start()
+ExUnit.start(exclude: [:skip])
 
 Ecto.Adapters.SQL.Sandbox.mode(NervesHubWebCore.Repo, :manual)


### PR DESCRIPTION
Addresses https://github.com/nerves-hub/nerves_hub_web/issues/665 by temporarily disabled delta updates to prevent timeouts and failing updates until a better solution can be developed.

cc/ @Mrjaco12 