### PR TITLE
Trigger an update after the penalty box is cleared

### DIFF
--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -52,6 +52,7 @@ defmodule NervesHub.Deployments.Orchestrator do
     match_conditions = [
       {:and, {:==, {:map_get, :deployment_id, :"$1"}, deployment.id},
        {:==, {:map_get, :updating, :"$1"}, false},
+       {:==, {:map_get, :updates_enabled, :"$1"}, true},
        {:"/=", {:map_get, :firmware_uuid, :"$1"}, deployment.firmware.uuid}}
     ]
 


### PR DESCRIPTION
Force the orchestrator to not consider these devices when picking a device to send an update to. Set a timer to clear out the penalty box after it's time is up. Also ignore devices that are set to disable updates entirely by a user.