### PR TITLE
Allow editing JITP for existing certificates

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate.ex
@@ -49,5 +49,6 @@ defmodule NervesHubWebCore.Devices.CACertificate do
 
   def update_changeset(%CACertificate{} = ca_certificate, params) do
     cast(ca_certificate, params, [:description, :last_used])
+    |> cast_assoc(:jitp)
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate/jitp.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate/jitp.ex
@@ -14,9 +14,13 @@ defmodule NervesHubWebCore.Devices.CACertificate.JITP do
     timestamps()
   end
 
+  def changeset(jitp, %{"delete" => "true"}) do
+    %{change(jitp) | action: :delete}
+  end
+
   def changeset(jitp, params) do
     jitp
-    |> cast(params, [:tags, :description])
-    |> validate_required([:tags, :description])
+    |> cast(params, [:tags, :description, :product_id])
+    |> validate_required([:tags, :description, :product_id])
   end
 end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20210511162245_add_jitp_to_ca_certificates.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20210511162245_add_jitp_to_ca_certificates.exs
@@ -12,7 +12,7 @@ defmodule NervesHubWebCore.Repo.Migrations.AddJitpToCaCertificates do
     create unique_index(:jitp, [:product_id])
 
     alter table(:ca_certificates) do
-      add :jitp_id, references(:jitp, on_delete: :delete_all)
+      add :jitp_id, references(:jitp, on_delete: :nilify_all)
     end
 
     create unique_index(:ca_certificates, [:jitp_id])

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/edit.html.eex
@@ -1,14 +1,58 @@
 <h1>Edit Certificate Authority</h1>
 
-<%= form_for @changeset, Routes.org_certificate_path(@conn, :update, @org.name, @cert.serial), fn f -> %>
+<%= form_for @changeset, Routes.org_certificate_path(@conn, :update, @org.name, @serial), fn f -> %>
   <div class="form-group">
     <%= label f, :description, for: "description_input" %>
     <%= text_input f, :description , class: "form-control", id: "description_input" %>
     <div class="has-error"><%= error_tag f, :description %></div>
   </div>
 
+  <%= inputs_for f, :jitp, fn fp -> %>
+    <label for="jitp_toggle"> Enable Just In Time Provisioning </label>
+    <input type="checkbox" name="jitp_toggle" id="jitp_toggle" <%= if f.data.jitp, do: "checked"%>>
+    <%= hidden_input fp, :delete, id: "jitp-delete" %>
+    <div <%= unless f.data.jitp, do: "hidden"%> id="jitp_form">
+      <div class="form-group">
+        <label for="description_input" class="tooltip-label h3 mb-1">
+          <span>JITP Description</span>
+          <span class="tooltip-info"></span>
+          <span class="tooltip-text">Device Description</span>
+        </label>
+        <%= text_input fp, :description, class: "form-control", id: "description_input" %>
+        <div class="has-error"><%= error_tag fp, :description %></div>
+      </div>
+
+      <div class="form-group" aria-hidden="true">
+        <label for="tag_input" class="tooltip-label h3 mb-1">
+          <span>JITP Tags</span>
+          <span class="tooltip-info"></span>
+          <span class="tooltip-text">Tags are used by deployments to target a device. A device must have matching tag(s) for the deployment to update it</span>
+        </label>
+        <%= text_input fp, :tags, class: "form-control", id: "tag_input" %>
+        <div class="has-error"><%= error_tag fp, :tags %></div>
+      </div>
+
+      <div class="form-group" aria-hidden="true">
+        <label for="tag_input" class="tooltip-label h3 mb-1">
+          <span>JITP Product</span>
+          <span class="tooltip-info"></span>
+          <span class="tooltip-text">JITP must be configured to use a particular product</span>
+        </label>
+        <%= select fp, :product_id, Enum.map(@products, &{&1.name, &1.id}), class: "form-control", id: "product_input" %>
+        <div class="has-error"><%= error_tag fp, :product_id %></div>
+      </div>
+    </div>
+  <% end %>
+
   <div class="button-submit-wrapper">
     <%= link "Back", to: Routes.org_certificate_path(@conn, :index, @org.name), class: "btn btn-outline-light" %>
     <%= submit "Update Certificate", class: "btn btn-primary" %>
   </div>
 <% end %>
+
+<script>
+document.getElementById("jitp_toggle").onclick = function() {
+  document.getElementById("jitp_form").hidden = !this.checked;
+  document.getElementById("jitp-delete").value = !this.checked;
+}
+</script>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/new.html.eex
@@ -44,7 +44,7 @@
 
   <%= inputs_for f, :jitp, fn fp -> %>
     <label for="jitp_toggle"> Enable Just In Time Provisioning </label>
-    <input type="checkbox" name="jitp_toggle" id="jitp_toggle">
+    <%= checkbox fp, :jitp_toggle, id: "jitp_toggle" %>
     <div hidden id="jitp_form">
       <div class="form-group">
         <label for="description_input" class="tooltip-label h3 mb-1">
@@ -72,7 +72,7 @@
           <span class="tooltip-info"></span>
           <span class="tooltip-text">JITP must be configured to use a particular product</span>
         </label>
-        <%= select fp, :product_id, Enum.map(@products, &{&1.name, &1.id}), class: "form-control", id: "product_input" %>
+        <%= select fp, :product_id, Enum.map(@products, &{&1.name, &1.id}), class: "form-control", id: "product_input", prompt: "Select Product" %>
         <div class="has-error"><%= error_tag fp, :product_id %></div>
       </div>
     </div>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
@@ -130,12 +130,13 @@ defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
 
     @tag :tmp_dir
     @tag timeout: :infinity
-    test "create with JITP", %{conn: conn, org: org, tmp_dir: tmp_dir} do
+    test "create with JITP", %{conn: conn, user: user, org: org, tmp_dir: tmp_dir} do
       conn = get(conn, Routes.org_certificate_path(conn, :new, org.name))
       session = Plug.Conn.get_session(conn)
       code = session["registration_code"]
       ca_file_path = Fixtures.device_certificate_authority_file()
       ca_key_file_path = Fixtures.device_certificate_authority_key_file()
+      product = Fixtures.product_fixture(user, org)
 
       %{verification_cert_pem: verification_cert_pem} =
         Fixtures.generate_certificate_authority_csr(ca_file_path, ca_key_file_path, code, tmp_dir)
@@ -152,7 +153,7 @@ defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
           cert: cert_upload,
           csr: csr_upload,
           description: description,
-          jitp: %{tags: ["prod"], description: "jitp"}
+          jitp: %{tags: ["prod"], description: "jitp", product_id: product.id}
         }
       }
 


### PR DESCRIPTION
There is a crucial fix in here that changes the JITP record migration to prevent deleting certificates when JITP profiles are deleted. see b66435c

The rest allows JITP CRUD actions on existing certificates. This will effectively grandfather in any existing CA certificates and allow them to be edited to use with JITP without the strict ownership check that was also introduced.