### PR TITLE
Lookup firmware by product and uuid

### DIFF
--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -236,7 +236,8 @@ defmodule NervesHubWeb.DeviceLive.Show do
   def handle_event("validate-cert", _, socket), do: {:noreply, socket}
 
   def handle_event("push-update", %{"uuid" => uuid}, socket) do
-    firmware = Firmwares.get_firmware_by_uuid(uuid)
+    product = socket.assigns.product
+    {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(product, uuid)
 
     {:ok, url} = Firmwares.get_firmware_url(firmware)
     {:ok, meta} = Firmwares.metadata_from_firmware(firmware)


### PR DESCRIPTION
The uuid is not guaranteed to be unique further than a product, so this was accidentally finding firmware for other organizations that happened to match (different environments essentially)