### PR TITLE
Remove TLS config around the API endpoint

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,20 +14,12 @@ config :phoenix, :stacktrace_depth, 20
 # NervesHubAPI
 #
 config :nerves_hub_www, NervesHubWeb.API.Endpoint,
+  http: [ip: {0, 0, 0, 0}, port: 4002],
   debug_errors: true,
   code_reloader: false,
   check_origin: false,
   watchers: [],
-  pubsub_server: NervesHub.PubSub,
-  https: [
-    port: 4002,
-    otp_app: :nerves_hub_www,
-    # Enable client SSL
-    verify: :verify_peer,
-    keyfile: Path.join(ssl_dir, "api.nerves-hub.org-key.pem"),
-    certfile: Path.join(ssl_dir, "api.nerves-hub.org.pem"),
-    cacertfile: Path.join(ssl_dir, "ca.pem")
-  ]
+  pubsub_server: NervesHub.PubSub
 
 ##
 # NervesHubDevice

--- a/config/release.exs
+++ b/config/release.exs
@@ -87,26 +87,5 @@ if nerves_hub_app in ["all", "device"] do
 end
 
 if nerves_hub_app in ["all", "api"] do
-  cacert_pems = [
-    "/etc/ssl/user-root-ca.pem",
-    "/etc/ssl/root-ca.pem"
-  ]
-
-  cacerts =
-    cacert_pems
-    |> Enum.map(&File.read!/1)
-    |> Enum.map(&X509.Certificate.from_pem!/1)
-    |> Enum.map(&X509.Certificate.to_der/1)
-
-  config :nerves_hub_www, NervesHubWeb.API.Endpoint,
-    url: [host: host],
-    https: [
-      port: 443,
-      otp_app: :nerves_hub_www,
-      # Enable client SSL
-      verify: :verify_peer,
-      keyfile: "/etc/ssl/#{host}-key.pem",
-      certfile: "/etc/ssl/#{host}.pem",
-      cacerts: cacerts ++ :certifi.cacerts()
-    ]
+  config :nerves_hub_www, NervesHubWeb.API.Endpoint, url: [host: host, port: port]
 end


### PR DESCRIPTION
With user certificates gone, we don't need this configuration and can simplify for future hosting.