### PR TITLE
Always allow the device header buttons to be clicked

### DIFF
--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -298,12 +298,7 @@ defmodule NervesHubWeb.DeviceLive.Show do
 
     socket.endpoint.broadcast_from(self(), "device:#{socket.assigns.device.id}", "reboot", %{})
 
-    socket =
-      socket
-      |> put_flash(:info, "Device Reboot Requested")
-      |> assign(:status, "reboot-requested")
-
-    {:noreply, socket}
+    {:noreply, put_flash(socket, :info, "Device Reboot Requested")}
   end
 
   defp do_reboot(%{assigns: %{device: device, user: user}} = socket, :blocked) do
@@ -320,11 +315,6 @@ defmodule NervesHubWeb.DeviceLive.Show do
       }
     )
 
-    socket =
-      socket
-      |> put_flash(:error, msg)
-      |> assign(:status, "reboot-blocked")
-
-    {:noreply, socket}
+    {:noreply, put_flash(socket, :error, msg)}
   end
 end

--- a/lib/nerves_hub_web/templates/device/show.html.heex
+++ b/lib/nerves_hub_web/templates/device/show.html.heex
@@ -26,15 +26,15 @@
         <span class="action-text">Destroy</span>
       </button>
     <% else %>
-      <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" {if @status == "offline", do: [disabled: true], else: []} data-confirm="Are you sure?">
+      <button class="btn btn-outline-light btn-action"  aria-label="Reboot device" type="button" phx-click="reboot" data-confirm="Are you sure?">
         <span class="button-icon power"></span>
         <span class="action-text">Reboot</span>
       </button>
-      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect" {if @status == "offline", do: [disabled: true], else: []}>
+      <button class="btn btn-outline-light btn-action"  aria-label="Reconnect device" type="button" phx-click="reconnect">
         <span class="button-icon power"></span>
         <span class="action-text">Reconnect</span>
       </button>
-      <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify" {if @status == "offline", do: [disabled: true], else: []}>
+      <button class="btn btn-outline-light btn-action"  aria-label="Identify device" type="button" phx-click="identify">
         <span class="button-icon identify"></span>
         <span class="action-text">Identify</span>
       </button>

--- a/test/nerves_hub_web/live/device_live_show_test.exs
+++ b/test/nerves_hub_web/live/device_live_show_test.exs
@@ -19,7 +19,7 @@ defmodule NervesHubWeb.DeviceLiveShowTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{}) =~ "reboot-requested"
+      _view = render_change(view, :reboot, %{})
       assert_broadcast("reboot", %{})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
@@ -38,7 +38,7 @@ defmodule NervesHubWeb.DeviceLiveShowTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{}) =~ "reboot-blocked"
+      _view = render_change(view, :reboot, %{})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
 


### PR DESCRIPTION
Broadcast the messages regardless of if the liveview node thinks the device is online. It might be and the tracker is out of sync. Something might be listening so let it try to happen.