### PR TITLE
Push deployment updates through an orchestrator process

### DIFF
--- a/lib/nerves_hub/deployments/monitor.ex
+++ b/lib/nerves_hub/deployments/monitor.ex
@@ -1,0 +1,54 @@
+defmodule NervesHub.Deployments.Monitor do
+  @moduledoc """
+  Deployment Monitor starts a deployment orchestrator per deployment
+
+  Listens for new deployments and starts as necessary
+  """
+
+  use GenServer
+
+  alias NervesHub.DeploymentDynamicSupervisor
+  alias NervesHub.Deployments
+  alias NervesHub.Deployments.Orchestrator
+  alias Phoenix.PubSub
+  alias Phoenix.Socket.Broadcast
+
+  defmodule State do
+    defstruct [:deployments]
+  end
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init(_) do
+    PubSub.subscribe(NervesHub.PubSub, "deployment:monitor")
+
+    {:ok, %State{}, {:continue, :boot}}
+  end
+
+  def handle_continue(:boot, state) do
+    deployments =
+      Enum.into(Deployments.all(), %{}, fn deployment ->
+        {:ok, pid} = DynamicSupervisor.start_child(DeploymentDynamicSupervisor, {Deployments.Orchestrator, deployment})
+
+        {deployment.id, pid}
+      end)
+
+    {:noreply, %{state | deployments: deployments}}
+  end
+
+  def handle_info(%Broadcast{event: "deployments/new", payload: payload}, state) do
+    {:ok, deployment} = Deployments.get(payload.deployment_id)
+    {:ok, pid} = DynamicSupervisor.start_child(DeploymentDynamicSupervisor, {Deployments.Orchestrator, deployment})
+    deployments = Map.put(state.deployments, deployment.id, pid)
+    {:noreply, %{state | deployments: deployments}}
+  end
+
+  def handle_info(%Broadcast{event: "deployments/delete", payload: payload}, state) do
+    pid = GenServer.whereis(Orchestrator.name(payload.deployment_id))
+    DynamicSupervisor.terminate_child(DeploymentDynamicSupervisor, pid)
+    deployments = Map.delete(state.deployments, payload.deployment_id)
+    {:noreply, %{state | deployments: deployments}}
+  end
+end

--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -1,0 +1,50 @@
+defmodule NervesHub.Deployments.Orchestrator do
+  @moduledoc """
+  Orchestration process to handle passing out updates to devices
+
+  When a deployment is updated, the orchestraor will tell every
+  device local to its node that there is a new update. This will
+  hook will allow the orchestrator to start slowly handing out
+  updates instead of blasting every device at once.
+  """
+
+  use GenServer
+
+  alias NervesHub.Repo
+  alias NervesHubDevice.Presence
+  alias Phoenix.PubSub
+  alias Phoenix.Socket.Broadcast
+
+  def start_link(deployment) do
+    GenServer.start_link(__MODULE__, deployment, name: name(deployment))
+  end
+
+  def name(deployment_id) when is_integer(deployment_id) do
+    {:via, Registry, {NervesHub.Deployments, deployment_id}}
+  end
+
+  def name(deployment), do: name(deployment.id)
+
+  def init(deployment) do
+    {:ok, deployment, {:continue, :boot}}
+  end
+
+  def handle_continue(:boot, deployment) do
+    PubSub.subscribe(NervesHub.PubSub, "deployment:#{deployment.id}")
+
+    {:noreply, deployment}
+  end
+
+  def handle_info(%Broadcast{event: "deployments/update"}, deployment) do
+    device_pids = Presence.local_deployment_device_pids(deployment)
+
+    Enum.each(device_pids, fn pid ->
+      send(pid, "deployments/update")
+    end)
+
+    {:noreply, Repo.reload(deployment)}
+  end
+
+  # Catch all for unknown broadcasts on a deployment
+  def handle_info(%Broadcast{topic: "deployment:" <> _}, deployment), do: {:noreply, deployment}
+end

