### PR TITLE
Allow more DB queue time to handle connection bursts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -73,6 +73,10 @@ config :nerves_hub_www,
   datadog_batch_size: System.get_env("SPANDEX_BATCH_SIZE") || "100",
   datadog_sync_threshold: System.get_env("SPANDEX_SYNC_THRESHOLD") || "100"
 
+config :nerves_hub_www, NervesHub.Repo,
+  queue_target: 500,
+  queue_interval: 5_000
+
 config :nerves_hub_www,
   statsd_host: System.get_env("STATSD_HOST", "localhost"),
   statsd_port: System.get_env("STATSD_PORT", "8125")


### PR DESCRIPTION
This will hopefully give it a bit more time to churn through bursts before it starts dropping connections and trigger alerts.