### PR TITLE
Make products patchable

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/product_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/product_view.ex
@@ -12,7 +12,8 @@ defmodule NervesHubAPIWeb.ProductView do
 
   def render("product.json", %{product: product}) do
     %{
-      name: product.name
+      name: product.name,
+      delta_updatable: product.delta_updatable
     }
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -143,7 +143,7 @@ defmodule NervesHubWebCore.Devices do
           {:error, :not_found} -> nil
         end
 
-      {:ok, url} = Firmwares.get_firmware_url(source, target, fwup_version)
+      {:ok, url} = Firmwares.get_firmware_url(source, target, fwup_version, product)
       {:ok, meta} = Firmwares.metadata_from_firmware(target)
 
       Phoenix.PubSub.broadcast(
@@ -419,7 +419,7 @@ defmodule NervesHubWebCore.Devices do
           {:error, :not_found} -> nil
         end
 
-      {:ok, url} = Firmwares.get_firmware_url(source, target, fwup_version)
+      {:ok, url} = Firmwares.get_firmware_url(source, target, fwup_version, product)
       {:ok, meta} = Firmwares.metadata_from_firmware(target)
 
       %{update_available: true, firmware_url: url, firmware_meta: meta}

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -342,23 +342,21 @@ defmodule NervesHubWebCore.Firmwares do
     end
   end
 
-  @spec get_firmware_url(Firmware.t(), Firmware.t(), String.t()) ::
+  @spec get_firmware_url(Firmware.t(), Firmware.t(), String.t(), Product.t()) ::
           {:ok, String.t()}
           | {:error, :failure}
 
-  ##
-  # TODO: Put this check back in once delta updates has been fixed
-  # Until then, skip attempting any delta updates for now ¬
-  #
-  # def get_firmware_url(source, target, fwup_version) when is_binary(fwup_version) do
-  #   if Version.match?(fwup_version, @min_fwup_delta_updatable_version) do
-  #     do_get_firmware_url(source, target)
-  #   else
-  #     @uploader.download_file(target)
-  #   end
-  # end
+  def get_firmware_url(source, target, fwup_version, %Product{delta_updatable: true})
+      when is_binary(fwup_version) do
+    if Version.match?(fwup_version, @min_fwup_delta_updatable_version) do
+      do_get_firmware_url(source, target)
+    else
+      @uploader.download_file(target)
+    end
+  end
 
-  def get_firmware_url(_source, target, _fwup_version), do: @uploader.download_file(target)
+  def get_firmware_url(_source, target, _fwup_version, _product),
+    do: @uploader.download_file(target)
 
   @spec create_firmware_delta(Firmware.t(), Firmware.t()) ::
           {:ok, FirmwareDelta.t()}

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/delta_updater/default.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/delta_updater/default.ex
@@ -59,8 +59,8 @@ defmodule NervesHubWebCore.Firmwares.DeltaUpdater.Default do
   end
 
   @impl NervesHubWebCore.Firmwares.DeltaUpdater
-  def cleanup_firmware_delta_files(patch_path) do
-    patch_path
+  def cleanup_firmware_delta_files(firmware_delta_path) do
+    firmware_delta_path
     |> Path.dirname()
     |> File.rm_rf!()
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products/product.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products/product.ex
@@ -8,7 +8,7 @@ defmodule NervesHubWebCore.Products.Product do
   alias NervesHubWebCore.Products.ProductUser
 
   @required_params [:name, :org_id]
-  @optional_params []
+  @optional_params [:delta_updatable]
 
   schema "products" do
     has_many(:devices, Device)
@@ -19,6 +19,7 @@ defmodule NervesHubWebCore.Products.Product do
     belongs_to(:org, Org)
 
     field(:name, :string)
+    field(:delta_updatable, :boolean, default: true)
 
     timestamps()
   end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products/product.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products/product.ex
@@ -19,7 +19,7 @@ defmodule NervesHubWebCore.Products.Product do
     belongs_to(:org, Org)
 
     field(:name, :string)
-    field(:delta_updatable, :boolean, default: true)
+    field(:delta_updatable, :boolean, default: false)
 
     timestamps()
   end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20201024000822_add_patchable_flag_to_products.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20201024000822_add_patchable_flag_to_products.exs
@@ -1,0 +1,9 @@
+defmodule NervesHubWebCore.Repo.Migrations.AddPatchableFlagToProducts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:products) do
+      add(:delta_updatable, :boolean, default: true)
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20201024000822_add_patchable_flag_to_products.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20201024000822_add_patchable_flag_to_products.exs
@@ -3,7 +3,7 @@ defmodule NervesHubWebCore.Repo.Migrations.AddPatchableFlagToProducts do
 
   def change do
     alter table(:products) do
