### PR TITLE
Ability to delete accounts

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/fallback_controller.ex
@@ -51,6 +51,6 @@ defmodule NervesHubAPIWeb.FallbackController do
   end
 
   defp conflict_error?(error) do
-    error in [:deployments, :firmwares]
+    error in [:deployments, :firmwares, :devices]
   end
 end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/firmware_controller.ex
@@ -39,7 +39,7 @@ defmodule NervesHubAPIWeb.FirmwareController do
 
   def delete(%{assigns: %{product: product}} = conn, %{"uuid" => uuid}) do
     with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
-         :ok <- Firmwares.delete_firmware(firmware) do
+         {:ok, _} <- Firmwares.delete_firmware(firmware) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/product_controller_test.exs
@@ -85,7 +85,8 @@ defmodule NervesHubAPIWeb.ProductControllerTest do
     } do
       # Create firmware for product
       org_key = Fixtures.org_key_fixture(org)
-      Fixtures.firmware_fixture(org_key, product)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+      Fixtures.device_fixture(org, product, firmware)
 
       conn = delete(conn, Routes.product_path(conn, :delete, org.name, product.name))
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/invite.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/invite.ex
@@ -9,7 +9,7 @@ defmodule NervesHubWebCore.Accounts.Invite do
   @type t :: %__MODULE__{}
 
   schema "invites" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:email, :string)
     field(:token, Ecto.UUID)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org.ex
@@ -24,15 +24,16 @@ defmodule NervesHubWebCore.Accounts.Org do
   schema "orgs" do
     has_many(:org_keys, OrgKey)
     has_many(:products, Product)
-    has_many(:devices, Device)
+    has_many(:devices, Device, where: [deleted_at: nil])
     has_many(:ca_certificates, CACertificate)
     has_one(:org_limits, OrgLimit)
 
-    has_many(:org_users, OrgUser)
+    has_many(:org_users, OrgUser, where: [deleted_at: nil])
     has_many(:users, through: [:org_users, :user])
 
     field(:name, :string)
     field(:type, Type, default: :group)
+    field(:deleted_at, :utc_datetime)
 
     timestamps()
   end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_key.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_key.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWebCore.Accounts.OrgKey do
   @optional_params []
 
   schema "org_keys" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
     has_many(:firmwares, Firmware)
 
     field(:name, :string)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_limit.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_limit.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWebCore.Accounts.OrgLimit do
   ]
 
   schema "org_limits" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:devices, :integer, default: @defaults[:devices])
     field(:firmware_per_product, :integer, default: @defaults[:firmware_per_product])

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_metric.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_metric.ex
@@ -16,7 +16,7 @@ defmodule NervesHubWebCore.Accounts.OrgMetric do
   ]
 
   schema "org_metrics" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:devices, :integer)
     field(:bytes_stored, :integer)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_user.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_user.ex
@@ -8,10 +8,11 @@ defmodule NervesHubWebCore.Accounts.OrgUser do
   @type t :: %__MODULE__{}
 
   schema "org_users" do
-    belongs_to(:org, Org)
-    belongs_to(:user, User)
+    belongs_to(:org, Org, where: [deleted_at: nil])
+    belongs_to(:user, User, where: [deleted_at: nil])
 
     field(:role, User.Role)
+    field(:deleted_at, :utc_datetime)
 
     timestamps()
   end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/remove_account.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/remove_account.ex
