### PR TITLE
Restructure Console page

### DIFF
--- a/apps/nerves_hub_www/assets/css/_console.scss
+++ b/apps/nerves_hub_www/assets/css/_console.scss
@@ -64,6 +64,11 @@
 #console-html, #console-body {
   background-color: black;
   height: 100%;
+  border: solid gray;
+  border-width: 2px;
+  .xterm {
+    height: 100%;
+  }
 }
 
 .console-details-row {
@@ -76,10 +81,7 @@
 }
 
 .console-v2 {
-  border-radius: 4px;
-  padding-bottom: 20px;
   height: 100%;
-  padding-left: 1.5rem;
   color: white;
 }
 

--- a/apps/nerves_hub_www/assets/css/_console.scss
+++ b/apps/nerves_hub_www/assets/css/_console.scss
@@ -1,3 +1,5 @@
+// Console V1
+
 .console-wrapper {
   background: black;
   padding: 1rem;
@@ -53,4 +55,52 @@
 
 .console-input:focus {
   outline: none;
+}
+
+// Console V2
+
+@import "~xterm/css/xterm.css";
+
+#console-html, #console-body {
+  background-color: black;
+  height: 100%;
+}
+
+.console-details-row {
+  padding: 1rem;
+  border-radius: 4px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.console-v2 {
+  border-radius: 4px;
+  padding-bottom: 20px;
+  height: 100%;
+  padding-left: 1.5rem;
+  color: white;
+}
+
+.online {
+  background-image: url("/images/icons/check.svg");
+  padding-left: 1.5rem;
+  background-repeat: no-repeat;
+  font-weight: bold;
+  display: inline-flex;
+  line-height: 44px;
+}
+
+.offline, .rebooting {
+  background-image: url("/images/icons/cross.svg");
+  padding-left: 1.5rem;
+  background-repeat: no-repeat;
+  font-weight: bold;
+  display: inline-flex;
+  line-height: 44px;
+}
+
+.console-progress {
+  width: 100px;
 }

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -6,7 +6,6 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap');
 
 @import "_animate.css";
-@import "~xterm/css/xterm.css";
 @import "audit_log_feed";
 @import "console";
 @import "layout";

--- a/apps/nerves_hub_www/assets/js/app.js
+++ b/apps/nerves_hub_www/assets/js/app.js
@@ -5,18 +5,15 @@ import 'bootstrap'
 import $ from 'jquery'
 import { Socket } from 'phoenix'
 import LiveSocket from 'phoenix_live_view'
-import IEx from './console'
 import Josh from 'joshjs'
 
 let dates = require('./dates')
-const iex = new IEx()
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute('content')
 let liveSocket = new LiveSocket('/live', Socket, {
   params: { _csrf_token: csrfToken }
 })
-let socket = new Socket('/socket', { params: { token: window.userToken } })
 
 liveSocket.connect()
 
@@ -39,7 +36,3 @@ $(function() {
 document.querySelectorAll('.date-time').forEach(d => {
   d.innerHTML = dates.formatDateTime(d.innerHTML)
 })
-
-if (window.location.pathname.endsWith('console')) {
-  iex.start(socket)
-}

--- a/apps/nerves_hub_www/assets/js/console.js
+++ b/apps/nerves_hub_www/assets/js/console.js
@@ -1,63 +1,99 @@
 /* eslint no-console: ["error", { allow: ["log"] }] */
 
+import { Socket } from 'phoenix'
 import { Terminal } from 'xterm'
-// import { FitAddon } from 'xterm-addon-fit';
+import { FitAddon } from 'xterm-addon-fit'
 
-export default class IEx {
-  start(socket) {
-    var term = new Terminal({
-      cursorBlink: true,
-      cursorStyle: 'bar',
-      macOptionIsMeta: true
-    })
-    var restart_button = document.getElementById('restart_button')
-    // const fitAddon = new FitAddon()
-    // term.loadAddon(fitAddon)
+let socket = new Socket('/socket', { params: { token: window.userToken } })
 
-    var device_id = document.getElementById('device_id').value
+var term = new Terminal({
+  cursorBlink: true,
+  cursorStyle: 'bar',
+  macOptionIsMeta: true
+})
+var restart_button = document.getElementById('restart_button')
+const fitAddon = new FitAddon()
+term.loadAddon(fitAddon)
 
-    socket.connect()
+var device_id = document.getElementById('device_id').value
+var product_id = document.getElementById('product_id').value
 
-    term.open(document.getElementById('terminal'))
-    // fitAddon.fit()
+socket.connect()
 
-    term.focus()
+term.open(document.getElementById('terminal'))
+fitAddon.fit()
 
-    let channel = socket.channel('user_console', { device_id })
+term.focus()
 
-    channel
-      .join()
-      .receive('ok', () => {
-        console.log('JOINED')
-        // Push CTL-L to refresh form line
-        channel.push('dn', { data: '\f' })
-      })
-      .receive('error', () => {
-        console.log('ERROR')
-      })
+let channel = socket.channel('user_console', { device_id, product_id })
 
-    // Stream all events straight to the device
-    term.onData(data => {
-      channel.push('dn', { data })
-    })
+channel
+  .join()
+  .receive('ok', () => {
+    console.log('JOINED')
+    // Push CTL-L to refresh form line
+    channel.push('dn', { data: '\f' })
+    channel.push('window_size', { height: term.rows, width: term.cols })
+  })
+  .receive('error', () => {
+    console.log('ERROR')
+  })
 
-    // Write data from device to console
-    channel.on('up', payload => {
-      term.write(payload.data)
-    })
+// Stream all events straight to the device
+term.onData(data => {
+  channel.push('dn', { data })
+})
 
-    channel.onClose(() => {
-      console.log('CLOSED')
-      term.blur()
-      term.setOption('cursorBlink', false)
-      term.write('DISCONNECTED')
-    })
+// Write data from device to console
+channel.on('up', payload => {
+  term.write(payload.data)
+})
 
-    restart_button.addEventListener('click', () => {
-      var check = confirm('Are you sure you want to restart the IEx process?')
-      if (check == true) {
-        channel.push('restart', {})
-      }
-    })
+// Update meta fields for page
+channel.on('meta_update', payload => {
+  var deets = document.getElementById('status-deets')
+  var inner
+  if (payload.status === 'updating') {
+    inner = `
+      <div class="progress console-progress">
+        <div class="progress-bar" role="progressbar" style="width: ${payload.fwup_progress}%">
+          ${payload.fwup_progress}%
+        </div>
+      </div>
+      `
+  } else {
+    inner = `
+    <span>${payload.status}</span>
+    <span class="ml-1">
+      <img alt="${payload.status}" class="table-icon ${payload.status}" />
+    </span>
+    `
   }
-}
+  deets.innerHTML = inner
+
+  if ('last_communication' in payload) {
+    document.getElementById('last_communication').value =
+      payload.last_communication
+  }
+})
+
+// Set new size on device when window changes
+window.addEventListener('resize', () => {
+  fitAddon.fit()
+  term.scrollToBottom()
+  channel.push('window_size', { height: term.rows, width: term.cols })
+})
+
+channel.onClose(() => {
+  console.log('CLOSED')
+  term.blur()
+  term.setOption('cursorBlink', false)
+  term.write('DISCONNECTED')
+})
+
+restart_button.addEventListener('click', () => {
+  var check = confirm('Are you sure you want to restart the IEx process?')
+  if (check == true) {
+    channel.push('restart', {})
+  }
+})

--- a/apps/nerves_hub_www/assets/webpack.config.js
+++ b/apps/nerves_hub_www/assets/webpack.config.js
@@ -13,10 +13,11 @@ module.exports = (env, options) => ({
     ]
   },
   entry: {
-    './js/app.js': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+    app: glob.sync('./vendor/**/*.js').concat(['./js/app.js']),
+    console: './js/console.js'
   },
   output: {
-    filename: 'app.js',
+    filename: '[name].js',
     path: path.resolve(__dirname, '../priv/static/js')
   },
   module: {

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/device_controller.ex
@@ -91,7 +91,13 @@ defmodule NervesHubWWWWeb.DeviceController do
     # be cleaned up once it is no longer used
     cond do
       Version.match?(version, ">= 0.9.0") ->
-        render(conn, "console.html", device: device, console_available: meta[:console_available])
+        conn
+        |> put_root_layout({NervesHubWWWWeb.LayoutView, :console})
+        |> put_layout(false)
+        |> render("console.html",
+          device: Map.merge(device, meta),
+          console_available: meta[:console_available]
+        )
 
       true ->
         conn

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.eex
@@ -1,42 +1,7 @@
 <input id="device_id" hidden type="text" value="<%= @device.id %>" />
 <input id="product_id" hidden type="text" value="<%= @device.product_id %>" />
-<div class="console-details-row">
-  <%= link @device.identifier, to: Routes.device_path(@conn, :show, @org.name, @product.name, @device.identifier), class: "back-link" %>
-  <div>
-    <div class="help-text">Status</div>
-    <p class="flex-row align-items-center tt-c" id="status-deets">
-      <%= if Map.has_key?(@device, :fwup_progress) && @device.fwup_progress do %>
-        <div class="progress console-progress">
-          <div class="progress-bar" role="progressbar" style="width: <%= @device.fwup_progress %>%">
-            <%= @device.fwup_progress %>%
-          </div>
-        </div>
-      <% else %>
-        <span><%= @device.status %></span>
-        <span class="ml-1">
-          <img alt="<%= @device.status %>" class="table-icon <%= @device.status %>" />
-        </span>
-      <% end %>
-    </p>
-  </div>
-  <div>
-    <div class="help-text">Last Handshake</div>
-    <p id="last_communication">
-      <%= if is_nil(@device.last_communication) do %>
-        Never
-      <% else %>
-        <%= @device.last_communication %>
-      <% end %>
-    </p>
-  </div>
-  <button class="btn btn-outline-light" id="restart_button" <%= if !@console_available do "disabled" end%>>
-    <span class="button-icon power"></span>
-    <span>Restart Console</span>
-  </button>
-</div>
-
 <%= if @console_available do %>
-    <div id="terminal" class="console-v2"></div>
+  <div id="terminal" class="console-v2"></div>
 <% else %>
   <h5>Console disabled or unavailable.</h5>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.eex
@@ -1,18 +1,42 @@
-<div class="action-row">
-  <%= link "Back to device", to: Routes.device_path(@conn, :show, @org.name, @product.name, @device.identifier), class: "back-link" %>
+<input id="device_id" hidden type="text" value="<%= @device.id %>" />
+<input id="product_id" hidden type="text" value="<%= @device.product_id %>" />
+<div class="console-details-row">
+  <%= link @device.identifier, to: Routes.device_path(@conn, :show, @org.name, @product.name, @device.identifier), class: "back-link" %>
+  <div>
+    <div class="help-text">Status</div>
+    <p class="flex-row align-items-center tt-c" id="status-deets">
+      <%= if Map.has_key?(@device, :fwup_progress) && @device.fwup_progress do %>
+        <div class="progress console-progress">
+          <div class="progress-bar" role="progressbar" style="width: <%= @device.fwup_progress %>%">
+            <%= @device.fwup_progress %>%
+          </div>
+        </div>
+      <% else %>
+        <span><%= @device.status %></span>
+        <span class="ml-1">
+          <img alt="<%= @device.status %>" class="table-icon <%= @device.status %>" />
+        </span>
+      <% end %>
+    </p>
+  </div>
+  <div>
+    <div class="help-text">Last Handshake</div>
+    <p id="last_communication">
+      <%= if is_nil(@device.last_communication) do %>
+        Never
+      <% else %>
+        <%= @device.last_communication %>
+      <% end %>
+    </p>
+  </div>
   <button class="btn btn-outline-light" id="restart_button" <%= if !@console_available do "disabled" end%>>
-    <span class="button-icon  power"></span>
+    <span class="button-icon power"></span>
     <span>Restart Console</span>
   </button>
 </div>
 
-<%= render("_header.html", device: @device) %>
-
 <%= if @console_available do %>
-  <input id="device_id" hidden type="text" value="<%= @device.id %>" />
-  <div class="console-wrapper">
-    <div id="terminal" class="console"></div>
-  </div>
+    <div id="terminal" class="console-v2"></div>
 <% else %>
   <h5>Console disabled or unavailable.</h5>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -8,6 +8,7 @@
     <%= link(
       class: "btn btn-outline-light btn-action #{unless Map.has_key?(@device, :console_available) && @device.console_available, do: "disabled"}",
       aria_label: "Console",
+      target: "_blank",
       to: Routes.device_path(@socket, :console, @org.name, @product.name, @device.identifier))
       do %>
       <span class="button-icon console-icon"></span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/console.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/console.html.eex
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" id="console-html">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title><%= @device.identifier %></title>
+    <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
+  </head>
+
+  <body id="console-body">
+    <%= @inner_content %>
+
+    <script>
+      window.userToken = "<%= assigns[:user_token] %>"
+    </script>
+    <%= csrf_meta_tag() %>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/console.js") %>"></script>
+  </body>
+</html>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/user_console_channel.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/user_console_channel.ex
@@ -51,39 +51,4 @@ defmodule NervesHubWWWWeb.UserConsoleChannel do
   defp console_topic(device_id) do
     "console:#{device_id}"
   end
-
-  # defp sync_device(%Device{id: id} = device, payload) when is_map(payload) do
-  #   id = to_string(id)
-  #   joins = Map.get(payload, :joins, %{})
-  #   leaves = Map.get(payload, :leaves, %{})
-
-  #   cond do
-  #     meta = joins[id] ->
-  #       updates =
-  #         Map.take(meta, [
-  #           :console_available,
-  #           :firmware_metadata,
-  #           :fwup_progress,
-  #           :last_communication,
-  #           :status
-  #         ])
-
-  #       Map.merge(device, updates)
-
-  #     leaves[id] ->
-  #       # We're counting a device leaving as its last_communication. This is
-  #       # slightly inaccurate to set here, but only by a minuscule amount
-  #       # and saves DB calls and broadcasts
-  #       disconnect_time = DateTime.truncate(DateTime.utc_now(), :second)
-
-  #       device
-  #       |> Map.put(:console_available, false)
-  #       |> Map.put(:fwup_progress, nil)
-  #       |> Map.put(:last_communication, disconnect_time)
-  #       |> Map.put(:status, "offline")
-
-  #     true ->
-  #       device
-  #   end
-  # end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -81,7 +81,6 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
         get(conn, Routes.device_path(conn, :console, org.name, product.name, device.identifier))
 
       assert html_response(result, 200) =~ device.identifier
-      assert html_response(result, 200) =~ "Status"
     end
   end
 end

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -80,8 +80,7 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       result =
         get(conn, Routes.device_path(conn, :console, org.name, product.name, device.identifier))
 
-      assert html_response(result, 200) =~ "<h1>#{device.identifier}</h1>"
-      assert html_response(result, 200) =~ "Health"
+      assert html_response(result, 200) =~ device.identifier
       assert html_response(result, 200) =~ "Status"
     end
   end


### PR DESCRIPTION
Based on some discussion from slack.

Resolves #689
Resolves #696
Resolves #654

* `console` button now opens console to a new window or tab
* console is the full window with minimal details at the top
* console is resizable
* device status _should_ update with presence changes...I'm not that good at javascript, so YMMV

![image](https://user-images.githubusercontent.com/11321326/99606171-764db680-29c6-11eb-8adf-bbfb86bec2cb.png)

