### PR TITLE
Reconnect button disconnects the socket

### DIFF
--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -48,8 +48,6 @@ defmodule NervesHub.Devices.Device do
     field(:connection_types, {:array, ConnectionType})
     field(:connecting_code, :string)
 
-    field(:status, :string, default: "offline", virtual: true)
-
     timestamps()
   end
 

--- a/lib/nerves_hub_device/presence.ex
+++ b/lib/nerves_hub_device/presence.ex
@@ -168,7 +168,7 @@ defmodule NervesHubDevice.Presence do
   def device_status(%Device{} = device) do
     case find(device) do
       nil ->
-        :offline
+        "offline"
 
       metadata ->
         metadata.status

--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -20,10 +20,6 @@ defmodule NervesHubWeb.ConsoleChannel do
     {:shutdown, :closed}
   end
 
-  def handle_in("reconnect", _payload, socket) do
-    {:stop, :shutdown, socket}
-  end
-
   def handle_in("init_attempt", %{"success" => success?} = payload, socket) do
     unless success? do
       socket.endpoint.broadcast_from(self(), console_topic(socket), "init_failure", payload)

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -351,7 +351,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
       AuditLogs.audit!(device, device, :update, description, %{
         last_communication: device.last_communication,
-        status: device.status
+        status: "offline"
       })
 
       Registry.unregister(NervesHub.Devices, device.id)

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -305,40 +305,6 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  # TODO save version into the database, it likely won't change often
-  def handle_info({:console, _version}, socket) do
-    # now that the console is connected, push down the device's elixir, line by line
-    device = socket.assigns.device
-    device = Repo.preload(device, [:deployment])
-    deployment = device.deployment
-
-    if deployment && deployment.connecting_code do
-      device.deployment.connecting_code
-      |> String.graphemes()
-      |> Enum.map(fn character ->
-        socket.endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{
-          "data" => character
-        })
-      end)
-
-      socket.endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => "\r"})
-    end
-
-    if device.connecting_code do
-      device.connecting_code
-      |> String.graphemes()
-      |> Enum.map(fn character ->
-        socket.endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{
-          "data" => character
-        })
-      end)
-
-      socket.endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => "\r"})
-    end
-
-    {:noreply, socket}
-  end
-
   def handle_out("presence_diff", _msg, socket) do
     {:noreply, socket}
   end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -284,10 +284,6 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, assign(socket, :device, device)}
   end
 
-  def handle_info(%Broadcast{event: "reconnect"}, socket) do
-    {:stop, :shutdown, socket}
-  end
-
   def handle_info(%Broadcast{event: event, payload: payload}, socket) do
     push(socket, event, payload)
     {:noreply, socket}

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -102,7 +102,7 @@ defmodule NervesHubWeb.API.DeviceController do
   end
 
   def reconnect(conn, _params) do
-    Endpoint.broadcast_from(self(), "device:#{conn.assigns.device.id}", "reconnect", %{})
+    Endpoint.broadcast("device_socket:#{conn.assigns.device.id}", "disconnect", %{})
     send_resp(conn, 200, "Success")
   end
 

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -142,7 +142,7 @@ defmodule NervesHubWeb.DeviceLive.Show do
   end
 
   def handle_event("reconnect", _value, %{assigns: %{device: device}} = socket) do
-    socket.endpoint.broadcast_from(self(), "device:#{device.id}", "reconnect", %{})
+    socket.endpoint.broadcast("device_socket:#{device.id}", "disconnect", %{})
     {:noreply, socket}
   end
 

--- a/lib/nerves_hub_web/templates/device/_header.html.heex
+++ b/lib/nerves_hub_web/templates/device/_header.html.heex
@@ -4,9 +4,9 @@
   <div>
     <div class="help-text">Status</div>
     <p class="flex-row align-items-center tt-c">
-      <span><%= @device.status %></span>
+      <span><%= @status %></span>
       <span class="ml-1">
-        <%= if @device.status in ["offline"] do %>
+        <%= if @status in ["offline"] do %>
           <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
         <% else %>
           <img src="/images/icons/check.svg" alt="online" class="table-icon" />

