### PR TITLE
Append timestamp to audit_log help-text message

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
@@ -2,23 +2,21 @@
 
 <div id="audit-log-feed">
   <%= if Enum.count(@audit_logs) > 0 do %>
-    <%= for audit_log <- @audit_logs do %>
-      <div class="audit-log-item" id='<%= audit_log.id %>'>
-        <div class="audit-action-icon icon-<%= audit_log.action %>"></div>
-        <div>
-          <p class="audit-description"><%= audit_log.description %></p>
-            <div class="help-text">
-              <%= DateTimeFormat.from_now(audit_log.inserted_at) %>
-            </div>
-        </div>
+  <%= for audit_log <- @audit_logs do %>
+  <div class="audit-log-item" id='<%= audit_log.id %>'>
+    <div class="audit-action-icon icon-<%= audit_log.action %>"></div>
+    <div>
+      <p class="audit-description"><%= audit_log.description %></p>
+      <div class="help-text">
+        <%= DateTimeFormat.from_now(audit_log.inserted_at) %><small> at <%= audit_log.inserted_at %></small>
       </div>
-    <% end %>
-    <%= pagination_links(@audit_log_ids, @paginate_opts) %>
-  <% else %>
-    <div class="audit-log-item">
-      <p class="text-muted">No activity</p>
     </div>
+  </div>
+  <% end %>
+  <%= pagination_links(@audit_log_ids, @paginate_opts) %>
+  <% else %>
+  <div class="audit-log-item">
+    <p class="text-muted">No activity</p>
+  </div>
   <% end %>
 </div>
-
-


### PR DESCRIPTION
closes #680 

Appends timestamp to the audit log to determine the exact time an event occurred

![image](https://user-images.githubusercontent.com/9411090/97754837-316ce900-1ac6-11eb-8f7f-3193cd24bf77.png)
