### PR TITLE
Fix Base62 requirement

### DIFF
--- a/apps/nerves_hub_api/mix.exs
+++ b/apps/nerves_hub_api/mix.exs
@@ -23,7 +23,7 @@ defmodule NervesHubAPI.Mixfile do
   def application do
     [
       mod: {NervesHubAPI.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :base62]
     ]
   end
 

--- a/apps/nerves_hub_web_core/mix.exs
+++ b/apps/nerves_hub_web_core/mix.exs
@@ -37,7 +37,7 @@ defmodule NervesHubWebCore.MixProject do
   def application do
     [
       mod: {NervesHubWebCore.Application, []},
-      extra_applications: [:logger, :jason, :inets],
+      extra_applications: [:logger, :jason, :inets, :base62],
       start_phases: [{:start_workers, []}]
     ]
   end


### PR DESCRIPTION
Base62 needs to be included in extra applications for the apps using it
since the dep is in the root of the umbrella, but apps can be deployed
individually
