### PR TITLE
Support view, downloading, and deleting device certificates

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -83,7 +83,8 @@ defmodule NervesHubWebCore.Devices do
     query =
       from(
         d in Device,
-        where: d.identifier == ^identifier and d.org_id == ^org_id
+        where: d.identifier == ^identifier and d.org_id == ^org_id,
+        preload: [:device_certificates]
       )
 
     query

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -143,6 +143,7 @@ defmodule NervesHubWWWWeb.Router do
             patch("/", DeviceController, :update)
             put("/", DeviceController, :update)
             delete("/", DeviceController, :delete)
+            get("/certificate/:cert_serial/download", DeviceController, :download_certificate)
           end
         end
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -97,3 +97,57 @@
     <%= render(NervesHubWWWWeb.AuditLogView, "_audit_log_feed.html", assigns) %>
   </div>
 </div>
+
+<h3 class="mb-2">Certificates</h3>
+<table class="table table-sm table-hover">
+  <thead>
+    <tr>
+      <th>Serial</th>
+      <th>Last used</th>
+      <th>Not before</th>
+      <th>Not after</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for cert <- @device.device_certificates do %>
+      <tr class="item">
+        <td>
+          <div class="mobile-label help-text">Serial</div>
+          <code class="color-white wb-ba"><%= format_serial(cert.serial) %></code>
+        </td>
+        <td title="<%= cert.last_used %>">
+          <div class="mobile-label help-text">Last used</div>
+          <%= if !is_nil(cert.last_used) do %>
+            <%= DateTimeFormat.from_now(cert.last_used) %>
+          <% else %>
+            <span class="text-muted">Never</span>
+          <% end %>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Not before</div>
+          <div class="date-time"><%= cert.not_before %></div>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Not after</div>
+          <div class="date-time"><%= cert.not_after %></div>
+        </td>
+
+        <td class="actions">
+          <div class="mobile-label help-text">Actions</div>
+          <div class="dropdown options">
+            <%= if cert.der do %>
+              <a class="dropdown-toggle options" href="#" id="<%= cert.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <div class="mobile-label pr-2">Open</div>
+                <img src="/images/icons/more.svg" alt="options" />
+              </a>
+            <% end %>
+            <div class="dropdown-menu dropdown-menu-right">
+              <%= link("Download", class: "dropdown-item", aria_label: "Download Device Certificate", to: Routes.device_path(@socket, :download_certificate, @org.name, @product.name, @device.identifier, cert.serial)) %>
+              <a class="dropdown-item" phx-click="delete-certificate" phx-value-serial="<%= cert.serial %>" data-confirm="Delete <%= format_serial(cert.serial) %>?">Delete</a>
+            </div>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWWWWeb.DeviceView do
   alias NervesHubDevice.Presence
   alias NervesHubWWWWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
   import NervesHubWWWWeb.LayoutView, only: [pagination_links: 1]
+  import NervesHubWWWWeb.OrgCertificateView, only: [format_serial: 1]
 
   def architecture_options do
     [


### PR DESCRIPTION
The CLI can interact with device certificates, but the web has no
context. This adds ability to see what devices certificates are
associated and also supports downloading and deleting

![image](https://user-images.githubusercontent.com/11321326/108768954-989b2700-7515-11eb-93c3-682d7f43889d.png)
