### PR TITLE
Version condition is an empty string, not nil

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -144,7 +144,14 @@ defmodule NervesHubWeb.DeviceChannel do
   # If it matches, we can set the deployment directly and only do 3 queries (update, two preloads)
   def handle_info(%Broadcast{event: "deployments/changed", topic: "deployment:none", payload: payload}, socket) do
     device = socket.assigns.device
-    version_requirement = Map.get(payload.conditions, "version") ||  "> 0.0.0"
+    version_requirement = Map.get(payload.conditions, "version")
+
+    version_requirement =
+      if version_requirement == "" || is_nil(version_requirement) do
+        "> 0.0.0"
+      else
+        version_requirement
+      end
 
     if payload.active &&
       device.product_id == payload.product_id &&

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -155,7 +155,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
     deployment =
       Fixtures.deployment_fixture(org, firmware, %{
-        conditions: %{"tags" => ["alpha"]}
+        conditions: %{"tags" => ["alpha"], "version" => ""}
       })
 
     {:ok, deployment} =


### PR DESCRIPTION
The validate conditions changeset for a deployment sets the version to an empty string if its not provided.