--- a/lib/nerves_hub/deployments/supervisor.ex
+++ b/lib/nerves_hub/deployments/supervisor.ex
@@ -1,0 +1,19 @@
+defmodule NervesHub.Deployments.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    children = [
+      {Registry, keys: :unique, name: NervesHub.Deployments},
+      NervesHub.Deployments.Monitor,
+      {DynamicSupervisor, strategy: :one_for_one, name: NervesHub.DeploymentDynamicSupervisor}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -49,6 +49,7 @@ defmodule NervesHubWeb.DeviceChannel do
           assign(socket, :deployment_channel, "deployment:none")
         end
 
+      # Let the orchestrator handle this going forward
       join_reply =
         device
         |> Devices.resolve_update()
@@ -130,6 +131,7 @@ defmodule NervesHubWeb.DeviceChannel do
       device,
       %{
         product_id: device.product_id,
+        deployment_id: device.deployment_id,
         connected_at: System.system_time(:second),
         last_communication: device.last_communication,
         update_available: update_available,
@@ -200,6 +202,10 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   def handle_info(%Broadcast{event: "deployments/update"}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_info("deployments/update", socket) do
     device = Repo.preload(socket.assigns.device, [deployment: [:firmware]], force: true)
 
     payload = Devices.resolve_update(device)

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -63,49 +63,6 @@ defmodule NervesHubWeb.DeviceChannelTest do
     assert join_reply.update_available == false
   end
 
-  test "update_available after a firmware update" do
-    user = Fixtures.user_fixture()
-    org = Fixtures.org_fixture(user)
-    product = Fixtures.product_fixture(user, org)
-    org_key = Fixtures.org_key_fixture(org)
-
-    firmware =
-      Fixtures.firmware_fixture(org_key, product, %{
-        version: "0.0.1"
-      })
-
-    deployment = Fixtures.deployment_fixture(org, firmware)
-
-    {:ok, deployment} =
-      NervesHub.Deployments.update_deployment(deployment, %{
-        is_active: true
-      })
-
-    device =
-      Fixtures.device_fixture(org, product, firmware, %{
-        tags: ["beta", "beta-edge"],
-        identifier: "123"
-      })
-
-    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
-    {:ok, socket} = connect(DeviceSocket, %{}, %{peer_data: %{ssl_cert: certificate.der}})
-
-    {:ok, %{update_available: false}, _socket} =
-      subscribe_and_join(socket, DeviceChannel, "device")
-
-    new_firmware =
-      Fixtures.firmware_fixture(org_key, product, %{
-        version: "0.0.2"
-      })
-
-    {:ok, _deployment} =
-      NervesHub.Deployments.update_deployment(deployment, %{
-        firmware_id: new_firmware.id
-      })
-
-    assert_push("update", %{firmware_meta: %{version: "0.0.2"}})
-  end
-
   test "the first fwup_progress marks an update as happening" do
     user = Fixtures.user_fixture()
     {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -379,10 +379,17 @@ defmodule NervesHubWeb.WebsocketTest do
 
       new_firmware = Fixtures.firmware_fixture(org_key, firmware.product, %{version: "0.0.2"})
 
-      {:ok, _deployment} =
+      {:ok, deployment} =
         Deployments.update_deployment(deployment, %{
           firmware_id: new_firmware.id
         })
+
+      # This is what the orchestrator process will do
+      device_pids = Presence.local_deployment_device_pids(deployment)
+
+      Enum.each(device_pids, fn pid ->
+        send(pid, "deployments/update")
+      end)
 
       message = SocketClient.wait_update(socket)
 


### PR DESCRIPTION
Don't push deployment updates directly to the device channel, introduce a process between the two in order to have a hook for rolling updates going forward.

There's no specific tests for this because I'm not entirely sure how to test it. But I've done manual testing with my ~200 devices and they upgraded without issue. This _shouldn't_ be any different than how things currently are.