### PR TITLE
Limit firmware choices to the same platform/architecture for deployments

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -31,6 +31,20 @@ defmodule NervesHub.Firmwares do
     |> Repo.all()
   end
 
+  def get_firmwares_for_deployment(deployment) do
+    deployment = Repo.preload(deployment, [:firmware])
+
+    from(
+      f in Firmware,
+      where: f.product_id == ^deployment.product_id,
+      where: f.platform == ^deployment.firmware.platform,
+      where: f.architecture == ^deployment.firmware.architecture,
+      order_by: [fragment("? collate numeric desc", f.version), desc: :inserted_at]
+    )
+    |> Firmware.with_product()
+    |> Repo.all()
+  end
+
   @spec get_firmware(Org.t(), integer()) ::
           {:ok, Firmware.t()}
           | {:error, :not_found}

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -133,8 +133,8 @@ defmodule NervesHubWeb.DeploymentController do
     )
   end
 
-  def edit(%{assigns: %{deployment: deployment, product: product}} = conn, _params) do
-    firmwares = Firmwares.get_firmwares_by_product(product.id)
+  def edit(%{assigns: %{deployment: deployment}} = conn, _params) do
+    firmwares = Firmwares.get_firmwares_for_deployment(deployment)
 
     conn
     |> render(

--- a/lib/nerves_hub_web/templates/deployment/edit.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/edit.html.heex
@@ -53,7 +53,11 @@
   </div>
 
   <div class="form-group">
-    <label for="firmware_id">Firmware version</label>
+    <label for="firmware_id" class="tooltip-label">
+      <span>Firmware version</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">Firmware listed is the same platform and architecture as the currently selected firmware.</span>
+    </label>
     <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
     <div class="select-icon"></div>
     <div class="has-error"><%= error_tag f, :firmware_id %></div>

--- a/lib/nerves_hub_web/templates/deployment/new.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/new.html.heex
@@ -21,7 +21,11 @@
   </div>
 
   <div class="form-group">
-    <label for="firmware_id">Firmware version</label>
+    <label for="firmware_id" class="tooltip-label">
+      <span>Firmware version</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">Once selected, deployments will use the same platform and architecture going forward.</span>
+    </label>
     <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
     <div class="select-icon"></div>
     <div class="has-error"><%= error_tag f, :firmware_id %></div>


### PR DESCRIPTION
When editing a deployment, limit the choices available to the same platform and architecture to reduce accidentally picking the wrong firmware and deploying something you didn't want.