### PR TITLE
Rolling Device Updates

### DIFF
--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -13,7 +13,17 @@ defmodule NervesHub.Deployments.Deployment do
   alias __MODULE__
 
   @type t :: %__MODULE__{}
-  @required_fields [:org_id, :firmware_id, :name, :conditions, :is_active, :product_id]
+
+  @required_fields [
+    :org_id,
+    :firmware_id,
+    :name,
+    :conditions,
+    :is_active,
+    :product_id,
+    :concurrent_updates
+  ]
+
   @optional_fields [
     :device_failure_threshold,
     :device_failure_rate_seconds,
@@ -45,6 +55,7 @@ defmodule NervesHub.Deployments.Deployment do
     field(:healthy, :boolean, default: true)
     field(:penalty_timeout_minutes, :integer, default: 1440)
     field(:connecting_code, :string)
+    field(:concurrent_updates, :integer, default: 10)
 
     timestamps()
   end
@@ -91,11 +102,8 @@ defmodule NervesHub.Deployments.Deployment do
   end
 
   def changeset(%Deployment{} = deployment, params) do
-    # set product_id by getting it from firmware
-    with_product_id = handle_product_id(deployment, params)
-
     deployment
-    |> cast(with_product_id, @required_fields ++ @optional_fields)
+    |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> unique_constraint(:name, name: :deployments_product_id_name_index)
     |> validate_conditions()

--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -75,13 +75,15 @@ defmodule NervesHub.Deployments.Orchestrator do
           {:ok, inflight_update} ->
             send(pid, {"deployments/update", inflight_update})
 
+            # Only continue to loop if we were able to update otherwise
+            # this will continue to trigger the same device over and over
+            send(self(), :trigger)
+
           :error ->
             Logger.error(
               "An inflight update could not be created or found for the device #{device.identifier} (#{device.id})"
             )
         end
-
-        send(self(), :trigger)
       end
     end
   end

--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -67,6 +67,8 @@ defmodule NervesHub.Deployments.Orchestrator do
 
     # Get a rough count of devices to update
     count = deployment.concurrent_updates - Devices.count_inflight_updates_for(deployment)
+    # Just in case inflight goes higher than concurrent, limit it to 0
+    count = Enum.max([count, 0])
 
     devices
     |> Enum.take(count)

--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -28,18 +28,46 @@ defmodule NervesHub.Deployments.Orchestrator do
 
   def name(deployment), do: name(deployment.id)
 
+  def device_updated(deployment_id) do
+    GenServer.cast(name(deployment_id), :trigger)
+  end
+
   @doc """
-  Send updates to connected devices for this deployment
+  Trigger an update for a device on the local node
+
+  Finds a device matching:
+
+  - the deployment
+  - not updating
+  - not using the deployment's current firmware
+
+  If there is space for the device based on the concurrent allowed updates
+  the device is told to update. This is not guaranteed to be at or under the
+  concurrent limit, it's a best effort.
+
+  As devices update and reconnect, the new orchestrator is told that the update
+  was successful, and the process is repeated.
   """
-  def send_update(deployment) do
-    match_return = %{device_id: {:element, 1, :"$_"}, pid: {:element, 1, {:element, 2, :"$_"}}}
+  def trigger_update(deployment) do
+    match_return = %{
+      device_id: {:element, 1, :"$_"},
+      pid: {:element, 1, {:element, 2, :"$_"}},
+      firmware_uuid: {:map_get, :firmware_uuid, {:element, 2, {:element, 2, :"$_"}}}
+    }
 
     devices =
       Registry.select(NervesHub.Devices, [
-        {{:_, :_, %{deployment_id: deployment.id}}, [], [match_return]}
+        {{:_, :_, %{deployment_id: deployment.id, updating: false}}, [], [match_return]}
       ])
 
-    Enum.each(devices, fn %{device_id: device_id, pid: pid} ->
+    device =
+      Enum.find(devices, fn device ->
+        device.firmware_uuid != deployment.firmware.uuid
+      end)
+
+    if device && Devices.count_inflight_updates_for(deployment) < deployment.concurrent_updates do
+      %{device_id: device_id, pid: pid} = device
+
       device = %Device{id: device_id}
 
       case Devices.told_to_update(device, deployment) do
@@ -49,7 +77,9 @@ defmodule NervesHub.Deployments.Orchestrator do
         {:error, _changeset} ->
           Logger.error("Could not update device #{device_id}")
       end
-    end)
+
+      send(self(), :trigger)
+    end
   end
 
   def init(deployment) do
@@ -59,6 +89,19 @@ defmodule NervesHub.Deployments.Orchestrator do
   def handle_continue(:boot, deployment) do
     PubSub.subscribe(NervesHub.PubSub, "deployment:#{deployment.id}")
 
+    # trigger every 5 minutes as a back up
+    :timer.send_interval(5 * 60 * 1000, :trigger)
+
+    deployment =
+      deployment
+      |> Repo.reload()
+      |> Repo.preload([:firmware], force: true)
+
+    {:noreply, deployment}
+  end
+
+  def handle_cast(:trigger, deployment) do
+    trigger_update(deployment)
     {:noreply, deployment}
   end
 
@@ -66,13 +109,18 @@ defmodule NervesHub.Deployments.Orchestrator do
     deployment =
       deployment
       |> Repo.reload()
-      |> Repo.preload([:firmware])
+      |> Repo.preload([:firmware], force: true)
 
-    send_update(deployment)
+    trigger_update(deployment)
 
     {:noreply, deployment}
   end
 
   # Catch all for unknown broadcasts on a deployment
   def handle_info(%Broadcast{topic: "deployment:" <> _}, deployment), do: {:noreply, deployment}
+
+  def handle_info(:trigger, deployment) do
+    trigger_update(deployment)
+    {:noreply, deployment}
+  end
 end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -10,6 +10,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.Certificate
   alias NervesHub.Deployments
   alias NervesHub.Deployments.Deployment
+  alias NervesHub.Deployments.Orchestrator
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
@@ -714,6 +715,7 @@ defmodule NervesHub.Devices do
       )
 
     if inflight_update != nil do