@@ -1,0 +1,133 @@
+defmodule NervesHubWebCore.Accounts.RemoveAccount do
+  import Ecto.{Query, Changeset}
+  alias Ecto.Multi
+
+  alias NervesHubWebCore.{
+    Accounts,
+    Firmwares,
+    Deployments.Deployment,
+    Products,
+    Repo,
+    OrgKey,
+    Devices
+  }
+
+  alias Firmwares.{Firmware, FirmwareDelta, FirmwareTransfer}
+  alias Accounts.{Org, OrgUser, OrgKey, Invite, User, UserCertificate, OrgLimit, OrgMetric}
+  alias Devices.{DeviceCertificate, Device, CACertificate}
+  alias Products.{Product, ProductUser}
+
+  def remove_account(user_id) do
+    Multi.new()
+    |> Multi.run(:user_id, fn _, _ -> {:ok, user_id} end)
+    |> Multi.run(:org_ids, &get_org_ids/2)
+    |> Multi.run(:firmware_ids, &get_firmware_ids/2)
+    |> Multi.delete_all(:invites, &query_by_org_id(Invite, &1))
+    |> Multi.delete_all(:device_certificates, &query_by_org_id(DeviceCertificate, &1))
+    |> Multi.delete_all(:ca_certificates, &query_by_org_id(CACertificate, &1))
+    |> Multi.delete_all(:deployments, &query_by_org_id(Deployment, &1))
+    |> Multi.delete_all(:firmware_deltas, &query_firmware_deltas/1)
+    |> Multi.delete_all(:firmware_transfers, &query_by_org_id(FirmwareTransfer, &1))
+    |> Multi.merge(&delete_firmwares/1)
+    |> Multi.delete_all(:product_users, &query_product_users/1)
+    |> Multi.delete_all(:org_keys, &query_by_org_id(OrgKey, &1))
+    |> Multi.delete_all(:org_limits, &query_by_org_id(OrgLimit, &1))
+    |> Multi.delete_all(:org_metrics, &query_by_org_id(OrgMetric, &1))
+    |> Multi.update_all(:soft_delete_products, &soft_delete_by_org_id(Product, &1), [])
+    |> Multi.update_all(:soft_delete_devices, &soft_delete_by_org_id(Device, &1), [])
+    |> Multi.update_all(:soft_delete_org_users, &soft_delete_by_org_id(OrgUser, &1), [])
+    |> Multi.update_all(:soft_delete_orgs, &soft_delete_orgs(&1), [])
+    |> Multi.delete_all(:user_certificates, &query_user_certificates/1)
+    |> Multi.update(:soft_delete_user, &soft_delete_user/1)
+    |> Repo.transaction()
+  end
+
+  defp query_org_users do
+    from(
+      org_user in OrgUser,
+      join: user in assoc(org_user, :user),
+      where: is_nil(user.deleted_at),
+      select: org_user.org_id
+    )
+  end
+
+  defp get_org_ids(repo, %{user_id: user_id}) do
+    where_org_has_users = where(query_org_users(), [ou], ou.user_id != ^user_id)
+
+    query =
+      query_org_users()
+      |> where([ou], ou.user_id == ^user_id)
+      |> except(^where_org_has_users)
+
+    {:ok, repo.all(query)}
+  end
+
+  defp get_firmware_ids(repo, %{org_ids: org_ids}) do
+    query =
+      from(
+        firmware in Firmware,
+        where: firmware.org_id in ^org_ids,
+        select: firmware.id
+      )
+
+    {:ok, repo.all(query)}
+  end
+
+  defp delete_firmwares(%{firmware_ids: firmware_ids}) do
+    Enum.reduce(firmware_ids, Multi.new(), fn firmware_id, multi ->
+      multi_key = "delete_firmware_#{firmware_id}"
+
+      Multi.run(multi, multi_key, fn _, _ ->
+        Firmware
+        |> Repo.get(firmware_id)
+        |> Firmwares.delete_firmware()
+      end)
+    end)
+  end
+
+  defp truncated_utc_now do
+    DateTime.truncate(DateTime.utc_now(), :second)
+  end
+
+  defp soft_delete_user(%{user_id: user_id}) do
+    User
+    |> Repo.get!(user_id)
+    |> change(deleted_at: truncated_utc_now())
+  end
+
+  defp soft_delete_by_org_id(queryable, %{org_ids: org_ids}) do
+    queryable
+    |> query_by_org_id(org_ids)
+    |> update(set: [deleted_at: ^truncated_utc_now()])
+  end
+
+  defp soft_delete_orgs(%{org_ids: ids}) do
+    Org
+    |> where([o], o.id in ^ids)
+    |> update(set: [deleted_at: ^truncated_utc_now()])
+  end
+
+  defp query_by_org_id(queryable, %{org_ids: ids}) do
+    query_by_org_id(queryable, ids)
+  end
+
+  defp query_by_org_id(queryable, ids) when is_list(ids) do
+    where(queryable, [d], d.org_id in ^ids)
+  end
+
+  defp query_product_users(%{user_id: id}), do: where(ProductUser, user_id: ^id)
+
+  defp query_user_certificates(%{user_id: id}) do
+    where(UserCertificate, user_id: ^id)
+  end
+
+  defp query_firmware_deltas(%{org_ids: ids}) do
+    join(
+      FirmwareDelta,
+      :inner,
+      [fp],
+      f in Firmware,
+      on: fp.target_id == f.id and f.org_id in ^ids
+    )
+  end
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/user.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/user.ex
@@ -24,8 +24,8 @@ defmodule NervesHubWebCore.Accounts.User do
   schema "users" do
     has_many(:user_certificates, UserCertificate)
 
