### PR TITLE
Start rate limiting device connections

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -68,6 +68,8 @@ config :nerves_hub, NervesHub.ObanRepo, ssl: false
 
 config :nerves_hub, NervesHub.Mailer, adapter: Bamboo.LocalAdapter
 
+config :nerves_hub, NervesHub.RateLimit, limit: 10
+
 ##
 # NervesHubWWW
 #

--- a/config/release.exs
+++ b/config/release.exs
@@ -9,6 +9,10 @@ nerves_hub_app =
 
 config :nerves_hub, app: nerves_hub_app
 
+rate_limit = System.get_env("DEVICE_CONNECT_RATE_LIMIT", "100") |> String.to_integer()
+
+config :nerves_hub, NerveHub.RateLimit, limit: rate_limit
+
 logger_level = System.get_env("LOG_LEVEL", "info") |> String.to_atom()
 
 config :logger, level: logger_level

--- a/config/test.exs
+++ b/config/test.exs
@@ -68,6 +68,8 @@ config :nerves_hub, NervesHub.Mailer, adapter: Bamboo.TestAdapter
 
 config :nerves_hub, Oban, queues: false, plugins: false
 
+config :nerves_hub, NervesHub.RateLimit, limit: 100
+
 ##
 # NervesHubWWW
 #

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -27,6 +27,7 @@ defmodule NervesHub.Application do
       ] ++
         metrics(@env) ++
         [
+          NervesHub.RateLimit,
           NervesHub.Supervisor,
           NervesHub.Tracker
         ] ++ endpoints(@env)

--- a/lib/nerves_hub/rate_limit.ex
+++ b/lib/nerves_hub/rate_limit.ex
@@ -1,0 +1,47 @@
+defmodule NervesHub.RateLimit do
+  @moduledoc """
+  Rate Limit devices connecting to the server
+  """
+
+  use GenServer
+
+  @doc """
+  Increment and check the rate limit
+
+  Return `true` if the request was under the rate limit
+  """
+  @spec increment() :: boolean()
+  def increment() do
+    bucket_key =
+      DateTime.utc_now()
+      |> DateTime.to_unix()
+
+    result = :ets.update_counter(:nerves_hub_rate_limit, bucket_key, 1, {bucket_key, 0})
+
+    config = Application.get_env(:nerves_hub, __MODULE__)
+
+    result < config[:limit]
+  end
+
+  @doc false
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  @impl true
+  def init(_) do
+    state = %{
+      ets_key: :nerves_hub_rate_limit
+    }
+
+    :ets.new(state.ets_key, [
+      :named_table,
+      :set,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    {:ok, state}
+  end
+end


### PR DESCRIPTION
Configured by ENV, but defaults to 100 / s in production. A websocket connection error is returned if the rate limit is dinged. NervesHubLink will retry the connection according to its own retry limits.