### PR TITLE
Allow AWS host to be configured

### DIFF
--- a/apps/nerves_hub_api/config/release.exs
+++ b/apps/nerves_hub_api/config/release.exs
@@ -39,6 +39,8 @@ config :nerves_hub_web_core, NervesHubWebCore.Workers.FirmwaresTransferS3Ingress
 
 config :ex_aws, region: System.fetch_env!("AWS_REGION")
 
+config :ex_aws, :s3, host: System.get_env("AWS_HOST", "amazonaws.com")
+
 config :nerves_hub_web_core, NervesHubWebCore.Mailer,
   adapter: Bamboo.SMTPAdapter,
   server: System.fetch_env!("SES_SERVER"),

--- a/apps/nerves_hub_device/config/release.exs
+++ b/apps/nerves_hub_device/config/release.exs
@@ -39,6 +39,8 @@ config :nerves_hub_web_core, NervesHubWebCore.Workers.FirmwaresTransferS3Ingress
 
 config :ex_aws, region: System.fetch_env!("AWS_REGION")
 
+config :ex_aws, :s3, host: System.get_env("AWS_HOST", "amazonaws.com")
+
 config :nerves_hub_device, NervesHubDeviceWeb.Endpoint, server: true
 
 config :nerves_hub_web_core, NervesHubWebCore.Mailer,

--- a/apps/nerves_hub_www/config/release.exs
+++ b/apps/nerves_hub_www/config/release.exs
@@ -39,6 +39,8 @@ config :nerves_hub_web_core, NervesHubWebCore.Workers.FirmwaresTransferS3Ingress
 
 config :ex_aws, region: System.fetch_env!("AWS_REGION")
 
+config :ex_aws, :s3, host: System.get_env("AWS_HOST", "amazonaws.com")
+
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint,
   secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
   live_view: [signing_salt: System.fetch_env!("LIVE_VIEW_SIGNING_SALT")]


### PR DESCRIPTION
This allows for NervesHub to be hosted outside of AWS such as Google Cloud