### PR TITLE
Deployment UI tweaks

### DIFF
--- a/lib/nerves_hub_web/templates/deployment/index.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/index.html.heex
@@ -18,74 +18,82 @@
     </a>
   </div>
 
-  <table class="table table-sm table-hover">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>State</th>
-        <th>Firmware version</th>
-        <th>Distributed to</th>
-        <th>Version requirement</th>
-      </tr>
-    </thead>
-    <%= for deployment <- @deployments do %>
-      <tr class="item">
-        <td>
-          <div class="mobile-label help-text">Name</div>
-          <div>
-            <a href={Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name)}><%= deployment.name %></a>
-          </div>
-        </td>
-        <td>
-          <div class="mobile-label help-text">State</div>
-          <div class={"deployment-state state-#{if deployment.is_active, do: "on", else: "off"}"}>
-            <%= if deployment.is_active, do: "On", else: "Off" %>
-          </div>
-        </td>
-        <td>
-          <div class="mobile-label help-text">Firmware version</div>
-          <div>
-            <span class="badge ff-m"><%= firmware_display_name(deployment.firmware) %></span>
-          </div>
-        </td>
-        <td>
-          <div class="mobile-label help-text">Distributed to</div>
-          <div>
-            <%= if Enum.count(tags(deployment)) > 0 do %>
-              <%= for tag <- tags(deployment) do %>
-                <span class="badge">
-                  <%= tag %>
-                </span>
-              <% end %>
-            <% else %>
-              -
-            <% end %>
-          </div>
-        </td>
-        <td>
-          <div class="mobile-label help-text">Version requirement</div>
-          <%= version(deployment) %>
-        </td>
-        <td class="actions">
-          <div class="mobile-label help-text">Actions</div>
-          <div class="dropdown options">
-            <a class="dropdown-toggle options" href="#" id={"deployment-#{deployment.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <div class="mobile-label pr-2">Open</div>
-              <img src="/images/icons/more.svg" alt="options" />
-            </a>
-            <div class="dropdown-menu dropdown-menu-right">
-              <%= link "details", class: "dropdown-item", to: Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name) %>
-              <div class="dropdown-divider"></div>
-              <%= link "edit", class: "dropdown-item", to: Routes.deployment_path(@conn, :edit, @org.name, @product.name, deployment.name) %>
-               <div class="dropdown-divider"></div>
-              <a class="dropdown-item" aria-label="Download Audit Logs" href={Routes.deployment_path(@conn, :export_audit_logs, @org.name, @product.name, deployment.name)}>
-                <div class="button-icon download"></div>
-                <span class="action-text">Download Audit Logs</span>
-              </a>
+  <%= for {platform, deployments} <- @deployments do %>
+    <h3 class="mt-4">Platform: <%= platform %></h3>
+
+    <table class="table table-sm table-hover">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>State</th>
+          <th>Firmware version</th>
+          <th>Distributed to</th>
+          <th>Version requirement</th>
+        </tr>
+      </thead>
+      <%= for deployment <- deployments do %>
+        <tr class="item">
+          <td>
+            <div class="mobile-label help-text">Name</div>
+            <div>
+              <a href={Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name)}><%= deployment.name %></a>
             </div>
