### PR TITLE
Validate the version condition on a deployment

### DIFF
--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -143,7 +143,7 @@ defmodule NervesHub.Deployments.Deployment do
         |> validate_length(:tags, min: 1)
         |> validate_change(:version, fn :version, version ->
           if not is_nil(version) and !String.match?(version, @version_regex) do
-            [version: "Must match the regex #{Regex.source(@version_regex)}"]
+            [version: "Invalid version format"]
           else
             []
           end

--- a/test/nerves_hub/deployments/deployments_test.exs
+++ b/test/nerves_hub/deployments/deployments_test.exs
@@ -90,6 +90,27 @@ defmodule NervesHub.DeploymentsTest do
 
       assert {:error, %Changeset{}} = Deployments.create_deployment(params)
     end
+
+    test "create_deployment checks for version formatting" do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user, %{name: "version"})
+      org_key = Fixtures.org_key_fixture(org)
+      product = Fixtures.product_fixture(user, org)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+
+      params = %{
+        org_id: org.id,
+        firmware_id: firmware.id,
+        name: "a different name",
+        conditions: %{
+          "version" => "<1.0.0",
+          "tags" => ["beta", "beta-edge"]
+        },
+        is_active: false
+      }
+
+      assert {:error, %Changeset{}} = Deployments.create_deployment(params)
+    end
   end
 
   describe "update_deployment" do

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -327,7 +327,7 @@ defmodule NervesHubWeb.WebsocketTest do
       Fixtures.deployment_fixture(org, firmware2, %{
         name: "a different name",
         conditions: %{
-          "version" => ">=0.0.1",
+          "version" => ">= 0.0.1",
           "tags" => ["beta", "beta-edge"]
         }
       })
@@ -373,7 +373,7 @@ defmodule NervesHubWeb.WebsocketTest do
         Fixtures.deployment_fixture(device.org, firmware2, %{
           name: "a different name",
           conditions: %{
-            "version" => ">=0.0.1",
+            "version" => ">= 0.0.1",
             "tags" => ["beta", "beta-edge"]
           }
         })

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -191,7 +191,7 @@ defmodule NervesHubWeb.DeploymentControllerTest do
           conn,
           Routes.deployment_path(conn, :update, org.name, product.name, deployment.name),
           deployment: %{
-            "version" => "4.3.2",
+            "version" => "= 4.3.2",
             "tags" => "new, tags, now",
             "name" => "not original",
             "firmware_id" => firmware.id
@@ -210,7 +210,7 @@ defmodule NervesHubWeb.DeploymentControllerTest do
                )
 
       assert reloaded_deployment.name == "not original"
-      assert reloaded_deployment.conditions["version"] == "4.3.2"
+      assert reloaded_deployment.conditions["version"] == "= 4.3.2"
       assert Enum.sort(reloaded_deployment.conditions["tags"]) == Enum.sort(~w(new tags now))
     end
 


### PR DESCRIPTION
If we don't have a space between the version condition then the deployment finding in the database breaks and render a 500 on the device page. This validates we have a proper string before you save it.