### PR TITLE
Device moving - Web

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_channel.ex
@@ -64,7 +64,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
   def handle_in("fwup_progress", %{"value" => percent}, socket) do
     Presence.update(
       socket.channel_pid,
-      "product:#{socket.assigns.device.product_id}:devices",
+      tracking_topic(socket),
       socket.assigns.device.id,
       %{fwup_progress: percent}
     )
@@ -75,7 +75,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
   def handle_in("status_update", %{"status" => status}, socket) do
     Presence.update(
       socket.channel_pid,
-      "product:#{socket.assigns.device.product_id}:devices",
+      tracking_topic(socket),
       socket.assigns.device.id,
       %{status: status}
     )
@@ -87,7 +87,7 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     # Device sends "rebooting" message back to signify ack of the request
     Presence.update(
       socket.channel_pid,
-      "product:#{socket.assigns.device.product_id}:devices",
+      tracking_topic(socket),
       socket.assigns.device.id,
       %{rebooting: true}
     )
@@ -96,18 +96,16 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
   end
 
   def handle_info({:after_join, device, update_available}, socket) do
-    %Device{id: device_id, firmware_metadata: firmware_metadata, product_id: product_id} = device
-
     {:ok, _} =
       Presence.track(
         socket.channel_pid,
-        "product:#{product_id}:devices",
-        device_id,
+        tracking_topic(device),
+        device.id,
         %{
           connected_at: System.system_time(:second),
           last_communication: device.last_communication,
           update_available: update_available,
-          firmware_metadata: firmware_metadata
+          firmware_metadata: device.firmware_metadata
         }
       )
 
@@ -129,6 +127,19 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
     push(socket, "update", payload)
 
     {:noreply, socket}
+  end
+
+  def handle_info(%Broadcast{event: "moved"}, socket) do
+    device = socket.assigns.device
+    meta = Presence.find(device, %{})
+
+    Presence.untrack(socket.channel_pid, tracking_topic(device), device.id)
+
+    reloaded = Repo.reload(device)
+
+    Presence.track(socket.channel_pid, tracking_topic(reloaded), reloaded.id, meta)
+
+    {:noreply, assign(socket, device: reloaded)}
   end
 
   def handle_info(%Broadcast{event: event, payload: payload}, socket) do
@@ -193,4 +204,12 @@ defmodule NervesHubDeviceWeb.DeviceChannel do
   end
 
   defp should_audit_log?(_join_reply, _params), do: true
+
+  defp tracking_topic(%{assigns: %{device: device}}) do
+    tracking_topic(device)
+  end
+
+  defp tracking_topic(%{product_id: product_id}) do
+    "product:#{product_id}:devices"
+  end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_key.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts/org_key.ex
@@ -29,7 +29,7 @@ defmodule NervesHubWebCore.Accounts.OrgKey do
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
     |> unique_constraint(:name, name: :org_keys_org_id_name_index)
-    |> unique_constraint(:key)
+    |> unique_constraint(:key, name: :org_keys_org_id_key_index)
   end
 
   def update_changeset(%OrgKey{id: _} = org_key, params) do
@@ -38,7 +38,7 @@ defmodule NervesHubWebCore.Accounts.OrgKey do
     |> cast(params, @required_params -- [:org_id])
     |> validate_required(@required_params)
     |> unique_constraint(:name, name: :org_keys_org_id_name_index)
-    |> unique_constraint(:key)
+    |> unique_constraint(:key, name: :org_keys_org_id_key_index)
   end
 
   def delete_changeset(%OrgKey{id: _} = org_key, params) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -8,24 +8,22 @@ defmodule NervesHubWebCore.Devices do
     Devices.UpdatePayload,
     Deployments.Deployment,
     Firmwares,
+    Firmwares.Firmware,
     Firmwares.FirmwareMetadata,
     AuditLogs,
     AuditLogs.AuditLog,
+    Accounts,
     Accounts.Org,
-    Repo
+    Accounts.OrgKey,
+    Repo,
+    Products.Product
   }
 
   alias NervesHubWebCore.Devices.{Device, DeviceCertificate, CACertificate}
+  alias NervesHubWebCore.TaskSupervisor, as: Tasks
 
-  def get_device(device_id) do
-    Device
-    |> Repo.get(device_id)
-  end
-
-  def get_device!(device_id) do
-    Device
-    |> Repo.get!(device_id)
-  end
+  def get_device(device_id), do: Repo.get(Device, device_id)
+  def get_device!(device_id), do: Repo.get!(Device, device_id)
 
   def get_devices_by_org_id(org_id) do
     query =
