### PR TITLE
Show platform in Firmware index and show page

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -25,7 +25,7 @@
         <th>Version</th>
         <th>Platform</th>
         <th>Firmware key</th>
-        <th>Created on</th>
+        <th>Uploaded on</th>
         <th></th>
       </tr>
     </thead>
@@ -52,7 +52,7 @@
           </div>
         </td>
         <td>
-          <div class="mobile-label help-text">Created on</div>
+          <div class="mobile-label help-text">Uploaded on</div>
           <div>
             <%= if is_nil(firmware.inserted_at) do %>
               <span class="color-white-50">Never</span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -23,6 +23,7 @@
       <tr>
         <th>UUID</th>
         <th>Version</th>
+        <th>Platform</th>
         <th>Firmware key</th>
         <th>Created on</th>
         <th></th>
@@ -39,6 +40,10 @@
         <td>
           <div class="mobile-label help-text">Version</div>
           <%= firmware.version %>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Platform</div>
+          <%= firmware.platform %>
         </td>
         <td>
           <div class="mobile-label help-text">Firmware key</div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
@@ -42,7 +42,7 @@
     <p><%= @firmware.author %></p>
   </div>
   <div class="gr-2">
-    <div class="help-text">Created On</div>
+    <div class="help-text">Uploaded On</div>
     <p class="date-time">
       <%= @firmware.inserted_at %>
     </p>
@@ -60,4 +60,3 @@
 </div>
 
 <div class="divider"></div>
-

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
@@ -30,6 +30,10 @@
     <p><%= @firmware.uuid %></p>
   </div>
   <div>
+    <div class="help-text">Platform</div>
+    <p><%= @firmware.platform %></p>
+  </div>
+  <div>
     <div class="help-text">Architecture</div>
     <p><%= @firmware.architecture %></p>
   </div>


### PR DESCRIPTION
Resolves #707

Also changes the `Created on` titles to `Uploaded on` to more accurately represent what that time means (It is using the firmware records `inserted_at` field). I'm wondering if that's even correct?