### PR TITLE
Worker to expire inflight updates after a set amount of time

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -65,7 +65,8 @@ config :nerves_hub, Oban,
   plugins: [
     {Oban.Plugins.Cron,
      crontab: [
-       {"0 * * * *", NervesHub.Workers.TruncateAuditLogs, max_attempts: 1}
+       {"0 * * * *", NervesHub.Workers.TruncateAuditLogs, max_attempts: 1},
+       {"*/5 * * * *", NervesHub.Workers.ExpireInflightUpdates}
      ]}
   ]
 

--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -21,7 +21,8 @@ defmodule NervesHub.Deployments.Deployment do
     :conditions,
     :is_active,
     :product_id,
-    :concurrent_updates
+    :concurrent_updates,
+    :inflight_update_expiration_minutes
   ]
 
   @optional_fields [
@@ -60,6 +61,7 @@ defmodule NervesHub.Deployments.Deployment do
     field(:concurrent_updates, :integer, default: 10)
     field(:total_updating_devices, :integer, default: 0)
     field(:current_updated_devices, :integer, default: 0)
+    field(:inflight_update_expiration_minutes, :integer, default: 60)
 
     timestamps()
   end

--- a/lib/nerves_hub/devices/inflight_update.ex
+++ b/lib/nerves_hub/devices/inflight_update.ex
@@ -12,6 +12,7 @@ defmodule NervesHub.Devices.InflightUpdate do
 
     field(:firmware_uuid, Ecto.UUID)
     field(:status, :string, default: "pending")
+    field(:expires_at, :utc_datetime)
 
     timestamps(updated_at: false)
   end

--- a/lib/nerves_hub/workers/expire_inflight_updates.ex
+++ b/lib/nerves_hub/workers/expire_inflight_updates.ex
@@ -1,0 +1,30 @@
+defmodule NervesHub.Workers.ExpireInflightUpdates do
+  @moduledoc """
+  Expire inflight updates every 5 minutes
+
+  Expiration is set from the deployment when the inflight update is recorded.
+  """
+
+  use Oban.Worker,
+    max_attempts: 1,
+    queue: :truncate
+
+  import Ecto.Query
+
+  require Logger
+
+  alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.Repo
+
+  @impl true
+  def perform(_) do
+    {count, _} =
+      InflightUpdate
+      |> where([iu], iu.expires_at < fragment("now()"))
+      |> Repo.delete_all()
+
+    Logger.info("Expired #{count} inflight updates")
+
+    :ok
+  end
+end

--- a/lib/nerves_hub_web/templates/deployment/edit.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/edit.html.heex
@@ -97,7 +97,17 @@
       <span class="tooltip-text">The number of devices that will update at any given time. This is a soft limit and concurrent updates may be slightly above this number.</span>
     </label>
     <%= number_input f, :concurrent_updates, class: "form-control", id: "concurrent_updates" %>
-    <div class="has-error"><%= error_tag f, :version %></div>
+    <div class="has-error"><%= error_tag f, :concurrent_updates %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="version_requirement" class="tooltip-label">
+      <span>Number of Minutes Before Expiring Updates</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">The number of minutes before an inflight update expires to clear the queue</span>
+    </label>
+    <%= number_input f, :inflight_update_expiration_minutes, class: "form-control", id: "concurrent_updates" %>
+    <div class="has-error"><%= error_tag f, :inflight_update_expiration_minutes %></div>
   </div>
 
   <!-- Advanced Options -->

--- a/lib/nerves_hub_web/templates/deployment/show.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/show.html.heex
@@ -59,13 +59,23 @@
           <div class="help-text mb-1">Version requirement</div>
           <p><%= version(@deployment) %></p>
         </div>
-        <div class="mb-1">
-          <div class="help-text mb-1 tooltip-label">
-            <span>Concurrent Device Updates</span>
-            <span class="tooltip-info"></span>
-            <span class="tooltip-text">The number of devices that will update at any given time. This is a soft limit and concurrent updates may be slightly above this number.</span>
+        <div class="row">
+          <div class="col-lg-6 mb-1">
+            <div class="help-text mb-1 tooltip-label">
+              <span>Concurrent Device Updates</span>
+              <span class="tooltip-info"></span>
+              <span class="tooltip-text">The number of devices that will update at any given time. This is a soft limit and concurrent updates may be slightly above this number.</span>
+            </div>
+            <p><%= @deployment.concurrent_updates %></p>
           </div>
-          <p><%= @deployment.concurrent_updates %></p>
+          <div class="col-lg-6 mb-1">
+            <div class="help-text mb-1 tooltip-label">
+              <span>Number of Minutes Before Expiring Updates</span>
+              <span class="tooltip-info"></span>
+              <span class="tooltip-text">The number of minutes before an inflight update expires to clear the queue</span>
+            </div>
+            <p><%= @deployment.inflight_update_expiration_minutes %></p>
+          </div>
         </div>
         <div class="row">
           <div class="col-lg-6 mb-1">

--- a/priv/repo/migrations/20230606174815_add_expires_at_to_inflight_updates.exs
+++ b/priv/repo/migrations/20230606174815_add_expires_at_to_inflight_updates.exs
@@ -1,0 +1,34 @@
+defmodule NervesHub.Repo.Migrations.AddExpiresAtToInflightUpdates do
+  use Ecto.Migration
+
+  def up do
+    alter table(:inflight_updates) do
+      add(:expires_at, :utc_datetime)
+    end
+
+    alter table(:deployments) do
+      add(:inflight_update_expiration_minutes, :integer, default: 60, null: false)
+    end
+
+    execute """
+      update inflight_updates
+      set expires_at = now() + interval '1 minute' * deployments.inflight_update_expiration_minutes
+      from deployments
+      where deployments.id = inflight_updates.deployment_id;
+    """
+
+    alter table(:inflight_updates) do
+      modify(:expires_at, :utc_datetime, null: false)
+    end
+  end
+
+  def down do
+    alter table(:deployments) do
+      remove(:inflight_update_expiration_minutes)
+    end
+
+    alter table(:inflight_updates) do
+      remove(:expires_at)
+    end
+  end
+end


### PR DESCRIPTION
Worker to clear inflight updates every 5 minutes based on the expiration from the deployment. This should help clear out devices that are clogging the rolling update queue and are just offline for unrelated reasons.