### PR TITLE
Device uniqueness fixes

### DIFF
--- a/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_api/test/nerves_hub_api_web/controllers/device_controller_test.exs
@@ -78,7 +78,7 @@ defmodule NervesHubAPIWeb.DeviceControllerTest do
       conn =
         get(conn, Routes.device_path(conn, :show, org.name, product.name, to_delete.identifier))
 
-      assert json_response(conn, 403)["status"] != ""
+      assert json_response(conn, 200)["status"] != ""
     end
 
     test "renders error when using deprecated api", %{conn: conn, org: org} do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -19,13 +19,11 @@ defmodule NervesHubWebCore.Devices do
 
   def get_device(device_id) do
     Device
-    |> Repo.exclude_deleted()
     |> Repo.get(device_id)
   end
 
   def get_device!(device_id) do
     Device
-    |> Repo.exclude_deleted()
     |> Repo.get!(device_id)
   end
 
@@ -103,7 +101,6 @@ defmodule NervesHubWebCore.Devices do
       )
 
     query
-    |> Repo.exclude_deleted()
     |> Device.with_org()
     |> Repo.one()
     |> case do
@@ -550,6 +547,10 @@ defmodule NervesHubWebCore.Devices do
       true ->
         {:ok, device}
     end
+  end
+
+  def restore_device(%Device{} = device) do
+    update_device(device, %{deleted_at: nil})
   end
 
   defp failures_query(%Device{id: device_id}, %Deployment{id: deployment_id} = deployment) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/device.ex
@@ -18,7 +18,8 @@ defmodule NervesHubWebCore.Devices.Device do
     :last_communication,
     :description,
     :healthy,
-    :tags
+    :tags,
+    :deleted_at
   ]
   @required_params [:org_id, :product_id, :identifier]
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/repo.ex
@@ -43,4 +43,6 @@ defmodule NervesHubWebCore.Repo do
   def exclude_deleted(query) do
     where(query, [o], is_nil(o.deleted_at))
   end
+
+  def destroy(struct_or_changeset), do: delete(struct_or_changeset)
 end

--- a/apps/nerves_hub_web_core/priv/repo/migrations/20210603174111_require_device_uniqueness.exs
+++ b/apps/nerves_hub_web_core/priv/repo/migrations/20210603174111_require_device_uniqueness.exs
@@ -1,0 +1,12 @@
+defmodule NervesHubWebCore.Repo.Migrations.RequireDeviceUniqueness do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(unique_index(:devices, [:org_id, :identifier], name: :devices_org_id_identifier_index, where: "deleted_at IS NULL"))
+
+    # Deduplicate devices that may exist from previously being deleted
+    execute "DELETE from devices where id not in (select max(id) from devices group by identifier)"
+
+    create_if_not_exists(unique_index(:devices, [:org_id, :identifier], name: :devices_org_id_identifier_index))
+  end
+end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/show.ex
@@ -130,6 +130,39 @@ defmodule NervesHubWWWWeb.DeviceLive.Show do
     end
   end
 
+  def handle_event("restore", _, socket) do
+    case Devices.restore_device(socket.assigns.device) do
+      {:ok, device} ->
+        {:noreply, assign(socket, device: device)}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Failed to restore device")}
+    end
+  end
+
+  def handle_event("destroy", _, socket) do
+    case Repo.destroy(socket.assigns.device) do
+      {:ok, _device} ->
+        path =
+          Routes.device_path(socket, :index, socket.assigns.org.name, socket.assigns.product.name)
+
+        {:noreply, redirect(socket, to: path)}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Failed to destroy device")}
+    end
+  end
+
+  def handle_event("delete", _, socket) do
+    case Devices.delete_device(socket.assigns.device) do
+      {:ok, %{device: device}} ->
+        {:noreply, assign(socket, device: device)}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Failed to delete device")}
+    end
+  end
+
   defp audit_log_assigns(%{assigns: %{device: device}} = socket) do
     all_logs = AuditLogs.logs_for_feed(device)
     paginate_opts = %{page_number: 1, page_size: 5}

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -1,6 +1,24 @@
+<%= if @device.deleted_at do %>
+  <div class="alert alert-danger">
+    <div class="content-container">
+      <center>Device is deleted and must be restored to use</center>
+    </div>
+  </div>
+<% end %>
+
 <div class="action-row">
   <%= link "All Devices", to: Routes.device_path(@socket, :index, @org.name, @product.name), class: "back-link"%>
   <div class="btn-group" role="group" aria-label="Device Actions">
+  <%= if @device.deleted_at do %>
+    <button class="btn btn-outline-light btn-action"  aria-label="Restore" type="button" phx-click="restore">
+      <span class="button-icon power"></span>
+      <span class="action-text">Restore</span>
+    </button>
+    <button class="btn btn-outline-light btn-action btn-primary" aria-label="Destroy" type="button" phx-click="destroy" data-confirm="Are you sure?">
+      <span class="button-icon delete"></span>
+      <span class="action-text">Destroy</span>
+    </button>
+  <% else %>
     <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" <%= if @device.status == "offline", do: "disabled" %> data-confirm="Are you sure?">
       <span class="button-icon power"></span>
       <span class="action-text">Reboot</span>
@@ -20,16 +38,10 @@
         <span class="action-text"><%= if @device.healthy, do: "Quarantine", else: "Unquarantine" %></span>
       <% end %>
     <% end %>
-    <%= link(
-      class: "btn btn-outline-light btn-action",
-      aria_label: "Delete",
-      to: Routes.device_path(@socket, :delete, @org.name, @product.name, @device.identifier),
-      method: :delete,
-      data: [confirm: "Are you sure?"])
-      do %>
+    <button class="btn btn-outline-light btn-action" aria-label="Delete" type="button" phx-click="delete" data-confirm="Are you sure?">
       <span class="button-icon delete"></span>
       <span class="action-text">Delete</span>
-    <% end %>
+    </button>
     <%= link(
       class: "btn btn-outline-light btn-action",
       aria_label: "Edit",
@@ -38,6 +50,7 @@
       <span class="button-icon edit"></span>
       <span class="action-text">Edit</span>
     <% end %>
+  <% end %>
   </div>
 </div>
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/device_controller_test.exs
@@ -62,7 +62,8 @@ defmodule NervesHubWWWWeb.DeviceControllerTest do
       conn =
         get(conn, Routes.device_path(conn, :show, org.name, product.name, to_delete.identifier))
 
-      assert html_response(conn, 404)
+      # Can still show soft deleted device
+      assert html_response(conn, 200)
     end
   end
 


### PR DESCRIPTION
099249f changes the uniqueness requirement for devices. Previously, a device identifier could be created in an org if that device was deleted. This causes lots of errors if it ever tries to connect again and leaves potential for lots of orphaned device records so we need to not exclude deleted devices in the index. Part of the migration will delete duplicate records before restoring the index.

The rest is to support being able to restore/destroy soft deleted device records in order to avoid unknown errors trying to recreate devices or connecting deleted ones