### PR TITLE
Add API endpoint for fetching JITP

### DIFF
--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/jitp_controller.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/controllers/jitp_controller.ex
@@ -1,0 +1,18 @@
+defmodule NervesHubAPIWeb.JITPController do
+  use NervesHubAPIWeb, :controller
+
+  alias NervesHubWebCore.Devices
+
+  action_fallback(NervesHubAPIWeb.FallbackController)
+
+  plug(:validate_role, [org: :delete] when action in [:delete])
+  plug(:validate_role, [org: :write] when action in [:create])
+  plug(:validate_role, [org: :read] when action in [:index, :show])
+
+  def show(%{assigns: %{org: _org}} = conn, %{"ski" => ski64}) do
+    with {:ok, ski} <- Base.decode64(ski64),
+         {:ok, jitp} <- Devices.get_jitp_by_ski(ski) do
+      render(conn, "show.json", jitp: jitp)
+    end
+  end
+end

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/router.ex
@@ -70,6 +70,10 @@ defmodule NervesHubAPIWeb.Router do
           delete("/:serial", CACertificateController, :delete)
         end
 
+        scope "/jitp" do
+          get("/:ski", JITPController, :show)
+        end
+
         # The /org/:org_id/device* endpoints should return an error
         scope "/devices" do
           get("/", DeviceController, :error_deprecated)

--- a/apps/nerves_hub_api/lib/nerves_hub_api_web/views/jitp_view.ex
+++ b/apps/nerves_hub_api/lib/nerves_hub_api_web/views/jitp_view.ex
@@ -1,0 +1,16 @@
+defmodule NervesHubAPIWeb.JITPView do
+  use NervesHubAPIWeb, :view
+  alias NervesHubAPIWeb.JITPView
+
+  def render("show.json", %{jitp: jitp}) do
+    %{data: render_one(jitp, JITPView, "jitp.json")}
+  end
+
+  def render("jitp.json", %{jitp: jitp}) do
+    %{
+      product: jitp.product.name,
+      description: jitp.description,
+      tags: jitp.tags
+    }
+  end
+end

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices.ex
@@ -411,6 +411,20 @@ defmodule NervesHubWebCore.Devices do
     end
   end
 
+  @spec get_jitp_by_ski(binary) :: {:ok, CACertificate.JITP.t()} | {:error, any()}
+  def get_jitp_by_ski(ski) do
+    Repo.get_by(CACertificate, ski: ski)
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      ca_cert ->
+        with {:ok, %{jitp: jitp}} <- preload_cert(ca_cert, jitp: :product) do
+          {:ok, jitp}
+        end
+    end
+  end
+
   @spec get_ca_certificate_by_serial(binary) :: {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_serial(serial) do
     Repo.get_by(CACertificate, serial: serial)
@@ -440,8 +454,8 @@ defmodule NervesHubWebCore.Devices do
     end
   end
 
-  def preload_cert(%CACertificate{} = certificate) do
-    {:ok, Repo.preload(certificate, [:jitp])}
+  def preload_cert(%CACertificate{} = certificate, opts \\ [:jitp]) do
+    {:ok, Repo.preload(certificate, opts)}
   end
 
   def update_ca_certificate(%CACertificate{} = certificate, params) do

--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate/jitp.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/devices/ca_certificate/jitp.ex
@@ -3,6 +3,8 @@ defmodule NervesHubWebCore.Devices.CACertificate.JITP do
   import Ecto.Changeset
   alias NervesHubWebCore.Products.Product
 
+  @type t :: %__MODULE__{}
+
   schema "jitp" do
     # JITP enabled CA Certs must be linked to a product
     # so devices can be created

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/devices/devices_test.exs
@@ -333,6 +333,42 @@ defmodule NervesHubWebCore.DevicesTest do
     assert {:ok, %CACertificate{serial: ^serial}} = Devices.get_ca_certificate_by_aki(aki)
   end
 
+  test "can get JITP metadata for certificate by ski", %{org: org, product: product} do
+    org_id = org.id
+
+    ca_key = X509.PrivateKey.new_ec(:secp256r1)
+    ca = X509.Certificate.self_signed(ca_key, "CN=#{org.name}", template: :root_ca)
+
+    {not_before, not_after} = NervesHubWebCore.Certificate.get_validity(ca)
+
+    serial = NervesHubWebCore.Certificate.get_serial_number(ca)
+    ski = NervesHubWebCore.Certificate.get_aki(ca)
+    aki = NervesHubWebCore.Certificate.get_ski(ca)
+
+    params = %{
+      serial: serial,
+      aki: aki,
+      ski: ski,
+      not_before: not_before,
+      not_after: not_after,
+      der: X509.Certificate.to_der(ca),
+      jitp: %{
+        product_id: product.id,
+        description: "description",
+        tags: ["tag1"]
+      }
+    }
+
+    assert {:ok, %CACertificate{org_id: ^org_id}} = Devices.create_ca_certificate(org, params)
+
+    assert {:ok,
+            %CACertificate.JITP{
+              product: ^product,
+              description: "description",
+              tags: ["tag1"]
+            }} = Devices.get_jitp_by_ski(ski)
+  end
+
   test "get_device_by_identifier with existing device", %{org: org, device: target_device} do
     assert {:ok, result} = Devices.get_device_by_identifier(org, target_device.identifier)
 


### PR DESCRIPTION
Hello NervesHub team!

This commit adds an additional endpoint to retrieve JITP for a given CACertificate. The certificate is identified by base64 encoded SKI resulting in an url like:

`GET orgs/test/jitp/NfGQXczGpi24p2/zGmJiLI4ahs4=`

which returns:

```
{:ok,
 %{
   "data" => %{
     "description" => "jitp description",
     "product" => "test",
     "tags" => ["test"]
   }
 }}
```

I originally tried to fit this new endpoint underneath the CACertificates endpoint, but it clashes with the existing "show" for that resource.

The CACertificateController.create was also updated to support passing in JITP as base64 encoded json. The "product" is expected to passed as the name of an existing product. This update was added to support testing the JITP feature in the nerves_hub_user_api library.

The motivation for this feature is that I have a service which our device connects to, and in order to authenticate the certificate via devices endpoint, I need to know it's product name. Using NervesKey we are only able to set "/O=org/CN=<serial_number>" so when the device connects to us, we have the certificate, the serial number, and organisation.


I've tried to follow conventions as much as possible, but feel free to request changes if required.