-          </div>
-        </td>
-      </tr>
-    <% end %>
-  </table>
+          </td>
+          <td>
+            <div class="mobile-label help-text">State</div>
+            <div class={"deployment-state state-#{if deployment.is_active, do: "on", else: "off"}"}>
+              <%= if deployment.is_active, do: "On", else: "Off" %>
+            </div>
+          </td>
+          <td>
+            <div class="mobile-label help-text">Firmware version</div>
+            <div>
+                <%= link(to: Routes.firmware_path(@conn, :show, @org.name, @product.name, deployment.firmware.uuid)) do %>
+              <span class="badge ff-m">
+                <%= firmware_simple_display_name(deployment.firmware) %>
+              </span>
+              <% end %>
+            </div>
+          </td>
+          <td>
+            <div class="mobile-label help-text">Distributed to</div>
+            <div>
+              <%= if Enum.count(tags(deployment)) > 0 do %>
+                <%= for tag <- tags(deployment) do %>
+                  <span class="badge">
+                    <%= tag %>
+                  </span>
+                <% end %>
+              <% else %>
+                -
+              <% end %>
+            </div>
+          </td>
+          <td>
+            <div class="mobile-label help-text">Version requirement</div>
+            <%= version(deployment) %>
+          </td>
+          <td class="actions">
+            <div class="mobile-label help-text">Actions</div>
+            <div class="dropdown options">
+              <a class="dropdown-toggle options" href="#" id={"deployment-#{deployment.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <div class="mobile-label pr-2">Open</div>
+                <img src="/images/icons/more.svg" alt="options" />
+              </a>
+              <div class="dropdown-menu dropdown-menu-right">
+                <%= link "details", class: "dropdown-item", to: Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name) %>
+                <div class="dropdown-divider"></div>
+                <%= link "edit", class: "dropdown-item", to: Routes.deployment_path(@conn, :edit, @org.name, @product.name, deployment.name) %>
+                <div class="dropdown-divider"></div>
+                <a class="dropdown-item" aria-label="Download Audit Logs" href={Routes.deployment_path(@conn, :export_audit_logs, @org.name, @product.name, deployment.name)}>
+                  <div class="button-icon download"></div>
+                  <span class="action-text">Download Audit Logs</span>
+                </a>
+              </div>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
 <% end %>

--- a/lib/nerves_hub_web/templates/deployment/new-platform.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/new-platform.html.heex
@@ -1,0 +1,17 @@
+<h1>Add Deployment</h1>
+
+<%= form_for @conn, Routes.deployment_path(@conn, :new, @org.name, @product.name), [as: :deployment, method: :get], fn f -> %>
+  <div class="form-group">
+    <label for="platform" class="tooltip-label">
+      <span>Platform</span>
+      <span class="tooltip-info"></span>
+      <span class="tooltip-text">Only allow this platform to be chosen when selecting firmware.</span>
+    </label>
+    <%= select f, :platform, @platforms, required: true, id: "platform", class: "form-control" %>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <a class="btn btn-secondary" href={Routes.deployment_path(@conn, :index, @org.name, @product.name)}>Cancel</a>
+    <%= submit "Next", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/lib/nerves_hub_web/templates/deployment/new.html.heex
+++ b/lib/nerves_hub_web/templates/deployment/new.html.heex
@@ -45,7 +45,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <a class="btn btn-secondary" href={Routes.deployment_path(@conn, :index, @org.name, @product.name)}>Cancel</a>
+    <a class="btn btn-secondary" href={Routes.deployment_path(@conn, :new, @org.name, @product.name)}>Back</a>
     <%= submit "Create Deployment", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/lib/nerves_hub_web/views/deployment_view.ex
+++ b/lib/nerves_hub_web/views/deployment_view.ex
@@ -70,10 +70,11 @@ defmodule NervesHubWeb.DeploymentView do
   end
 
   def firmware_display_name(%Firmware{} = f) do
-    case f.version do
-      nil -> "--"
-      version -> "#{version} #{f.platform} #{f.architecture} #{f.uuid}"
-    end
+    "#{f.version} #{f.platform} #{f.architecture} #{f.uuid}"
+  end
+
+  def firmware_simple_display_name(%Firmware{} = f) do
+    "#{f.version} #{f.uuid}"
   end
 
   def help_message_for(field) do


### PR DESCRIPTION
- Split the deployment listing by platform
- When creating a new deployment, you must select a platform to filter firmware by, to reduce mistakes when selecting from a large firmware list


<img width="740" alt="Screenshot 2023-07-27 at 5 02 20 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/449228/745df52a-3d8b-490c-8ecd-c2f0b242e0e4">

<img width="819" alt="Screenshot 2023-07-27 at 5 02 35 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/449228/3416eccd-8151-45e0-bd7e-754eb2b0fba5">

<img width="1440" alt="Screenshot 2023-07-27 at 5 02 48 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/449228/371b3095-6458-4190-b074-163e71ba7903">
