### PR TITLE
Fix device index status reset bug

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -222,12 +222,14 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
   end
 
   def handle_info(
-        %Broadcast{event: "presence_diff", payload: payload},
+        %Broadcast{event: "presence_diff", payload: %{leaves: leaves}},
         %{assigns: %{org: org, product: product}} = socket
       ) do
     devices = Devices.get_devices_by_org_id_and_product_id(org.id, product.id)
+    joins = Presence.list("product:#{product.id}:devices")
 
-    socket = assign_display_devices(socket, sync_devices(devices, payload))
+    socket =
+      assign_display_devices(socket, sync_devices(devices, %{joins: joins, leaves: leaves}))
 
     {:noreply, socket}
   end


### PR DESCRIPTION
Why:

* We were not applying presence statuses to new devices from DB
* Fixes #670 

This change addresses the need by:

* Apply statuses from presence after a presence_diff event and devices are fetched