### PR TITLE
Forward the APIRouter from the web Router

### DIFF
--- a/lib/nerves_hub_web.ex
+++ b/lib/nerves_hub_web.ex
@@ -56,7 +56,7 @@ defmodule NervesHubWeb do
 
       import Phoenix.LiveView.Controller
 
-      alias NervesHubWeb.API.Router.Helpers, as: Routes
+      alias NervesHubWeb.APIRouter.Helpers, as: Routes
 
       def whitelist(params, keys) do
         keys
@@ -145,7 +145,7 @@ defmodule NervesHubWeb do
       import NervesHubWeb.ErrorHelpers
       import NervesHubWeb.Gettext
 
-      alias NervesHubWeb.API.Router.Helpers, as: Routes
+      alias NervesHubWeb.APIRouter.Helpers, as: Routes
 
       def render("error.json", %{error: error}) do
         %{

--- a/lib/nerves_hub_web/api_endpoint.ex
+++ b/lib/nerves_hub_web/api_endpoint.ex
@@ -40,7 +40,7 @@ defmodule NervesHubWeb.API.Endpoint do
     signing_salt: "WVt9MTK1"
   )
 
-  plug(NervesHubWeb.API.Router)
+  plug(NervesHubWeb.APIRouter)
 
   @doc """
   Callback invoked for dynamically configuring the endpoint.

--- a/lib/nerves_hub_web/api_router.ex
+++ b/lib/nerves_hub_web/api_router.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.API.Router do
+defmodule NervesHubWeb.APIRouter do
   use NervesHubWeb, :router
 
   pipeline :api do

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -37,6 +37,8 @@ defmodule NervesHubWeb.Router do
     plug(NervesHubWeb.Plugs.Firmware)
   end
 
+  forward "/api", NervesHubWeb.APIRouter
+
   scope "/", NervesHubWeb do
     # Use the default browser stack
     pipe_through(:browser)

--- a/test/nerves_hub_web/plugs/api/user_test.exs
+++ b/test/nerves_hub_web/plugs/api/user_test.exs
@@ -5,7 +5,7 @@ defmodule NervesHubWeb.API.Plugs.UserTest do
   setup do
     conn =
       build_conn()
-      |> bypass_through(NervesHubWeb.API.Router)
+      |> bypass_through(NervesHubWeb.APIRouter)
       |> dispatch(NervesHubWeb.API.Endpoint, :get, "/users/me")
 
     %{conn: conn}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -66,7 +66,7 @@ defmodule NervesHubWeb.APIConnCase do
       use DefaultMocks
       import NervesHubWeb.APIConnCase, only: [build_auth_conn: 1, peer_data: 1]
 
-      alias NervesHubWeb.API.Router.Helpers, as: Routes
+      alias NervesHubWeb.APIRouter.Helpers, as: Routes
 
       # The default endpoint for testing
       @endpoint NervesHubWeb.API.Endpoint


### PR DESCRIPTION
Start to deprecate the API node, since it no longer needs user certs its similar to the web node and we don't need to have separation.