### PR TITLE
Select only firmware version numbers for the device filters

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -21,11 +21,9 @@ defmodule NervesHub.Firmwares do
 
   @spec get_firmwares_by_product(integer()) :: [Firmware.t()]
   def get_firmwares_by_product(product_id) do
-    from(
-      f in Firmware,
-      where: f.product_id == ^product_id,
-      order_by: [fragment("? collate numeric desc", f.version), desc: :inserted_at]
-    )
+    Firmware
+    |> where([f], f.product_id == ^product_id)
+    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
     |> Firmware.with_product()
     |> Repo.all()
   end
@@ -42,6 +40,19 @@ defmodule NervesHub.Firmwares do
     )
     |> Firmware.with_product()
     |> Repo.all()
+  end
+
+  @doc """
+  Get only version numbers for a product, sorted highest first
+  """
+  def get_firmware_versions_by_product(product_id) do
+    Firmware
+    |> select([f], f.version)
+    |> distinct(true)
+    |> where([f], f.product_id == ^product_id)
+    |> Repo.all()
+    |> Enum.sort(Version)
+    |> Enum.reverse()
   end
 
   @spec get_firmware(Org.t(), integer()) ::

--- a/lib/nerves_hub_web/live/device_live/index.ex
+++ b/lib/nerves_hub_web/live/device_live/index.ex
@@ -448,6 +448,6 @@ defmodule NervesHubWeb.DeviceLive.Index do
   end
 
   defp firmware_versions(product_id) do
-    Firmwares.get_firmwares_by_product(product_id) |> Enum.map(& &1.version)
+    Firmwares.get_firmware_versions_by_product(product_id)
   end
 end


### PR DESCRIPTION
If you have multiple version numbers for differing platforms (or just different UUIDs) they show up multiple times in this list.
<img width="282" alt="Screenshot 2023-03-31 at 9 36 11 AM" src="https://user-images.githubusercontent.com/449228/229178982-cfd79a2a-4ae7-4ca8-a8f7-c7c5ea40ec76.png">
