### PR TITLE
Add worker for periodically cleaning up audit logs

### DIFF
--- a/apps/nerves_hub_api/config/release.exs
+++ b/apps/nerves_hub_api/config/release.exs
@@ -79,3 +79,13 @@ config :nerves_hub_web_core, NervesHubWebCore.CertificateAuthority,
     certfile: "/etc/ssl/#{host}.pem",
     cacertfile: "/etc/ssl/ca.pem"
   ]
+
+config :nerves_hub_web_core, NervesHubWebCore.Workers.TruncateAuditLogs,
+  enabled: System.get_env("TRUNCATE_AUDIT_LOGS_ENABLED", "false") |> String.to_atom(),
+  max_records_per_resource_per_run:
+    System.get_env("TRUNCATE_AUDIT_LOGS_MAX_RECORDS_PER_RESOURCE_PER_RUN", "100000")
+    |> String.to_integer(),
+  max_resources_per_run:
+    System.get_env("TRUNCATE_AUDIT_LOGS_MAX_RESOURCES_PER_RUN", "500") |> String.to_integer(),
+  retain_per_resource:
+    System.get_env("TRUNCATE_AUDIT_LOGS_RETAIN_PER_RESOURCE", "10000") |> String.to_integer()

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/truncate_audit_logs.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/workers/truncate_audit_logs.ex
@@ -1,0 +1,13 @@
+defmodule NervesHubWebCore.Workers.TruncateAuditLogs do
+  use NervesHubWebCore.Worker,
+    args: %{run_utc_time: "01:00:00.000000"},
+    max_attempts: 5,
+    queue: :truncate,
+    schedule: "0 */3 * * *"
+
+  @impl true
+  def run(_) do
+    config = Application.get_env(:nerves_hub_web_core, __MODULE__)
+    if config[:enabled], do: NervesHubWebCore.AuditLogs.truncate(config)
+  end
+end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/audit_logs_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/audit_logs_test.exs
@@ -1,0 +1,91 @@
+defmodule NervesHubWebCore.AuditLogsTest do
+  use NervesHubWebCore.DataCase, async: true
+  alias NervesHubWebCore.AuditLogs
+  alias NervesHubWebCore.Fixtures
+
+  describe "truncate/1" do
+    test "can truncate logs" do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+      device_1 = Fixtures.device_fixture(org, product, firmware)
+      device_2 = Fixtures.device_fixture(org, product, firmware)
+      device_3 = Fixtures.device_fixture(org, product, firmware)
+
+      now = ~U[2022-12-07 00:00:00Z]
+
+      for i <- 1..10 do
+        AuditLogs.audit!(device_1, device_1, :update, %{
+          last_communication: DateTime.add(now, i)
+        })
+      end
+
+      for i <- 1..8 do
+        AuditLogs.audit!(device_2, device_2, :update, %{
+          last_communication: DateTime.add(now, i)
+        })
+      end
+
+      for i <- 1..5 do
+        AuditLogs.audit!(device_3, device_3, :update, %{
+          last_communication: DateTime.add(now, i)
+        })
+      end
+
+      assert :ok =
+               AuditLogs.truncate(
+                 retain_per_resource: 5,
+                 max_resources_per_run: 3,
+                 max_records_per_resource_per_run: 3
+               )
+
+      assert 7 = device_1 |> AuditLogs.logs_for() |> length()
+      assert 5 = device_2 |> AuditLogs.logs_for() |> length()
+      assert 5 = device_3 |> AuditLogs.logs_for() |> length()
+    end
+
+    test "limited number of resources truncated per run" do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+      device_1 = Fixtures.device_fixture(org, product, firmware)
+      device_2 = Fixtures.device_fixture(org, product, firmware)
+      device_3 = Fixtures.device_fixture(org, product, firmware)
+
+      now = ~U[2022-12-07 00:00:00Z]
+
+      for i <- 1..10 do
+        AuditLogs.audit!(device_1, device_1, :update, %{
+          last_communication: DateTime.add(now, i)
+        })
+      end
+
+      for i <- 1..8 do
+        AuditLogs.audit!(device_2, device_2, :update, %{
+          last_communication: DateTime.add(now, i)
+        })
+      end
+
+      for i <- 1..5 do
+        AuditLogs.audit!(device_3, device_3, :update, %{
+          last_communication: DateTime.add(now, i)
+        })
+      end
+
+      assert :ok =
+               AuditLogs.truncate(
+                 retain_per_resource: 5,
+                 max_resources_per_run: 1,
+                 max_records_per_resource_per_run: 3
+               )
+
+      assert 7 = device_1 |> AuditLogs.logs_for() |> length()
+      assert 8 = device_2 |> AuditLogs.logs_for() |> length()
+      assert 5 = device_3 |> AuditLogs.logs_for() |> length()
+    end
+  end
+end


### PR DESCRIPTION
At sparkmeter we've had some very noicy devices, which generated so many logs, that it needed cleanup before the system became usable again. This adds a worker (which I hope I added correctly) to periodically cleanup the audit log, so things stay working. By default the worker is disabled, so we don't delete data for people expecting nothing to get deleted.