### PR TITLE
Fix Accounts.get_user_by_email_or_username/1

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/accounts.ex
@@ -316,9 +316,9 @@ defmodule NervesHubWebCore.Accounts do
 
   def get_user_by_email_or_username(email_or_username) do
     User
-    |> Repo.exclude_deleted()
     |> where(username: ^email_or_username)
     |> or_where(email: ^email_or_username)
+    |> Repo.exclude_deleted()
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/accounts/accounts_test.exs
@@ -212,6 +212,26 @@ defmodule NervesHubWebCore.AccountsTest do
     assert {:ok, %User{}} = Accounts.authenticate(user.username, user.password)
   end
 
+  test "authenticate with previously used and deleted email address" do
+    email = "ThatsTesty@mctesterson.com"
+    password = "test_password"
+
+    params = %{
+      username: "Testy-McTesterson",
+      org_name: "mctesterson.com",
+      email: email,
+      password: password
+    }
+
+    {:ok, %User{} = user} = Accounts.create_user(params)
+
+    NervesHubWebCore.Accounts.RemoveAccount.remove_account(user.id)
+
+    {:ok, %User{} = _user} = Accounts.create_user(params)
+
+    assert {:ok, %User{email: ^email}} = Accounts.authenticate(email, password)
+  end
+
   test "create_org_with_user_with_certificate with valid params" do
     params = %{
       username: "Testy-McTesterson",


### PR DESCRIPTION
Previously the function would generate a query with the OR grouped incorrectly. This commit changes the position of the `exclude_deleted/0`
call so that the query looks for `(username: X or email: X) and not deleted`
instead of `(username: X and not deleted) or email: X)`