### PR TITLE
Add tooltips for exact device last-handshake time

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/_header.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/_header.html.heex
@@ -16,7 +16,7 @@
   </div>
   <div>
     <div class="help-text">Last Handshake</div>
-    <p>
+    <p title={@device.last_communication}>
       <%= if is_nil(@device.last_communication) do %>
         Never
       <% else %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.heex
@@ -134,7 +134,7 @@
           </div>
         </td>
 
-        <td>
+        <td title={device.last_communication}>
           <div class="mobile-label help-text">Last handshake</div>
           <%= if is_nil(device.last_communication) do %>
             <span class="color-white-50">Never</span>


### PR DESCRIPTION
This mirrors the tooltip for last certificate use: https://github.com/nerves-hub/nerves_hub_web/blob/5d7c4148b6d30ab663bae2658d39e21c199c6dfe/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.heex#L131-L138