--- a/lib/nerves_hub_web/templates/device/index.html.heex
+++ b/lib/nerves_hub_web/templates/device/index.html.heex
@@ -205,7 +205,6 @@
         <th>Connection</th>
         <th>Firmware</th>
         <th>Platform</th>
-        <th>Firmware Status</th>
         <%= devices_table_header("Tags", "tags", @current_sort, @sort_direction) %>
         <th></th>
       </tr>
@@ -227,7 +226,7 @@
         <td>
           <div class="mobile-label help-text">Connection</div>
           <div>
-            <%= if device.status == "offline" do %>
+            <%= if @device_statuses[device.id] == "offline" do %>
               <div title={"Last connected #{DateTimeFormat.from_now(device.last_communication)}"}>
                 <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
               </div>
@@ -263,20 +262,6 @@
           </div>
         </td>
 
-        <td class="tt-c-first-letter">
-          <div class="mobile-label help-text">Firmware status</div>
-          <div>
-            <%= cond do %>
-              <% device.status == "offline" -> %>
-                <span class="color-white-50">Unknown</span>
-              <% device.status == "online" -> %>
-                Up to date
-              <% true -> %>
-                <%= display_status(device.status) %>
-            <% end %>
-          </div>
-        </td>
-
         <td>
           <div class="mobile-label help-text">Tags</div>
           <div>
@@ -298,7 +283,7 @@
             <div class="dropdown-menu dropdown-menu-right">
               <%= link "details", class: "dropdown-item", to: Routes.device_path(@socket, :show, @org.name, @product.name, device.identifier) %>
               <div class="dropdown-divider"></div>
-              <button class="dropdown-item" type="button" phx-click="reboot" phx-value-device-id={device.id} {if device.status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
+              <button class="dropdown-item" type="button" phx-click="reboot" phx-value-device-id={device.id} {if @device_statuses[device.id] == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
                 <span>Reboot</span>
               </button>
               <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/templates/device/show.html.heex
+++ b/lib/nerves_hub_web/templates/device/show.html.heex
@@ -26,15 +26,15 @@
         <span class="action-text">Destroy</span>
       </button>
     <% else %>
-      <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" {if @device.status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
+      <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" {if @status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
         <span class="button-icon power"></span>
         <span class="action-text">Reboot</span>
       </button>
-      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect" {if @device.status == "offline", do: [disabled: true], else: []}>
+      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect" {if @status == "offline", do: [disabled: true], else: []}>
         <span class="button-icon power"></span>
         <span class="action-text">Reconnect</span>
       </button>
-      <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify" {if @device.status == "offline", do: [disabled: true], else: []}>
+      <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify" {if @status == "offline", do: [disabled: true], else: []}>
         <span class="button-icon identify"></span>
         <span class="action-text">Identify</span>
       </button>
@@ -123,12 +123,12 @@
         <div class="help-text mb-1">Status</div>
         <div class="tt-c-first-letter">
           <%= cond do %>
-            <% @device.status == "offline" -> %>
+            <% @status == "offline" -> %>
               <span class="color-white-50">Unknown</span>
-            <% @device.status == "online" -> %>
+            <% @status == "online" -> %>
               Up to date
             <% true -> %>
-              <%= display_status(@device.status) %>
+              <%= display_status(@status) %>
           <% end %>
         </div>
       </div>

--- a/test/nerves_hub_web/live/device_live_index_test.exs
+++ b/test/nerves_hub_web/live/device_live_index_test.exs
@@ -17,7 +17,7 @@ defmodule NervesHubWeb.DeviceLiveIndexTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot requested"
+      render_change(view, :reboot, %{"device-id" => device.id})
       assert_broadcast("reboot", %{})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
@@ -36,7 +36,7 @@ defmodule NervesHubWeb.DeviceLiveIndexTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot blocked"
+      render_change(view, :reboot, %{"device-id" => device.id})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
 


### PR DESCRIPTION
Disconnect the socket so the device channel isn't the only thing terminated. Leaving the console channel open and having the device not try to reconnect the main channel.