### PR TITLE
Readme improvements and various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ iex-server:
 	iex -S mix phx.server
 
 reset-db:
-	mix exto.reset
+	mix ecto.reset
 
 reset-test-db:
 	MIX_ENV=test \

--- a/README.md
+++ b/README.md
@@ -79,15 +79,14 @@ is needed in order to run both applications. When you create certificates from `
      ```
 
 2. Fetch dependencies: `mix do deps.get, compile`
-3. Initialize the database: `make reset-db`
+3. Initialize the database: `make reset-db` (or mix `ecto.reset`)
 4. Compile web assets (this only needs to be done once and requires python2):
    `mix assets.install`
 
 ### Starting the application
 
-* `make server` - start the server process
-* `make iex-server` - start the server with the
-   interactive shell
+* `make server` - start the server process (or run `mix phx.server`)
+* `make iex-server` - start the server with the interactive shell (or run `iex -S mix phx.server`)
 
 > **_Note_**: The whole app may need to be compiled the first time you run this, so please be patient
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -49,6 +49,7 @@ config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
 # NervesHub
 #
 config :nerves_hub_www,
+  namespace: NervesHub,
   ecto_repos: [NervesHub.Repo],
   from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
 


### PR DESCRIPTION
Fixes:
- `make reset-db` was broken because of a typo
- Adds getting started commands that don't rely on make because many elixir developers may not have make installed
- Adds the `namespace: NervesHub` to the configuration
  - Without this `mix phx.routes` doesn't work by default

Split out from https://github.com/nerves-hub/nerves_hub_web/pull/909