### PR TITLE
Truncate audit logs hourly

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -61,7 +61,13 @@ config :nerves_hub_www, NervesHub.PubSub,
 config :nerves_hub_www, Oban,
   repo: NervesHub.Repo,
   log: false,
-  queues: [delete_firmware: 1, firmware_delta_builder: 2]
+  queues: [delete_firmware: 1, firmware_delta_builder: 2, truncate: 1],
+  plugins: [
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"0 * * * *", NervesHub.Workers.TruncateAuditLogs, max_attempts: 1}
+     ]}
+  ]
 
 config :spandex_phoenix, tracer: NervesHub.Tracer
 

--- a/lib/nerves_hub/config.ex
+++ b/lib/nerves_hub/config.ex
@@ -25,4 +25,17 @@ defmodule NervesHub.Config do
            {:url_port, "URL_PORT", default: "443", map: &String.to_integer/1},
            {:url_scheme, "URL_SCHEME", default: "https"}
          ])
+
+  config :audit_logs,
+         env([
+           {:enabled, "TRUNATE_AUDIT_LOGS_ENABLED", default: "true", map: &to_boolean/1},
+           {:max_records_per_run, "TRUNCATE_AUDIT_LOGS_MAX_RECORDS_PER_RUN",
+            default: "10000", map: &String.to_integer/1},
+           {:days_kept, "TRUNCATE_AUDIT_LOGS_MAX_DAYS_KEPT",
+            default: "30", map: &String.to_integer/1}
+         ])
+
+  def to_boolean("true"), do: true
+
+  def to_boolean(_), do: false
 end

--- a/lib/nerves_hub/config.ex
+++ b/lib/nerves_hub/config.ex
@@ -28,7 +28,7 @@ defmodule NervesHub.Config do
 
   config :audit_logs,
          env([
-           {:enabled, "TRUNATE_AUDIT_LOGS_ENABLED", default: "true", map: &to_boolean/1},
+           {:enabled, "TRUNATE_AUDIT_LOGS_ENABLED", default: "false", map: &to_boolean/1},
            {:max_records_per_run, "TRUNCATE_AUDIT_LOGS_MAX_RECORDS_PER_RUN",
             default: "10000", map: &String.to_integer/1},
            {:days_kept, "TRUNCATE_AUDIT_LOGS_MAX_DAYS_KEPT",

--- a/lib/nerves_hub/workers/truncate_audit_logs.ex
+++ b/lib/nerves_hub/workers/truncate_audit_logs.ex
@@ -1,0 +1,19 @@
+defmodule NervesHub.Workers.TruncateAuditLogs do
+  use Oban.Worker,
+    max_attempts: 5,
+    queue: :truncate
+
+  alias NervesHub.Config
+
+  @impl true
+  def perform(_) do
+    vapor_config = Vapor.load!(Config)
+    config = vapor_config.audit_logs
+
+    if config.enabled do
+      NervesHub.AuditLogs.truncate(config)
+    end
+
+    :ok
+  end
+end

--- a/test/nerves_hub/audit_logs_test.exs
+++ b/test/nerves_hub/audit_logs_test.exs
@@ -1,0 +1,49 @@
+defmodule NervesHub.AuditLogsTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.AuditLogs
+  alias NervesHub.Devices.Device
+  alias NervesHub.Fixtures
+  alias NervesHub.Repo
+
+  describe "truncate logs" do
+    test "keeps a max amount of days" do
+      now = NaiveDateTime.utc_now()
+
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+
+      Enum.map(0..5, fn days ->
+        inserted_at = NaiveDateTime.add(now, -1 * days * 24 * 60 * 60, :second)
+
+        AuditLogs.audit!(%Device{id: 10}, %Device{id: 10, org_id: org.id}, :update, "Updating")
+        |> Ecto.Changeset.change(%{inserted_at: inserted_at})
+        |> Repo.update!()
+      end)
+
+      AuditLogs.truncate(%{max_records_per_run: 10, days_kept: 3})
+
+      assert Enum.count(Repo.all(AuditLogs.AuditLog)) == 3
+    end
+
+    test "limits amount deleted" do
+      now = NaiveDateTime.utc_now()
+
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+
+      # Create 12 records from 5 days ago
+      Enum.map(0..11, fn _ ->
+        inserted_at = NaiveDateTime.add(now, -1 * 5 * 24 * 60 * 60, :second)
+
+        AuditLogs.audit!(%Device{id: 10}, %Device{id: 10, org_id: org.id}, :update, "Updating")
+        |> Ecto.Changeset.change(%{inserted_at: inserted_at})
+        |> Repo.update!()
+      end)
+
+      AuditLogs.truncate(%{max_records_per_run: 10, days_kept: 3})
+
+      assert Enum.count(Repo.all(AuditLogs.AuditLog)) == 2
+    end
+  end
+end


### PR DESCRIPTION
Prune beyond a date and limit the amount of data deleted each run. Run hourly to prune a little bit every hour instead of a huge amount once a day to be night to the vacuum.