### PR TITLE
Remove "all" tag and allow tags on device create

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
@@ -21,8 +21,14 @@
     <div class="has-error"><%= error_tag f, :description %></div>
   </div>
 
-  <div class="form-group hidden" aria-hidden="true">
-    <%= text_input f, :tags, class: "form-control", id: "group_input", value: "all" %>
+  <div class="form-group" aria-hidden="true">
+    <label for="tag_input" class="tooltip-label h3 mb-1">
+      <span>Tags</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">Tags are used by deployments to target a device. A device must have matching tag(s) for the deployment to update it</span>
+    </label>
+    <%= text_input f, :tags, class: "form-control", id: "tag_input" %>
+    <div class="has-error"><%= error_tag f, :tags %></div>
   </div>
 
   <div class="button-submit-wrapper">


### PR DESCRIPTION
Resolves #652

* Removes the `all` tag from being added by default to new devices from web UI
* Adds ability to add tags when creating device from web UI

<img width="677" alt="image" src="https://user-images.githubusercontent.com/11321326/100553854-d1e13500-324d-11eb-97bc-b44d196b1ea0.png">

<img width="651" alt="image" src="https://user-images.githubusercontent.com/11321326/100553869-e6253200-324d-11eb-958b-dcaea2859448.png">
