### PR TITLE
Default preventing signups

### DIFF
--- a/apps/nerves_hub_api/config/release.exs
+++ b/apps/nerves_hub_api/config/release.exs
@@ -46,7 +46,8 @@ config :nerves_hub_web_core, NervesHubWebCore.Mailer,
   server: System.fetch_env!("SES_SERVER"),
   port: System.fetch_env!("SES_PORT"),
   username: System.fetch_env!("SMTP_USERNAME"),
-  password: System.fetch_env!("SMTP_PASSWORD")
+  password: System.fetch_env!("SMTP_PASSWORD"),
+  allow_signups?: System.get_env("ALLOW_SIGNUPS", "false") |> String.to_atom()
 
 host = System.fetch_env!("HOST")
 

--- a/apps/nerves_hub_www/config/release.exs
+++ b/apps/nerves_hub_www/config/release.exs
@@ -56,6 +56,6 @@ config :nerves_hub_web_core,
   host: host,
   port: port,
   from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
-  allow_signups?: System.get_env("ALLOW_SIGNUPS", "true") |> String.to_atom()
+  allow_signups?: System.get_env("ALLOW_SIGNUPS", "false") |> String.to_atom()
 
 config :nerves_hub_www, NervesHubWWWWeb.Endpoint, url: [host: host, port: port]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,7 +22,6 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint, server: true
 # NervesHubWebCore
 #
 config :nerves_hub_web_core,
-  allow_signups?: true,
   enable_workers: true,
   firmware_upload: NervesHubWebCore.Firmwares.Upload.S3,
   host: "www.nerves-hub.org",


### PR DESCRIPTION
This may eventually be removed, but this changes the default to prevent
signups and require that a user explicitly set it. This will help cases
of orgs running their own instance of NH and not wanting to accidentally
allow a bunch of unknown accounts