### PR TITLE
Remove `org_id` from the unique constraint on devices

### DIFF
--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -57,7 +57,7 @@ defmodule NervesHub.Devices.Device do
     |> cast_embed(:firmware_metadata)
     |> validate_required(@required_params)
     |> validate_length(:tags, min: 1)
-    |> unique_constraint(:identifier, name: :devices_org_id_identifier_index)
+    |> unique_constraint(:identifier)
   end
 
   def with_org(device_query) do

--- a/priv/repo/migrations/20230726201750_create_unique_index_on_devices.exs
+++ b/priv/repo/migrations/20230726201750_create_unique_index_on_devices.exs
@@ -1,0 +1,11 @@
+defmodule NervesHub.Repo.Migrations.CreateUniqueIndexOnDevices do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create index(:devices, [:identifier], unique: true, concurrently: true)
+    drop index(:devices, [:org_id, :identifier])
+  end
+end


### PR DESCRIPTION
Since we're moving towards a single company running a single NervesHub, this constraint doesn't make a ton of sense now.