### PR TITLE
Add progressbar to device details page

### DIFF
--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -143,3 +143,25 @@ html body {
     background-color: var(--warning);
   }
 }
+
+.progress {
+  background: rgba(255, 255, 255, 0.1);
+
+  .progress-bar {
+    background-color: var(--primary);
+    font-weight: 700;
+  }
+
+  &.device-show {
+    height: 1.5rem;
+    margin-top: .5rem;
+
+    .progress-bar {
+      height: 1.5rem;
+      font-size: .875rem;
+      text-align: right;
+      padding: 0 .5rem;
+      min-width: 2rem;
+    }
+  }
+}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/_header.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/_header.html.leex
@@ -49,4 +49,13 @@
   </div>
 </div>
 
+<%= if Map.has_key?(@device, :fwup_progress) && @device.fwup_progress do %>
+  <div class="help-text mt-3">Progress</div>
+  <div class="progress device-show">
+    <div class="progress-bar" role="progressbar" style="width: <%= @device.fwup_progress %>%">
+      <%= @device.fwup_progress %>%
+    </div>
+  </div>
+<% end %>
+
 <div class="divider"></div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -124,7 +124,7 @@
           <div>
             <%= if Map.has_key?(device, :fwup_progress) && device.fwup_progress do %>
               <div class="progress">
-                <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= device.fwup_progress %>%"><%= device.fwup_progress %>%</div>
+                <div class="progress-bar" role="progressbar" style="width: <%= device.fwup_progress %>%"><%= device.fwup_progress %>%</div>
               </div>
             <% else %>
               <%= if is_nil(device.firmware_metadata) do %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -42,7 +42,6 @@
 
 <%= render("_header.html", device: @device) %>
 
-
 <div class="row">
   <div class="col-lg-7">
     <h3 class="mb-2">Deployments</h3>


### PR DESCRIPTION
### Why
- The progress bar showing a device updating should be displayed on the device details page

### How
- Added the progress bar to the device `_header` 
- Slightly updated the styles for the progress bar to be more inline with the rest of the styles.