### PR TITLE
Rename nerves_hub_device_web UserSocket to DeviceSocket

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_socket.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/channels/device_socket.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubDeviceWeb.UserSocket do
+defmodule NervesHubDeviceWeb.DeviceSocket do
   use Phoenix.Socket
 
   ## Channels

--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/endpoint.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/endpoint.ex
@@ -3,7 +3,7 @@ defmodule NervesHubDeviceWeb.Endpoint do
 
   socket(
     "/socket",
-    NervesHubDeviceWeb.UserSocket,
+    NervesHubDeviceWeb.DeviceSocket,
     websocket: [
       connect_info: [:peer_data, :x_headers]
     ]

--- a/apps/nerves_hub_device/test/nerves_hub_device_web/channels/console_channel_test.exs
+++ b/apps/nerves_hub_device/test/nerves_hub_device_web/channels/console_channel_test.exs
@@ -1,7 +1,7 @@
 defmodule NervesHubDeviceWeb.ConsoleChannelTest do
   use NervesHubDeviceWeb.ChannelCase
 
-  alias NervesHubDeviceWeb.{ConsoleChannel, Endpoint, UserSocket}
+  alias NervesHubDeviceWeb.{ConsoleChannel, Endpoint, DeviceSocket}
   alias NervesHubWebCore.Fixtures
   alias Phoenix.Socket.Broadcast
 
@@ -62,10 +62,8 @@ defmodule NervesHubDeviceWeb.ConsoleChannelTest do
 
   defp connect_device(%{device: device, device_certificate: device_certificate}) do
     {:ok, _, socket} =
-      UserSocket
-      |> socket("device_socket:#{device.id}", %{
-        certificate: device_certificate
-      })
+      DeviceSocket
+      |> socket("device_socket:#{device.id}", %{certificate: device_certificate})
       |> Map.put(:endpoint, Endpoint)
       |> subscribe_and_join(ConsoleChannel, "console")
 


### PR DESCRIPTION
This seems to be a leftover from initial project generation a long time ago. Naming is hard.