### PR TITLE
Don't store device status on the ecto struct

### DIFF
--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -48,8 +48,6 @@ defmodule NervesHub.Devices.Device do
     field(:connection_types, {:array, ConnectionType})
     field(:connecting_code, :string)
 
-    field(:status, :string, default: "offline", virtual: true)
-
     timestamps()
   end
 

--- a/lib/nerves_hub_device/presence.ex
+++ b/lib/nerves_hub_device/presence.ex
@@ -168,7 +168,7 @@ defmodule NervesHubDevice.Presence do
   def device_status(%Device{} = device) do
     case find(device) do
       nil ->
-        :offline
+        "offline"
 
       metadata ->
         metadata.status

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -351,7 +351,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
       AuditLogs.audit!(device, device, :update, description, %{
         last_communication: device.last_communication,
-        status: device.status
+        status: "offline"
       })
 
       Registry.unregister(NervesHub.Devices, device.id)

--- a/lib/nerves_hub_web/templates/device/_header.html.heex
+++ b/lib/nerves_hub_web/templates/device/_header.html.heex
@@ -4,9 +4,9 @@
   <div>
     <div class="help-text">Status</div>
     <p class="flex-row align-items-center tt-c">
-      <span><%= @device.status %></span>
+      <span><%= @status %></span>
       <span class="ml-1">
-        <%= if @device.status in ["offline"] do %>
+        <%= if @status in ["offline"] do %>
           <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
         <% else %>
           <img src="/images/icons/check.svg" alt="online" class="table-icon" />

--- a/lib/nerves_hub_web/templates/device/index.html.heex
+++ b/lib/nerves_hub_web/templates/device/index.html.heex
@@ -205,7 +205,6 @@
         <th>Connection</th>
         <th>Firmware</th>
         <th>Platform</th>
-        <th>Firmware Status</th>
         <%= devices_table_header("Tags", "tags", @current_sort, @sort_direction) %>
         <th></th>
       </tr>
@@ -227,7 +226,7 @@
         <td>
           <div class="mobile-label help-text">Connection</div>
           <div>
-            <%= if device.status == "offline" do %>
+            <%= if @device_statuses[device.id] == "offline" do %>
               <div title={"Last connected #{DateTimeFormat.from_now(device.last_communication)}"}>
                 <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
               </div>
@@ -263,20 +262,6 @@
           </div>
         </td>
 
-        <td class="tt-c-first-letter">
-          <div class="mobile-label help-text">Firmware status</div>
-          <div>
-            <%= cond do %>
-              <% device.status == "offline" -> %>
-                <span class="color-white-50">Unknown</span>
-              <% device.status == "online" -> %>
-                Up to date
-              <% true -> %>
-                <%= display_status(device.status) %>
-            <% end %>
-          </div>
-        </td>
-
         <td>
           <div class="mobile-label help-text">Tags</div>
           <div>
@@ -298,7 +283,7 @@
             <div class="dropdown-menu dropdown-menu-right">
               <%= link "details", class: "dropdown-item", to: Routes.device_path(@socket, :show, @org.name, @product.name, device.identifier) %>
               <div class="dropdown-divider"></div>
-              <button class="dropdown-item" type="button" phx-click="reboot" phx-value-device-id={device.id} {if device.status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
+              <button class="dropdown-item" type="button" phx-click="reboot" phx-value-device-id={device.id} {if @device_statuses[device.id] == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
                 <span>Reboot</span>
               </button>
               <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/templates/device/show.html.heex
+++ b/lib/nerves_hub_web/templates/device/show.html.heex
@@ -26,15 +26,15 @@
         <span class="action-text">Destroy</span>
       </button>
     <% else %>
-      <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" {if @device.status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
+      <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" {if @status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
         <span class="button-icon power"></span>
         <span class="action-text">Reboot</span>
       </button>
-      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect" {if @device.status == "offline", do: [disabled: true], else: []}>
+      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect" {if @status == "offline", do: [disabled: true], else: []}>
         <span class="button-icon power"></span>
         <span class="action-text">Reconnect</span>
       </button>
-      <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify" {if @device.status == "offline", do: [disabled: true], else: []}>
+      <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify" {if @status == "offline", do: [disabled: true], else: []}>
         <span class="button-icon identify"></span>
         <span class="action-text">Identify</span>
       </button>
@@ -123,12 +123,12 @@
         <div class="help-text mb-1">Status</div>
         <div class="tt-c-first-letter">
           <%= cond do %>
-            <% @device.status == "offline" -> %>
+            <% @status == "offline" -> %>
               <span class="color-white-50">Unknown</span>
-            <% @device.status == "online" -> %>
+            <% @status == "online" -> %>
               Up to date
             <% true -> %>
-              <%= display_status(@device.status) %>
+              <%= display_status(@status) %>
           <% end %>
         </div>
       </div>

--- a/test/nerves_hub_web/live/device_live_index_test.exs
+++ b/test/nerves_hub_web/live/device_live_index_test.exs
@@ -17,7 +17,7 @@ defmodule NervesHubWeb.DeviceLiveIndexTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot requested"
+      render_change(view, :reboot, %{"device-id" => device.id})
       assert_broadcast("reboot", %{})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
@@ -36,7 +36,7 @@ defmodule NervesHubWeb.DeviceLiveIndexTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot blocked"
+      render_change(view, :reboot, %{"device-id" => device.id})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
 


### PR DESCRIPTION
It's used in the device liveviews and is merged in from the presence server as merging in metadta. Instead, store the status separately which can be more easily updated via a map on the device id.