### PR TITLE
Remove `:ca_integration` tests

### DIFF
--- a/test/nerves_hub_web/controllers/account_certificate_controller_test.exs
+++ b/test/nerves_hub_web/controllers/account_certificate_controller_test.exs
@@ -4,11 +4,6 @@ defmodule NervesHubWeb.AccountCertificateControllerTest do
   alias NervesHub.Fixtures
   alias NervesHub.Accounts
 
-  @create_attrs %{
-    description: "test cert",
-    serial: "1580653878678601091983566405937658689714637"
-  }
-
   describe "index" do
     test "lists all appropriate account certificates", %{
       conn: conn,
@@ -41,26 +36,6 @@ defmodule NervesHubWeb.AccountCertificateControllerTest do
     test "renders form", %{conn: conn, user: user} do
       conn = get(conn, Routes.account_certificate_path(conn, :new, user.username))
       assert html_response(conn, 200) =~ "Generate an Account Certificate"
-    end
-  end
-
-  describe "create certificate" do
-    @tag :ca_integration
-    test "redirects to show when data is valid", %{conn: conn, user: user} do
-      %{params: params} = Fixtures.user_certificate_params(user, @create_attrs)
-
-      conn =
-        post(conn, Routes.account_certificate_path(conn, :create, user.username),
-          user_certificate: params
-        )
-
-      assert %{id: id} = redirected_params(conn)
-
-      assert redirected_to(conn) =~
-               Routes.account_certificate_path(conn, :show, user.username, id)
-
-      conn = get(conn, Routes.account_certificate_path(conn, :show, user.username, id))
-      assert html_response(conn, 200) =~ "User Certificate"
     end
   end
 

--- a/test/nerves_hub_web/controllers/api/user_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/user_controller_test.exs
@@ -2,8 +2,6 @@ defmodule NervesHubWeb.API.UserControllerTest do
   use NervesHubWeb.APIConnCase, async: true
 
   alias NervesHub.Fixtures
-  alias NervesHub.Certificate
-  alias NervesHub.Accounts
 
   test "me", %{conn: conn, user: user} do
     conn = get(conn, Routes.user_path(conn, :me))
@@ -100,34 +98,5 @@ defmodule NervesHubWeb.API.UserControllerTest do
              "username" => user.username,
              "email" => user.email
            }
-  end
-
-  @tag :ca_integration
-  test "sign new registration certificates" do
-    subject = "/O=NervesHub/CN=username"
-    key = X509.PrivateKey.new_ec(:secp256r1)
-
-    csr =
-      X509.CSR.new(key, subject)
-      |> X509.CSR.to_pem()
-      |> Base.encode64()
-
-    params =
-      Fixtures.user_fixture(name: "username")
-      |> Map.take([:email, :password])
-      |> Map.put(:csr, csr)
-      |> Map.put(:description, "test-machine")
-
-    conn = build_conn()
-
-    conn = post(conn, Routes.user_path(conn, :sign), params)
-    resp_data = json_response(conn, 200)["data"]
-    assert %{"cert" => cert} = resp_data
-
-    cert = X509.Certificate.from_pem!(cert)
-    serial = Certificate.get_serial_number(cert)
-
-    user = Accounts.get_user_by_certificate_serial(serial)
-    assert user.email == params.email
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,6 @@
 Logger.remove_backend(:console)
 Code.compiler_options(ignore_module_conflict: true)
 
-ExUnit.start(exclude: [:ca_integration])
+ExUnit.start(exclude: [])
 
 Ecto.Adapters.SQL.Sandbox.mode(NervesHub.Repo, :manual)


### PR DESCRIPTION
They are excluded from `mix test` and some amount of the code behind it has been removed (due to removing NervesHubCA integration.)