### PR TITLE
Migrate certain device routes to be higher up in paths

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -194,6 +194,16 @@ defmodule NervesHub.Devices do
     |> Repo.one!()
   end
 
+  def get_by_identifier(identifier) do
+    case Repo.get_by(Device, identifier: identifier) do
+      nil ->
+        {:error, :not_found}
+
+      device ->
+        {:ok, Repo.preload(device, [:org, :product])}
+    end
+  end
+
   @spec get_device_by_identifier(Org.t(), String.t()) :: {:ok, Device.t()} | {:error, :not_found}
   def get_device_by_identifier(%Org{id: org_id}, identifier) when is_binary(identifier) do
     query =

--- a/lib/nerves_hub_web/api_router.ex
+++ b/lib/nerves_hub_web/api_router.ex
@@ -35,6 +35,17 @@ defmodule NervesHubWeb.APIRouter do
     post("/login", UserController, :login)
   end
 
+  scope "/devices", NervesHubWeb.API do
+    pipe_through([:api, :user])
+
+    get("/:identifier", DeviceController, :show)
+    post("/:identifier/reboot", DeviceController, :reboot)
+    post("/:identifier/reconnect", DeviceController, :reconnect)
+    post("/:identifier/code", DeviceController, :code)
+    post("/:identifier/upgrade", DeviceController, :upgrade)
+    delete("/:identifier/penalty", DeviceController, :penalty)
+  end
+
   scope "/", NervesHubWeb.API do
     pipe_through(:api)
     pipe_through(:user)
@@ -85,7 +96,7 @@ defmodule NervesHubWeb.APIRouter do
               post("/", DeviceController, :create)
               post("/auth", DeviceController, :auth)
 
-              scope "/:device_identifier" do
+              scope "/:identifier" do
                 pipe_through(:device)
                 get("/", DeviceController, :show)
                 delete("/", DeviceController, :delete)

--- a/lib/nerves_hub_web/controllers/api/device_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_certificate_controller.ex
@@ -10,7 +10,7 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
   plug(:validate_role, [org: :write] when action in [:create])
   plug(:validate_role, [org: :read] when action in [:index, :show])
 
-  def index(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier}) do
+  def index(%{assigns: %{org: org}} = conn, %{"identifier" => identifier}) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do
       device_certificates = Devices.get_device_certificates(device)
       render(conn, "index.json", device_certificates: device_certificates)

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.API.DeviceController do
   use NervesHubWeb, :api_controller
 
+  alias NervesHub.Accounts
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
   alias NervesHub.Devices.DeviceCertificate
@@ -13,8 +14,7 @@ defmodule NervesHubWeb.API.DeviceController do
 
   plug(:validate_role, [org: :delete] when action in [:delete])
   plug(:validate_role, [org: :write] when action in [:create, :update])
-  plug(:validate_role, [org: :write] when action in [:reboot, :reconnect, :code, :upgrade])
-  plug(:validate_role, [org: :read] when action in [:index, :show, :auth])
+  plug(:validate_role, [org: :read] when action in [:index, :auth])
 
   def index(%{assigns: %{org: org, product: product}} = conn, params) do
     opts = %{
@@ -48,22 +48,37 @@ defmodule NervesHubWeb.API.DeviceController do
     end
   end
 
-  def show(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier}) do
-    with {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do
-      render(conn, "show.json", device: device)
+  def show(conn, %{"identifier" => identifier}) do
+    %{user: user} = conn.assigns
+
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :read) do
+          conn
+          |> assign(:device, device)
+          |> render("show.json")
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: read"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
     end
   end
 
-  def delete(%{assigns: %{org: org}} = conn, %{
-        "device_identifier" => identifier
-      }) do
+  def delete(%{assigns: %{org: org}} = conn, %{"identifier" => identifier}) do
     {:ok, device} = Devices.get_device_by_identifier(org, identifier)
     {:ok, _device} = Devices.delete_device(device)
 
     send_resp(conn, :no_content, "")
   end
 
