### PR TITLE
Only send update message if available

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -129,18 +129,20 @@ defmodule NervesHubWebCore.Devices do
   the payload over Phoenix PubSub
   """
   def send_update_message(%Device{} = device, %Deployment{} = deployment) do
-    %UpdatePayload{} = update_available = resolve_update(device, deployment)
+    %UpdatePayload{} = update_payload = resolve_update(device, deployment)
 
-    Phoenix.PubSub.broadcast(
-      NervesHubWeb.PubSub,
-      "device:#{device.id}",
-      %Phoenix.Socket.Broadcast{
-        event: "update",
-        payload: update_available
-      }
-    )
+    if update_payload.update_available do
+      Phoenix.PubSub.broadcast(
+        NervesHubWeb.PubSub,
+        "device:#{device.id}",
+        %Phoenix.Socket.Broadcast{
+          event: "update",
+          payload: update_payload
+        }
+      )
+    end
 
-    update_available
+    update_payload
   end
 
   @spec create_device(map) ::


### PR DESCRIPTION
This is mostly just a nuisance. This will create a failure on the server when attempting to create an audit log event for `update_available: false` and may send an unknown message to the device. However, in the situation where updates are available, everything works as expected.