### PR TITLE
Set TLS version to 1.2 for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,16 @@ Devices and Firmware.
 
 For a Device to be considered eligible for a given Deployment, it must have
 *all* the tags in the Deployment's "tags" condition.
+
+### Potential SSL issues
+
+OTP > 24.2.2 switched to use TLS1.3 by default and made quite a few fixes/changes
+to how it is implemented in the `:ssl` module. This has affected the setup of
+client authentication in a few different ways depending on how you have your
+server and device configured:
+
+| Server | Client | Effect |
+| --- | --- | --- |
+|TLS1.3 | TLS1.3| `certificate_required` error (needs OTP 25.2 - see https://github.com/erlang/otp/issues/6106)  |
+|TLS1.3|TLS1.2|  `CLIENT ALERT: Fatal - Handshake Failure - :unacceptable_ecdsa_key` - Happens because the client is attempting to sign with `:she` as the signature algorithm. The workaround is to specify `ssl: [signature_algs: [{:sha256, :ecdsa},{:sha512, :ecdsa}]]`|
+|TLS1.2 | TLS1.3 or TLS1.2 | Successful|

--- a/apps/nerves_hub_device/config/release.exs
+++ b/apps/nerves_hub_device/config/release.exs
@@ -53,6 +53,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
     port: 443,
     otp_app: :nerves_hub_device,
     # Enable client SSL
+    versions: [:"tlsv1.2"],
     verify: :verify_peer,
     fail_if_no_peer_cert: true,
     keyfile: "/etc/ssl/#{host}-key.pem",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,6 +43,7 @@ config :nerves_hub_device, NervesHubDeviceWeb.Endpoint,
     port: 4001,
     otp_app: :nerves_hub_device,
     # Enable client SSL
+    versions: [:"tlsv1.2"],
     verify: :verify_peer,
     verify_fun: {&NervesHubDevice.SSL.verify_fun/3, nil},
     fail_if_no_peer_cert: true,


### PR DESCRIPTION
OTP >= 24.3 made changes to the TLS 1.3 implementation and now prefers it as the default. Some of the hardended rules break the custom client authentication setup of NervesHub in slightly confusing ways.

This sets the expected server version to TLS1.2 to hopefully reduce these errors and make things a bit more consistent and predictable for now until able to implement #852 and other changes with later OTP releases.

Thanks to @tonnenpinguin and Klaus Grössinger for help identifying this!