### PR TITLE
set `update_available: true` in when a deployment is updated

### DIFF
--- a/apps/nerves_hub_device/lib/nerves_hub_device_web/views/device_view.ex
+++ b/apps/nerves_hub_device/lib/nerves_hub_device_web/views/device_view.ex
@@ -1,6 +1,7 @@
 defmodule NervesHubDeviceWeb.DeviceView do
   use NervesHubDeviceWeb, :view
   alias NervesHubDeviceWeb.DeviceView
+  alias NervesHubWebCore.Devices.UpdatePayload
 
   def render("show.json", %{device: device}) do
     %{data: render_one(device, DeviceView, "device.json")}
@@ -12,7 +13,11 @@ defmodule NervesHubDeviceWeb.DeviceView do
     }
   end
 
-  def render("update.json", %{reply: reply}) do
-    %{data: reply}
+  # We don't use the standard Phoenix render flow here because
+  # this same payload gets dispatched via PubSub, which means it
+  # already derives Jason.Encoder. This allows that implementation
+  # to be the only source of where this payload gets serialized to JSON.
+  def render("update.json", %{reply: %UpdatePayload{} = update_available}) do
+    %{data: update_available}
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -160,6 +160,7 @@ defmodule NervesHubWebCore.Devices do
         %Phoenix.Socket.Broadcast{
           event: "update",
           payload: %{
+            update_available: true,
             deployment: deployment,
             deployment_id: deployment.id,
             firmware_url: url,

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/update_payload.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/update_payload.ex
@@ -1,0 +1,38 @@
+defmodule NervesHubWebCore.Devices.UpdatePayload do
+  @moduledoc """
+  This struct represents the payload that gets dispatched to devices
+  """
+
+  alias NervesHubWebCore.Firmwares.FirmwareMetadata
+  alias NervesHubWebCore.Deployments.Deployment
+
+  @derive {Jason.Encoder,
+           only: [
+             :update_available,
+             :firmware_url,
+             :firmware_meta,
+             :deployment_id
+           ]}
+
+  defstruct update_available: false,
+            firmware_url: nil,
+            firmware_meta: nil,
+            deployment: nil,
+            deployment_id: nil
+
+  @type t ::
+          %__MODULE__{
+            update_available: false,
+            firmware_meta: nil,
+            firmware_url: nil,
+            deployment: nil,
+            deployment_id: nil
+          }
+          | %__MODULE__{
+              update_available: true,
+              firmware_meta: FirmwareMetadata.t(),
+              firmware_url: String.t(),
+              deployment: Deployment.t(),
+              deployment_id: non_neg_integer()
+            }
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -27,12 +27,12 @@ defmodule NervesHubWebCore.Fixtures do
   @deployment_params %{
     name: "Test Deployment",
     conditions: %{
-      "version" => "< 1.0.0",
+      "version" => "<= 1.0.0",
       "tags" => ["beta", "beta-edge"]
     },
     is_active: false
   }
-  @device_params %{tags: ["beta", "test"]}
+  @device_params %{tags: ["beta", "beta-edge"]}
   @product_params %{name: "valid product", delta_updatable: true}
 
   @user_ca_key Path.expand("../fixtures/ssl/user-root-ca-key.pem", __DIR__)


### PR DESCRIPTION
this is a work around fix for an issue where the payload that gets sent to devices when an update is available is
different if the update happened on `join` or while a device is connected.

I don't believe this is a long term fix, but a work around. 

There are **two different** functions that calculate if a device should receive an update, the other being called `resolve_update` in the same module as is changed here. 
While trying to document and make sense of this payload on the [client side here](https://github.com/nerves-hub/nerves_hub_link_common/commit/db64d190f331184535c26eab253020cec24afb06#diff-3b8725c177a5e6ae0bf2f15149de38d16bf617b238617ecd7cfce5f94a503247) 
i only took that first function into account as i assumed that the other case would use the same function. I think ultimately what needs to happen here is a small refactor to get both of these systems to output the same data as i don't believe having two different flavors of this very important payload is sustainable long term. 