-    has_many(:org_users, OrgUser)
-    has_many(:orgs, through: [:org_users, :org])
+    has_many(:org_users, OrgUser, where: [deleted_at: nil])
+    has_many(:orgs, through: [:org_users, :org], where: [deleted_at: nil])
 
     field(:username, :string)
     field(:email, :string)
@@ -34,6 +34,7 @@ defmodule NervesHubWebCore.Accounts.User do
     field(:password_hash, :string)
     field(:password_reset_token, UUID)
     field(:password_reset_token_expires, :utc_datetime)
+    field(:deleted_at, :utc_datetime)
 
     timestamps()
   end
@@ -81,7 +82,7 @@ defmodule NervesHubWebCore.Accounts.User do
 
   defp default_org_query() do
     # For now just get first inserted org
-    from(o in Org) |> first(:inserted_at)
+    from(o in Org) |> first(:inserted_at) |> Repo.exclude_deleted()
   end
 
   def with_default_org(%User{} = u) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/user_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/user_certificate.ex
@@ -21,7 +21,7 @@ defmodule NervesHubWebCore.Accounts.UserCertificate do
   ]
 
   schema "user_certificates" do
-    belongs_to(:user, User)
+    belongs_to(:user, User, where: [deleted_at: nil])
 
     field(:serial, :string)
     field(:description, :string)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
@@ -38,7 +38,7 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
   defenum(Action, :action, [:create, :update, :delete])
 
   schema "audit_logs" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:action, Action)
     field(:actor_id, :id)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments.ex
@@ -162,6 +162,7 @@ defmodule NervesHubWebCore.Deployments do
       where: d.healthy == false,
       select: count(d.id)
     )
+    |> Repo.exclude_deleted()
     |> Repo.one()
     |> Kernel.>=(deployment.failure_threshold)
   end
@@ -220,6 +221,7 @@ defmodule NervesHubWebCore.Deployments do
       where: d.org_id == ^org_id,
       where: d.healthy
     )
+    |> Repo.exclude_deleted()
     |> Repo.all()
   end
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments/deployment.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments/deployment.ex
@@ -25,8 +25,8 @@ defmodule NervesHubWebCore.Deployments.Deployment do
 
   schema "deployments" do
     belongs_to(:firmware, Firmware)
-    belongs_to(:product, Product)
-    belongs_to(:org, Org)
+    belongs_to(:product, Product, where: [deleted_at: nil])
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:conditions, :map)
     field(:device_failure_threshold, :integer, default: 3)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate.ex
@@ -23,7 +23,7 @@ defmodule NervesHubWebCore.Devices.CACertificate do
   ]
 
   schema "ca_certificates" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:description, :string)
     field(:serial, :string)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device_certificate.ex