-  def update(%{assigns: %{org: org}} = conn, %{"device_identifier" => identifier} = params) do
+  def update(%{assigns: %{org: org}} = conn, %{"identifier" => identifier} = params) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
          {:ok, updated_device} <- Devices.update_device(device, params) do
       conn
@@ -88,82 +103,154 @@ defmodule NervesHubWeb.API.DeviceController do
     end
   end
 
-  def reboot(conn, _params) do
-    %{device: device, user: user} = conn.assigns
+  def reboot(conn, %{"identifier" => identifier}) do
+    %{user: user} = conn.assigns
 
-    AuditLogs.audit!(
-      user,
-      device,
-      :update,
-      "user #{user.username} rebooted device #{device.identifier}",
-      %{reboot: true}
-    )
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :write) do
+          message = "user #{user.username} rebooted device #{device.identifier}"
+          AuditLogs.audit!(user, device, :update, message, %{reboot: true})
 
-    Endpoint.broadcast_from(self(), "device:#{device.id}", "reboot", %{})
+          Endpoint.broadcast_from(self(), "device:#{device.id}", "reboot", %{})
 
-    send_resp(conn, 200, "Success")
+          send_resp(conn, 200, "Success")
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: write"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
+    end
   end
 
-  def reconnect(conn, _params) do
-    Endpoint.broadcast("device_socket:#{conn.assigns.device.id}", "disconnect", %{})
-    send_resp(conn, 200, "Success")
+  def reconnect(conn, %{"identifier" => identifier}) do
+    %{user: user} = conn.assigns
+
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :write) do
+          Endpoint.broadcast("device_socket:#{device.id}", "disconnect", %{})
+
+          send_resp(conn, 200, "Success")
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: write"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
+    end
   end
 
-  def code(conn, %{"body" => body}) do
-    device = conn.assigns.device
+  def code(conn, %{"identifier" => identifier, "body" => body}) do
+    %{user: user} = conn.assigns
 
-    body
-    |> String.graphemes()
-    |> Enum.map(fn character ->
-      Endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => character})
-    end)
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :write) do
+          body
+          |> String.graphemes()
+          |> Enum.map(fn character ->
+            Endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => character})
+          end)
 
-    Endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => "\r"})
+          Endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => "\r"})
 
-    send_resp(conn, 200, "Success")
+          send_resp(conn, 200, "Success")
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: write"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
+    end
   end
 
-  def upgrade(conn, %{"uuid" => uuid}) do
-    product = conn.assigns.product
-    {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(product, uuid)
+  def upgrade(conn, %{"identifier" => identifier, "uuid" => uuid}) do
+    %{user: user} = conn.assigns
 
-    {:ok, url} = Firmwares.get_firmware_url(firmware)
-    {:ok, meta} = Firmwares.metadata_from_firmware(firmware)
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :write) do
+          {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(device.product, uuid)
 
-    %{device: device, user: user} = conn.assigns
+          {:ok, url} = Firmwares.get_firmware_url(firmware)
+          {:ok, meta} = Firmwares.metadata_from_firmware(firmware)
 
-    {:ok, device} = Devices.disable_updates(device, user)
-    device = Repo.preload(device, [:device_certificates])
+          {:ok, device} = Devices.disable_updates(device, user)
+          device = Repo.preload(device, [:device_certificates])
 
-    description =
-      "user #{user.username} pushed firmware #{firmware.version} #{firmware.uuid} to device #{device.identifier}"
+          description =
+            "user #{user.username} pushed firmware #{firmware.version} #{firmware.uuid} to device #{device.identifier}"
 
-    AuditLogs.audit!(user, device, :update, description, %{firmware_uuid: firmware.uuid})
+          AuditLogs.audit!(user, device, :update, description, %{firmware_uuid: firmware.uuid})
 
-    payload = %UpdatePayload{
-      update_available: true,
-      firmware_url: url,
-      firmware_meta: meta
-    }
+          payload = %UpdatePayload{
+            update_available: true,
+            firmware_url: url,
+            firmware_meta: meta
+          }
 
-    NervesHubWeb.Endpoint.broadcast(
-      "device:#{device.id}",
-      "deployments/update",
-      payload
-    )
+          NervesHubWeb.Endpoint.broadcast(
+            "device:#{device.id}",
+            "deployments/update",
+            payload
+          )
 
-    send_resp(conn, 204, "")
+          send_resp(conn, 204, "")
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: write"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
+    end
   end
 
-  def penalty(conn, _params) do
-    %{device: device, user: user} = conn.assigns
+  def penalty(conn, %{"identifier" => identifier}) do
+    %{user: user} = conn.assigns
 
-    case Devices.clear_penalty_box(device, user) do
-      {:ok, _device} ->
-        send_resp(conn, 204, "")
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :write) do
+          case Devices.clear_penalty_box(device, user) do
+            {:ok, _device} ->
+              send_resp(conn, 204, "")
 
