### PR TITLE
Rename OTP app to :nerves_hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nerves_hub_www
+# NervesHub
 
 [![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_web.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_web)
 
@@ -7,7 +7,7 @@ server.
 
 **Important**
 
-This is the 2.0 development branch of NervesHubWeb. If you have been using
+This is the 2.0 development branch of NervesHub. If you have been using
 NervesHub prior to around April, 2023 and are not following 2.0 development, see
 the [`maint-v1.0`
 branch](https://github.com/nerves-hub/nerves_hub_web/tree/maint-v1.0). The

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,7 +28,7 @@ config :phoenix,
 #  ecto_repos: [NervesHub.Repo]
 
 # Configures the endpoint
-config :nerves_hub_www, NervesHubWeb.API.Endpoint,
+config :nerves_hub, NervesHubWeb.API.Endpoint,
   render_errors: [view: NervesHubWeb.API.ErrorView, accepts: ~w(json)],
   pubsub_server: NervesHub.PubSub
 
@@ -41,24 +41,24 @@ config :nerves_hub_www, NervesHubWeb.API.Endpoint,
 #   namespace: NervesHubDevice
 
 # Configures the endpoint
-config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
+config :nerves_hub, NervesHubWeb.DeviceEndpoint,
   render_errors: [view: NervesHubWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: NervesHub.PubSub
 
 ##
 # NervesHub
 #
-config :nerves_hub_www,
+config :nerves_hub,
   namespace: NervesHub,
   ecto_repos: [NervesHub.Repo],
   from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
 
-config :nerves_hub_www, NervesHub.PubSub,
+config :nerves_hub, NervesHub.PubSub,
   name: NervesHub.PubSub,
   adapter_name: Phoenix.PubSub.PG2,
   fastlane: Phoenix.Channel.Server
 
-config :nerves_hub_www, Oban,
+config :nerves_hub, Oban,
   repo: NervesHub.Repo,
   log: false,
   queues: [delete_firmware: 1, firmware_delta_builder: 2, truncate: 1],
@@ -73,43 +73,43 @@ config :spandex_phoenix, tracer: NervesHub.Tracer
 
 config :spandex, :decorators, tracer: NervesHub.Tracer
 
-config :nerves_hub_www,
+config :nerves_hub,
   datadog_host: System.get_env("DATADOG_HOST") || "localhost",
   datadog_port: System.get_env("DATADOG_PORT") || "8126",
   datadog_batch_size: System.get_env("SPANDEX_BATCH_SIZE") || "100",
   datadog_sync_threshold: System.get_env("SPANDEX_SYNC_THRESHOLD") || "100"
 
-config :nerves_hub_www, NervesHub.Repo,
+config :nerves_hub, NervesHub.Repo,
   queue_target: 500,
   queue_interval: 5_000
 
-config :nerves_hub_www,
+config :nerves_hub,
   statsd_host: System.get_env("STATSD_HOST", "localhost"),
   statsd_port: System.get_env("STATSD_PORT", "8125")
 
-config :nerves_hub_www, NervesHub.Tracer,
-  service: :nerves_hub_www,
+config :nerves_hub, NervesHub.Tracer,
+  service: :nerves_hub,
   adapter: SpandexDatadog.Adapter,
   disabled?: false,
   type: :web
 
 config :spandex_ecto, SpandexEcto.EctoLogger,
-  service: :nerves_hub_www,
+  service: :nerves_hub,
   tracer: NervesHub.Tracer,
-  otp_app: :nerves_hub_www
+  otp_app: :nerves_hub
 
 ##
 # NervesHubWWW
 #
-config :nerves_hub_www,
+config :nerves_hub,
   ecto_repos: [NervesHub.Repo],
   # Options are :ssl or :header
   websocket_auth_methods: [:ssl]
 
-config :nerves_hub_www, NervesHubWeb.Gettext, default_locale: "en"
+config :nerves_hub, NervesHubWeb.Gettext, default_locale: "en"
 
 # Configures the endpoint
-config :nerves_hub_www, NervesHubWeb.Endpoint,
+config :nerves_hub, NervesHubWeb.Endpoint,
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
   render_errors: [view: NervesHubWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: NervesHub.PubSub

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Start all of the applications
-config :nerves_hub_www, app: "all"
+config :nerves_hub, app: "all"
 
 ssl_dir =
   (System.get_env("NERVES_HUB_CA_DIR") || Path.join([__DIR__, "../test/fixtures/ssl/"]))
@@ -13,7 +13,7 @@ config :phoenix, :stacktrace_depth, 20
 ##
 # NervesHubAPI
 #
-config :nerves_hub_www, NervesHubWeb.API.Endpoint,
+config :nerves_hub, NervesHubWeb.API.Endpoint,
   http: [ip: {0, 0, 0, 0}, port: 4002],
   debug_errors: true,
   code_reloader: false,
@@ -24,7 +24,7 @@ config :nerves_hub_www, NervesHubWeb.API.Endpoint,
 ##
 # NervesHubDevice
 #
-config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
+config :nerves_hub, NervesHubWeb.DeviceEndpoint,
   debug_errors: true,
   code_reloader: false,
   check_origin: false,
@@ -32,7 +32,7 @@ config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
   https: [
     ip: {0, 0, 0, 0},
     port: 4001,
-    otp_app: :nerves_hub_www,
+    otp_app: :nerves_hub,
     # Enable client SSL
     # Older versions of OTP 25 may break using using devices
     # that support TLS 1.3 or 1.2 negotiation. To mitigate that
@@ -53,30 +53,30 @@ config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
 ##
 # NervesHub
 #
-config :nerves_hub_www, firmware_upload: NervesHub.Firmwares.Upload.File
+config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.File
 
-config :nerves_hub_www, NervesHub.Firmwares.Upload.File,
+config :nerves_hub, NervesHub.Firmwares.Upload.File,
   enabled: true,
   local_path: Path.expand("tmp/firmware"),
   public_path: "/firmware"
 
-# config :nerves_hub_www, NervesHub.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")
+# config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")
 
-config :nerves_hub_www, NervesHub.Repo, ssl: false
+config :nerves_hub, NervesHub.Repo, ssl: false
 
-config :nerves_hub_www, NervesHub.Mailer, adapter: Bamboo.LocalAdapter
+config :nerves_hub, NervesHub.Mailer, adapter: Bamboo.LocalAdapter
 
 ##
 # NervesHubWWW
 #
-config :nerves_hub_www, NervesHubWeb.Endpoint,
+config :nerves_hub, NervesHubWeb.Endpoint,
   http: [ip: {0, 0, 0, 0}, port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
   watchers: [npm: ["run", "watch", cd: Path.expand("../assets", __DIR__)]]
 
-config :nerves_hub_www, NervesHubWeb.Endpoint,
+config :nerves_hub, NervesHubWeb.Endpoint,
   live_reload: [
     patterns: [
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -8,7 +8,7 @@ config :phoenix, logger: false
 ##
 # NervesHub API
 #
-config :nerves_hub_www, NervesHubWeb.API.Endpoint,
+config :nerves_hub, NervesHubWeb.API.Endpoint,
   load_from_system_env: true,
   server: true,
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
@@ -16,29 +16,29 @@ config :nerves_hub_www, NervesHubWeb.API.Endpoint,
 ##
 # NervesHub Device
 #
-config :nerves_hub_www, NervesHubWeb.DeviceEndpoint, server: true
+config :nerves_hub, NervesHubWeb.DeviceEndpoint, server: true
 
 ##
 # NervesHub
 #
-config :nerves_hub_www,
+config :nerves_hub,
   enable_workers: true,
   firmware_upload: NervesHub.Firmwares.Upload.S3,
   host: "www.nerves-hub.org",
   port: 80
 
-config :nerves_hub_www, NervesHub.Mailer,
+config :nerves_hub, NervesHub.Mailer,
   adapter: Bamboo.SMTPAdapter,
   tls: :always,
   ssl: false,
   retries: 1
 
-config :nerves_hub_www, NervesHub.Repo, pool_size: 20
+config :nerves_hub, NervesHub.Repo, pool_size: 20
 
 ##
 # NervesHubWWW
 #
-config :nerves_hub_www, NervesHubWeb.Endpoint,
+config :nerves_hub, NervesHubWeb.Endpoint,
   load_from_system_env: true,
   server: true,
   force_ssl: [rewrite_on: [:x_forwarded_proto]]

--- a/config/release.exs
+++ b/config/release.exs
@@ -7,7 +7,7 @@ nerves_hub_app =
     other -> other
   end
 
-config :nerves_hub_www, app: nerves_hub_app
+config :nerves_hub, app: nerves_hub_app
 
 logger_level = System.get_env("LOG_LEVEL", "info") |> String.to_atom()
 
@@ -33,37 +33,37 @@ config :kernel,
   inet_dist_listen_min: 9100,
   inet_dist_listen_max: 9155
 
-config :nerves_hub_www, NervesHub.Firmwares.Upload.S3, bucket: System.fetch_env!("S3_BUCKET_NAME")
+config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: System.fetch_env!("S3_BUCKET_NAME")
 
 config :ex_aws, region: System.fetch_env!("AWS_REGION")
 
-config :nerves_hub_www, NervesHub.Mailer,
+config :nerves_hub, NervesHub.Mailer,
   adapter: Bamboo.SMTPAdapter,
   server: System.fetch_env!("SES_SERVER"),
   port: System.fetch_env!("SES_PORT"),
   username: System.fetch_env!("SMTP_USERNAME"),
   password: System.fetch_env!("SMTP_PASSWORD")
 
-config :nerves_hub_www,
+config :nerves_hub,
   host: host,
   port: port,
   from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
 
-config :nerves_hub_www, NervesHub.Tracer, env: System.get_env("DD_ENV") || "dev"
+config :nerves_hub, NervesHub.Tracer, env: System.get_env("DD_ENV") || "dev"
 
 if nerves_hub_app in ["all", "web"] do
-  config :nerves_hub_www, NervesHubWeb.Endpoint,
+  config :nerves_hub, NervesHubWeb.Endpoint,
     url: [host: host, port: port],
     secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
     live_view: [signing_salt: System.fetch_env!("LIVE_VIEW_SIGNING_SALT")]
 end
 
 if nerves_hub_app in ["all", "device"] do
-  config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
+  config :nerves_hub, NervesHubWeb.DeviceEndpoint,
     url: [host: host],
     https: [
       port: 443,
-      otp_app: :nerves_hub_www,
+      otp_app: :nerves_hub,
       # Enable client SSL
       # Older versions of OTP 25 may break using using devices
       # that support TLS 1.3 or 1.2 negotiation. To mitigate that
@@ -83,5 +83,5 @@ if nerves_hub_app in ["all", "device"] do
 end
 
 if nerves_hub_app in ["all", "api"] do
-  config :nerves_hub_www, NervesHubWeb.API.Endpoint, url: [host: host, port: port]
+  config :nerves_hub, NervesHubWeb.API.Endpoint, url: [host: host, port: port]
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Start all of the applications
-config :nerves_hub_www, app: "all"
+config :nerves_hub, app: "all"
 
 web_port = 5000
 
@@ -15,14 +15,14 @@ config :logger, level: :warn
 #
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
-config :nerves_hub_www, NervesHubWeb.API.Endpoint,
+config :nerves_hub, NervesHubWeb.API.Endpoint,
   http: [port: 4002],
   server: false
 
 ##
 # NervesHub Device
 #
-config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
+config :nerves_hub, NervesHubWeb.DeviceEndpoint,
   code_reloader: false,
   debug_errors: true,
   check_origin: false,
@@ -30,7 +30,7 @@ config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
   server: true,
   https: [
     port: 4101,
-    otp_app: :nerves_hub_www,
+    otp_app: :nerves_hub,
     # Enable client SSL
     verify: :verify_peer,
     verify_fun: {&NervesHubDevice.SSL.verify_fun/3, nil},
@@ -43,31 +43,31 @@ config :nerves_hub_www, NervesHubWeb.DeviceEndpoint,
 ##
 # NervesHub
 #
-config :nerves_hub_www,
+config :nerves_hub,
   firmware_upload: NervesHub.UploadMock,
   port: web_port
 
-config :nerves_hub_www,
+config :nerves_hub,
   delta_updater: NervesHub.DeltaUpdaterMock
 
-config :nerves_hub_www, NervesHub.Firmwares.Upload.S3, bucket: "mybucket"
+config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: "mybucket"
 
-config :nerves_hub_www, NervesHub.Firmwares.Upload.File,
+config :nerves_hub, NervesHub.Firmwares.Upload.File,
   local_path: System.tmp_dir(),
   public_path: "/firmware"
 
-config :nerves_hub_www, NervesHub.Repo,
+config :nerves_hub, NervesHub.Repo,
   ssl: false,
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :nerves_hub_www, NervesHub.Mailer, adapter: Bamboo.TestAdapter
+config :nerves_hub, NervesHub.Mailer, adapter: Bamboo.TestAdapter
 
-config :nerves_hub_www, Oban, queues: false, plugins: false
+config :nerves_hub, Oban, queues: false, plugins: false
 
 ##
 # NervesHubWWW
 #
-config :nerves_hub_www, NervesHubWeb.Endpoint,
+config :nerves_hub, NervesHubWeb.Endpoint,
   http: [port: web_port],
   server: false,
   secret_key_base: "x7Vj9rmmRke//ctlapsPNGHXCRTnArTPbfsv6qX4PChFT9ARiNR5Ua8zoRilNCmX",

--- a/lib/nerves_hub/accounts/email.ex
+++ b/lib/nerves_hub/accounts/email.ex
@@ -87,7 +87,7 @@ defmodule NervesHub.Accounts.Email do
   end
 
   defp from_address do
-    email = Application.fetch_env!(:nerves_hub_www, :from_email)
+    email = Application.fetch_env!(:nerves_hub, :from_email)
     {"NervesHub", email}
   end
 end

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -27,7 +27,7 @@ defmodule NervesHub.Application do
   end
 
   defp endpoints() do
-    case Application.get_env(:nerves_hub_www, :app) do
+    case Application.get_env(:nerves_hub, :app) do
       "all" ->
         [
           NervesHubWeb.API.Endpoint,

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -17,7 +17,7 @@ defmodule NervesHub.Firmwares do
 
   @type upload_file_2 :: (filepath :: String.t(), filename :: String.t() -> :ok | {:error, any()})
 
-  @uploader Application.compile_env!(:nerves_hub_www, :firmware_upload)
+  @uploader Application.compile_env!(:nerves_hub, :firmware_upload)
 
   @spec get_firmwares_by_product(integer()) :: [Firmware.t()]
   def get_firmwares_by_product(product_id) do
@@ -528,7 +528,7 @@ defmodule NervesHub.Firmwares do
 
   defp delta_updater() do
     Application.get_env(
-      :nerves_hub_www,
+      :nerves_hub,
       :delta_updater,
       NervesHub.Firmwares.DeltaUpdater.Default
     )

--- a/lib/nerves_hub/firmwares/upload/file.ex
+++ b/lib/nerves_hub/firmwares/upload/file.ex
@@ -36,7 +36,7 @@ defmodule NervesHub.Firmwares.Upload.File do
     vapor_config = Vapor.load!(NervesHub.Config)
     web_config = vapor_config.web_endpoint
 
-    config = Application.get_env(:nerves_hub_www, __MODULE__)
+    config = Application.get_env(:nerves_hub, __MODULE__)
     common_path = "#{org_id}"
     local_path = Path.join([config[:local_path], common_path, filename])
     port = if Enum.member?([443, 80], web_config.url_port), do: "", else: ":#{web_config.url_port}"

--- a/lib/nerves_hub/firmwares/upload/s3.ex
+++ b/lib/nerves_hub/firmwares/upload/s3.ex
@@ -54,7 +54,7 @@ defmodule NervesHub.Firmwares.Upload.S3 do
   end
 
   def bucket do
-    Application.get_env(:nerves_hub_www, __MODULE__)[:bucket]
+    Application.get_env(:nerves_hub, __MODULE__)[:bucket]
   end
 
   def key_prefix() do

--- a/lib/nerves_hub/mailer.ex
+++ b/lib/nerves_hub/mailer.ex
@@ -1,3 +1,3 @@
 defmodule NervesHub.Mailer do
-  use Bamboo.Mailer, otp_app: :nerves_hub_www
+  use Bamboo.Mailer, otp_app: :nerves_hub
 end

--- a/lib/nerves_hub/release/tasks.ex
+++ b/lib/nerves_hub/release/tasks.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Release.Tasks do
   alias Ecto.Migrator
 
-  @otp_app :nerves_hub_www
+  @otp_app :nerves_hub
   @start_apps [:logger, :ssl, :postgrex, :ecto_sql]
 
   def migrate_and_seed do

--- a/lib/nerves_hub/repo.ex
+++ b/lib/nerves_hub/repo.ex
@@ -1,6 +1,6 @@
 defmodule NervesHub.Repo do
   use Ecto.Repo,
-    otp_app: :nerves_hub_www,
+    otp_app: :nerves_hub,
     adapter: Ecto.Adapters.Postgres
 
   use Scrivener

--- a/lib/nerves_hub/stats.ex
+++ b/lib/nerves_hub/stats.ex
@@ -12,8 +12,8 @@ defmodule NervesHub.Stats do
 
   def init(_opts) do
     Process.flag(:trap_exit, true)
-    host = Application.get_env(:nerves_hub_www, :statsd_host, nil)
-    port = Application.get_env(:nerves_hub_www, :statsd_port, nil)
+    host = Application.get_env(:nerves_hub, :statsd_host, nil)
+    port = Application.get_env(:nerves_hub, :statsd_port, nil)
 
     if host && port do
       :ok = ServerStatix.connect()
@@ -107,12 +107,12 @@ defmodule NervesHub.Stats do
   end
 
   def options(additional_tags) do
-    env = Application.get_env(:nerves_hub_www, :env)
+    env = Application.get_env(:nerves_hub, :env)
 
     base_options = [
       tags: [
         "env:#{env}",
-        "service:nerves_hub_www",
+        "service:nerves_hub",
         "dyno:#{dyno_type()}"
       ]
     ]
@@ -124,19 +124,19 @@ defmodule NervesHub.Stats do
   @doc """
   Format additional tags from other applications together with our base tags in a way that will cause Statix to not error
   ## Examples
-      iex> base_options = [prefix: "nerves_hub_www.", tags: ["env:dev", "service:nerves_hub_www"]]
+      iex> base_options = [prefix: "nerves_hub_www.", tags: ["env:dev", "service:nerves_hub"]]
       iex> additional = [{:sample_rate, 1.0}, tags: ["http_status:200", "http_host:smarthome-cahatlas-qa.herokuapp.com", "http_status_family:2xx"]]
       iex> NervesHub.Stats.handle_additional_tags(additional, base_options)
       [
         tags: ["http_status:200", "http_host:smarthome-cahatlas-qa.herokuapp.com",
-        "http_status_family:2xx", "env:dev", "service:nerves_hub_www"],
+        "http_status_family:2xx", "env:dev", "service:nerves_hub"],
         sample_rate: 1.0,
         prefix: "nerves_hub_www."
       ]
-      iex> base_options = [prefix: "nerves_hub_www.", tags: ["env:dev", "service:nerves_hub_www"]]
+      iex> base_options = [prefix: "nerves_hub_www.", tags: ["env:dev", "service:nerves_hub"]]
       iex> additional = []
       iex> NervesHub.Stats.handle_additional_tags(additional, base_options)
-      [prefix: "nerves_hub_www.", tags: ["env:dev", "service:nerves_hub_www"]]
+      [prefix: "nerves_hub_www.", tags: ["env:dev", "service:nerves_hub"]]
   """
   def handle_additional_tags(additional_tags, base_options) do
     Enum.reduce(additional_tags, base_options, fn x, acc ->
@@ -156,7 +156,7 @@ defmodule NervesHub.Stats do
   end
 
   defp dyno_type do
-    Application.get_env(:nerves_hub_www, :dyno, "web")
+    Application.get_env(:nerves_hub, :dyno, "web")
   end
 end
 

--- a/lib/nerves_hub/supervisor.ex
+++ b/lib/nerves_hub/supervisor.ex
@@ -8,7 +8,7 @@ defmodule NervesHub.Supervisor do
   end
 
   def init(:undefined) do
-    pubsub_config = Application.get_env(:nerves_hub_www, NervesHub.PubSub)
+    pubsub_config = Application.get_env(:nerves_hub, NervesHub.PubSub)
 
     children = [
       datadog_children(),
@@ -21,7 +21,7 @@ defmodule NervesHub.Supervisor do
 
     :telemetry.attach(
       "spandex-query-tracer",
-      [:nerves_hub_www, :repo, :query],
+      [:nerves_hub, :repo, :query],
       &SpandexEcto.TelemetryAdapter.handle_event/4,
       nil
     )
@@ -41,15 +41,15 @@ defmodule NervesHub.Supervisor do
   end
 
   defp configure_oban() do
-    Application.get_env(:nerves_hub_www, Oban, [])
+    Application.get_env(:nerves_hub, Oban, [])
   end
 
   defp datadog_children() do
     opts = [
-      host: Application.get_env(:nerves_hub_www, :datadog_host, "localhost"),
-      port: to_integer(Application.get_env(:nerves_hub_www, :datadog_port)),
-      batch_size: to_integer(Application.get_env(:nerves_hub_www, :datadog_batch_size)),
-      sync_threshold: to_integer(Application.get_env(:nerves_hub_www, :datadog_sync_threshold)),
+      host: Application.get_env(:nerves_hub, :datadog_host, "localhost"),
+      port: to_integer(Application.get_env(:nerves_hub, :datadog_port)),
+      batch_size: to_integer(Application.get_env(:nerves_hub, :datadog_batch_size)),
+      sync_threshold: to_integer(Application.get_env(:nerves_hub, :datadog_sync_threshold)),
       http: HTTPoison
     ]
 

--- a/lib/nerves_hub/tracer.ex
+++ b/lib/nerves_hub/tracer.ex
@@ -1,5 +1,5 @@
 defmodule NervesHub.Tracer do
-  use Spandex.Tracer, otp_app: :nerves_hub_www
+  use Spandex.Tracer, otp_app: :nerves_hub
 
   defoverridable start_span: 1, start_span: 2
 

--- a/lib/nerves_hub/workers/delete_firmware.ex
+++ b/lib/nerves_hub/workers/delete_firmware.ex
@@ -3,7 +3,7 @@ defmodule NervesHub.Workers.DeleteFirmware do
     max_attempts: 5,
     queue: :delete_firmware
 
-  @uploader Application.compile_env!(:nerves_hub_www, :firmware_upload)
+  @uploader Application.compile_env!(:nerves_hub, :firmware_upload)
 
   @impl true
   def perform(%Oban.Job{args: args}), do: @uploader.delete_file(args)

--- a/lib/nerves_hub_web/api_endpoint.ex
+++ b/lib/nerves_hub_web/api_endpoint.ex
@@ -1,5 +1,5 @@
 defmodule NervesHubWeb.API.Endpoint do
-  use Phoenix.Endpoint, otp_app: :nerves_hub_www
+  use Phoenix.Endpoint, otp_app: :nerves_hub
   use SpandexPhoenix
 
   alias NervesHub.Config
@@ -11,7 +11,7 @@ defmodule NervesHubWeb.API.Endpoint do
   plug(
     Plug.Static,
     at: "/",
-    from: :nerves_hub_www,
+    from: :nerves_hub,
     gzip: false,
     only: ~w(css fonts images js favicon.ico robots.txt)
   )

--- a/lib/nerves_hub_web/controllers/firmware_controller.ex
+++ b/lib/nerves_hub_web/controllers/firmware_controller.ex
@@ -76,7 +76,7 @@ defmodule NervesHubWeb.FirmwareController do
 
   def download(%{assigns: %{product: product}} = conn, %{"firmware_uuid" => uuid}) do
     with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid) do
-      if uploader = Application.get_env(:nerves_hub_www, :firmware_upload) do
+      if uploader = Application.get_env(:nerves_hub, :firmware_upload) do
         uploader.download_file(firmware)
         |> case do
           {:ok, url} ->

--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -1,5 +1,5 @@
 defmodule NervesHubWeb.DeviceEndpoint do
-  use Phoenix.Endpoint, otp_app: :nerves_hub_www
+  use Phoenix.Endpoint, otp_app: :nerves_hub
   use SpandexPhoenix
 
   socket(

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -1,5 +1,5 @@
 defmodule NervesHubWeb.Endpoint do
-  use Phoenix.Endpoint, otp_app: :nerves_hub_www
+  use Phoenix.Endpoint, otp_app: :nerves_hub
   use SpandexPhoenix
 
   alias NervesHub.Config
@@ -23,13 +23,13 @@ defmodule NervesHubWeb.Endpoint do
   plug(
     Plug.Static,
     at: "/",
-    from: :nerves_hub_www,
+    from: :nerves_hub,
     gzip: false,
     only: ~w(css fonts images js favicon.ico robots.txt)
   )
 
   file_upload_config =
-    Application.compile_env(:nerves_hub_www, NervesHub.Firmwares.Upload.File, [])
+    Application.compile_env(:nerves_hub, NervesHub.Firmwares.Upload.File, [])
 
   if Keyword.get(file_upload_config, :enabled, false) do
     plug(

--- a/lib/nerves_hub_web/gettext.ex
+++ b/lib/nerves_hub_web/gettext.ex
@@ -20,5 +20,5 @@ defmodule NervesHubWeb.Gettext do
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """
-  use Gettext, otp_app: :nerves_hub_www
+  use Gettext, otp_app: :nerves_hub
 end

--- a/lib/nerves_hub_web/plugs/set_locale.ex
+++ b/lib/nerves_hub_web/plugs/set_locale.ex
@@ -11,7 +11,7 @@ defmodule NervesHubWeb.Plugs.SetLocale do
         conn
         |> put_resp_header(
           "content-language",
-          Application.get_env(:nerves_hub_www, NervesHubWeb.Gettext)[:default_locale]
+          Application.get_env(:nerves_hub, NervesHubWeb.Gettext)[:default_locale]
         )
 
       locale ->

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule NervesHubUmbrella.MixProject do
 
   def project do
     [
-      app: :nerves_hub_www,
+      app: :nerves_hub,
       version: "0.1.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -25,7 +25,7 @@ defmodule NervesHubUmbrella.MixProject do
           runtime_config_path: "config/release.exs",
           reboot_system_after_config: true,
           applications: [
-            nerves_hub_www: :permanent
+            nerves_hub: :permanent
           ]
         ]
       ]

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -9,7 +9,7 @@ defmodule NervesHubWeb.WebsocketTest do
   @valid_serial "device-1234"
   @valid_product "test-product"
 
-  @device_port Application.compile_env(:nerves_hub_www, DeviceEndpoint) |> get_in([:https, :port])
+  @device_port Application.compile_env(:nerves_hub, DeviceEndpoint) |> get_in([:https, :port])
 
   @bad_socket_config [
     uri: "wss://127.0.0.1:#{@device_port}/socket/websocket",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -20,7 +20,7 @@ defmodule NervesHub.Fixtures do
 
   def compiler_options(_, _), do: Code.compiler_options(ignore_module_conflict: false)
 
-  @uploader Application.compile_env(:nerves_hub_www, :firmware_upload)
+  @uploader Application.compile_env(:nerves_hub, :firmware_upload)
 
   @org_params %{name: "Test-Org"}
 


### PR DESCRIPTION
:nerves_hub_www went "deprecated" when we dropped the umbrella and this makes more sense to go with.