### PR TITLE
Increase deploy timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ migrate: &migrate
 
 deploy: &deploy
   run:
-    name: Deploy to production
+    name: Deploy to env
+    no_output_timeout: 12m
     command: |
       rel/scripts/ecs-deploy.sh \
         $CLUSTER \


### PR DESCRIPTION
Deployments frequently "fail" because CircleCI has an automatic 10 min timeout. However, the [`ecs-deploy` task sets a timeout for 12 minutes](https://github.com/nerves-hub/nerves_hub_web/blob/main/rel/scripts/ecs-deploy.sh#L21) which means our CI may fail before the deploy is actually done.