### PR TITLE
Fix return value passed to consume_upload_entry/3

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/product_live/import.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/product_live/import.ex
@@ -138,7 +138,9 @@ defmodule NervesHubWWWWeb.ProductLive.Import do
   defp handle_progress(:csv, entry, socket) do
     socket =
       if entry.done? do
-        consume_uploaded_entry(socket, entry, &parse_csv(socket, &1.path))
+        consume_uploaded_entry(socket, entry, fn entry ->
+          {:ok, parse_csv(socket, entry.path)}
+        end)
       else
         socket
       end
@@ -149,7 +151,9 @@ defmodule NervesHubWWWWeb.ProductLive.Import do
   defp handle_progress(:jose, entry, socket) do
     socket =
       if entry.done? do
-        consume_uploaded_entry(socket, entry, &parse_jose(socket, &1.path))
+        consume_uploaded_entry(socket, entry, fn entry ->
+          {:ok, parse_jose(socket, entry.path)}
+        end)
       else
         socket
       end


### PR DESCRIPTION
The function passed to `consume_uploaded_entry/3` should returned either `{:ok, result} ` or `{:postpone, my_result}`

https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#consume_uploaded_entry/3