+      Orchestrator.device_updated(inflight_update.deployment_id)
       Repo.delete(inflight_update)
     end
 
@@ -988,5 +990,12 @@ defmodule NervesHub.Devices do
     |> where([iu], iu.deployment_id == ^deployment.id)
     |> preload([:device])
     |> Repo.all()
+  end
+
+  def count_inflight_updates_for(%Deployment{} = deployment) do
+    InflightUpdate
+    |> select([iu], count(iu))
+    |> where([iu], iu.deployment_id == ^deployment.id)
+    |> Repo.one()
   end
 end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -993,6 +993,12 @@ defmodule NervesHub.Devices do
     end
   end
 
+  def clear_inflight_update(device) do
+    InflightUpdate
+    |> where([iu], iu.device_id == ^device.id)
+    |> Repo.delete_all()
+  end
+
   def update_started!(inflight_update) do
     inflight_update
     |> Ecto.Changeset.change()

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -138,6 +138,9 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   def handle_info({:after_join, device, update_available}, socket) do
+    # clear out any inflight updates, there shouldn't be one at this point
+    Devices.clear_inflight_update(device)
+
     # local node tracking
     Registry.register(NervesHub.Devices, device.id, %{
       deployment_id: device.deployment_id,

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -156,29 +156,10 @@ defmodule NervesHubWeb.DeploymentController do
     )
   end
 
-  def update(
-        %{assigns: %{org: org, product: product, user: user, deployment: deployment}} = conn,
-        %{"deployment" => deployment_params}
-      ) do
-    allowed_fields = [
-      :conditions,
-      :device_failure_rate_amount,
-      :device_failure_rate_seconds,
-      :device_failure_threshold,
-      :failure_rate_amount,
-      :failure_rate_seconds,
-      :failure_threshold,
-      :firmware_id,
-      :name,
-      :is_active,
-      :penalty_timeout_minutes,
-      :connecting_code
-    ]
+  def update(conn, %{"deployment" => params}) do
+    %{org: org, product: product, user: user, deployment: deployment} = conn.assigns
 
-    params =
-      deployment_params
-      |> inject_conditions_map()
-      |> whitelist(allowed_fields)
+    params = inject_conditions_map(params)
 
     case Deployments.update_deployment(deployment, params) do
       {:ok, updated} ->
@@ -206,14 +187,12 @@ defmodule NervesHubWeb.DeploymentController do
         )
 
       {:error, changeset} ->
-        render(
-          conn,
-          "edit.html",
-          deployment: deployment,
-          firmware: deployment.firmware,
-          firmwares: Firmwares.get_firmwares_by_product(product.id),
-          changeset: changeset |> tags_to_string()
-        )
+        conn
+        |> assign(:deployment, deployment)
+        |> assign(:firmware, deployment.firmware)
+        |> assign(:firmwares, Firmwares.get_firmwares_by_product(product.id))
+        |> assign(:changeset, tags_to_string(changeset))
+        |> render("edit.html")
     end
   end
 

--- a/lib/nerves_hub_web/templates/deployment/edit.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/edit.html.heex
@@ -88,6 +88,18 @@
     <div class="has-error"><%= error_tag f, :version %></div>
   </div>
 
