### PR TITLE
Catch `noproc` exits in trackers for lots of new nodes

### DIFF
--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -269,6 +269,11 @@ defmodule NervesHub.Tracker.DeviceShard do
         try do
           :ok = GenServer.call({name(state.index), node}, :start_sync)
         catch
+          # process doesn't exist
+          :exit, _reason ->
+            Process.send_after(self(), :sync, 500)
+
+          # didn't hear back in the timeout
           :error, _timeout ->
             Process.send_after(self(), :sync, 500)
         end


### PR DESCRIPTION
When a lot of new nodes come online during a deploy, we will have a large number of nodes that don't have the tracker online and start getting GenServer calls that exit because the new node hasn't fully started yet.