### PR TITLE
Log what we rescue before redirecting

### DIFF
--- a/lib/nerves_hub_web/live/account_live/show.ex
+++ b/lib/nerves_hub_web/live/account_live/show.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.AccountLive.Show do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHubWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
 
   alias NervesHub.{Accounts, Accounts.UserToken, Repo}
@@ -106,8 +108,9 @@ defmodule NervesHubWeb.AccountLive.Show do
 
     {:ok, socket}
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.

--- a/lib/nerves_hub_web/live/deployment_live/show.ex
+++ b/lib/nerves_hub_web/live/deployment_live/show.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.DeploymentLive.Show do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHub.{Accounts, Deployments, Products, Firmwares}
 
   def render(assigns) do
@@ -29,8 +31,9 @@ defmodule NervesHubWeb.DeploymentLive.Show do
 
     {:ok, socket}
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.

--- a/lib/nerves_hub_web/live/device_live/console.ex
+++ b/lib/nerves_hub_web/live/device_live/console.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.DeviceLive.Console do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHubDevice.Presence
   alias NervesHub.{Accounts, Devices, Products}
   alias Phoenix.Socket.Broadcast
@@ -43,8 +45,9 @@ defmodule NervesHubWeb.DeviceLive.Console do
     |> assign(:user_role, org_user.role)
     |> init_iex()
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.

--- a/lib/nerves_hub_web/live/device_live/edit.ex
+++ b/lib/nerves_hub_web/live/device_live/edit.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.DeviceLive.Edit do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHub.AuditLogs
   alias NervesHub.Accounts
   alias NervesHub.Devices
@@ -36,8 +38,9 @@ defmodule NervesHubWeb.DeviceLive.Edit do
 
     {:ok, socket}
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.

--- a/lib/nerves_hub_web/live/device_live/index.ex
+++ b/lib/nerves_hub_web/live/device_live/index.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.DeviceLive.Index do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHubDevice.Presence
   alias NervesHub.Accounts
   alias NervesHub.AuditLogs
@@ -68,8 +70,9 @@ defmodule NervesHubWeb.DeviceLive.Index do
 
     {:ok, socket}
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.DeviceLive.Show do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHubDevice.Presence
 
   alias NervesHub.Accounts
@@ -61,8 +63,9 @@ defmodule NervesHubWeb.DeviceLive.Show do
 
     {:ok, socket}
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.

--- a/lib/nerves_hub_web/live/product_live/import.ex
+++ b/lib/nerves_hub_web/live/product_live/import.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.ProductLive.Import do
   use NervesHubWeb, :live_view
 
+  require Logger
+
   alias NervesHub.{Accounts, Devices, Devices.Device, Products}
   alias NimbleCSV.RFC4180, as: CSV
 
@@ -35,8 +37,9 @@ defmodule NervesHubWeb.ProductLive.Import do
 
     {:ok, socket}
   rescue
-    e ->
-      socket_error(socket, live_view_error(e))
+    exception ->
+      Logger.error(Exception.format(:error, exception, __STACKTRACE__))
+      socket_error(socket, live_view_error(exception))
   end
 
   # Catch-all to handle when LV sessions change.


### PR DESCRIPTION
Some of our LiveViews completely swallow errors and make it nearly impossible to debug and figure out what went wrong. This formats the exception as an error to have it in logs for future us.