### PR TITLE
Remove all keys from presence tracking except for status

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -108,9 +108,6 @@ defmodule NervesHubWeb.DeviceChannel do
       end
 
     {:noreply, socket}
-  rescue
-    PresenceException ->
-      {:stop, :shutdown, socket}
   end
 
   def handle_in("status_update", %{"status" => status}, socket) do
@@ -169,9 +166,6 @@ defmodule NervesHubWeb.DeviceChannel do
     else
       {:noreply, socket}
     end
-  rescue
-    PresenceException ->
-      {:stop, :shutdown, socket}
   end
 
   def handle_info(%Broadcast{event: "deployments/changed", payload: payload}, socket) do
@@ -214,9 +208,6 @@ defmodule NervesHubWeb.DeviceChannel do
     end)
 
     {:noreply, assign(socket, :device, device)}
-  rescue
-    PresenceException ->
-      {:stop, :shutdown, socket}
   end
 
   # manually pushed
@@ -274,9 +265,6 @@ defmodule NervesHubWeb.DeviceChannel do
     send(self(), :resolve_changed_deployment)
 
     {:noreply, assign(socket, device: device)}
-  rescue
-    PresenceException ->
-      {:stop, :shutdown, socket}
   end
 
   # Update local state and tell the various servers of the new information
@@ -349,9 +337,6 @@ defmodule NervesHubWeb.DeviceChannel do
     end
 
     {:noreply, socket}
-  rescue
-    PresenceException ->
-      {:stop, :shutdown, socket}
   end
 
   def handle_out("presence_diff", _msg, socket) do
@@ -459,9 +444,6 @@ defmodule NervesHubWeb.DeviceChannel do
     socket
     |> assign(:device, device)
     |> assign(:deployment_channel, "deployment:#{device.deployment_id}")
-  rescue
-    PresenceException ->
-      {:stop, :shutdown, socket}
   end
 
   @doc """

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -86,16 +86,11 @@ defmodule NervesHubWeb.DeviceController do
     |> redirect(to: Routes.device_path(conn, :index, org.name, product.name))
   end
 
-  def console(%{assigns: %{device: device}} = conn, _params) do
-    meta = NervesHubDevice.Presence.find(device, %{})
-
+  def console(conn, _params) do
     conn
     |> put_root_layout({NervesHubWeb.LayoutView, :console})
     |> put_layout(false)
-    |> render("console.html",
-      device: Map.merge(device, meta),
-      console_available: !is_nil(meta[:console_version])
-    )
+    |> render("console.html")
   end
 
   def download_certificate(%{assigns: %{device: device}} = conn, %{"cert_serial" => serial}) do

--- a/lib/nerves_hub_web/live/device_live/index.ex
+++ b/lib/nerves_hub_web/live/device_live/index.ex
@@ -355,12 +355,7 @@ defmodule NervesHubWeb.DeviceLive.Index do
           Map.put(device, :status, "offline")
 
         false ->
-          fields = [
-            :firmware_metadata,
-            :status,
-            :fwup_progress
-          ]
-
+          fields = [:status]
           device = Map.merge(device, Map.take(meta, fields))
 
           if Map.get(payload, :device_id) == device.id do

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -117,7 +117,16 @@ defmodule NervesHubWeb.DeviceLive.Show do
   end
 
   def handle_info(%Broadcast{event: "connection_change", payload: payload}, socket) do
-    {:noreply, assign(socket, :device, sync_device(socket.assigns.device, payload))}
+    socket =
+      socket
+      |> assign(:device, sync_device(socket.assigns.device, payload))
+      |> assign(:fwup_progress, nil)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(%Broadcast{event: "fwup_progress", payload: payload}, socket) do
+    {:noreply, assign(socket, :fwup_progress, payload.percent)}
   end
 
   # Ignore unknown messages
@@ -331,13 +340,7 @@ defmodule NervesHubWeb.DeviceLive.Show do
 
     case is_nil(metadata) do
       false ->
-        updates =
-          Map.take(metadata, [
-            :firmware_metadata,
-            :fwup_progress,
-            :status
-          ])
-
+        updates = Map.take(metadata, [:status])
         Map.merge(device, updates)
 
       true ->

--- a/lib/nerves_hub_web/templates/device/_header.html.heex
+++ b/lib/nerves_hub_web/templates/device/_header.html.heex
@@ -65,11 +65,11 @@
   </div>
 </div>
 
-<%= if Map.has_key?(@device, :fwup_progress) && @device.fwup_progress do %>
+<%= if Map.has_key?(assigns, :fwup_progress) && assigns.fwup_progress do %>
   <div class="help-text mt-3">Progress</div>
   <div class="progress device-show">
-    <div class="progress-bar" role="progressbar" style={"width: #{@device.fwup_progress}%"}>
-      <%= @device.fwup_progress %>%
+    <div class="progress-bar" role="progressbar" style={"width: #{@fwup_progress}%"}>
+      <%= @fwup_progress %>%
     </div>
   </div>
 <% end %>

--- a/lib/nerves_hub_web/templates/device/console.html.heex
+++ b/lib/nerves_hub_web/templates/device/console.html.heex
@@ -1,7 +1,3 @@
 <input id="device_id" hidden type="text" value={@device.id} />
 <input id="product_id" hidden type="text" value={@device.product_id} />
-<%= if @console_available do %>
-  <div id="terminal" class="console-v2"></div>
-<% else %>
-  <h5>Console disabled or unavailable.</h5>
-<% end %>
+<div id="terminal" class="console-v2"></div>

--- a/lib/nerves_hub_web/templates/device/show.html.heex
+++ b/lib/nerves_hub_web/templates/device/show.html.heex
@@ -58,7 +58,7 @@
   </div>
 </div>
 
-<%= render("_header.html", device: @device) %>
+<%= render("_header.html", assigns) %>
 
 <div class="row">
   <div class="col-lg-6">

--- a/lib/nerves_hub_web/views/api/device_view.ex
+++ b/lib/nerves_hub_web/views/api/device_view.ex
@@ -4,8 +4,6 @@ defmodule NervesHubWeb.API.DeviceView do
   alias NervesHubWeb.API.DeviceView
   alias NervesHubDevice.Presence
 
-  defdelegate console_available(device), to: Presence
-
   defdelegate device_status(device), to: Presence
 
   def render("index.json", %{devices: devices, pagination: pagination}) do
@@ -25,7 +23,6 @@ defmodule NervesHubWeb.API.DeviceView do
       tags: device.tags,
       version: version(device),
       status: device_status(device),
-      console_available: console_available(device),
       last_communication: last_communication(device),
       description: device.description,
       firmware_metadata: device.firmware_metadata,

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -3,7 +3,6 @@ defmodule NervesHubWeb.DeviceControllerTest do
 
   alias NervesHub.Devices
   alias NervesHub.Fixtures
-  alias NervesHubDevice.Presence
 
   setup %{user: user, org: org} do
     [product: Fixtures.product_fixture(user, org)]
@@ -73,10 +72,6 @@ defmodule NervesHubWeb.DeviceControllerTest do
       org_key = Fixtures.org_key_fixture(org)
       firmware = Fixtures.firmware_fixture(org_key, product)
       device = Fixtures.device_fixture(org, product, firmware)
-
-      Presence.track(device, %{
-        console_version: "0.9.0"
-      })
 
       result =
         get(conn, Routes.device_path(conn, :console, org.name, product.name, device.identifier))


### PR DESCRIPTION
Preparing for a new way of tracking presence that doesn't use gproc, and the less we store, the better this will work out. We only really need to know that something is online for presence tracking. The rest is stored or we can get live while it happens as a broadcast.