### PR TITLE
Migrate presence tracking to the DeviceLink process

### DIFF
--- a/lib/nerves_hub/devices/device_link.ex
+++ b/lib/nerves_hub/devices/device_link.ex
@@ -6,8 +6,12 @@ defmodule NervesHub.Devices.DeviceLink do
   e.g. websockets.
   """
 
+  # TODO any presence updates through a call should delay the message
+  # for ~2 seconds and try again, using the call ref to reply.
+
   use GenServer
 
+  alias NervesHubDevice.Presence
   alias Phoenix.Socket.Broadcast
 
   require Logger
@@ -34,6 +38,14 @@ defmodule NervesHub.Devices.DeviceLink do
     GenServer.call(pid, {:update_device, device})
   end
 
+  def update_status(pid, status) do
+    GenServer.call(pid, {:update_status, status})
+  end
+
+  def fwup_progress(pid, progress) do
+    GenServer.call(pid, {:fwup_progress, progress})
+  end
+
   def init(device) do
     {:ok, %State{device: device}, {:continue, :boot}}
   end
@@ -51,6 +63,20 @@ defmodule NervesHub.Devices.DeviceLink do
       end
 
     {:noreply, state}
+  end
+
+  # tracked after the device connects, so transport_pid should be present
+  def handle_continue(:track, state) do
+    Presence.track(state.device, %{})
+
+    {:noreply, state}
+  rescue
+    PresenceException ->
+      if state.transport_pid do
+        send(state.transport_pid, :shutdown)
+      end
+
+      {:stop, :shutdown, state}
   end
 
   def handle_call({:update_device, device}, _from, state) do
@@ -73,7 +99,70 @@ defmodule NervesHub.Devices.DeviceLink do
   def handle_call({:connect, transport_pid}, _from, state) do
     ref = Process.monitor(transport_pid)
     state = %{state | transport_pid: transport_pid, transport_ref: ref}
+    {:reply, :ok, state, {:continue, :track}}
+  end
+
+  def handle_call({:update_status, status}, from, state) do
+    Presence.update(state.device, %{status: status})
+
     {:reply, :ok, state}
+  rescue
+    PresenceException ->
+      GenServer.reply(from, :shutdown)
+      {:stop, :shutdown, state}
+  end
+
+  def handle_call({:fwup_progress, progress}, from, state) do
+    # No need to update the product channel which will spam anyone listening on
+    # the listing of devices.
+    Presence.update(state.device, %{status: progress}, product: false)
+
+    {:reply, :ok, state}
+  rescue
+    PresenceException ->
+      GenServer.reply(from, :shutdown)
+      {:stop, :shutdown, state}
+  end
+
+  def handle_info({:console, console_version}, state) do
+    Presence.update(state.device, %{console_version: console_version})
+
+    # now that the console is connected, push down the device's elixir, line by line
+    device = state.device
+    deployment = device.deployment
+
+    if deployment && deployment.connecting_code do
+      device.deployment.connecting_code
+      |> String.graphemes()
+      |> Enum.map(fn character ->
+        broadcast("console:#{device.id}", "dn", %{
+          "data" => character
+        })
+      end)
+
+      broadcast("console:#{device.id}", "dn", %{"data" => "\r"})
+    end
+
+    if device.connecting_code do
+      device.connecting_code
+      |> String.graphemes()
+      |> Enum.map(fn character ->
+        broadcast("console:#{device.id}", "dn", %{
+          "data" => character
+        })
+      end)
+
+      broadcast("console:#{device.id}", "dn", %{"data" => "\r"})
+    end
+
+    {:noreply, state}
+  rescue
+    PresenceException ->
+      if state.transport_pid do
+        send(state.transport_pid, :shutdown)
+      end
+
+      {:stop, :shutdown, state}
   end
 
   def handle_info({:DOWN, transport_ref, :process, _pid, _reason}, state) do
@@ -112,5 +201,12 @@ defmodule NervesHub.Devices.DeviceLink do
 
   defp unsubscribe(topic) do
     Phoenix.PubSub.unsubscribe(NervesHub.PubSub, topic)
+  end
+
+  defp broadcast(topic, event, payload) do
+    Phoenix.PubSub.broadcast(NervesHub.PubSub, topic, %Phoenix.Socket.Broadcast{
+      event: event,
+      payload: payload
+    })
   end
 end

--- a/lib/nerves_hub_device/presence.ex
+++ b/lib/nerves_hub_device/presence.ex
@@ -77,9 +77,15 @@ defmodule NervesHubDevice.Presence do
     publish_change(device, metadata)
   rescue
     ArgumentError ->
+      self_pid = self()
+
       case whereis(device.id) do
         nil ->
           track(device, metadata, times + 1)
+
+        # The DeviceLink process is debouncing the reconnection
+        ^self_pid ->
+          :ok
 
         pid ->
           GenServer.stop(pid)

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -124,6 +124,10 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, assign(socket, :device, device)}
   end
 
+  def handle_info(:shutdown, socket) do
+    {:stop, :shutdown, socket}
+  end
+
   def handle_info({:after_join, device}, socket) do
     {:ok, pid} = Devices.Supervisor.start_device(device)
     DeviceLink.connect(pid, self())

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -333,7 +333,6 @@ defmodule NervesHubWeb.DeviceLive.Show do
       false ->
         updates =
           Map.take(metadata, [
-            :firmware_metadata,
             :fwup_progress,
             :status
           ])

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -73,7 +73,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
     # Since fwup_progress doesn't reply, we need to use sys to grab the socket
     # _after_ the handle_in has run
     socket = :sys.get_state(socket.channel_pid)
-    assert socket.assigns.update_started?
+    state = :sys.get_state(socket.assigns.device_link_pid)
+    assert state.update_started?
   end
 
   test "set connection types for the device" do


### PR DESCRIPTION
Have the DeviceLink handle presence tracking as part of the migration of logic from the DeviceChannel