### PR TITLE
Fix alert layout on homepage

### DIFF
--- a/apps/nerves_hub_www/assets/css/_home.scss
+++ b/apps/nerves_hub_www/assets/css/_home.scss
@@ -48,6 +48,27 @@ $primary: #A72B2A;
     line-height: 1.75rem;
   }
 
+  .alert {
+    border-radius: 0;
+    margin: 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 99;
+    padding: 0;
+
+    .content-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .close {
+      position: static;
+      padding: .75rem;
+    }
+  }
+
   .btn-home {
     max-width: 264px;
     width: 100%;

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
@@ -38,14 +38,18 @@
         <main role="main" class="flex-column">
           <%= if get_flash(@conn, :info) do %>
             <div class="alert alert-info alert-dismissible">
-              <button type="button" class="close" data-dismiss="alert">&times;</button>
-              <%= get_flash(@conn, :info) %>
+              <div class="content-container">
+                <%= get_flash(@conn, :info) %>
+                <button type="button" class="close" data-dismiss="alert">&times;</button>
+              </div>
             </div>
           <% end %>
           <%= if get_flash(@conn, :error) do %>
             <div class="alert alert-danger alert-dismissible">
-              <button type="button" class="close" data-dismiss="alert">&times;</button>
-              <%= get_flash(@conn, :error) %>
+              <div class="content-container">
+                <%= get_flash(@conn, :error) %>
+                <button type="button" class="close" data-dismiss="alert">&times;</button>
+              </div>
             </div>
           <% end %>
           <%= @inner_content %>


### PR DESCRIPTION
### Why
- Alerts were overlapping with content on the homepage

### How
- Updated styles for alerts specifically on the homepage. They will now always display properly at the top and not overlap content.