### PR TITLE
Enable mix_test_watch in :dev for 'make test-watch'

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule NervesHubUmbrella.MixProject do
     [
       # {:excoveralls, "~> 0.8", only: :test},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:mix_test_watch, "~> 1.0", only: :test, runtime: false},
+      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},
       {:recon, "~> 2.5"}
     ]
   end


### PR DESCRIPTION
Until now, `make test-watch` did not seem to be enabled.

```
$ make test-watch
DB=db_test \
. ./.env && \
mix test.watch
** (Mix) The task "test.watch" could not be found
make: *** [Makefile:55: test-watch] エラー 1
```

refs) https://github.com/lpil/mix-test.watch#usage