### PR TITLE
Track inflight updates for devices based on a deployment

### DIFF
--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -5,6 +5,7 @@ defmodule NervesHub.Deployments.Deployment do
   import Ecto.Query
 
   alias NervesHub.Accounts.Org
+  alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Firmwares.Firmware
   alias NervesHub.Products.Product
   alias NervesHub.Repo
@@ -29,6 +30,8 @@ defmodule NervesHub.Deployments.Deployment do
     belongs_to(:firmware, Firmware)
     belongs_to(:product, Product, where: [deleted_at: nil])
     belongs_to(:org, Org, where: [deleted_at: nil])
+
+    has_many(:inflight_updates, InflightUpdate)
 
     field(:conditions, :map)
     field(:device_failure_threshold, :integer, default: 3)

--- a/lib/nerves_hub/devices/inflight_update.ex
+++ b/lib/nerves_hub/devices/inflight_update.ex
@@ -1,0 +1,18 @@
+defmodule NervesHub.Devices.InflightUpdate do
+  use Ecto.Schema
+
+  alias NervesHub.Devices.Device
+  alias NervesHub.Deployments.Deployment
+  alias NervesHub.Firmwares.Firmware
+
+  schema "inflight_updates" do
+    belongs_to(:device, Device)
+    belongs_to(:deployment, Deployment)
+    belongs_to(:firmware, Firmware)
+
+    field(:firmware_uuid, Ecto.UUID)
+    field(:status, :string, default: "pending")
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.DeploymentController do
   alias NervesHub.Firmwares
   alias NervesHub.Deployments
   alias NervesHub.Deployments.Deployment
+  alias NervesHub.Devices
   alias Ecto.Changeset
 
   plug(:validate_role, [product: :delete] when action in [:delete])
@@ -131,8 +132,11 @@ defmodule NervesHubWeb.DeploymentController do
       |> Map.put(:links, true)
       |> Map.put(:anchor, "latest-activity")
 
+    inflight_updates = Devices.inflight_updates_for(deployment)
+
     conn
     |> assign(:audit_logs, logs)
+    |> assign(:inflight_updates, inflight_updates)
     |> assign(:firmware, deployment.firmware)
     |> render("show.html")
   end

--- a/lib/nerves_hub_web/templates/deployment/show.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/show.html.heex
@@ -121,6 +121,24 @@
 </div>
 
 <div>
+  <h3 id="inflight-updates" class="mb-2">Inflight Updates</h3>
+
+  <div class="display-box">
+    <%= if Enum.empty?(@inflight_updates) do %>
+      No inflight updates
+    <% end %>
+
+    <div>
+      <%= for inflight_update <- @inflight_updates do %>
+        <span class="ff-m badge">
+          <%= link(inflight_update.device.identifier, to: Routes.device_path(@conn, :show, @org.name, @product.name, inflight_update.device.identifier)) %>
+        </span>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div>
   <h3 id="latest-activity" class="mb-2">Latest Activity</h3>
 
   <%= render(NervesHubWeb.AuditLogView, "_audit_log_feed.html", assigns) %>

--- a/priv/repo/migrations/20230512142158_create_inflight_updates.exs
+++ b/priv/repo/migrations/20230512142158_create_inflight_updates.exs
@@ -1,0 +1,18 @@
+defmodule NervesHub.Repo.Migrations.CreateInflightUpdates do
+  use Ecto.Migration
+
+  def change do
+    create table(:inflight_updates) do
+      add(:device_id, references(:devices), null: false)
+      add(:deployment_id, references(:deployments), null: false)
+      add(:firmware_id, references(:firmwares), null: false)
+
+      add(:firmware_uuid, :uuid, null: false)
+      add(:status, :string, default: "pending", null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    create index(:inflight_updates, [:device_id, :deployment_id], unique: true)
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -564,6 +564,16 @@ defmodule NervesHub.DevicesTest do
       assert Enum.count(device.update_attempts) == 0
     end
 
+    test "clears an inflight update if it matches", %{device: device, deployment: deployment} do
+      deployment = Repo.preload(deployment, [:firmware])
+      {:ok, inflight_update} = Devices.told_to_update(device, deployment)
+
+      {:ok, _device} = Devices.firmware_update_successful(device)
+
+      inflight_update = Repo.reload(inflight_update)
+      assert is_nil(inflight_update)
+    end
+
     test "device updates successfully", %{device: device, deployment: deployment} do
       deployment = Repo.preload(deployment, [:firmware])
 

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -1,8 +1,13 @@
 defmodule NervesHubWeb.WebsocketTest do
-  use ExUnit.Case
   use NervesHubWeb.ChannelCase
+
   alias NervesHub.Fixtures
-  alias NervesHub.{Accounts, Deployments, Devices, Devices.Device, Repo}
+  alias NervesHub.Accounts
+  alias NervesHub.Deployments
+  alias NervesHub.Deployments.Orchestrator
+  alias NervesHub.Devices
+  alias NervesHub.Devices.Device
+  alias NervesHub.Repo
   alias NervesHubDevice.Presence
   alias NervesHubWeb.DeviceEndpoint
 
@@ -385,14 +390,7 @@ defmodule NervesHubWeb.WebsocketTest do
         })
 
       # This is what the orchestrator process will do
-      device_pids =
-        Registry.select(NervesHub.Devices, [
-          {{:_, :_, %{deployment_id: deployment.id}}, [], [{:element, 1, {:element, 2, :"$_"}}]}
-        ])
-
-      Enum.each(device_pids, fn pid ->
-        send(pid, "deployments/update")
-      end)
+      Orchestrator.send_update(deployment)
 
       message = SocketClient.wait_update(socket)
 


### PR DESCRIPTION
When a deployment tells the device to update, track its progress and display on the deployment page.

This is not paginated because the next step of rolling deployments is to limit the amount of inflight updates at any given time.

There is a potential issue of getting stuck while updating and not being able to create a new inflight update because one exists for a deployment already. Right now it just logs that there was a problem. We could make a clear all progress button on the deployment, a little "X" for each identifier to clear just that one, or do the same on the device page. I'm not sure which one is better or if there's a better way.

![image](https://github.com/nerves-hub/nerves_hub_web/assets/449228/3cd60c03-0a37-4596-a25b-02989fb6a1d0)
