### PR TITLE
Allow for deleted devices to be found for specific pages

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -170,7 +170,6 @@ defmodule NervesHub.Devices do
   def get_device_by_product(device_id, product_id, org_id) do
     device_by_product_query(device_id, product_id, org_id)
     |> preload([:deployment])
-    |> Repo.exclude_deleted()
     |> Repo.one!()
   end
 


### PR DESCRIPTION
The `exclude_deleted/0` call prevented the edit and show pages from being able to be reloaded. So you can only destroy a device if you stay on the page and don't refresh or visit again. This let's you destroy a device from visiting it's URL.