@@ -25,7 +25,7 @@ defmodule NervesHubWebCore.Devices.DeviceCertificate do
 
   schema "device_certificates" do
     belongs_to(:device, Device)
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:serial, :string)
     field(:aki, :binary)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
@@ -48,8 +48,8 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
   ]
 
   schema "firmwares" do
-    belongs_to(:org, Org)
-    belongs_to(:product, Product)
+    belongs_to(:org, Org, where: [deleted_at: nil])
+    belongs_to(:product, Product, where: [deleted_at: nil])
     belongs_to(:org_key, OrgKey)
     has_many(:deployments, Deployment)
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_transfer.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_transfer.ex
@@ -18,7 +18,7 @@ defmodule NervesHubWebCore.Firmwares.FirmwareTransfer do
   ]
 
   schema "firmware_transfers" do
-    belongs_to(:org, Org)
+    belongs_to(:org, Org, where: [deleted_at: nil])
 
     field(:firmware_uuid)
     field(:remote_ip)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/file.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/file.ex
@@ -21,15 +21,14 @@ defmodule NervesHubWebCore.Firmwares.Upload.File do
   end
 
   @impl NervesHubWebCore.Firmwares.Upload
-  def delete_file(%{upload_metadata: %{local_path: path}}) do
+  def delete_file(%{local_path: path}), do: delete_file(path)
+  def delete_file(%{"local_path" => path}), do: delete_file(path)
+
+  def delete_file(path) when is_binary(path) do
     # Sometimes fw files may be stored in temporary places that
     # get cleared on reboots, especially when using this locally.
     # So if the file doesn't exist, don't attempt to remove
     if File.exists?(path), do: File.rm!(path), else: :ok
-  end
-
-  def delete_file(%{upload_metadata: %{"local_path" => path}}) do
-    delete_file(%{upload_metadata: %{local_path: path}})
   end
 
   @impl NervesHubWebCore.Firmwares.Upload

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/s3.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/s3.ex
@@ -36,9 +36,10 @@ defmodule NervesHubWebCore.Firmwares.Upload.S3 do
   end
 
   @impl NervesHubWebCore.Firmwares.Upload
-  def delete_file(firmware) do
-    s3_key = firmware.upload_metadata["s3_key"]
+  def delete_file(%{s3_key: s3_key}), do: delete_file(s3_key)
+  def delete_file(%{"s3_key" => s3_key}), do: delete_file(s3_key)
 
+  def delete_file(s3_key) when is_binary(s3_key) do
     S3.delete_object(bucket(), s3_key)
     |> ExAws.request()
     |> case do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products.ex
@@ -33,6 +33,7 @@ defmodule NervesHubWebCore.Products do
       )
 
     query
+    |> Repo.exclude_deleted()
     |> Repo.all()
   end
 
@@ -50,10 +51,15 @@ defmodule NervesHubWebCore.Products do
       ** (Ecto.NoResultsError)
 
   """
-  def get_product!(id), do: Repo.get!(Product, id)
+  def get_product!(id) do
+    Product
+    |> Repo.exclude_deleted()
+    |> Repo.get!(id)
+  end
 
   def get_product_by_org_id_and_name(org_id, name) do
     Product
+    |> Repo.exclude_deleted()
     |> Repo.get_by(org_id: org_id, name: name)
     |> case do
       nil -> {:error, :not_found}
@@ -207,7 +213,7 @@ defmodule NervesHubWebCore.Products do
   def delete_product(%Product{} = product) do
     product
     |> Product.delete_changeset()
-    |> Repo.delete()
+    |> Repo.update()
   end
 
   @doc """

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products/product_user.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products/product_user.ex
@@ -7,8 +7,8 @@ defmodule NervesHubWebCore.Products.ProductUser do
   alias NervesHubWebCore.Accounts.User
 
   schema "product_users" do
