### PR TITLE
Fix allow_signups runtime config is not available

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/plugs/allow_uninvited_signups.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/plugs/allow_uninvited_signups.ex
@@ -6,30 +6,34 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignups do
 
   alias Phoenix.Controller
 
-  def init(opts) do
-    Keyword.put(opts, :allow_signups, allow_signups())
-  end
-
-  def call(conn, allow_signups: true), do: conn
+  def init(opts), do: opts
 
   def call(%{private: %{phoenix_router: APIRouter}} = conn, _opts) do
-    conn
-    |> put_resp_header("content-type", "application/json")
-    |> send_resp(
-      403,
-      Jason.encode!(%{status: "Public signups disabled. Invite required to signup"})
-    )
-    |> halt()
+    if allow_signups() do
+      conn
+    else
+      conn
+      |> put_resp_header("content-type", "application/json")
+      |> send_resp(
+        403,
+        Jason.encode!(%{status: "Public signups disabled. Invite required to signup"})
+      )
+      |> halt()
+    end
   end
 
   def call(%{private: %{phoenix_router: WebRouter}} = conn, _opts) do
-    conn
-    |> Controller.put_flash(:error, "Sorry signups are not enabled at this time.")
-    |> Controller.redirect(to: "/")
-    |> halt()
+    if allow_signups() do
+      conn
+    else
+      conn
+      |> Controller.put_flash(:error, "Sorry signups are not enabled at this time.")
+      |> Controller.redirect(to: "/")
+      |> halt()
+    end
   end
 
-  defp allow_signups do
+  defp allow_signups() do
     Application.get_env(:nerves_hub_web_core, :allow_signups)
   end
 end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/plugs/allow_uninvited_signups.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/plugs/allow_uninvited_signups.ex
@@ -9,7 +9,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignups do
   def init(opts), do: opts
 
   def call(%{private: %{phoenix_router: APIRouter}} = conn, _opts) do
-    if allow_signups() do
+    if allow_signups?() do
       conn
     else
       conn
@@ -23,7 +23,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignups do
   end
 
   def call(%{private: %{phoenix_router: WebRouter}} = conn, _opts) do
-    if allow_signups() do
+    if allow_signups?() do
       conn
     else
       conn
@@ -33,7 +33,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignups do
     end
   end
 
-  defp allow_signups() do
-    Application.get_env(:nerves_hub_web_core, :allow_signups)
+  defp allow_signups?() do
+    Application.get_env(:nerves_hub_web_core, :allow_signups?)
   end
 end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/plugs/allow_uninvited_signups_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/plugs/allow_uninvited_signups_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Phoenix.ConnTest
   import Plug.Conn
 
@@ -11,6 +11,8 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
         |> fetch_flash
         |> bypass_through(NervesHubWWWWeb.Router)
         |> dispatch(NervesHubWWWWeb.Endpoint, :get, "/")
+
+      on_exit(fn -> Application.put_env(:nerves_hub_web_core, :allow_signups?, true) end)
 
       %{conn: conn}
     end
@@ -41,6 +43,8 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
         build_conn()
         |> bypass_through(NervesHubAPIWeb.Router)
         |> dispatch(NervesHubAPIWeb.Endpoint, :post, "/users/register")
+
+      on_exit(fn -> Application.put_env(:nerves_hub_web_core, :allow_signups?, true) end)
 
       %{conn: conn}
     end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/plugs/allow_uninvited_signups_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/plugs/allow_uninvited_signups_test.exs
@@ -16,7 +16,8 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "user is redirected when signups are disabled", %{conn: conn} do
-      conn = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, allow_signups: false)
+      Application.put_env(:nerves_hub_web_core, :allow_signups, false)
+      conn = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert redirected_to(conn) == "/"
 
@@ -26,7 +27,8 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "user is not redirected when signups are enabled", %{conn: conn} do
-      conn_through = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, allow_signups: true)
+      Application.put_env(:nerves_hub_web_core, :allow_signups, true)
+      conn_through = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert conn_through.status != 302
       assert conn_through == conn
