### PR TITLE
Use equality comparison to find firmware deltas

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -351,10 +351,10 @@ defmodule NervesHubWebCore.Firmwares do
   def get_firmware_delta_by_source_and_target(%Firmware{id: source_id}, %Firmware{id: target_id}) do
     q =
       from(
-        fp in FirmwareDelta,
+        fd in FirmwareDelta,
         where:
-          fp.source_id == ^source_id and
-            fp.target_id >= ^target_id
+          fd.source_id == ^source_id and
+            fd.target_id == ^target_id
       )
 
     case Repo.one(q) do


### PR DESCRIPTION
When finding a firmware delta, the source and target firmware ID's should be equal to `source_id` and `target_id`.