### PR TITLE
Device index endpoint can filter and paginate

### DIFF
--- a/lib/nerves_hub_web/views/api/device_view.ex
+++ b/lib/nerves_hub_web/views/api/device_view.ex
@@ -8,8 +8,11 @@ defmodule NervesHubWeb.API.DeviceView do
 
   defdelegate device_status(device), to: Presence
 
-  def render("index.json", %{devices: devices}) do
-    %{data: render_many(devices, DeviceView, "device.json")}
+  def render("index.json", %{devices: devices, pagination: pagination}) do
+    %{
+      data: render_many(devices, DeviceView, "device.json"),
+      pagination: pagination
+    }
   end
 
   def render("show.json", %{device: device}) do


### PR DESCRIPTION
Don't return all results in this endpoint, and allow for filtering to limit the results to a certain set of tags / platforms / arch / etc