-      add(:delta_updatable, :boolean, default: true)
+      add(:delta_updatable, :boolean, default: false)
     end
   end
 end

--- a/apps/nerves_hub_www/assets/css/_buttons.scss
+++ b/apps/nerves_hub_www/assets/css/_buttons.scss
@@ -109,7 +109,7 @@ html {
   }
 
   .button-submit-wrapper {
-    margin-top: 2rem;
+    margin-top: 4rem;
     display: flex;
     align-items: center;
 

--- a/apps/nerves_hub_www/assets/css/_custom.scss
+++ b/apps/nerves_hub_www/assets/css/_custom.scss
@@ -147,8 +147,8 @@
     padding: .5rem;
     background: var(--backgroundDark);
     position: absolute;
-    left: calc(100% + .5rem);
-    top: 0;
+    left: 100%;
+    top: -.25rem;
     display: none;
     width: 13rem;
     text-transform: none;
@@ -161,14 +161,14 @@
   }
 
   .tooltip-info {
-    width: 1rem;
+    width: 2rem;
     height: 1rem;
     opacity: .5;
     transition: opacity 200ms ease;
     background-image: url("/images/icons/info.svg");
     background-position: center;
     background-size: 1rem;
-    margin-left: .5rem;
+    background-repeat: no-repeat;
   }
 
   &.help-tooltip {

--- a/apps/nerves_hub_www/assets/css/_form.scss
+++ b/apps/nerves_hub_www/assets/css/_form.scss
@@ -43,7 +43,7 @@ html {
 
     &:disabled {
       background-color: var(--white-25);
-      opacity: .8;
+      opacity: 0.8;
       cursor: not-allowed;
     }
 
@@ -104,6 +104,13 @@ html {
     font-size: 16px;
   }
 
+  .checkbox {
+    display: inline-block;
+    height: 25px;
+    width: 25px;
+    -webkit-filter: grayscale(100%);
+  }
+
   .form-page-wrapper {
     align-items: center;
     display: flex;
@@ -132,7 +139,7 @@ html {
 
     .help-text {
       color: var(--white-50);
-      margin: 3.25rem 0 .75rem;
+      margin: 3.25rem 0 0.75rem;
       font-weight: 500;
     }
   }
@@ -143,25 +150,25 @@ html {
     padding: 0;
 
     li {
-      margin: .5rem 0 0;
+      margin: 0.5rem 0 0;
       padding: 0 0 0 24px;
       position: relative;
 
       &:before {
-        background-color: #5B5D5F;
+        background-color: #5b5d5f;
         border-radius: 100%;
         content: '';
         display: inline-block;
-        height: .5rem;
+        height: 0.5rem;
         left: 0;
         position: absolute;
-        width: .5rem;
+        width: 0.5rem;
         top: 7px;
       }
 
       &.validated:before {
         background-color: transparent;
-        background-image: url("/images/icons/check.svg");
+        background-image: url('/images/icons/check.svg');
         background-position: center;
         background-repeat: no-repeat;
         background-size: 20px;
@@ -182,19 +189,19 @@ html {
       pointer-events: none;
       width: 1.5rem;
       height: 1.5rem;
-      background-image: url("/images/icons/dropdown-red.svg");
+      background-image: url('/images/icons/dropdown-red.svg');
       background-position: center;
       background-repeat: no-repeat;
       position: absolute;
-      right: .75rem;
-      bottom: .75rem;
+      right: 0.75rem;
+      bottom: 0.75rem;
       margin: auto;
     }
   }
 
   .has-error {
     color: var(--danger);
-    margin-top: .25rem;
+    margin-top: 0.25rem;
     font-weight: 500;
     font-size: 1rem;
     text-transform: capitalize;
@@ -225,7 +232,7 @@ html {
 
         .file-name {
           color: white;
-          padding-top: .5rem;
+          padding-top: 0.5rem;
         }
       }
 
@@ -254,7 +261,6 @@ html {
   }
 
   .filter-form {
-
     &.device-filters {
       display: grid;
       grid-template-columns: 3fr 3fr 3fr 2fr 2fr;
@@ -271,7 +277,7 @@ html {
     }
 
     label {
-      font-size: .875rem;
+      font-size: 0.875rem;
     }
   }
 }

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -116,7 +116,6 @@ defmodule NervesHubWWWWeb.Router do
       pipe_through(:org)
 
       get("/", ProductController, :index)
-      put("/", ProductController, :update)
       get("/new", ProductController, :new)
       post("/", ProductController, :create)
 
@@ -125,6 +124,7 @@ defmodule NervesHubWWWWeb.Router do
 
         get("/", ProductController, :show)
         get("/edit", ProductController, :edit)
+        put("/", ProductController, :update)
         delete("/", ProductController, :delete)
 
         scope "/devices" do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/edit.html.eex
@@ -1,6 +1,3 @@
 <h1>Product Settings</h1>
 
-<%= render "form.html", Map.put(assigns, :action, Routes.product_path(@conn, :edit, @org.name, @product)) %>
-
-
-
+<%= render "form.html", Map.put(assigns, :action, Routes.product_path(@conn, :update, @org.name, @product.name)) %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
@@ -21,16 +21,20 @@
 
   <div class="form-group">
       <label for="delta_updatable_input" class="tooltip-label">
-      <span>Generate delta firmware updates</span>
+      <span>Firmware updates</span>
       <span class="tooltip-info"></span>
       <span class="tooltip-text">
-        Check out the documentation at 
-        <a href="https://docs.nerves-hub.org" target="_blank">https://docs.nerves-hub.org </a> 
-        for more information about 
-        <a href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank">delta updates</a>
+        Check out the documentation at
+        <a href="https://docs.nerves-hub.org" target="_blank" class="inline">https://docs.nerves-hub.org </a>
+        for more information about
+        <a href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank" class="inline">delta updates</a>
       </span>
     </label>
-    <%= checkbox f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input" %>    
+    <div class="flex-row align-items-center">
+      <%= checkbox f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input" %>
+      <label for="delta_updatable_input" class="color-white pl-1 m-0">Enable delta firmware updates</label>
+    </div>
+
     <div class="has-error"><%= error_tag f, :delta_updatable %></div>
   </div>
 
@@ -41,6 +45,5 @@
     <% else %>
       <%= submit "Create Product", class: "btn btn-primary" %>
     <% end %>
-
   </div>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
@@ -20,7 +20,16 @@
   </div>
 
   <div class="form-group">
-    <label for="delta_updatable_input">Patchable</label>    
+      <label for="delta_updatable_input" class="tooltip-label">
+      <span>Generate delta firmware updates</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">
+        Check out the documentation at 
+        <a href="https://docs.nerves-hub.org" target="_blank">https://docs.nerves-hub.org </a> 
+        for more information about 
+        <a href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank">delta updates</a>
+      </span>
+    </label>
     <%= checkbox f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input" %>    
     <div class="has-error"><%= error_tag f, :delta_updatable %></div>
   </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @changeset, Routes.product_path(@conn, :create, @org.name), fn f -> %>
+<%= form_for @changeset, assigns[:action], fn f -> %>
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>
@@ -19,10 +19,16 @@
     <div class="has-error"><%= error_tag f, :name %></div>
   </div>
 
+  <div class="form-group">
+    <label for="delta_updatable_input">Patchable</label>    
+    <%= checkbox f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input" %>    
+    <div class="has-error"><%= error_tag f, :delta_updatable %></div>
+  </div>
+
   <div class="button-submit-wrapper">
     <%= if assigns[:product] do %>
       <%= link "Remove Product", class: "btn btn-secondary", to: Routes.product_path(@conn, :delete, @org.name, @product.name), method: :delete, data: [confirm: "Are you sure you want to delete this product? This can not be undone."] %>
-      <%= submit "Save Changes", class: "btn btn-primary", disabled: "true" %>
+      <%= submit "Save Changes", class: "btn btn-primary" %>
     <% else %>
       <%= submit "Create Product", class: "btn btn-primary" %>
     <% end %>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/product_controller_test.exs
@@ -1,9 +1,10 @@
 defmodule NervesHubWWWWeb.ProductControllerTest do
   use NervesHubWWWWeb.ConnCase.Browser, async: true
 
-  alias NervesHubWebCore.Fixtures
+  alias NervesHubWebCore.{Fixtures, Products}
 
   @create_attrs %{name: "some name"}
+  @update_attrs %{delta_updatable: false}
   @invalid_attrs %{name: nil}
 
   describe "index" do
@@ -24,7 +25,6 @@ defmodule NervesHubWWWWeb.ProductControllerTest do
     test "redirects to show when data is valid", %{conn: conn, org: org} do
       params = @create_attrs
       conn = post(conn, Routes.product_path(conn, :create, org.name), product: params)
-      assert %{product_name: product_name} = redirected_params(conn)
       assert redirected_to(conn) == Routes.device_path(conn, :index, org.name, params.name)
 
       conn = get(conn, Routes.product_path(conn, :show, org.name, params.name))
@@ -36,6 +36,22 @@ defmodule NervesHubWWWWeb.ProductControllerTest do
     test "renders errors when data is invalid", %{conn: conn, org: org} do
       conn = post(conn, Routes.product_path(conn, :create, org.name), product: @invalid_attrs)
       assert html_response(conn, 200) =~ "Create Product"
+    end
+  end
+
+  describe "update product" do
+    test "redirects to show when data is valid", %{
+      conn: conn,
+      fixture: %{product: product},
+      org: org
+    } do
+      params = @update_attrs
+
+      conn =
+        put(conn, Routes.product_path(conn, :update, org.name, product.name), product: params)
+
+      assert redirected_to(conn) == Routes.device_path(conn, :index, org.name, product.name)
+      assert %{delta_updatable: false} = Products.get_product!(product.id)
     end
   end
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWebCore.Fixtures do
     is_active: false
   }
   @device_params %{tags: ["beta", "test"]}
-  @product_params %{name: "valid product"}
+  @product_params %{name: "valid product", patchable: true}
 
   @user_ca_key Path.expand("../fixtures/ssl/user-root-ca-key.pem", __DIR__)
   @user_ca_cert Path.expand("../fixtures/ssl/user-root-ca.pem", __DIR__)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWebCore.Fixtures do
     is_active: false
   }
   @device_params %{tags: ["beta", "test"]}
-  @product_params %{name: "valid product", patchable: true}
+  @product_params %{name: "valid product", delta_updatable: true}
 
   @user_ca_key Path.expand("../fixtures/ssl/user-root-ca-key.pem", __DIR__)
   @user_ca_cert Path.expand("../fixtures/ssl/user-root-ca.pem", __DIR__)


### PR DESCRIPTION
This fixes #674 

Why:

* We want users to be able to configure patchability of firmware per product

This change addresses the need by:

* Add a patchable flag in the DB
* Update the router to allow updating products
* Update the product form to use the correct endpoint
* Update product form with new fields
* Update CSS for patchable field
* Add a new condition to the fetch_firmware_url function for patchable product
* Add tests to ensure that patches are created for patchable products
* Add test for updating product

Note: The `get_firmware_url` function is getting a bit wild with parameters. If anyone has ideas about how to reorganize this to make check the check a little nicer, would be appreciated.