### PR TITLE
Add an endpoint to try reconnecting to expected nodes

### DIFF
--- a/lib/nerves_hub_web/api_router.ex
+++ b/lib/nerves_hub_web/api_router.ex
@@ -25,6 +25,7 @@ defmodule NervesHubWeb.APIRouter do
     pipe_through(:api)
 
     get("/", HealthCheckController, :health_check)
+    get("/nodes", HealthCheckController, :node_check)
   end
 
   scope "/users", NervesHubWeb.API do

--- a/lib/nerves_hub_web/controllers/api/health_check_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/health_check_controller.ex
@@ -3,6 +3,8 @@ defmodule NervesHubWeb.API.HealthCheckController do
 
   use NervesHubWeb, :api_controller
 
+  require Logger
+
   @doc """
   Just return a 200 response.
 
@@ -10,4 +12,19 @@ defmodule NervesHubWeb.API.HealthCheckController do
   """
   def health_check(conn, _),
     do: json(conn, %{status: "UP"})
+
+  def node_check(conn, _) do
+    sync_nodes =
+      System.get_env("SYNC_NODES_OPTIONAL", "")
+      |> String.split(" ")
+      |> Enum.reject(& &1 == "")
+      |> Enum.map(&String.to_atom/1)
+      |> Enum.into(%{}, fn node ->
+        {node, Node.connect(node)}
+      end)
+
+    Logger.info("Reconnected nodes - #{inspect(sync_nodes)}")
+
+    json(conn, %{status: "CONNECTED"})
+  end
 end


### PR DESCRIPTION
Manual way to force reconnecting nodes as a test.

![image](https://user-images.githubusercontent.com/449228/235510066-99696416-a5b8-43cb-b390-6af9d9263675.png)
