### PR TITLE
Allow web registration and various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ iex-server:
 	iex -S mix phx.server
 
 reset-db:
-	mix exto.reset
+	mix ecto.reset
 
 reset-test-db:
 	MIX_ENV=test \

--- a/README.md
+++ b/README.md
@@ -79,17 +79,18 @@ is needed in order to run both applications. When you create certificates from `
      ```
 
 2. Fetch dependencies: `mix do deps.get, compile`
-3. Initialize the database: `make reset-db`
+3. Initialize the database: `make reset-db` (or mix `ecto.reset`)
 4. Compile web assets (this only needs to be done once and requires python2):
    `mix assets.install`
 
 ### Starting the application
 
-* `make server` - start the server process
-* `make iex-server` - start the server with the
-   interactive shell
+* `make server` - start the server process (or run `mix phx.server`)
+* `make iex-server` - start the server with the interactive shell (or run `iex -S mix phx.server`)
 
 > **_Note_**: The whole app may need to be compiled the first time you run this, so please be patient
+
+Then visit http://localhost:4000/register to create your first account
 
 ### Running Tests
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -49,6 +49,7 @@ config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
 # NervesHub
 #
 config :nerves_hub_www,
+  namespace: NervesHub,
   ecto_repos: [NervesHub.Repo],
   from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
 

--- a/lib/nerves_hub_web/controllers/account_controller.ex
+++ b/lib/nerves_hub_web/controllers/account_controller.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.AccountController do
   alias NervesHub.Accounts
   alias NervesHub.Accounts.Email
   alias NervesHub.Mailer
+  alias NervesHub.Accounts.User
 
   def edit(conn, _params) do
     conn
@@ -31,6 +32,29 @@ defmodule NervesHubWeb.AccountController do
       conn
       |> put_flash(:info, "Success")
       |> redirect(to: "/login")
+    end
+  end
+
+  def new(conn, _params) do
+    changeset = Accounts.change_user(%User{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"user" => user_params}) do
+    params = %{
+      username: user_params["username"],
+      email: user_params["email"],
+      password: user_params["password"]
+    }
+
+    case Accounts.create_user(params) do
+      {:ok, _user} ->
+        conn
+        |> put_flash(:info, "User created successfully.")
+        |> redirect(to: "/login")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
     end
   end
 

--- a/lib/nerves_hub_web/templates/account/new.html.heex
+++ b/lib/nerves_hub_web/templates/account/new.html.heex
@@ -1,0 +1,30 @@
+<h1>Register</h1>
+
+<.form let={f} for={@changeset} action={Routes.account_path(@conn, :create)}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :username %>
+  <%= text_input f, :username, required: true %>
+  <%= error_tag f, :username %>
+
+  <%= label f, :email %>
+  <%= email_input f, :email, required: true %>
+  <%= error_tag f, :email %>
+
+  <%= label f, :password %>
+  <%= password_input f, :password, required: true %>
+  <%= error_tag f, :password %>
+
+  <div>
+    <%= submit "Register" %>
+  </div>
+</.form>
+
+<p>
+  <%= link "Log in", to: Routes.session_path(@conn, :new) %> |
+  <%= link "Forgot your password?", to: Routes.password_reset_path(@conn, :new) %>
+</p>

--- a/lib/nerves_hub_web/templates/session/new.html.heex
+++ b/lib/nerves_hub_web/templates/session/new.html.heex
@@ -21,4 +21,10 @@
       <%= submit "Login", class: "btn btn-primary btn-lg w-100" %>
     </div>
   <% end %>
+
+  <div style="margin-top: 10px">
+    <a href={Routes.account_path(@conn, :new)} class="forgot-password">
+      Register
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
Before this only registration via mix task or an invitation was allowed.

Adds a very basic registration route/page:
![image](https://user-images.githubusercontent.com/9973/230706986-584f317c-3cbb-4056-937d-7572cc4f9ffb.png)

Also adds a registration link to the login page:
![image](https://user-images.githubusercontent.com/9973/230706998-5cfb2dec-2ff6-4239-bdaf-e52d79af5dae.png)

Also fixes some other issues
- `make reset-db` was broken because of a typo
- Adds getting started commands that don't rely on make because many elixir developers may not have make installed
  - Would it make sense to remove the reliance of `make` entirely? I don't think I've seen any other Phoenix projects that require `make` for common tasks
- Points the user to `/register` after they initial get the app running

Adds the `namespace: NervesHub` to the configuration, without this `mix phx.routes` doesn't work by default

TODO:
- [ ] Add tests