### PR TITLE
Use TLS 1.2 for API

### DIFF
--- a/apps/nerves_hub_api/config/release.exs
+++ b/apps/nerves_hub_api/config/release.exs
@@ -64,6 +64,7 @@ config :nerves_hub_api, NervesHubAPIWeb.Endpoint,
     otp_app: :nerves_hub_api,
     # Enable client SSL
     verify: :verify_peer,
+    versions: [:"tlsv1.2"],
     keyfile: "/etc/ssl/#{host}-key.pem",
     certfile: "/etc/ssl/#{host}.pem",
     cacerts: cacerts ++ :certifi.cacerts()

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -25,6 +25,7 @@ config :nerves_hub_api, NervesHubAPIWeb.Endpoint,
     otp_app: :nerves_hub_api,
     # Enable client SSL
     verify: :verify_peer,
+    versions: [:"tlsv1.2"],
     keyfile: Path.join(ssl_dir, "api.nerves-hub.org-key.pem"),
     certfile: Path.join(ssl_dir, "api.nerves-hub.org.pem"),
     cacertfile: Path.join(ssl_dir, "ca.pem")


### PR DESCRIPTION
Similar issues to the troubles devices were having with TLS 1.3. If users are using `nerves_hub_user_api` or another Elixir/Erlang lib with <= 25.1, then requests will fail to the API.

To mitigate that, we'll just force API and Device to be TLS 1.2