### PR TITLE
Add a reconnect button to device page

### DIFF
--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -20,6 +20,10 @@ defmodule NervesHubWeb.ConsoleChannel do
     {:shutdown, :closed}
   end
 
+  def handle_in("reconnect", _payload, socket) do
+    {:stop, :shutdown, socket}
+  end
+
   def handle_in("init_attempt", %{"success" => success?} = payload, socket) do
     unless success? do
       socket.endpoint.broadcast_from(self(), console_topic(socket), "init_failure", payload)

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -120,6 +120,10 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
+  def handle_in("reconnect", _payload, socket) do
+    {:stop, :shutdown, socket}
+  end
+
   def handle_in("connection_types", %{"value" => types}, socket) do
     {:ok, device} = Devices.update_device(socket.assigns.device, %{"connection_types" => types})
     {:noreply, assign(socket, :device, device)}

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -132,6 +132,11 @@ defmodule NervesHubWeb.DeviceLive.Show do
     end
   end
 
+  def handle_event("reconnect", _value, %{assigns: %{device: device, user: user}} = socket) do
+    socket.endpoint.broadcast_from(self(), "device:#{socket.assigns.device.id}", "reconnect", %{})
+    {:noreply, socket}
+  end
+
   def handle_event("identify", _value, socket) do
     socket.endpoint.broadcast_from(self(), "device:#{socket.assigns.device.id}", "identify", %{})
     {:noreply, socket}

--- a/lib/nerves_hub_web/templates/device/show.html.heex
+++ b/lib/nerves_hub_web/templates/device/show.html.heex
@@ -30,6 +30,10 @@
         <span class="button-icon power"></span>
         <span class="action-text">Reboot</span>
       </button>
+      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect" {if @device.status == "offline", do: [disabled: true], else: []}>
+        <span class="button-icon power"></span>
+        <span class="action-text">Reconnect</span>
+      </button>
       <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify" {if @device.status == "offline", do: [disabled: true], else: []}>
         <span class="button-icon identify"></span>
         <span class="action-text">Identify</span>


### PR DESCRIPTION
Force a NervesHub reconnect by using a button on the device page. This won't reboot the device, just force a `NervesHubLink.reconnect/0`