### PR TITLE
Change domain shown in emails

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/templates/email/forgot_password.html.eex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/templates/email/forgot_password.html.eex
@@ -1,6 +1,6 @@
 <p>Hi <%= @user.username %>,</p>
 
-<p>We received a request to reset your password on nerves-hub.org. Click on the link below to begin:</p>
+<p>We received a request to reset your password on <%= base_url() %>. Click on the link below to begin:</p>
 
 <a href="<%= "#{base_url()}/password-reset/#{@user.password_reset_token}"%>">Reset Password</a>
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/templates/email/invite.html.eex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/templates/email/invite.html.eex
@@ -1,5 +1,5 @@
 <p>Hi!</p>
-<p>You've been invited to join <%= @org.name %> on nerves-hub.org.</p>
+<p>You've been invited to join <%= @org.name %> on <%= base_url() %></p>
 
 <p>To get started click on the link below to register your account and set up your password:</p>
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/templates/email/org_user_created.html.eex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/templates/email/org_user_created.html.eex
@@ -1,5 +1,5 @@
 <p>Welcome!</p>
-<p>You've been added to the <strong><%= @org.name %></strong> organization on nerves-hub.org.</p>
+<p>You've been added to the <strong><%= @org.name %></strong> organization on <%= base_url() %>.</p>
 
 <p><a href="<%= "#{base_url()}/login" %>">Login</a> to view it's details.</p>
 

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/email_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/email_test.exs
@@ -40,7 +40,9 @@ defmodule NervesHubWebCore.Accounts.EmailTest do
     assert email.to == "nunya@bidness.com"
 
     assert email.html_body =~
-             "You've been added to the <strong>#{org.name}</strong> organization on nerves-hub.org."
+             "You've been added to the <strong>#{org.name}</strong> organization on #{
+               EmailView.base_url()
+             }."
   end
 
   test "tell org about new user" do


### PR DESCRIPTION
When a user is created or requests a password change, the email says its an action on `nerves-hub.org`. However, if this is self hosted, that may not actually be the domain.

This changes to use the `EmailView.base_url()` instead when referencing where the email was generated which pulls from Application config variables that may have been customized in a self-hosted instance.