### PR TITLE
Increase download URL valid time to 24 hours

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/s3.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/s3.ex
@@ -3,6 +3,9 @@ defmodule NervesHubWebCore.Firmwares.Upload.S3 do
 
   @behaviour NervesHubWebCore.Firmwares.Upload
 
+  # Provide URLs to devices that are valid for a day
+  @firmware_url_validity_time 60 * 60 * 24
+
   @type upload_metadata :: %{s3_key: String.t()}
 
   @impl NervesHubWebCore.Firmwares.Upload
@@ -22,7 +25,7 @@ defmodule NervesHubWebCore.Firmwares.Upload.S3 do
     s3_key = firmware.upload_metadata["s3_key"]
 
     ExAws.Config.new(:s3)
-    |> S3.presigned_url(:get, bucket(), s3_key, expires_in: 600)
+    |> S3.presigned_url(:get, bucket(), s3_key, expires_in: @firmware_url_validity_time)
     |> case do
       {:ok, url} ->
         {:ok, url}


### PR DESCRIPTION
Firmware download URLs sent to devices are currently valid for 10
minutes. Devices that can restart downloads need the URL to be valid for
the duration of the download. This causes an issue for devices
downloading over slow cellular links that may not be able to complete
the firmware update for an hour or two.

This changes the URL valid time to be 24 hours. This should be more than
long enough for any device to download a firmware update and if it takes
a device longer than this, requiring some special case handling to fetch
a new URL seems reasonable. 

Lengthening the URL valid time only changes the signature, so this doesn't
have side effects like preventing an administrator from deleting a
firmware on NervesHub. Security-wise, the signed URL is sent over the
encrypted channel or HTTPS connection, so if that's compromised, then
the firmware could be downloaded by an unauthorized party. Presumably
anyone with this ability would be able to download the firmware within
10 minutes as well.