### PR TITLE
Fix org_certificate_controller :edit cannot render

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/edit.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/edit.html.heex
@@ -9,9 +9,9 @@
 
   <%= inputs_for f, :jitp, fn fp -> %>
     <label for="jitp_toggle"> Enable Just In Time Provisioning </label>
-    <input type="checkbox" name="jitp_toggle" id="jitp_toggle" checked={f.data.jitp}>
+    <input type="checkbox" name="jitp_toggle" id="jitp_toggle" checked={not is_nil(f.data.jitp)}>
     <%= hidden_input fp, :delete, id: "jitp-delete" %>
-    <div hidden={!f.data.jitp} id="jitp_form">
+    <div hidden={is_nil(f.data.jitp)} id="jitp_form">
       <div class="form-group">
         <label for="description_input" class="tooltip-label h3 mb-1">
           <span>JITP Description</span>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_certificate_controller_test.exs
@@ -173,7 +173,28 @@ defmodule NervesHubWWWWeb.OrgCertificateControllerTest do
     test "renders form", %{conn: conn, org: org} do
       %{db_cert: ca} = Fixtures.ca_certificate_fixture(org)
       conn = get(conn, Routes.org_certificate_path(conn, :edit, org.name, ca.serial))
-      assert html_response(conn, 200) =~ "Edit Certificate Authority"
+
+      html = html_response(conn, 200)
+      assert html =~ "Edit Certificate Authority"
+
+      assert html
+             |> Floki.parse_document!()
+             |> Floki.find("#jitp_form")
+             |> Floki.attribute("hidden") == ["hidden"]
+    end
+
+    test "renders form, jitp enabled", %{conn: conn, org: org, user: user} do
+      product = Fixtures.product_fixture(user, org)
+      %{db_cert: ca} = Fixtures.ca_certificate_jitp_enabled_fixture(org, product)
+      conn = get(conn, Routes.org_certificate_path(conn, :edit, org.name, ca.serial))
+
+      html = html_response(conn, 200)
+      assert html =~ "Edit Certificate Authority"
+
+      assert html
+             |> Floki.parse_document!()
+             |> Floki.find("#jitp_form")
+             |> Floki.attribute("hidden") == []
     end
 
     test "redirects to index when not found", %{conn: conn, org: org} do


### PR DESCRIPTION
related commit is https://github.com/nerves-hub/nerves_hub_web/pull/804/commits/8be8a6faac40b759419771a59f49a22d5257585a?diff=split&w=0#diff-e253447b15c2a82a129c72a07aae8d99cc3c86efed4fc04bb9c6cd859a9738ee

This bug could have been prevented with tests, so added a test.