### PR TITLE
Remove unused audit_log_info/1 function

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/audit_log_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/audit_log_view.ex
@@ -8,13 +8,6 @@ defmodule NervesHubWWWWeb.AuditLogView do
     link_to_resource(type, id, current_id, "audit-log-actor")
   end
 
-  def audit_log_info(audit_log) do
-    audit_log
-    |> Map.take([:changes, :params])
-    |> inspect(IEx.inspect_opts())
-    |> AnsiToHTML.generate_phoenix_html(%AnsiToHTML.Theme{container: :none})
-  end
-
   def resource_link(%{resource_id: id, resource_type: type}, current_id) do
     link_to_resource(type, id, current_id, "audit-log-resource")
   end


### PR DESCRIPTION
This removes the reference to the `:iex` application. The default IEx
inspect options should match the current use (80 char limit, etc.). If
nothing else, someone customizing their IEx options won't have an
unexpected effect on the audit log rendering.
