### PR TITLE
Add device firmware update status to the API

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1058,4 +1058,27 @@ defmodule NervesHub.Devices do
     |> where([iu], iu.deployment_id == ^deployment.id)
     |> Repo.one()
   end
+
+  @doc """
+  Get the firmware status for a device
+
+  "latest", "pending", or "updating"
+  """
+  def firmware_status(device) do
+    device = Repo.preload(device, deployment: [:firmware])
+
+    cond do
+      is_nil(device.deployment_id) ->
+        "latest"
+
+      device.firmware_metadata.uuid == device.deployment.firmware.uuid ->
+        "latest"
+
+      !Enum.empty?(device.update_attempts) ->
+        "updating"
+
+      true ->
+        "pending"
+    end
+  end
 end

--- a/lib/nerves_hub_web/views/api/device_view.ex
+++ b/lib/nerves_hub_web/views/api/device_view.ex
@@ -1,8 +1,8 @@
 defmodule NervesHubWeb.API.DeviceView do
   use NervesHubWeb, :api_view
 
+  alias NervesHub.Devices
   alias NervesHub.Tracker
-  alias NervesHubWeb.DeviceView
 
   def render("index.json", %{devices: devices, pagination: pagination}) do
     %{
@@ -24,7 +24,7 @@ defmodule NervesHubWeb.API.DeviceView do
       last_communication: last_communication(device),
       description: device.description,
       firmware_metadata: device.firmware_metadata,
-      firmware_status: DeviceView.firmware_update_title(device),
+      firmware_update_status: Devices.firmware_status(device),
       updates_enabled: device.updates_enabled,
       updates_blocked_until: device.updates_blocked_until
     }


### PR DESCRIPTION
- latest: updates disabled, no deployment, matching the deployment
- updating: update attempts are present and it doesn't match the above
- pending: anything else, which should be only devices that haven't started updating and don't match the current deployment firmare