### PR TITLE
Plugs and views should load orgs/products less

### DIFF
--- a/lib/nerves_hub_web/live/device_live/index.ex
+++ b/lib/nerves_hub_web/live/device_live/index.ex
@@ -1,6 +1,9 @@
 defmodule NervesHubWeb.DeviceLive.Index do
   use NervesHubWeb, :live_view
 
+  # For the preloads below
+  import Ecto.Query
+
   require Logger
 
   alias NervesHubDevice.Presence
@@ -50,7 +53,6 @@ defmodule NervesHubWeb.DeviceLive.Index do
       socket
       |> assign(:user, user)
       |> assign_new(:orgs, fn ->
-        import Ecto.Query
         # Taken from the FetchUser plug
         # Duplicated because we can't pass in what the plug already loaded
         org_query = from(o in NervesHub.Accounts.Org, where: is_nil(o.deleted_at))

--- a/lib/nerves_hub_web/plugs/fetch_user.ex
+++ b/lib/nerves_hub_web/plugs/fetch_user.ex
@@ -1,7 +1,11 @@
 defmodule NervesHubWeb.Plugs.FetchUser do
+  import Ecto.Query
   import Plug.Conn
 
   alias NervesHub.Accounts
+  alias NervesHub.Accounts.Org
+  alias NervesHub.Products.Product
+  alias NervesHub.Repo
 
   def init(opts), do: opts
 
@@ -11,8 +15,15 @@ defmodule NervesHubWeb.Plugs.FetchUser do
         conn
 
       user_id ->
-        case Accounts.get_user_with_all_orgs(user_id) do
+        case Accounts.get_user(user_id) do
           {:ok, user} ->
+            # Preload orgs and products for the navigation bar
+            # Since we've loaded everything then we can reuse it for plugs
+            # further down the pipeline
+            org_query = from(o in Org, where: is_nil(o.deleted_at))
+            product_query = from(p in Product, where: is_nil(p.deleted_at))
+            user = Repo.preload(user, orgs: {org_query, products: product_query})
+
             conn
             |> assign(:user, user)
             |> assign(:orgs, user.orgs)

--- a/lib/nerves_hub_web/plugs/org.ex
+++ b/lib/nerves_hub_web/plugs/org.ex
@@ -1,23 +1,30 @@
 defmodule NervesHubWeb.Plugs.Org do
   use NervesHubWeb, :plug
 
-  alias NervesHub.Accounts
+  alias NervesHub.Repo
 
   def init(opts) do
     opts
   end
 
-  def call(%{params: %{"org_name" => org_name}, assigns: %{user: user}} = conn, _opts) do
-    with {:ok, org} <- Accounts.get_org_by_name_and_user(org_name, user),
-         {:ok, org} <- Accounts.get_org_with_org_keys(org.id) do
-      assign(conn, :org, org)
-    else
-      _error ->
+  def call(%{params: %{"org_name" => org_name}} = conn, _opts) do
+    %{orgs: orgs} = conn.assigns
+
+    org =
+      Enum.find(orgs, fn org ->
+        org.name == org_name
+      end)
+
+    case !is_nil(org) do
+      true ->
+        assign(conn, :org, Repo.preload(org, [:org_keys]))
+
+      false ->
         conn
         |> put_status(:not_found)
         |> put_view(NervesHubWeb.ErrorView)
         |> render("404.html")
-        |> halt
+        |> halt()
     end
   end
 end

--- a/lib/nerves_hub_web/plugs/product.ex
+++ b/lib/nerves_hub_web/plugs/product.ex
@@ -1,24 +1,28 @@
 defmodule NervesHubWeb.Plugs.Product do
   use NervesHubWeb, :plug
 
-  alias NervesHub.Products
-
   def init(opts) do
     opts
   end
 
   def call(%{params: %{"product_name" => product_name}} = conn, _opts) do
-    with {:ok, product} <-
-           Products.get_product_by_org_id_and_name(conn.assigns.org.id, product_name) do
-      conn
-      |> assign(:product, product)
-    else
-      _error ->
+    %{org: org} = conn.assigns
+
+    product =
+      Enum.find(org.products, fn product ->
+        product.name == product_name
+      end)
+
+    case !is_nil(product) do
+      true ->
+        assign(conn, :product, product)
+
+      false ->
         conn
         |> put_status(:not_found)
         |> put_view(NervesHubWeb.ErrorView)
         |> render("404.html")
-        |> halt
+        |> halt()
     end
   end
 end

--- a/lib/nerves_hub_web/templates/device/index.html.heex
+++ b/lib/nerves_hub_web/templates/device/index.html.heex
@@ -139,7 +139,7 @@
             <div class="flex-grow pos-rel">
               <select name="product" id="move_to" class="form-control">
                 <option value=""></option>
-                <%= for org <- user_orgs(@user), products = user_org_products(@user, org), length(products) > 0 do %>
+                <%= for org <- @orgs, products = org.products, length(products) > 0 do %>
                   <optgroup label={org.name}>
                     <%= for product <- products, product.id != @product.id do %>
                       <option value={"#{org.id}:#{product.id}:#{product.name}"}><%= product.name %></option>

--- a/lib/nerves_hub_web/templates/home/index.html.heex
+++ b/lib/nerves_hub_web/templates/home/index.html.heex
@@ -8,7 +8,7 @@
           <div class="help-text">Total Products</div>
           <div class="flex-row mt-1 align-items-center">
             <img src="/images/icons/product.svg" alt="products" class="mr-1" style="margin-top: -1px" />
-            <p><%= OrgView.count_org_products(@conn.assigns.user, org) %></p>
+            <p><%= Enum.count(org.products) %></p>
           </div>
         </div>
       </div>

--- a/lib/nerves_hub_web/templates/layout/_navigation.html.heex
+++ b/lib/nerves_hub_web/templates/layout/_navigation.html.heex
@@ -24,8 +24,8 @@
                 <ul class="dropdown-menu">
                   <div class="help-text">Select a product</div>
                   <div class="dropdown-divider"></div>
-                  <%= if user_org_products(@conn.assigns.user, org) !== [] do %>
-                    <%= for product <- take_user_org_products(@conn.assigns.user, org, 5) do %>
+                  <%= if org.products !== [] do %>
+                    <%= for product <- org.products do %>
                       <li>
                         <%= active_link(@conn, to: Routes.device_path(@conn, :index, org.name, product.name), class_active: "active dropdown-item product", class_inactive: "dropdown-item product") do %>
                           <%= product.name %>
@@ -39,10 +39,6 @@
                     <div class="dropdown-divider"></div>
                   <% end %>
 
-                  <%= if count_user_org_products(@conn.assigns.user, org) > 5 do %>
-                    <a href={Routes.product_path(@conn, :index, org.name)} class="all-nav-link">View All Products (<%= count_user_org_products(@conn.assigns.user, org) %>)</a>
-                  <% end %>
-
                   <a class="btn btn-outline-light mt-2 mb-3 ml-3 mr-3" aria-label="Create product" href={Routes.product_path(@conn, :new, org.name)}>
                     <span class="action-text">Create Product</span>
                     <span class="button-icon add"></span>
@@ -50,10 +46,6 @@
                 </ul>
                 <div class="dropdown-divider"></div>
               </div>
-            <% end %>
-
-            <%= if count_user_orgs(@conn) > 5 do %>
-            <a class="all-nav-link" href={Routes.org_path(@conn, :index, @conn.assigns.user.username)}>View All Organizations (<%= count_user_orgs(@conn) %>)</a>
             <% end %>
 
             <a class="btn btn-outline-light mt-2 mb-3 ml-3 mr-3" aria-label="Create organization" href={Routes.org_path(@conn, :new)}>

--- a/lib/nerves_hub_web/templates/layout/_tabnav.html.heex
+++ b/lib/nerves_hub_web/templates/layout/_tabnav.html.heex
@@ -11,9 +11,9 @@
           </li>
         <% end %>
       </ul>
-      <%= if !is_nil(device_count(@conn)) do %>
+      <%= if device_count = device_count(@conn) do %>
         <div class="device-limit-indicator" title="Device total" aria-label="Device total">
-          <%= device_count(@conn) %>
+          <%= device_count %>
         </div>
       <% end %>
     </nav>

--- a/lib/nerves_hub_web/templates/org/index.html.heex
+++ b/lib/nerves_hub_web/templates/org/index.html.heex
@@ -9,7 +9,7 @@
           <div class="help-text">Total Products</div>
           <div class="flex-row mt-1 align-items-center">
             <img src="/images/icons/product.svg" alt="products" class="mr-1" style="margin-top: -1px" />
-            <p><%= count_org_products(@conn.assigns.user, org) %></p>
+            <p><%= Enum.count(org.products) %></p>
           </div>
         </div>
       </div>

--- a/lib/nerves_hub_web/views/device_view.ex
+++ b/lib/nerves_hub_web/views/device_view.ex
@@ -7,7 +7,7 @@ defmodule NervesHubWeb.DeviceView do
   alias NervesHubWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
 
   import NervesHubWeb.LayoutView,
-    only: [pagination_links: 1, user_orgs: 1, user_org_products: 2]
+    only: [pagination_links: 1]
 
   import NervesHubWeb.OrgCertificateView, only: [format_serial: 1]
 

--- a/lib/nerves_hub_web/views/home_view.ex
+++ b/lib/nerves_hub_web/views/home_view.ex
@@ -1,5 +1,3 @@
 defmodule NervesHubWeb.HomeView do
   use NervesHubWeb, :view
-
-  alias NervesHubWeb.OrgView
 end

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -5,7 +5,6 @@ defmodule NervesHubWeb.LayoutView do
   alias NervesHub.Accounts
   alias NervesHub.Accounts.User
   alias NervesHub.Devices
-  alias NervesHub.Products
   alias NervesHub.Products.Product
 
   def product(%{assigns: %{product: %Product{} = product}}) do
@@ -14,32 +13,6 @@ defmodule NervesHubWeb.LayoutView do
 
   def product(_conn) do
     nil
-  end
-
-  def user_orgs(%{assigns: %{user: %User{} = user}}) do
-    user_orgs(user)
-  end
-
-  def user_orgs(%User{} = user) do
-    Accounts.get_user_orgs_with_product_role(user, :read)
-  end
-
-  def user_orgs(_conn), do: []
-
-  def count_user_orgs(conn) do
-    Enum.count(user_orgs(conn))
-  end
-
-  def user_org_products(user, org) do
-    Products.get_products_by_user_and_org(user, org)
-  end
-
-  def count_user_org_products(user, org) do
-    Enum.count(user_org_products(user, org))
-  end
-
-  def take_user_org_products(user, org, amount) do
-    Enum.take(user_org_products(user, org), amount)
   end
 
   def device_count(%{assigns: %{org: %{id: org_id}}}) do
@@ -51,6 +24,7 @@ defmodule NervesHubWeb.LayoutView do
   end
 
   def logged_in?(%{assigns: %{user: %User{}}}), do: true
+
   def logged_in?(_), do: false
 
   def has_org_role?(org, user, role) do

--- a/lib/nerves_hub_web/views/org_view.ex
+++ b/lib/nerves_hub_web/views/org_view.ex
@@ -1,9 +1,3 @@
 defmodule NervesHubWeb.OrgView do
   use NervesHubWeb, :view
-
-  import NervesHubWeb.LayoutView, only: [user_org_products: 2]
-
-  def count_org_products(user, org) do
-    Enum.count(user_org_products(user, org))
-  end
 end


### PR DESCRIPTION
- Top level plug that fetches everything the layout needs when loading the user
- Update plugs below the `FetchUser` plug to use what was already loaded
- Update views to use the already loaded data instead of fetching multiple times and count on a new query