+  <h3 class="mb-2">Rolling Updates</h3>
+
+  <div class="form-group">
+    <label for="version_requirement" class="tooltip-label">
+      <span>Concurrent Device Updates</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">The number of devices that will update at any given time. This is a soft limit and concurrent updates may be slightly above this number.</span>
+    </label>
+    <%= number_input f, :concurrent_updates, class: "form-control", id: "concurrent_updates" %>
+    <div class="has-error"><%= error_tag f, :version %></div>
+  </div>
+
   <!-- Advanced Options -->
   <button class="btn btn-outline-light mb-4" type="button" data-toggle="collapse" data-target="#advancedOptionsToggle" aria-expanded="false" aria-controls="advancedOptionsToggle">
     Show Advanced Options

--- a/lib/nerves_hub_web/templates/deployment/show.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/show.html.heex
@@ -59,8 +59,16 @@
           <div class="help-text mb-1">Version requirement</div>
           <p><%= version(@deployment) %></p>
         </div>
+        <div class="mb-1">
+          <div class="help-text mb-1 tooltip-label">
+            <span>Concurrent Device Updates</span>
+            <span class="tooltip-info"></span>
+            <span class="tooltip-text">The number of devices that will update at any given time. This is a soft limit and concurrent updates may be slightly above this number.</span>
+          </div>
+          <p><%= @deployment.concurrent_updates %></p>
+        </div>
         <div class="row">
-          <div class="col-lg-6">
+          <div class="col-lg-6 mb-1">
             <div>
               <div class="help-text mb-1 tooltip-label help-tooltip">
                 <span>Failure Rate</span>
@@ -70,7 +78,7 @@
               <p><%= @deployment.failure_rate_amount %> devices per <%= @deployment.failure_rate_seconds %> seconds</p>
             </div>
           </div>
-          <div class="col-lg-6">
+          <div class="col-lg-6 mb-1">
             <div>
               <div class="help-text mb-1 tooltip-label help-tooltip">
                 <span>Failure Threshold</span>
@@ -82,7 +90,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-lg-6">
+          <div class="col-lg-6 mb-1">
             <div>
               <div class="help-text mb-1 tooltip-label help-tooltip">
                 <span>Device Failure Rate</span>
@@ -92,7 +100,7 @@
               <p><%= @deployment.device_failure_rate_amount %> failures per <%= @deployment.device_failure_rate_seconds %> seconds</p>
             </div>
           </div>
-          <div class="col-lg-6">
+          <div class="col-lg-6 mb-1">
             <div>
               <div class="help-text mb-1 tooltip-label help-tooltip">
                 <span>Device Failure Threshold</span>
@@ -104,7 +112,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-lg-6">
+          <div class="col-lg-6 mb-1">
             <div>
               <div class="help-text mb-1 tooltip-label help-tooltip">
                 <span>Device Penalty Box Timeout</span>
@@ -114,6 +122,14 @@
               <p><%= @deployment.penalty_timeout_minutes %> minutes</p>
             </div>
           </div>
+        </div>
+        <div>
+          <div class="help-text mb-1">Code sent on Device Connect</div>
+          <%= if @deployment.connecting_code do %>
+            <pre><code><%= @deployment.connecting_code %></code></pre>
+          <% else %>
+            <p>-</p>
+          <% end %>
         </div>
       </div>
     </div>

--- a/priv/repo/migrations/20230515201055_add_rolling_update_fields_to_deployments.exs
+++ b/priv/repo/migrations/20230515201055_add_rolling_update_fields_to_deployments.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddRollingUpdateFieldsToDeployments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add(:concurrent_updates, :integer, default: 10, null: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20230523153509_add_index_to_deployment_id_for_inflight_updates.exs
+++ b/priv/repo/migrations/20230523153509_add_index_to_deployment_id_for_inflight_updates.exs
@@ -1,0 +1,7 @@
+defmodule NervesHub.Repo.Migrations.AddIndexToDeploymentIdForInflightUpdates do
+  use Ecto.Migration
+
+  def change do
+    create index(:inflight_updates, :deployment_id)
+  end
+end

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -390,7 +390,7 @@ defmodule NervesHubWeb.WebsocketTest do
         })
 
       # This is what the orchestrator process will do
-      Orchestrator.send_update(deployment)
+      Orchestrator.trigger_update(deployment)
 
       message = SocketClient.wait_update(socket)
 


### PR DESCRIPTION
Adds a new field `concurrent_updates` that sets the maximum number of updating devices that NH will tell to update at any given time. There is still a spike for reconnecting devices, this is expected for now. We're going to see how it works with that and come back later.

Devices will be told one at a time on deployment update for each node. They will grab a slot and tell the device to update. When the device comes back online, it will tell its new orchestrator that it updated and the orchestrator will tell another device to update if there's a slot.

There's a 5 minute tick to trigger deployment again as a catch all if devices don't evenly connect to nodes.