### PR TITLE
Remove references to a paid version of NervesHub

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/home/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/home/index.html.eex
@@ -106,10 +106,6 @@
       <h3>Check out our repositories on Github</h3>
       <a class="btn btn-primary btn-lg btn-home" target="_blank" rel="noopener noreferrer" href="https://github.com/nerves-hub">NervesHub on Github</a>
     </div>
-    <div class="item">
-      <h3>Learn more about NervesHub managed services</h3>
-      <a class="btn btn-primary btn-lg btn-home" target="_blank" rel="noopener noreferrer" href="https://www.verypossible.com/contact">Contact Us</a>
-    </div>
   </div>
 </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
@@ -14,20 +14,6 @@
       <a href="https://github.com/nerves-hub/nerves_hub_web/issues" target="_blank" rel="noopener noreferrer">Report an issue</a>
       <a href="mailto:support@nerves-hub.org" target="_blank" rel="noopener noreferrer">Contact support</a>
     </div>
-    <div class="footer-nav very">
-      <h6>Need help using NervesHub for your project?</h6>
-      <a href="https://www.verypossible.com/" target="_blank" rel="noopener noreferrer">
-        <img src="/images/home/very-logo-colored.svg" alt="Very logo" />
-      </a>
-      <p class="p-small mt-2 mb-0">Very delivers high-impact IoT solutions with Nerves and offers expert consulting.</p>
-      <a href="https://www.verypossible.com/" target="_blank" rel="noopener noreferrer">
-        Visit Very's website
-        <img src="/images/icons/arrow-forward-red.svg" alt=""  class="arrow" />
-      </a>
-      <a href="https://www.verypossible.com/contact" target="_blank" rel="noopener noreferrer">
-        Get in touch
-        <img src="/images/icons/arrow-forward-red.svg" alt=""  class="arrow" /></a>
-    </div>
   </div>
   <div class="tos-grid">
     <div></div>


### PR DESCRIPTION
I've been receiving inquiries into how to pay for NervesHub and Very
hasn't worked on NervesHub for quite a while (at least in public). It
feels like it's time to make the website reflect the current state more
accurately.
