### PR TITLE
Fix checkbox class

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.heex
@@ -84,7 +84,7 @@
       </span>
     </label>
     <div class="flex-row align-items-center">
-      <%= checkbox f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input" %>
+      <%= checkbox f, :delta_updatable, class: "checkbox", id: "delta_updatable_input" %>
       <label for="delta_updatable_input" class="color-white pl-1 m-0">Enable delta firmware updates</label>
     </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.heex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.heex
@@ -52,7 +52,7 @@
       </span>
     </label>
     <div class="flex-row align-items-center">
-      <%= checkbox f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input" %>
+      <%= checkbox f, :delta_updatable, class: "checkbox", id: "delta_updatable_input" %>
       <label for="delta_updatable_input" class="color-white pl-1 m-0">Enable delta firmware updates</label>
     </div>
 


### PR DESCRIPTION
Seems like the classes on the checkbox markup I copied weren't correct. With the `form-control` class the checkmark doesn't properly show.