### PR TITLE
Use a separate registry for DeviceLinks

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -23,7 +23,8 @@ defmodule NervesHub.Application do
 
     children =
       [
-        {Registry, keys: :unique, name: NervesHub.Devices}
+        {Registry, keys: :unique, name: NervesHub.Devices},
+        {Registry, keys: :unique, name: NervesHub.DeviceLinks}
       ] ++
         metrics(@env) ++
         [

--- a/lib/nerves_hub/devices/device_link.ex
+++ b/lib/nerves_hub/devices/device_link.ex
@@ -22,7 +22,7 @@ defmodule NervesHub.Devices.DeviceLink do
   end
 
   def name(device_id) when is_integer(device_id) do
-    {:via, Registry, {NervesHub.Devices, {:link, device_id}}}
+    {:via, Registry, {NervesHub.DeviceLinks, {:link, device_id}}}
   end
 
   def name(device), do: name(device.id)


### PR DESCRIPTION
Causing the online device count to be doubled because the same registry is being used more than once. They should probably be separate anyways.