### PR TITLE
Ignore SSL auth when device has been soft deleted

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -241,7 +241,8 @@ defmodule NervesHubWebCore.Devices do
             c.serial == ^serial and
             c.aki == ^aki and
             c.not_before == ^not_before and
-            c.not_after == ^not_after
+            c.not_after == ^not_after,
+        preload: :device
       )
 
     query

--- a/docs/device_authentication.md
+++ b/docs/device_authentication.md
@@ -26,7 +26,10 @@ device's certificate on file.
 Devices connect to NervesHub over TLS. NervesHub requests a certificate from the
 device. After the TLS stack receives the certificate, it does some processing
 and then passes it on to NervesHub code that does the following.  Note that
-nothing in the X.509 certificate from the device is trusted at the beginning.
+nothing in the X.509 certificate from the device is trusted at the beginning and
+if the device has been soft deleted, all certificate validation is skipped and
+authentication halted. The device record will need to be restored (or completely
+deleted) to authenticate again.
 
 1. Compute a SHA-1 hash on the device certificate in DER form. This is
    called the certificate fingerprint.


### PR DESCRIPTION
Right now if a device is deleted, it is a soft delete. When it
attempts to connect again, SSL verification will succeed but the
device will not show anywhere in the UI.

This instead fixes that to prevent authentication for devices that are
deleted and require the user to explicitly restore it.