### PR TITLE
Fix dropdown menu toggling

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.heex
@@ -40,7 +40,7 @@
       <td class="actions">
         <div class="mobile-label help-text">Actions</div>
         <div class="dropdown options">
-          <a class="dropdown-toggle options" href="#" id={to_string(cert.id)} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="dropdown-toggle options" href="#" id={to_string(cert.id)} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <div class="mobile-label pr-2">Open</div>
             <img src="/images/icons/more.svg" alt="options" />
           </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.heex
@@ -69,7 +69,7 @@
         <td class="actions">
           <div class="mobile-label help-text">Actions</div>
           <div class="dropdown options">
-            <a class="dropdown-toggle options" href="#" id={to_string(deployment.id)} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="dropdown-toggle options" href="#" id={to_string(deployment.id)} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <div class="mobile-label pr-2">Open</div>
               <img src="/images/icons/more.svg" alt="options" />
             </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.heex
@@ -190,7 +190,7 @@
         <td class="actions">
           <div class="mobile-label help-text">Actions</div>
           <div class="dropdown options">
-            <a class="dropdown-toggle options" href="#" id={device.identifier} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="dropdown-toggle options" href="#" id={device.identifier} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <div class="mobile-label pr-2">Open</div>
               <img src="/images/icons/more.svg" alt="options" />
             </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.heex
@@ -148,7 +148,7 @@
         <td class="actions">
           <div class="mobile-label help-text">Actions</div>
           <div class="dropdown options">
-              <a class="dropdown-toggle options" href="#" id={to_string(cert.id)} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="dropdown-toggle options" href="#" id={to_string(cert.id)} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <div class="mobile-label pr-2">Open</div>
                 <img src="/images/icons/more.svg" alt="options" />
               </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.heex
@@ -64,7 +64,7 @@
         <td class="actions">
           <div class="mobile-label help-text">Actions</div>
           <div class="dropdown options">
-            <a class="dropdown-toggle options" href="#" id={firmware.uuid} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="dropdown-toggle options" href="#" id={firmware.uuid} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <div class="mobile-label pr-2">Open</div>
               <img src="/images/icons/more.svg" alt="options" />
             </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.heex
@@ -8,7 +8,7 @@
     <%= if logged_in?(@conn) do %>
       <ul class="navbar-nav me-auto flex-grow">
         <li class="nav-item dropdown switcher">
-          <a class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= if org = get_in(@conn.assigns, [:org]), do: org.name, else: @conn.assigns.user.username %><%= if product = product(@conn) do %> <span class="workspace-divider">:</span> <%= product.name %><% end %>
           </a>
 
@@ -65,7 +65,7 @@
       </ul>
       <ul class="navbar-nav">
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle user-menu" href="#" id="menu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a class="nav-link dropdown-toggle user-menu" href="#" id="menu1" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span><%= @conn.assigns.user.username %></span>
             <img src="/images/icons/settings.svg" alt="settings" />
           </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.heex
@@ -54,7 +54,7 @@
         <td class="actions">
           <div class="mobile-label help-text">Actions</div>
           <div class="dropdown options">
-            <a class="dropdown-toggle options" href="#" id={to_string(cert.id)} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="dropdown-toggle options" href="#" id={to_string(cert.id)} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <div class="mobile-label pr-2">Open</div>
               <img src="/images/icons/more.svg" alt="options" />
             </a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.heex
@@ -43,7 +43,7 @@
         <%= if org_user.user.id != assigns.user.id do %>
           <td class="actions">
             <div class="dropdown options">
-              <a class="dropdown-toggle options" href="#" id={to_string(org_user.id)} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="dropdown-toggle options" href="#" id={to_string(org_user.id)} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <img src="/images/icons/more.svg" alt="options" />
               </a>
               <div class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
With updated bootstrap 5, the `data-toggle="dropdown"` attribute needs to be changed to `data-bs-toggle="dropdown"` for the popper lib and boostrap to work on the element

/cc @tonnenpinguin 