@@ -147,14 +145,7 @@ defmodule NervesHubWebCore.Devices do
     %UpdatePayload{} = update_payload = resolve_update(device, deployment)
 
     if update_payload.update_available do
-      Phoenix.PubSub.broadcast(
-        NervesHubWeb.PubSub,
-        "device:#{device.id}",
-        %Phoenix.Socket.Broadcast{
-          event: "update",
-          payload: update_payload
-        }
-      )
+      broadcast(device, "update", update_payload)
     end
 
     update_payload
@@ -553,6 +544,86 @@ defmodule NervesHubWebCore.Devices do
     update_device(device, %{deleted_at: nil})
   end
 
+  @doc """
+  Move a device to a different product
+
+  If the new target product is in a different organization, this will
+  attempt to also copy any firmware keys the device might be expecting
+  to the new organization. However, it is best effort only.
+
+  Moving a device will also trigger a deployment check to see if there
+  is an update available from the new product/org for the device. It is
+  up to the user to ensure the new device is configured with any new/different
+  firmware keys from the new org before moving otherwise the device
+  might fail to update because of an unknown key.
+  """
+  @spec move(Device.t() | [Device.t()], Product.t(), User.t()) :: Repo.transaction()
+  def move(%Device{} = device, product, user) do
+    product = Repo.preload(product, :org)
+    attrs = %{org_id: product.org_id, product_id: product.id}
+
+    _ = maybe_copy_firmware_keys(device, product.org)
+
+    audit_params = %{
+      log_description:
+        "user #{user.username} moved device #{device.identifier} to #{product.org.name} : #{
+          product.name
+        }"
+    }
+
+    source_product = %Product{id: device.product_id, org_id: device.org_id}
+
+    Multi.new()
+    |> Multi.run(:move, fn _, _ -> update_device(device, attrs) end)
+    |> Multi.run(:audit_device, fn _, _ ->
+      AuditLogs.audit(user, device, :update, audit_params)
+    end)
+    |> Multi.run(:audit_target, fn _, _ ->
+      AuditLogs.audit(user, product, :update, audit_params)
+    end)
+    |> Multi.run(:audit_source, fn _, _ ->
+      AuditLogs.audit(user, source_product, :update, audit_params)
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{move: updated}} ->
+        broadcast(updated, "moved")
+        {:ok, updated}
+
+      err ->
+        err
+    end
+  end
+
+  @spec move_many([Device.t()], Product.t(), User.t()) :: %{
+          ok: [Device.t()],
+          error: [{Ecto.Multi.name(), any()}]
+        }
+  def move_many(devices, product, user) do
+    product = Repo.preload(product, :org)
+
+    Enum.map(devices, &Task.Supervisor.async(Tasks, __MODULE__, :move, [&1, product, user]))
+    |> Task.await_many(20_000)
+    |> Enum.reduce(%{ok: [], error: []}, fn
+      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
+      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
+    end)
+  end
+
+  @spec get_devices_by_id([non_neg_integer()]) :: [Device.t()]
+  def get_devices_by_id(ids) when is_list(ids) do
+    from(d in Device, where: d.id in ^ids)
+    |> Repo.all()
+  end
+
+  def broadcast(%Device{id: id}, event, payload \\ %{}) do
+    Phoenix.PubSub.broadcast(
+      NervesHubWeb.PubSub,
+      "device:#{id}",
+      %Phoenix.Socket.Broadcast{event: event, payload: payload}
+    )
+  end
+
   defp failures_query(%Device{id: device_id}, %Deployment{id: deployment_id} = deployment) do
     deployment = Repo.preload(deployment, :firmware)
 
@@ -587,4 +658,26 @@ defmodule NervesHubWebCore.Devices do
   defp tags_match?(device_tags, deployment_tags) do
     Enum.all?(deployment_tags, fn tag -> tag in device_tags end)
   end
+
+  def maybe_copy_firmware_keys(%{firmware_metadata: %{uuid: uuid}, org_id: source}, %Org{
+        id: target
+      }) do
+    existing_target_keys = from(k in OrgKey, where: [org_id: ^target], select: k.key)
+
+    from(
+      k in OrgKey,
+      join: f in Firmware,
+      on: [org_key_id: k.id],
+      where: f.uuid == ^uuid and k.org_id == ^source,
+      where: k.key not in subquery(existing_target_keys),
+      select: %{name: k.name, key: k.key, org_id: type(^target, :integer)}
+    )
+    |> Repo.one()
+    |> case do
+      %{} = attrs -> Accounts.create_org_key(attrs)
+      _ -> :ignore
+    end
+  end
+
+  def maybe_copy_firmware_keys(_old, _updated), do: :ignore
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
@@ -5,6 +5,11 @@ defmodule NervesHubWebCore.Repo do
 
   import Ecto.Query, only: [where: 3]
 
