### PR TITLE
Build firmware deltas with Oban jobs 

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/deployments.ex
@@ -20,6 +20,12 @@ defmodule NervesHubWebCore.Deployments do
     |> Repo.all()
   end
 
+  @spec get_deployments_by_firmware(integer()) :: [Deployment.t()]
+  def get_deployments_by_firmware(firmware_id) do
+    from(d in Deployment, where: d.firmware_id == ^firmware_id)
+    |> Repo.all()
+  end
+
   @spec get_deployment(Product.t(), String.t()) :: {:ok, Deployment.t()} | {:error, :not_found}
   def get_deployment(%Product{id: product_id}, deployment_id) do
     from(
@@ -87,10 +93,7 @@ defmodule NervesHubWebCore.Deployments do
     |> case do
       {:ok, deployment} ->
         Firmwares.update_firmware_ttl(deployment.firmware_id)
-
-        deployment
-        |> fetch_relevant_devices()
-        |> update_relevant_devices(deployment)
+        fetch_and_update_relevant_devices(deployment)
 
       error ->
         error
@@ -193,6 +196,12 @@ defmodule NervesHubWebCore.Deployments do
       true ->
         {:ok, deployment}
     end
+  end
+
+  def fetch_and_update_relevant_devices(deployment) do
+    deployment
+    |> fetch_relevant_devices()
+    |> update_relevant_devices(deployment)
   end
 
   def fetch_relevant_devices(%Deployment{is_active: false}) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -493,12 +493,17 @@ defmodule NervesHubWebCore.Devices do
     %UpdatePayload{update_available: false}
   end
 
-  @spec delta_updatable?(source :: Firmware.t(), target :: Firmware.t(), Product.t(), fwup_version :: String.t()) :: boolean()
+  @spec delta_updatable?(
+          source :: Firmware.t(),
+          target :: Firmware.t(),
+          Product.t(),
+          fwup_version :: String.t()
+        ) :: boolean()
   def delta_updatable?(source, target, product, fwup_version) do
-    product.delta_updatable
-    and target.delta_updatable
-    and source.delta_updatable
-    and Version.match?(fwup_version, @min_fwup_delta_updatable_version)
+    product.delta_updatable and
+      target.delta_updatable and
+      source.delta_updatable and
+      Version.match?(fwup_version, @min_fwup_delta_updatable_version)
   end
 
   @doc """

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -469,15 +469,15 @@ defmodule NervesHubWebCore.Devices do
             build_no_update_payload()
         end
       else
-        build_update_payload(source, target, deployment)
+        build_update_payload(target, target, deployment)
       end
     else
       _ -> build_no_update_payload()
     end
   end
 
-  defp build_update_payload(source, target, deployment) do
-    {:ok, url} = Firmwares.get_firmware_url(source)
+  defp build_update_payload(target_or_delta_firmware, target, deployment) do
+    {:ok, url} = Firmwares.get_firmware_url(target_or_delta_firmware)
     {:ok, meta} = Firmwares.metadata_from_firmware(target)
 
     %UpdatePayload{

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -14,13 +14,16 @@ defmodule NervesHubWebCore.Devices do
     AuditLogs.AuditLog,
     Accounts,
     Accounts.Org,
-    Repo,
     Accounts.OrgKey,
-    Products.Product
+    Repo,
+    Products.Product,
+    Workers
   }
 
   alias NervesHubWebCore.Devices.{Device, DeviceCertificate, CACertificate}
   alias NervesHubWebCore.TaskSupervisor, as: Tasks
+
+  @min_fwup_delta_updatable_version ">=1.6.0"
 
   def get_device(device_id), do: Repo.get(Device, device_id)
   def get_device!(device_id), do: Repo.get!(Device, device_id)
@@ -454,26 +457,63 @@ defmodule NervesHubWebCore.Devices do
     with {:ok, %{healthy: true}} <- verify_update_eligibility(device, deployment),
          true <- matches_deployment?(device, deployment),
          %Device{product: product} <- Repo.preload(device, :product),
-         fwup_version <- Map.get(device.firmware_metadata, :fwup_version),
+         {:ok, source} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
          %{firmware: target} <- Repo.preload(deployment, :firmware) do
-      source =
-        case Firmwares.get_firmware_by_product_and_uuid(product, uuid) do
-          {:ok, source} -> source
-          {:error, :not_found} -> nil
+      if delta_updatable?(device, deployment) do
+        case Firmwares.get_firmware_delta_by_source_and_target(source, target) do
+          {:ok, firmware_delta} ->
+            build_update_payload(firmware_delta, target, deployment)
+
+          {:error, :not_found} ->
+            :ok = Workers.FirmwareDeltaBuilder.start(source.id, target.id)
+            build_no_update_payload()
         end
-
-      {:ok, url} = Firmwares.get_firmware_url(source, target, fwup_version, product)
-      {:ok, meta} = Firmwares.metadata_from_firmware(target)
-
-      %UpdatePayload{
-        update_available: true,
-        firmware_url: url,
-        firmware_meta: meta,
-        deployment: deployment,
-        deployment_id: deployment.id
-      }
+      else
+        build_update_payload(source, target, deployment)
+      end
     else
-      _ -> %UpdatePayload{update_available: false}
+      _ -> build_no_update_payload()
+    end
+  end
+
+  defp build_update_payload(source, target, deployment) do
+    {:ok, url} = Firmwares.get_firmware_url(source)
+    {:ok, meta} = Firmwares.metadata_from_firmware(target)
+
+    %UpdatePayload{
+      update_available: true,
+      firmware_url: url,
+      firmware_meta: meta,
+      deployment: deployment,
+      deployment_id: deployment.id
+    }
+  end
+
+  defp build_no_update_payload() do
+    %UpdatePayload{update_available: false}
+  end
+
+  @spec delta_updatable?(Device.t(), Deployment.t()) :: boolean()
+  def delta_updatable?(
+        %Device{firmware_metadata: %{uuid: uuid, fwup_version: fwup_version}} = device,
+        deployment
+      ) do
+    %{firmware: target} = Repo.preload(deployment, :firmware)
+    %{product: product} = Repo.preload(device, :product)
+
+    source =
+      case Firmwares.get_firmware_by_product_and_uuid(product, uuid) do
+        {:ok, source} -> source
+        {:error, :not_found} -> nil
+      end
+
+    cond do
+      !is_binary(fwup_version) -> false
+      !Version.match?(fwup_version, @min_fwup_delta_updatable_version) -> false
+      !product.delta_updatable -> false
+      !target.delta_updatable -> false
+      !source.delta_updatable -> false
+      true -> true
     end
   end
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares.ex
@@ -11,8 +11,6 @@ defmodule NervesHubWebCore.Firmwares do
 
   require Logger
 
-  @min_fwup_delta_updatable_version ">=1.6.0"
-
   @type upload_file_2 :: (filepath :: String.t(), filename :: String.t() -> :ok | {:error, any()})
 
   @uploader Application.fetch_env!(:nerves_hub_web_core, :firmware_upload)
@@ -350,8 +348,14 @@ defmodule NervesHubWebCore.Firmwares do
   @spec get_firmware_delta_by_source_and_target(Firmware.t(), Firmware.t()) ::
           {:ok, FirmwareDelta.t()}
           | {:error, :not_found}
-
   def get_firmware_delta_by_source_and_target(%Firmware{id: source_id}, %Firmware{id: target_id}) do
+    get_firmware_delta_by_source_and_target(source_id, target_id)
+  end
+
+  @spec get_firmware_delta_by_source_and_target(integer(), integer()) ::
+          {:ok, FirmwareDelta.t()}
+          | {:error, :not_found}
+  def get_firmware_delta_by_source_and_target(source_id, target_id) do
     q =
       from(
         fd in FirmwareDelta,
@@ -366,21 +370,12 @@ defmodule NervesHubWebCore.Firmwares do
     end
   end
 
-  @spec get_firmware_url(Firmware.t(), Firmware.t(), String.t(), Product.t()) ::
+  @spec get_firmware_url(Firmware.t() | FirmwareDelta.t()) ::
           {:ok, String.t()}
           | {:error, :failure}
-
-  def get_firmware_url(source, target, fwup_version, %Product{delta_updatable: true})
-      when is_binary(fwup_version) do
-    if Version.match?(fwup_version, @min_fwup_delta_updatable_version) do
-      do_get_firmware_url(source, target)
-    else
-      @uploader.download_file(target)
-    end
+  def get_firmware_url(fw_or_delta) do
+    @uploader.download_file(fw_or_delta)
   end
-
-  def get_firmware_url(_source, target, _fwup_version, _product),
-    do: @uploader.download_file(target)
 
   @spec create_firmware_delta(Firmware.t(), Firmware.t()) ::
           {:ok, FirmwareDelta.t()}
@@ -423,21 +418,6 @@ defmodule NervesHubWebCore.Firmwares do
     |> FirmwareDelta.changeset(params)
     |> Repo.insert()
   end
-
-  defp do_get_firmware_url(
-         %Firmware{delta_updatable: true} = source,
-         %Firmware{delta_updatable: true} = target
-       ) do
-    {:ok, firmware_delta} =
-      case get_firmware_delta_by_source_and_target(source, target) do
-        {:error, :not_found} -> create_firmware_delta(source, target)
-        firmware_delta -> firmware_delta
-      end
-
-    @uploader.download_file(firmware_delta)
-  end
-
-  defp do_get_firmware_url(_, target), do: @uploader.download_file(target)
 
   defp insert_firmware(params) do
     %Firmware{}

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/file.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/firmwares/upload/file.ex
@@ -16,9 +16,9 @@ defmodule NervesHubWebCore.Firmwares.Upload.File do
   end
 
   @impl NervesHubWebCore.Firmwares.Upload
-  def download_file(firmware) do
-    {:ok, firmware.upload_metadata["public_path"]}
-  end
+  def download_file(%{upload_metadata: metadata}), do: do_download_file(metadata)
+  defp do_download_file(%{public_path: path}), do: {:ok, path}
+  defp do_download_file(%{"public_path" => path}), do: {:ok, path}
 
   @impl NervesHubWebCore.Firmwares.Upload
   def delete_file(%{local_path: path}), do: delete_file(path)

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/firmware_delta_builder.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/firmware_delta_builder.ex
@@ -3,6 +3,7 @@ defmodule NervesHubWebCore.Workers.FirmwareDeltaBuilder do
     max_attempts: 5,
     queue: :firmware_delta_builder,
     unique: [
+      period: 60 * 10,
       states: [:available, :scheduled, :executing]
     ]
 

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/firmware_delta_builder.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/firmware_delta_builder.ex
@@ -1,0 +1,42 @@
+defmodule NervesHubWebCore.Workers.FirmwareDeltaBuilder do
+  use Oban.Worker,
+    max_attempts: 5,
+    queue: :firmware_delta_builder,
+    unique: [
+      states: [:available, :scheduled, :executing]
+    ]
+
+  alias NervesHubWebCore.{Deployments, Firmwares}
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"source_id" => source_id, "target_id" => target_id}}) do
+    source = Firmwares.get_firmware!(source_id)
+    target = Firmwares.get_firmware!(target_id)
+
+    {:ok, _firmware_delta} = maybe_create_firmware_delta(source, target)
+
+    Deployments.get_deployments_by_firmware(target_id)
+    |> Enum.each(&Deployments.fetch_and_update_relevant_devices/1)
+
+    :ok
+  end
+
+  def start(source_id, target_id) do
+    {:ok, _job} =
+      %{source_id: source_id, target_id: target_id}
+      |> __MODULE__.new()
+      |> Oban.insert()
+
+    :ok
+  end
+
+  defp maybe_create_firmware_delta(source, target) do
+    case Firmwares.get_firmware_delta_by_source_and_target(source, target) do
+      {:ok, firmware_delta} ->
+        {:ok, firmware_delta}
+
+      {:error, :not_found} ->
+        {:ok, _firmware_delta} = Firmwares.create_firmware_delta(source, target)
+    end
+  end
+end

--- a/apps/nerves_hub_web_core/mix.exs
+++ b/apps/nerves_hub_web_core/mix.exs
@@ -55,7 +55,7 @@ defmodule NervesHubWebCore.MixProject do
       {:postgrex, "~> 0.14"},
       {:bcrypt_elixir, "~> 3.0"},
       {:comeonin, "~> 5.3"},
-      {:oban, "~> 2.1"},
+      {:oban, "~> 2.8"},
       {:crontab, "~> 1.1"},
       {:timex, "~> 3.1"},
       {:sweet_xml, "~> 0.6"},

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -618,23 +618,20 @@ defmodule NervesHubWebCore.DevicesTest do
   test "delta_updatable?", %{
     firmware: source,
     product: product,
-    device: device,
     deployment: deployment
   } do
-    assert Devices.delta_updatable?(device, deployment) == false
-
-    source = Ecto.Changeset.change(source, delta_updatable: true) |> Repo.update!()
+    fwup_version = @valid_fwup_version
     %{firmware: target} = Repo.preload(deployment, :firmware)
 
-    device =
-      device
-      |> Ecto.Changeset.change(firmware_metadata: [fwup_version: @valid_fwup_version])
-      |> Repo.update!()
+    assert Devices.delta_updatable?(source, target, product, fwup_version) == false
+
+    source = Ecto.Changeset.change(source, delta_updatable: true) |> Repo.update!()
+    target = Ecto.Changeset.change(target, delta_updatable: true) |> Repo.update!()
 
     assert product.delta_updatable == true
     assert source.delta_updatable == true
     assert target.delta_updatable == true
 
-    assert Devices.delta_updatable?(device, deployment) == true
+    assert Devices.delta_updatable?(source, target, product, fwup_version) == true
   end
 end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -15,6 +15,8 @@ defmodule NervesHubWebCore.DevicesTest do
   alias NervesHubWebCore.Devices.{DeviceCertificate, UpdatePayload}
   alias Ecto.Changeset
 
+  @valid_fwup_version "1.6.0"
+
   setup do
     user = Fixtures.user_fixture()
     org = Fixtures.org_fixture(user)
@@ -611,5 +613,28 @@ defmodule NervesHubWebCore.DevicesTest do
     Devices.device_connected(device)
     assert [%AuditLog{description: desc}] = AuditLogs.logs_for(device)
     assert desc =~ "device #{device.identifier} connected to the server"
+  end
+
+  test "delta_updatable?", %{
+    firmware: source,
+    product: product,
+    device: device,
+    deployment: deployment
+  } do
+    assert Devices.delta_updatable?(device, deployment) == false
+
+    source = Ecto.Changeset.change(source, delta_updatable: true) |> Repo.update!()
+    %{firmware: target} = Repo.preload(deployment, :firmware)
+
+    device =
+      device
+      |> Ecto.Changeset.change(firmware_metadata: [fwup_version: @valid_fwup_version])
+      |> Repo.update!()
+
+    assert product.delta_updatable == true
+    assert source.delta_updatable == true
+    assert target.delta_updatable == true
+
+    assert Devices.delta_updatable?(device, deployment) == true
   end
 end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -548,6 +548,72 @@ defmodule NervesHubWebCore.DevicesTest do
       assert result.firmware_url =~ firmware.uuid
       assert result.firmware_meta.uuid == meta.uuid
     end
+
+    test "update message with delta updatable device & firmware delta", %{
+      product: product,
+      org: org,
+      org_key: org_key
+    } do
+      source = Fixtures.firmware_fixture(org_key, product)
+      target = Fixtures.firmware_fixture(org_key, product)
+
+      source = Ecto.Changeset.change(source, delta_updatable: true) |> Repo.update!()
+      target = Ecto.Changeset.change(target, delta_updatable: true) |> Repo.update!()
+
+      deployment = Fixtures.deployment_fixture(org, target, %{name: "resolve-update"})
+      device = Fixtures.device_fixture(org, product, source)
+      {:ok, device} = Devices.update_firmware_metadata(device, %{fwup_version: "1.6.0"})
+      %{firmware_metadata: %{fwup_version: fwup_version}} = device
+
+      firmware_delta = Fixtures.firmware_delta_fixture(source, target)
+      assert Devices.delta_updatable?(source, target, product, fwup_version)
+
+      {:ok, firmware_delta_url} = Firmwares.get_firmware_url(firmware_delta)
+
+      result = Devices.resolve_update(device, deployment)
+      assert result.update_available
+      assert result.firmware_url == firmware_delta_url
+    end
+
+    test "no update message with delta updatable device & no firmware delta", %{
+      product: product,
+      org: org,
+      org_key: org_key
+    } do
+      source = Fixtures.firmware_fixture(org_key, product)
+      target = Fixtures.firmware_fixture(org_key, product)
+
+      source = Ecto.Changeset.change(source, delta_updatable: true) |> Repo.update!()
+      target = Ecto.Changeset.change(target, delta_updatable: true) |> Repo.update!()
+
+      deployment = Fixtures.deployment_fixture(org, target, %{name: "resolve-update"})
+      device = Fixtures.device_fixture(org, product, source)
+      {:ok, device} = Devices.update_firmware_metadata(device, %{fwup_version: "1.6.0"})
+      %{firmware_metadata: %{fwup_version: fwup_version}} = device
+
+      assert Devices.delta_updatable?(source, target, product, fwup_version)
+
+      result = Devices.resolve_update(device, deployment)
+      refute result.update_available
+    end
+
+    test "update message with non-delta-updatable device", %{
+      product: product,
+      org: org,
+      org_key: org_key
+    } do
+      source = Fixtures.firmware_fixture(org_key, product)
+      target = Fixtures.firmware_fixture(org_key, product)
+
+      deployment = Fixtures.deployment_fixture(org, target, %{name: "resolve-update"})
+      device = Fixtures.device_fixture(org, product, source)
+
+      {:ok, target_url} = Firmwares.get_firmware_url(target)
+
+      result = Devices.resolve_update(device, deployment)
+      assert result.update_available
+      assert result.firmware_url == target_url
+    end
   end
 
   test "failure_rate_met?", %{deployment: deployment, device: device} do

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -549,6 +549,25 @@ defmodule NervesHubWebCore.DevicesTest do
       assert result.firmware_meta.uuid == meta.uuid
     end
 
+    test "update when source is not present", %{
+      product: product,
+      org: org,
+      org_key: org_key
+    } do
+      source = Fixtures.firmware_fixture(org_key, product)
+      target = Fixtures.firmware_fixture(org_key, product)
+
+      deployment = Fixtures.deployment_fixture(org, target, %{name: "resolve-update"})
+      device = Fixtures.device_fixture(org, product, source)
+      {:ok, _source} = Firmwares.delete_firmware(source)
+
+      {:ok, firmware_url} = Firmwares.get_firmware_url(target)
+
+      result = Devices.resolve_update(device, deployment)
+      assert result.update_available
+      assert result.firmware_url == firmware_url
+    end
+
     test "update message with delta updatable device & firmware delta", %{
       product: product,
       org: org,
@@ -699,5 +718,8 @@ defmodule NervesHubWebCore.DevicesTest do
     assert target.delta_updatable == true
 
     assert Devices.delta_updatable?(source, target, product, fwup_version) == true
+
+    # case where the source firmware does not exist
+    assert Devices.delta_updatable?(nil, target, product, fwup_version) == false
   end
 end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/firmwares/firmwares_test.exs
@@ -5,20 +5,17 @@ defmodule NervesHubWebCore.FirmwaresTest do
   alias NervesHubWebCore.{
     Accounts,
     Accounts.OrgLimit,
+    DeltaUpdaterMock,
+    Deployments,
     Firmwares,
     Firmwares.Firmware,
-    Repo,
     Fixtures,
+    Repo,
     Support.Fwup,
-    Deployments,
-    DeltaUpdaterMock,
-    Products,
     UploadMock
   }
 
   alias Ecto.Changeset
-
-  @valid_fwup_version "1.6.0"
 
   setup context do
     Mox.verify_on_exit!(context)
@@ -376,119 +373,6 @@ defmodule NervesHubWebCore.FirmwaresTest do
 
       assert {:error, :not_found} =
                Firmwares.get_firmware_delta_by_source_and_target(firmware, new_firmware)
-    end
-  end
-
-  describe "get_firmware_url/4" do
-    test "returns target download_file when there is no source", %{
-      firmware: target,
-      product: product
-    } do
-      url = "http://somefilestore.com/firmware.fw"
-      Mox.expect(UploadMock, :download_file, fn ^target -> {:ok, url} end)
-
-      assert {:ok, _url} = Firmwares.get_firmware_url(nil, target, @valid_fwup_version, product)
-    end
-
-    test "returns target download_file when source does not support delta updating", %{
-      firmware: source,
-      org_key: org_key,
-      product: product
-    } do
-      Mox.stub(NervesHubWebCore.DeltaUpdaterMock, :delta_updatable?, fn _ -> true end)
-      target = Fixtures.firmware_fixture(org_key, product)
-      url = "http://somefilestore.com/firmware.fw"
-      Mox.expect(UploadMock, :download_file, fn ^target -> {:ok, url} end)
-
-      assert {:ok, _url} =
-               Firmwares.get_firmware_url(source, target, @valid_fwup_version, product)
-    end
-
-    test "returns target download_file when target does not support delta updating", %{
-      firmware: target,
-      org_key: org_key,
-      product: product
-    } do
-      Mox.stub(NervesHubWebCore.DeltaUpdaterMock, :delta_updatable?, fn _ -> true end)
-      source = Fixtures.firmware_fixture(org_key, product)
-      url = "http://somefilestore.com/firmware.fw"
-      Mox.expect(UploadMock, :download_file, fn ^target -> {:ok, url} end)
-
-      assert {:ok, _url} =
-               Firmwares.get_firmware_url(source, target, @valid_fwup_version, product)
-    end
-
-    test "returns target download_file when fwup version is too old", %{
-      firmware: source,
-      org_key: org_key,
-      product: product
-    } do
-      source = %Firmware{source | delta_updatable: true}
-      Mox.stub(NervesHubWebCore.DeltaUpdaterMock, :delta_updatable?, fn _ -> true end)
-      target = Fixtures.firmware_fixture(org_key, product)
-      url = "http://somefilestore.com/firmware.fw"
-      Mox.expect(UploadMock, :download_file, fn ^target -> {:ok, url} end)
-
-      assert {:ok, _url} = Firmwares.get_firmware_url(source, target, "1.5.999", product)
-    end
-
-    test "returns target download_file when product does not support delta updating", %{
-      firmware: source,
-      org_key: org_key,
-      product: product
-    } do
-      {:ok, product} = Products.update_product(product, %{delta_updatable: false})
-      source = %Firmware{source | delta_updatable: true}
-      Mox.stub(NervesHubWebCore.DeltaUpdaterMock, :delta_updatable?, fn _ -> true end)
-      target = Fixtures.firmware_fixture(org_key, product)
-      url = "http://somefilestore.com/firmware.fw"
-      Mox.expect(UploadMock, :download_file, fn ^target -> {:ok, url} end)
-
-      assert {:ok, _url} =
-               Firmwares.get_firmware_url(source, target, @valid_fwup_version, product)
-    end
-
-    test "returns firmware delta download_file when one exists", %{
-      firmware: source,
-      org_key: org_key,
-      product: product
-    } do
-      source = %Firmware{source | delta_updatable: true}
-      Mox.stub(NervesHubWebCore.DeltaUpdaterMock, :delta_updatable?, fn _ -> true end)
-      target = Fixtures.firmware_fixture(org_key, product)
-      firmware_delta = Fixtures.firmware_delta_fixture(source, target)
-      firmware_delta_id = firmware_delta.id
-      url = "http://somefilestore.com/firmware.fw"
-      Mox.expect(UploadMock, :download_file, fn %{id: ^firmware_delta_id} -> {:ok, url} end)
-
-      assert {:ok, _url} =
-               Firmwares.get_firmware_url(source, target, @valid_fwup_version, product)
-    end
-
-    test "returns download_file for a new firmware delta", %{
-      firmware: source,
-      org_key: org_key,
-      product: product
-    } do
-      source = %Firmware{source | delta_updatable: true}
-      Mox.stub(NervesHubWebCore.DeltaUpdaterMock, :delta_updatable?, fn _ -> true end)
-      target = Fixtures.firmware_fixture(org_key, product)
-      url = "http://somefilestore.com/firmware.fw"
-      firmware_delta_path = "/path/to/firmware.fw"
-      Mox.expect(UploadMock, :download_file, 3, fn _ -> {:ok, url} end)
-
-      Mox.expect(DeltaUpdaterMock, :create_firmware_delta_file, fn ^url, ^url ->
-        firmware_delta_path
-      end)
-
-      Mox.expect(UploadMock, :upload_file, fn ^firmware_delta_path, _ -> :ok end)
-
-      Mox.expect(DeltaUpdaterMock, :cleanup_firmware_delta_files, fn ^firmware_delta_path ->
-        :ok
-      end)
-
-      assert {:ok, _url} =
-               Firmwares.get_firmware_url(source, target, @valid_fwup_version, product)
     end
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -62,7 +62,7 @@ config :nerves_hub_web_core, NervesHubWeb.PubSub,
 config :nerves_hub_web_core, Oban,
   repo: NervesHubWebCore.Repo,
   log: false,
-  queues: [delete_firmware: 1]
+  queues: [delete_firmware: 1, firmware_delta_builder: 2]
 
 ##
 # NervesHubWWW

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -200,14 +200,13 @@ defmodule NervesHubWebCore.Fixtures do
 
   def firmware_delta_fixture(%Firmwares.Firmware{id: source_id}, %Firmwares.Firmware{
         id: target_id,
-        org_id: org_id,
-        uuid: uuid
+        org_id: org_id
       }) do
     {:ok, firmware_delta} =
       Firmwares.insert_firmware_delta(%{
         source_id: source_id,
         target_id: target_id,
-        upload_metadata: @uploader.metadata(org_id, "#{uuid}.fw")
+        upload_metadata: @uploader.metadata(org_id, "#{Ecto.UUID.generate()}.fw")
       })
 
     firmware_delta


### PR DESCRIPTION
(Originally written by @chrisdambrosio)

Resolves an issue where performance is degraded while updating a
deployment that triggers builds of firmware delta files. The same
firmware delta was being built many times simultaneously until one
finished.

- Moves firmware delta build to an Oban job
- Initially sends negative update payload if a delta needs to be built
- After the firmware delta is built, the job will look up relevant
  deployments and restart the `fetch_and_update_relevant_devices`
  cycle, and send update messages to any relevant devices

This solution has the following advantages:
- Makes the firmware delta creation idempotent: many requests can come
  in and the firmware delta will only be built once, but all devices
  requiring the update will be notified.
- Ability to control concurrency: can easily adjust the number of
  simultaneous jobs running based on performance needs
- Unblocks the web UI: building a firmware delta in response to updating
  a deployment no longer causes the page to wait before returning the
  page in the web UI