### PR TITLE
Find CA by ski and not aki

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device/ssl.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device/ssl.ex
@@ -71,7 +71,7 @@ defmodule NervesHubDevice.SSL do
 
       _ ->
         with aki <- Certificate.get_aki(certificate),
-             {:ok, %CACertificate{org_id: org_id}} <- Devices.get_ca_certificate_by_aki(aki),
+             {:ok, %CACertificate{org_id: org_id}} <- Devices.get_ca_certificate_by_ski(aki),
              {:ok, org} <- Accounts.get_org(org_id),
              identifier <- Certificate.get_common_name(certificate),
              {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -295,6 +295,15 @@ defmodule NervesHubWebCore.Devices do
     end
   end
 
+  @spec get_ca_certificate_by_ski(binary) :: {:ok, CACertificate.t()} | {:error, any()}
+  def get_ca_certificate_by_ski(ski) do
+    Repo.get_by(CACertificate, ski: ski)
+    |> case do
+      nil -> {:error, :not_found}
+      ca_cert -> {:ok, ca_cert}
+    end
+  end
+
   @spec get_ca_certificate_by_serial(binary) :: {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_serial(serial) do
     Repo.get_by(CACertificate, serial: serial)


### PR DESCRIPTION
The current code assumes that all ca certificates are root certificates by searching for one who has the same authority and subject identifier (a self signed root cert) This behavior is wrong and prevents intermediates from being used for signing. Updating the lookup to find the ca by ski will allow for both self signed and intermediates to be used.