+  @type transaction ::
+          {:ok, any()}
+          | {:error, any()}
+          | {:error, Ecto.Multi.name(), any(), %{required(Ecto.Multi.name()) => any()}}
+
   @doc """
   Dynamically loads the repository url from the
   DATABASE_URL environment variable.

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20210106235038_change_org_key_index.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20210106235038_change_org_key_index.exs
@@ -1,0 +1,13 @@
+defmodule NervesHubWebCore.Repo.Migrations.ChangeOrgKeyIndex do
+  use Ecto.Migration
+
+  def up do
+    drop unique_index(:org_keys, [:key])
+    create unique_index(:org_keys, [:org_id, :key], name: :org_keys_org_id_key_index)
+  end
+
+  def down do
+    drop unique_index(:org_keys, [:org_id, :key], name: :org_keys_org_id_key_index)
+    create unique_index(:org_keys, [:key])
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -55,6 +55,7 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
       |> assign(:currently_filtering, false)
       |> assign(:page_size_valid, true)
       |> assign(:selected_devices, [])
+      |> assign(:target_product, nil)
       |> assign_display_devices()
 
     {:ok, socket}
@@ -227,18 +228,32 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
     {:noreply, assign(socket, :selected_devices, [id | socket.assigns.selected_devices])}
   end
 
-  def handle_event("move-devices", attrs, socket) do
-    %{"product" => pid_str, "org" => org_id_str, "name" => name} = attrs
+  def handle_event("deselect-all", _, socket) do
+    {:noreply, assign(socket, selected_devices: [])}
+  end
 
-    product = %Product{
-      id: String.to_integer(pid_str),
-      org_id: String.to_integer(org_id_str),
-      name: name
-    }
+  def handle_event("target-product", %{"product" => attrs}, socket) do
+    target =
+      case String.split(attrs, ":") do
+        [org_id_str, pid_str, name] ->
+          %Product{
+            id: String.to_integer(pid_str),
+            org_id: String.to_integer(org_id_str),
+            name: name
+          }
 
+        _ ->
+          # ignore attempted move if no product/org selected
+          nil
+      end
+
+    {:noreply, assign(socket, target_product: target)}
+  end
+
+  def handle_event("move-devices", _, socket) do
     %{ok: successfuls} =
       Devices.get_devices_by_id(socket.assigns.selected_devices)
-      |> Devices.move_many(product, socket.assigns.user)
+      |> Devices.move_many(socket.assigns.target_product, socket.assigns.user)
 
     success_ids = Enum.map(successfuls, & &1.id)
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -102,39 +102,26 @@
   <% end %>
   <%= if length(@selected_devices) > 0 do %>
     <div class="filter-wrapper">
-      <h4 class="color-white mb-2">Bulk Actions <span class="help-text"><%= length(@selected_devices) %> selected</span></h4>
-
-      <button class="btn btn-primary" type="button" phx-click="deselect-all">Deselect All</button>
-      <button class="btn btn-secondary" type="button">
-        <ul class="navbar-nav mr-auto flex-grow">
-          <li class="nav-item dropdown switcher">
-            <a class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Move
-            </a>
-
-            <div class="dropdown-menu workspace-dropdown" aria-labelledby="navbarDropdownMenuLink">
-              <div class="help-text">Select an organization</div>
-              <div class="dropdown-divider"></div>
-              <%= for org <- user_orgs(@user), products = user_org_products(@user, org), length(products) > 0 do %>
-                <div class="dropdown-submenu">
-                  <a aria-haspopup="true" class="dropdown-item org dropdown-toggle"><%= org.name %></a>
-                  <ul class="dropdown-menu">
-                    <div class="help-text">Select a product</div>
-                    <div class="dropdown-divider"></div>
-                      <%= for product <- products, product.id != @product.id do %>
-                        <li>
-                          <a class="dropdown-item product" phx-click="move-devices" phx-value-product="<%= product.id %>" phx-value-org="<%= product.org_id %>" phx-value-name="<%= product.name %>" data-confirm="<%= move_alert(product.name) %>"><%= product.name %></a>
-                          <div class="dropdown-divider"></div>
-                        </li>
-                      <% end %>
-                  </ul>
-                  <div class="dropdown-divider"></div>
-                </div>
-              <% end %>
-            </div>
-          </li>
-        </ul>
-      </button>
+      <h4 class="color-white mb-2 flex-row align-items-center">Bulk Actions <span class="help-text ml-2"><%= length(@selected_devices) %> selected</span></h4>
+      <div class="form-group">
+        <label for="input_transfer">Transfer device</label>
+        <div class="pos-rel">
+          <select name="transfer device" id="input_transfer" class="form-control">
+            <%= for org <- user_orgs(@user), products = user_org_products(@user, org), length(products) > 0 do %>
+              <optgroup label=<%= org.name %>>
+                <%= for product <- products, product.id != @product.id do %>
+                  <option><%= product.name %></option>
+                <% end %>
+              </optgroup>
+            <% end %>
+          </select>
+          <div class="select-icon"></div>
+        </div>
+      </div>
+      <div class="flex-row align-items-center">
+        <button class="btn btn-secondary" type="button" phx-click="deselect-all">Deselect All</button>
+        <button class="btn btn-primary ml-3" type="button">Apply</button>
+      </div>
     </div>
   <% end %>
   <table class="table table-sm table-hover">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -100,9 +100,47 @@
       <button class="btn btn-secondary" type="button" phx-click="reset-filters">Reset Filters</button>
     </div>
   <% end %>
+  <%= if length(@selected_devices) > 0 do %>
+    <div class="filter-wrapper">
+      <h4 class="color-white mb-2">Bulk Actions <span class="help-text"><%= length(@selected_devices) %> selected</span></h4>
+
+      <button class="btn btn-primary" type="button" phx-click="deselect-all">Deselect All</button>
+      <button class="btn btn-secondary" type="button">
+        <ul class="navbar-nav mr-auto flex-grow">
+          <li class="nav-item dropdown switcher">
+            <a class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Move
+            </a>
+
+            <div class="dropdown-menu workspace-dropdown" aria-labelledby="navbarDropdownMenuLink">
+              <div class="help-text">Select an organization</div>
+              <div class="dropdown-divider"></div>
+              <%= for org <- user_orgs(@user), products = user_org_products(@user, org), length(products) > 0 do %>
+                <div class="dropdown-submenu">
+                  <a aria-haspopup="true" class="dropdown-item org dropdown-toggle"><%= org.name %></a>
+                  <ul class="dropdown-menu">
+                    <div class="help-text">Select a product</div>
+                    <div class="dropdown-divider"></div>
+                      <%= for product <- products, product.id != @product.id do %>
+                        <li>
+                          <a class="dropdown-item product" phx-click="move-devices" phx-value-product="<%= product.id %>" phx-value-org="<%= product.org_id %>" phx-value-name="<%= product.name %>" data-confirm="<%= move_alert(product.name) %>"><%= product.name %></a>
+                          <div class="dropdown-divider"></div>
+                        </li>
+                      <% end %>
+                  </ul>
+                  <div class="dropdown-divider"></div>
+                </div>
+              <% end %>
+            </div>
+          </li>
+        </ul>
+      </button>
+    </div>
+  <% end %>
   <table class="table table-sm table-hover">
     <thead>
       <tr>
+        <%= devices_table_header("Selected", "selected", @current_sort, @sort_direction) %>
         <%= devices_table_header("Identifier", "identifier", @current_sort, @sort_direction) %>
         <th>Connection</th>
         <%= devices_table_header("Last handshake", "last_communication", @current_sort, @sort_direction) %>
@@ -114,6 +152,9 @@
     </thead>
     <%= for device <- @devices do %>
       <tr class="item">
+        <td>
+          <input class="checkbox" <%= if device.id in @selected_devices, do: "checked" %> type="checkbox" id="<%= device.id %>-select" phx-value-id="<%= device.id %>" phx-click="select">
+        </td>
         <td>
           <div class="mobile-label help-text">Identifier</div>
           <div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -103,25 +103,30 @@
   <%= if length(@selected_devices) > 0 do %>
     <div class="filter-wrapper">
       <h4 class="color-white mb-2 flex-row align-items-center">Bulk Actions <span class="help-text ml-2"><%= length(@selected_devices) %> selected</span></h4>
-      <div class="form-group">
-        <label for="input_transfer">Transfer device</label>
-        <div class="pos-rel">
-          <select name="transfer device" id="input_transfer" class="form-control">
-            <%= for org <- user_orgs(@user), products = user_org_products(@user, org), length(products) > 0 do %>
-              <optgroup label=<%= org.name %>>
-                <%= for product <- products, product.id != @product.id do %>
-                  <option><%= product.name %></option>
-                <% end %>
-              </optgroup>
-            <% end %>
-          </select>
-          <div class="select-icon"></div>
+      <form id="move" phx-change="target-product" phx-submit="move-devices">
+        <div class="form-group">
+          <label for="move_to">Move device(s) to:</label>
+          <div class="pos-rel">
+            <select name="product" id="move_to" class="form-control">
+              <option value=""></option>
+              <%= for org <- user_orgs(@user), products = user_org_products(@user, org), length(products) > 0 do %>
+                <optgroup label=<%= org.name %>>
+                  <%= for product <- products, product.id != @product.id do %>
+                    <option value="<%= org.id %>:<%= product.id %>:<%= product.name %>"><%= product.name %></option>
+                  <% end %>
+                </optgroup>
+              <% end %>
+            </select>
+            <div class="select-icon"></div>
+          </div>
         </div>
-      </div>
-      <div class="flex-row align-items-center">
-        <button class="btn btn-secondary" type="button" phx-click="deselect-all">Deselect All</button>
-        <button class="btn btn-primary ml-3" type="button">Apply</button>
-      </div>
+        <div class="flex-row align-items-center">
+          <button class="btn btn-secondary" type="button" phx-click="deselect-all">Deselect All</button>
+          <%= if @target_product do %>
+            <button class="btn btn-primary ml-3" type="submit" data-confirm="<%= move_alert(@target_product) %>">Move</button>
+          <% end %>
+        </div>
+      </form>
     </div>
   <% end %>
   <table class="table table-sm table-hover">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -3,7 +3,8 @@ defmodule NervesHubWWWWeb.DeviceView do
 
   alias NervesHubDevice.Presence
   alias NervesHubWWWWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
-  import NervesHubWWWWeb.LayoutView, only: [pagination_links: 1]
+  import NervesHubWWWWeb.LayoutView,
+    only: [pagination_links: 1, user_orgs: 1, user_org_products: 2]
   import NervesHubWWWWeb.OrgCertificateView, only: [format_serial: 1]
 
   def architecture_options do
@@ -67,4 +68,16 @@ defmodule NervesHubWWWWeb.DeviceView do
   defdelegate device_status(device), to: Presence
 
   def selected?(filters, field, value), do: if(filters[field] == value, do: "selected")
+
+  def move_alert(product_name) do
+    """
+    This will move the selected device(s) to the #{product_name} product
+
+    Any existing firmware keys the devices may use will attempt to be migrated if they do not exist on the target organization.
+
+    Moving devices may also trigger an update if there are matching deployments on the new product. It is up to the user to ensure any required firmware keys are on the device before migrating them to a new product with a new firmware or the device may fail to update.
+
+    Do you wish to continue?
+    """
+  end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -3,8 +3,10 @@ defmodule NervesHubWWWWeb.DeviceView do
 
   alias NervesHubDevice.Presence
   alias NervesHubWWWWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
+
   import NervesHubWWWWeb.LayoutView,
     only: [pagination_links: 1, user_orgs: 1, user_org_products: 2]
+
   import NervesHubWWWWeb.OrgCertificateView, only: [format_serial: 1]
 
   def architecture_options do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -69,7 +69,7 @@ defmodule NervesHubWWWWeb.DeviceView do
 
   def selected?(filters, field, value), do: if(filters[field] == value, do: "selected")
 
-  def move_alert(product_name) do
+  def move_alert(%{name: product_name}) do
     """
     This will move the selected device(s) to the #{product_name} product
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -17,6 +17,10 @@ defmodule NervesHubWWWWeb.LayoutView do
   end
 
   def user_orgs(%{assigns: %{user: %User{} = user}}) do
+    user_orgs(user)
+  end
+
+  def user_orgs(%User{} = user) do
     Accounts.get_user_orgs_with_product_role(user, :read)
   end
 


### PR DESCRIPTION
Add support for moving devices between products/orgs.

The context is in place and this also adds support to complete the function in the web. The next step will be to reproduce from the API . 

In the move, this will attempt to copy any required firmware keys from one org to another if it detects that a device uses it. Coincidentally, this required I resolve #687 via 7e59db8

EDIT:

UI updated


https://user-images.githubusercontent.com/11321326/105080779-8cbbd100-5a4e-11eb-9c9b-7d6b540ed75e.mov



