### PR TITLE
Add specs for functions involved in the firmware update payload

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware.ex
@@ -13,26 +13,38 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
 
   alias __MODULE__
 
-  @type t :: %__MODULE__{}
+  @type t :: %Firmware{
+          architecture: String.t(),
+          author: String.t() | nil,
+          description: String.t() | nil,
+          misc: String.t() | nil,
+          platform: String.t(),
+          product: Ecto.Association.NotLoaded.t() | Product.t(),
+          uuid: Ecto.UUID.t(),
+          vcs_identifier: String.t() | nil,
+          version: Version.build()
+        }
+
   @optional_params [
     :author,
+    :delta_updatable,
     :description,
     :misc,
     :org_key_id,
-    :delta_updatable,
     :ttl_until,
     :vcs_identifier
   ]
+
   @required_params [
-    :org_id,
     :architecture,
+    :org_id,
     :platform,
     :product_id,
+    :size,
     :ttl,
-    :uuid,
     :upload_metadata,
-    :version,
-    :size
+    :uuid,
+    :version
   ]
 
   schema "firmwares" do
@@ -43,13 +55,13 @@ defmodule NervesHubWebCore.Firmwares.Firmware do
 
     field(:architecture, :string)
     field(:author, :string)
-    field(:description, :string)
-    field(:size, :integer)
-    field(:misc, :string)
     field(:delta_updatable, :boolean, default: false)
+    field(:description, :string)
+    field(:misc, :string)
     field(:platform, :string)
-    field(:ttl, :integer)
+    field(:size, :integer)
     field(:ttl_until, :utc_datetime)
+    field(:ttl, :integer)
     field(:upload_metadata, :map)
     field(:uuid, :string)
     field(:vcs_identifier, :string)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_metadata.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/firmware_metadata.ex
@@ -38,6 +38,19 @@ defmodule NervesHubWebCore.Firmwares.FirmwareMetadata do
           version: Version.build()
         }
 
+  @type metadata :: %{
+          :architecture => String.t(),
+          :author => String.t() | nil,
+          :description => String.t() | nil,
+          optional(:fwup_version) => Version.build() | nil,
+          :misc => String.t() | nil,
+          :platform => String.t(),
+          :product => String.t(),
+          :uuid => Ecto.UUID.t(),
+          :vcs_identifier => String.t() | nil,
+          :version => Version.build()
+        }
+
   @derive Jason.Encoder
   embedded_schema do
     field(:uuid)


### PR DESCRIPTION
This adds some specs and types for the payload that gets sent to the device when an update is available.
The `NervesHubWebCore.Firmwares.FirmwareMetadata.metadata` type isn't as specific as i wanted, but Dialyzer refuses to play ball. without listing the payload as `optional` which isn't actually true.
Would love a second look