-      {:error, _changeset} ->
-        send_resp(conn, 400, "")
+            {:error, _changeset} ->
+              send_resp(conn, 400, "")
+          end
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: write"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
     end
   end
 end

--- a/lib/nerves_hub_web/plugs/api/device.ex
+++ b/lib/nerves_hub_web/plugs/api/device.ex
@@ -7,8 +7,8 @@ defmodule NervesHubWeb.API.Plugs.Device do
     opts
   end
 
-  def call(%{params: %{"device_identifier" => device_identifier}} = conn, _opts) do
-    case Devices.get_device_by_identifier(conn.assigns.org, device_identifier) do
+  def call(%{params: %{"identifier" => identifier}} = conn, _opts) do
+    case Devices.get_device_by_identifier(conn.assigns.org, identifier) do
       {:ok, device} ->
         conn
         |> assign(:device, device)
@@ -16,7 +16,7 @@ defmodule NervesHubWeb.API.Plugs.Device do
       _ ->
         conn
         |> put_resp_header("content-type", "application/json")
-        |> send_resp(403, Jason.encode!(%{status: "Invalid device: #{device_identifier}"}))
+        |> send_resp(403, Jason.encode!(%{status: "Invalid device: #{identifier}"}))
         |> halt()
     end
   end

--- a/test/nerves_hub_web/controllers/api/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/device_controller_test.exs
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.API.DeviceControllerTest do
       conn = post(conn, Routes.device_path(conn, :create, org.name, product.name), device)
       assert json_response(conn, 201)["data"]
 
-      conn = get(conn, Routes.device_path(conn, :show, org.name, product.name, device.identifier))
+      conn = get(conn, Routes.device_path(conn, :show, device.identifier))
       assert json_response(conn, 200)["data"]["identifier"] == identifier
       assert json_response(conn, 200)["data"]["updates_enabled"] == true
     end
@@ -67,8 +67,7 @@ defmodule NervesHubWeb.API.DeviceControllerTest do
 
       assert response(conn, 204)
 
-      conn =
-        get(conn, Routes.device_path(conn, :show, org.name, product.name, to_delete.identifier))
+      conn = get(conn, Routes.device_path(conn, :show, to_delete.identifier))
 
       assert json_response(conn, 200)["status"] != ""
     end
@@ -95,8 +94,7 @@ defmodule NervesHubWeb.API.DeviceControllerTest do
 
       assert json_response(conn, 201)["data"]
 
-      conn =
-        get(conn, Routes.device_path(conn, :show, org.name, product.name, to_update.identifier))
+      conn = get(conn, Routes.device_path(conn, :show, to_update.identifier))
 
       assert json_response(conn, 200)
       assert conn.assigns.device.tags == ["a", "b", "c", "d"]


### PR DESCRIPTION
Since we have unique identifiers across the entire NH, we can skip having the org and the product in the route. Role validation will happen in the route actions for now, and as the rest of the controller is filled out we can figure out a better way to load these and validate.