### PR TITLE
Track less information in gproc

### DIFF
--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -94,7 +94,7 @@ defmodule NervesHubWeb.DeviceController do
     |> put_layout(false)
     |> render("console.html",
       device: Map.merge(device, meta),
-      console_available: meta[:console_available]
+      console_available: !is_nil(meta[:console_version])
     )
   end
 

--- a/lib/nerves_hub_web/live/device_live/index.ex
+++ b/lib/nerves_hub_web/live/device_live/index.ex
@@ -357,10 +357,8 @@ defmodule NervesHubWeb.DeviceLive.Index do
         false ->
           fields = [
             :firmware_metadata,
-            :last_communication,
             :status,
-            :fwup_progress,
-            :console_available
+            :fwup_progress
           ]
 
           device = Map.merge(device, Map.take(meta, fields))

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -333,10 +333,8 @@ defmodule NervesHubWeb.DeviceLive.Show do
       false ->
         updates =
           Map.take(metadata, [
-            :console_available,
             :firmware_metadata,
             :fwup_progress,
-            :last_communication,
             :status
           ])
 

--- a/lib/nerves_hub_web/templates/device/_header.html.heex
+++ b/lib/nerves_hub_web/templates/device/_header.html.heex
@@ -6,7 +6,7 @@
     <p class="flex-row align-items-center tt-c">
       <span><%= @device.status %></span>
       <span class="ml-1">
-        <%= if @device.status in ["offline", "rebooting"] do %>
+        <%= if @device.status in ["offline"] do %>
           <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
         <% else %>
           <img src="/images/icons/check.svg" alt="online" class="table-icon" />

--- a/lib/nerves_hub_web/templates/device/index.html.heex
+++ b/lib/nerves_hub_web/templates/device/index.html.heex
@@ -302,7 +302,7 @@
                 <span>Reboot</span>
               </button>
               <div class="dropdown-divider"></div>
-              <%= link "Console", to: Routes.device_path(@socket, :console, @org.name, @product.name, device.identifier), class: "dropdown-item #{unless Map.has_key?(device, :console_available) && device.console_available, do: "disabled"}" %>
+              <%= link "Console", to: Routes.device_path(@socket, :console, @org.name, @product.name, device.identifier), class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
               <%= link "edit", class: "dropdown-item", to: Routes.device_path(@socket, :edit, @org.name, @product.name, device.identifier) %>
               <div class="dropdown-divider"></div>

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -25,11 +25,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     {:ok, _, _socket} = subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
 
     presence = Presence.find(device)
-    assert presence.connected_at
-    assert presence.last_communication
     assert presence.status == "online"
-    assert presence.update_available == false
-    assert presence.firmware_metadata
   end
 
   test "device disconnected adds audit log" do

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -348,7 +348,6 @@ defmodule NervesHubWeb.WebsocketTest do
         |> NervesHub.Repo.get(device.id)
         |> NervesHub.Repo.preload(:org)
 
-      assert Presence.device_status(device) == "update pending"
       assert Time.diff(DateTime.utc_now(), device.last_communication) < 2
     end
 

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -75,8 +75,6 @@ defmodule NervesHubWeb.DeviceControllerTest do
       device = Fixtures.device_fixture(org, product, firmware)
 
       Presence.track(device, %{
-        product_id: product.id,
-        console_available: true,
         console_version: "0.9.0"
       })
 


### PR DESCRIPTION
Reducing the amount stored in gproc should help with staleness in gproc, since there's less data shuffling around. There's also less updates if we're not storing the deployment_id and product_id.