### PR TITLE
Remove s3-sync file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,9 @@ ENV URL_SCHEME=https \
 
 COPY --from=builder /build/_build/$MIX_ENV/rel/nerves_hub_www/ ./
 COPY --from=builder /build/rel/scripts/docker-entrypoint.sh .
-COPY --from=builder /build/rel/scripts/s3-sync.sh .
 COPY --from=builder /build/rel/scripts/ecs-cluster.sh .
 
 RUN ["chmod", "+x", "/app/docker-entrypoint.sh"]
-RUN ["chmod", "+x", "/app/s3-sync.sh"]
 RUN ["chmod", "+x", "/app/ecs-cluster.sh"]
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/rel/scripts/docker-entrypoint.sh
+++ b/rel/scripts/docker-entrypoint.sh
@@ -11,6 +11,4 @@ eval $(aws-env)
 
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
-$SCRIPT_PATH/s3-sync.sh
-
 exec $@

--- a/rel/scripts/s3-sync.sh
+++ b/rel/scripts/s3-sync.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-WORKING_DIR=${WORKING_DIR:-/etc/ssl}
-S3_SSL_BUCKET=${S3_SSL_BUCKET:-"nerves-hub-$ENVIRONMENT-ca"}
-
-mkdir -p $WORKING_DIR
-aws s3 sync s3://$S3_SSL_BUCKET/ssl $WORKING_DIR


### PR DESCRIPTION
Since we're not using the Nerves Hub CA anymore, we can stop running this on app boot.