### PR TITLE
Cluster fixes

### DIFF
--- a/apps/nerves_hub_api/config/release.exs
+++ b/apps/nerves_hub_api/config/release.exs
@@ -8,8 +8,7 @@ sync_nodes_optional =
   case System.fetch_env("SYNC_NODES_OPTIONAL") do
     {:ok, sync_nodes_optional} ->
       sync_nodes_optional
-      |> String.trim()
-      |> String.split(" ")
+      |> String.split(" ", trim: true)
       |> Enum.map(&String.to_atom/1)
 
     :error ->

--- a/apps/nerves_hub_device/config/release.exs
+++ b/apps/nerves_hub_device/config/release.exs
@@ -8,8 +8,7 @@ sync_nodes_optional =
   case System.fetch_env("SYNC_NODES_OPTIONAL") do
     {:ok, sync_nodes_optional} ->
       sync_nodes_optional
-      |> String.trim()
-      |> String.split(" ")
+      |> String.split(" ", trim: true)
       |> Enum.map(&String.to_atom/1)
 
     :error ->

--- a/apps/nerves_hub_www/config/release.exs
+++ b/apps/nerves_hub_www/config/release.exs
@@ -11,8 +11,7 @@ sync_nodes_optional =
   case System.fetch_env("SYNC_NODES_OPTIONAL") do
     {:ok, sync_nodes_optional} ->
       sync_nodes_optional
-      |> String.trim()
-      |> String.split(" ")
+      |> String.split(" ", trim: true)
       |> Enum.map(&String.to_atom/1)
 
     :error ->

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Do not print debug messages in production
-config :logger, level: :warn
+config :logger, level: :info
 
 config :rollbax,
   environment: to_string(Mix.env()),

--- a/rel/scripts/ecs-cluster.sh
+++ b/rel/scripts/ecs-cluster.sh
@@ -37,6 +37,6 @@ NODES=$(echo "$DEVICE_NODES $WWW_NODES $API_NODES" | tr '\n' ' ')
 # we should now have something that looks like
 # nerves_hub_www@10.0.2.120 nerves_hub_device@10.0.3.99 nerves_hub_api@10.0.3.101
 export SYNC_NODES_OPTIONAL="$NODES"
-echo $SYNC_NODES_OPTIONAL
+echo "SYNC_NODES_OPTIONAL=${SYNC_NODES_OPTIONAL}"
 
 exec /app/bin/$APP_NAME start


### PR DESCRIPTION
* Increase the log level which should be a best practice for any production instance.
* Add a qualifier to the echo statement so we can tell if the other nodes are actually found. Otherwise, this could fail and print a blank line and we wouldn't know.
* Remove empty strings from sync nodes