-    belongs_to(:product, Product)
-    belongs_to(:user, User)
+    belongs_to(:product, Product, where: [deleted_at: nil])
+    belongs_to(:user, User, where: [deleted_at: nil])
 
     field(:role, User.Role)
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
@@ -3,6 +3,8 @@ defmodule NervesHubWebCore.Repo do
     otp_app: :nerves_hub_web_core,
     adapter: Ecto.Adapters.Postgres
 
+  import Ecto.Query, only: [where: 3]
+
   @doc """
   Dynamically loads the repository url from the
   DATABASE_URL environment variable.
@@ -27,4 +29,20 @@ defmodule NervesHubWebCore.Repo do
   end
 
   def reload_assoc({:error, changeset}, _), do: {:error, changeset}
+
+  def soft_delete(struct_or_changeset) do
+    struct_or_changeset
+    |> soft_delete_changeset()
+    |> update()
+  end
+
+  def soft_delete_changeset(struct_or_changeset) do
+    deleted_at = DateTime.truncate(DateTime.utc_now(), :second)
+
+    Ecto.Changeset.change(struct_or_changeset, deleted_at: deleted_at)
+  end
+
+  def exclude_deleted(query) do
+    where(query, [o], is_nil(o.deleted_at))
+  end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/delete_firmware.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/delete_firmware.ex
@@ -1,0 +1,11 @@
+defmodule NervesHubWebCore.Workers.DeleteFirmware do
+  use NervesHubWebCore.Worker,
+    max_attempts: 5,
+    queue: :delete_firmware,
+    schedule: "*/15 * * * *"
+
+  @uploader Application.fetch_env!(:nerves_hub_web_core, :firmware_upload)
+
+  @impl true
+  def run(%{args: args}), do: @uploader.delete_file(args)
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/firmwares_gc.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/firmwares_gc.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWebCore.Workers.FirmwaresGC do
     Firmwares.get_firmware_by_expired_ttl()
     |> Enum.each(fn firmware ->
       case Firmwares.delete_firmware(firmware) do
-        :ok ->
+        {:ok, _} ->
           Logger.debug("Garbage collected firmware #{firmware.uuid}")
 
         {:error, reason} ->

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20201110152253_soft_delete_changes.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20201110152253_soft_delete_changes.exs
@@ -1,0 +1,31 @@
+defmodule NervesHubWebCore.Repo.Migrations.SoftDeleteChanges do
+  use Ecto.Migration
+
+  def change do
+    alter(table(:orgs)) do
+      add(:deleted_at, :utc_datetime)
+    end
+
+    alter(table(:org_users)) do
+      add(:deleted_at, :utc_datetime)
+    end
+
+    alter(table(:devices)) do
+      add(:deleted_at, :utc_datetime)
+    end
+
+    alter(table(:users)) do
+      add(:deleted_at, :utc_datetime)
+    end
+
+    alter(table(:products)) do
+      add(:deleted_at, :utc_datetime)
+    end
+
+    create_if_not_exists(index(:orgs, [:deleted_at]))
+    create_if_not_exists(index(:org_users, [:deleted_at]))
+    create_if_not_exists(index(:devices, [:deleted_at]))
+    create_if_not_exists(index(:users, [:deleted_at]))
+    create_if_not_exists(index(:products, [:deleted_at]))
+  end
+end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20201119021119_update_user_uniqueness.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20201119021119_update_user_uniqueness.exs
@@ -1,0 +1,19 @@
+defmodule NervesHubWebCore.Repo.Migrations.UpdateUserUniqueness do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(unique_index(:users, [:email]))
+    drop_if_exists(unique_index(:users, [:username]))
+    drop_if_exists(unique_index(:orgs, [:name]))
+    drop_if_exists(unique_index(:org_users, [:org_id, :user_id], name: "org_users_index"))
+    drop_if_exists(unique_index(:products, [:org_id, :name], name: :products_org_id_name_index))
+    drop_if_exists(unique_index(:devices, [:org_id, :identifier], name: :devices_org_id_identifier_index))
+
+    create_if_not_exists(unique_index(:users, [:email], where: "deleted_at IS NULL"))
+    create_if_not_exists(unique_index(:users, [:username], where: "deleted_at IS NULL"))
+    create_if_not_exists(unique_index(:orgs, [:name], where: "deleted_at IS NULL"))
+    create_if_not_exists(unique_index(:org_users, [:org_id, :user_id], name: "org_users_index", where: "deleted_at IS NULL"))
+    create_if_not_exists(unique_index(:products, [:org_id, :name], name: :products_org_id_name_index, where: "deleted_at IS NULL"))
+    create_if_not_exists(unique_index(:devices, [:org_id, :identifier], name: :devices_org_id_identifier_index, where: "deleted_at IS NULL"))
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -143,12 +143,6 @@ defmodule NervesHubWebCore.AccountsTest do
     assert user_orgs == [default_org, org_1]
   end
 
-  test "Unable to remove last user from org" do
-    user = Fixtures.user_fixture()
-    org = Fixtures.org_fixture(user)
-    assert {:error, :last_user} = Accounts.remove_org_user(org, user)
-  end
-
   test "Unable to remove user from user org" do
     user = Fixtures.user_fixture()
     [org] = Accounts.get_user_orgs(user)

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/remove_account_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/remove_account_test.exs
@@ -1,0 +1,58 @@
+defmodule NervesHubWebCore.Accounts.RemoveAccountTest do
+  use NervesHubWebCore.DataCase, async: true
+
+  alias NervesHubWebCore.{Accounts, Fixtures}
+
+  test "remove_account for basic account" do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    org_key = Fixtures.org_key_fixture(org)
+    product = Fixtures.product_fixture(user, org)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+    Fixtures.deployment_fixture(org, firmware)
+
+    NervesHubWebCore.Accounts.RemoveAccount.remove_account(user.id)
+
+    assert {:error, :not_found} = Accounts.get_user(user.id)
+  end
+
+  test "remove_account with org_users" do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    org_key = Fixtures.org_key_fixture(org)
+    product = Fixtures.product_fixture(user, org)
+    firmware1 = Fixtures.firmware_fixture(org_key, product)
+    Fixtures.deployment_fixture(org, firmware1)
+    device = Fixtures.device_fixture(org, product, firmware1)
+    Fixtures.device_certificate_fixture(device)
+    firmware2 = Fixtures.firmware_fixture(org_key, product)
+    Fixtures.firmware_delta_fixture(firmware1, firmware2)
+
+    org2 = Fixtures.org_fixture(user, %{name: "Test-Org2"})
+    {:ok, invite} = Accounts.add_or_invite_to_org(%{"email" => "test@test.org"}, org2)
+    params = %{username: "Test-User2", password: "Test-Password"}
+    {:ok, org_user} = Accounts.create_user_from_invite(invite, org2, params)
+
+    org2_key = Fixtures.org_key_fixture(org2)
+    org2_product = Fixtures.product_fixture(org_user.user, org2)
+    org2_firmware = Fixtures.firmware_fixture(org2_key, org2_product)
+    Fixtures.deployment_fixture(org, org2_firmware)
+
+    %{firmware: firmware1, org_key: org_key, product: product} = Fixtures.standard_fixture()
+    firmware2 = Fixtures.firmware_fixture(org_key, product)
+    Fixtures.firmware_delta_fixture(firmware1, firmware2)
+
+    org3 = Fixtures.org_fixture(org_user.user, %{name: "org3"})
+    org3_key = Fixtures.org_key_fixture(org3)
+    org3_product = Fixtures.product_fixture(org_user.user, org3)
+    org3_firmware = Fixtures.firmware_fixture(org3_key, org3_product)
+    Fixtures.deployment_fixture(org, org3_firmware)
+
+    NervesHubWebCore.Accounts.RemoveAccount.remove_account(user.id)
+
+    assert {:error, _} = Accounts.get_user(user.id)
+    assert {:error, _} = Accounts.get_org(org.id)
+    assert {:ok, _} = Accounts.get_org(org2.id)
+    assert {:ok, _} = Accounts.get_org(org3.id)
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/account_controller.ex
@@ -38,6 +38,26 @@ defmodule NervesHubWWWWeb.AccountController do
     )
   end
 
+  def confirm_delete(conn, _) do
+    render(conn, "delete.html")
+  end
+
+  def delete(conn, %{"user_name" => username, "confirm_username" => confirmed_username})
+      when username != confirmed_username do
+    conn
+    |> put_flash(:error, "Please type #{username} to confirm.")
+    |> redirect(to: Routes.account_path(conn, :confirm_delete, username))
+  end
+
+  def delete(conn, %{"user_name" => username}) do
+    with {:ok, user} <- Accounts.get_user_by_username(username),
+         {:ok, _} <- Accounts.remove_account(user.id) do
+      conn
+      |> put_flash(:info, "Success")
+      |> redirect(to: "/login")
+    end
+  end
+
   def update(conn, params) do
     cleaned =
       params["user"]

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/fallback_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/fallback_controller.ex
@@ -7,7 +7,7 @@ defmodule NervesHubWWWWeb.FallbackController do
   use NervesHubWWWWeb, :controller
 
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
-    [{_, {reason, _}}] = changeset.errors
+    [{_, {reason, _}} | _] = changeset.errors
 
     conn
     |> put_flash(:error, reason)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -100,7 +100,7 @@ defmodule NervesHubWWWWeb.FirmwareController do
 
   def delete(%{assigns: %{org: org, product: product}} = conn, %{"firmware_uuid" => uuid}) do
     with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
-         :ok <- Firmwares.delete_firmware(firmware) do
+         {:ok, _} <- Firmwares.delete_firmware(firmware) do
       conn
       |> put_flash(:info, "Firmware successfully deleted")
       |> redirect(to: Routes.firmware_path(conn, :index, org.name, product.name))

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -96,6 +96,8 @@ defmodule NervesHubWWWWeb.Router do
     scope "/account/:user_name" do
       get("/", AccountController, :edit)
       put("/", AccountController, :update)
+      get("/delete_account", AccountController, :confirm_delete)
+      delete("/delete_account", AccountController, :delete)
 
       scope "/certificates" do
         get("/", AccountCertificateController, :index)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/delete.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/delete.html.eex
@@ -1,0 +1,14 @@
+<h1>Are you absolutely sure?</h1>
+<p>Unexpected bad things will happen if you don’t read this!</p>
+<p>This action cannot be undone. This will permanently delete the <%= @user.username %> and orgs.</p>
+
+<%= form_for @conn, Routes.account_path(@conn, :delete, @user.username), [method: "delete"], fn f -> %>
+  <div class="form-group">
+    <label for="username_input">Please type <%= @user.username %> to confirm.</label>
+    <%= text_input f, :confirm_username, class: "form-control", id: "username_input" %>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <%= submit "I understand the consequences, delete this account", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/edit.html.eex
@@ -6,6 +6,14 @@
   <a class="btn btn-outline-light" href="<%= Routes.account_certificate_path(@conn, :index, @user.username)%>">
       User Certificates
   </a>
+  <%=
+    link(
+      "Delete Account",
+      class: "btn btn-outline-light",
+      aria_label: "Delete Account",
+      to: Routes.account_path(@conn, :confirm_delete, @user.username)
+    )
+  %>
 </div>
 
 <%= form_for @changeset, Routes.account_path(@conn, :update, @user.username), fn f -> %>
@@ -39,4 +47,3 @@
     <%= submit "Save Changes", class: "btn btn-primary" %>
   </div>
 <% end %>
-


### PR DESCRIPTION
connect #421 

This pull request allows users to delete their accounts when they're done using NervesHub. When an account is deleted, most things can be "hard deleted". However, in order to handle orphaned devices that may become disruptive we elect to "soft delete". I've identified users, orgs, org_users, products, and devices to become soft deleted.
