### PR TITLE
Optimize device deployment reassignment when previously assigned

### DIFF
--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -200,11 +200,58 @@ defmodule NervesHubWeb.DeviceChannelTest do
         conditions: %{"tags" => ["beta"]}
       })
 
+    # skip the jitter
+    send(socket_alpha.channel_pid, :resolve_changed_deployment)
     socket_alpha = :sys.get_state(socket_alpha.channel_pid)
     assert is_nil(socket_alpha.assigns.device.deployment_id)
 
     socket_beta = :sys.get_state(socket_beta.channel_pid)
     refute is_nil(socket_beta.assigns.device.deployment_id)
+  end
+
+  test "deployment condition changing causes a deployment relookup but it still matches" do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org)
+
+    firmware =
+      Fixtures.firmware_fixture(org_key, product, %{
+        version: "0.0.1"
+      })
+
+    deployment =
+      Fixtures.deployment_fixture(org, firmware, %{
+        conditions: %{"tags" => ["alpha"], "version" => ""}
+      })
+
+    {:ok, deployment} =
+      NervesHub.Deployments.update_deployment(deployment, %{
+        is_active: true
+      })
+
+    device_alpha =
+      Fixtures.device_fixture(org, product, firmware, %{
+        tags: ["alpha", "device"],
+        identifier: "123"
+      })
+
+    %{db_cert: alpha_certificate, cert: _cert} = Fixtures.device_certificate_fixture(device_alpha, X509.PrivateKey.new_ec(:secp256r1))
+    {:ok, socket_alpha} = connect(DeviceSocket, %{}, %{peer_data: %{ssl_cert: alpha_certificate.der}})
+
+    {:ok, %{update_available: false}, socket_alpha} =
+      subscribe_and_join(socket_alpha, DeviceChannel, "device")
+
+    socket_alpha = :sys.get_state(socket_alpha.channel_pid)
+    refute is_nil(socket_alpha.assigns.device.deployment_id)
+
+    {:ok, _deployment} =
+      NervesHub.Deployments.update_deployment(deployment, %{
+        conditions: %{"tags" => ["alpha", "device"]}
+      })
+
+    socket_alpha = :sys.get_state(socket_alpha.channel_pid)
+    refute is_nil(socket_alpha.assigns.device.deployment_id)
   end
 
   def device_fixture(user, device_params \\ %{}, org \\ nil) do


### PR DESCRIPTION
Check the incoming payload to see if it still matches the old deployment and set back to that deployment. If not, delay looking up for a spaced out amount of time to not cause a thundering herd of devices checking the database (they still will but it will be a little better)