### PR TITLE
Fix exporting devices CSV

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/products.ex
@@ -250,7 +250,7 @@ defmodule NervesHubWebCore.Products do
         %{
           serial: db_cert.serial,
           aki: Base.encode16(db_cert.aki),
-          ski: Base.encode16(db_cert.ski),
+          ski: if(db_cert.ski, do: Base.encode16(db_cert.ski)),
           not_before: db_cert.not_before,
           not_after: db_cert.not_after
         }


### PR DESCRIPTION
In some cases, DeviceCertificates are allowed to not have a Subject Key Identifier (ski) field. The previous implementation assumed this would always be present which breaks in these cases.

This fixes that to check for the field when exporting the CSV.