### PR TITLE
Show UUID with firmware version

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
@@ -34,7 +34,7 @@ defmodule NervesHubWWWWeb.DeploymentView do
   def firmware_display_name(%Firmware{} = f) do
     case f.version do
       nil -> "--"
-      version -> "#{version}"
+      version -> "#{version} - #{f.uuid}"
     end
   end
 


### PR DESCRIPTION
Fixes #668

Adds the firmware UUID with the displayed version when in a dropdown list or in the Deployment #show page