@@ -44,7 +46,8 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "fails registration when signups are disabled", %{conn: conn} do
-      conn = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, allow_signups: false)
+      Application.put_env(:nerves_hub_web_core, :allow_signups, false)
+      conn = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert json_response(conn, 403) == %{
                "status" => "Public signups disabled. Invite required to signup"
@@ -52,7 +55,9 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "passes conn when signups are allowed", %{conn: conn} do
-      conn_through = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, allow_signups: true)
+      Application.put_env(:nerves_hub_web_core, :allow_signups, true)
+      conn_through = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
+
       assert conn_through == conn
     end
   end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/plugs/allow_uninvited_signups_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/plugs/allow_uninvited_signups_test.exs
@@ -16,7 +16,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "user is redirected when signups are disabled", %{conn: conn} do
-      Application.put_env(:nerves_hub_web_core, :allow_signups, false)
+      Application.put_env(:nerves_hub_web_core, :allow_signups?, false)
       conn = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert redirected_to(conn) == "/"
@@ -27,7 +27,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "user is not redirected when signups are enabled", %{conn: conn} do
-      Application.put_env(:nerves_hub_web_core, :allow_signups, true)
+      Application.put_env(:nerves_hub_web_core, :allow_signups?, true)
       conn_through = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert conn_through.status != 302
@@ -46,7 +46,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "fails registration when signups are disabled", %{conn: conn} do
-      Application.put_env(:nerves_hub_web_core, :allow_signups, false)
+      Application.put_env(:nerves_hub_web_core, :allow_signups?, false)
       conn = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert json_response(conn, 403) == %{
@@ -55,7 +55,7 @@ defmodule NervesHubWebCore.Plugs.AllowUninvitedSignupsTest do
     end
 
     test "passes conn when signups are allowed", %{conn: conn} do
-      Application.put_env(:nerves_hub_web_core, :allow_signups, true)
+      Application.put_env(:nerves_hub_web_core, :allow_signups?, true)
       conn_through = NervesHubWebCore.Plugs.AllowUninvitedSignups.call(conn, [])
 
       assert conn_through == conn

--- a/apps/nerves_hub_www/config/release.exs
+++ b/apps/nerves_hub_www/config/release.exs
@@ -53,17 +53,7 @@ config :nerves_hub_web_core, NervesHubWebCore.Mailer,
 config :nerves_hub_web_core,
   host: host,
   port: port,
-  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
+  allow_signups?: System.get_env("ALLOW_SIGNUPS", "true") |> String.to_atom()
 
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint, url: [host: host, port: port]
-
-to_boolean = fn
-  "true" -> true
-  "1" -> true
-  _ -> false
-end
-
-if allow_signups = System.get_env("ALLOW_SIGNUPS", "1") do
-  config :nerves_hub_www, NervesHubWWWWeb.AccountController,
-    allow_signups: to_boolean.(allow_signups)
-end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -74,7 +74,7 @@ defmodule NervesHubWWWWeb.LayoutView do
   end
 
   def permit_uninvited_signups do
-    Application.get_env(:nerves_hub_web_core, :allow_signups)
+    Application.get_env(:nerves_hub_web_core, :allow_signups?)
   end
 
   @tib :math.pow(2, 40)

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,7 +54,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
 # NervesHubWebCore
 #
 config :nerves_hub_web_core,
-  allow_signups: false,
+  allow_signups?: false,
   ecto_repos: [NervesHubWebCore.Repo],
   from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
   host: host

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,7 +22,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint, server: true
 # NervesHubWebCore
 #
 config :nerves_hub_web_core,
-  allow_signups: true,
+  allow_signups?: true,
   enable_workers: true,
   firmware_upload: NervesHubWebCore.Firmwares.Upload.S3,
   host: "www.nerves-hub.org",

--- a/config/test.exs
+++ b/config/test.exs
@@ -41,7 +41,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
 # NervesHubWebCore
 #
 config :nerves_hub_web_core,
-  allow_signups: true,
+  allow_signups?: true,
   firmware_upload: NervesHubWebCore.UploadMock,
   port: web_port
 


### PR DESCRIPTION
The reason why this issue occurs is due to the fact that
the value of allow_signups is assigned in the init function of plug.

This is mentioned in [the Plug documentation](https://github.com/elixir-plug/plug/blob/fa579592ebf53306e3a4b13e2414a40997add1f7/lib/plug.ex#L22-L24).
> Note that init/1 may be called during compilation and as such
> it must not return pids, ports or values that are specific to the runtime.

