### PR TITLE
Wrap :gproc calls in try/catch and raise a custom exception

### DIFF
--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.ConsoleChannel do
   use Phoenix.Channel
 
   alias NervesHubDevice.Presence
+  alias NervesHubDevice.PresenceException
   alias NervesHub.Devices
   alias Phoenix.Socket.Broadcast
 
@@ -55,6 +56,9 @@ defmodule NervesHubWeb.ConsoleChannel do
     send(pid, {:console, version})
 
     {:noreply, socket}
+  rescue
+    PresenceException ->
+      {:stop, :shutdown, socket}
   end
 
   def handle_info(%{event: "phx_leave"}, socket) do


### PR DESCRIPTION
:crossed_fingers:  gracefully shutdown device sockets if there's an issue during a deployment and gproc times out.