### PR TITLE
Add a reference id to audit logs

### DIFF
--- a/lib/nerves_hub/audit_logs.ex
+++ b/lib/nerves_hub/audit_logs.ex
@@ -18,6 +18,12 @@ defmodule NervesHub.AuditLogs do
     |> Repo.insert!()
   end
 
+  def audit_with_ref!(actor, resource, action, description, reference_id) do
+    AuditLog.build(actor, resource, action, description, reference_id, %{})
+    |> AuditLog.changeset()
+    |> Repo.insert!()
+  end
+
   def logs_by(%actor_type{id: id}) do
     actor_type = to_string(actor_type)
 

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -469,14 +469,7 @@ defmodule NervesHub.Devices do
   end
 
   def device_connected(device) do
-    last_communication = DateTime.utc_now()
-    description = "device #{device.identifier} connected to the server"
-
-    AuditLogs.audit!(device, device, :update, description, %{
-      last_communication: last_communication
-    })
-
-    update_device(device, %{last_communication: last_communication})
+    update_device(device, %{last_communication: DateTime.utc_now()})
   end
 
   def update_firmware_metadata(device, nil) do

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -30,7 +30,14 @@ defmodule NervesHubWeb.DeviceSocket do
       |> Devices.get_device_certificate_by_x509()
       |> case do
         {:ok, db_cert} ->
-          {:ok, assign(socket, :certificate, db_cert)}
+          reference_id = Base.encode32(:crypto.strong_rand_bytes(2), padding: false)
+
+          socket =
+            socket
+            |> assign(:certificate, db_cert)
+            |> assign(:reference_id, reference_id)
+
+          {:ok, socket}
 
         _e ->
           :error

--- a/lib/nerves_hub_web/templates/audit_log/_audit_log_feed.html.heex
+++ b/lib/nerves_hub_web/templates/audit_log/_audit_log_feed.html.heex
@@ -11,6 +11,9 @@
           <p class="audit-description"><%= audit_log.description %></p>
           <div class="help-text">
             <%= DateTimeFormat.from_now(audit_log.inserted_at) %><small> at <%= audit_log.inserted_at %></small>
+            <%= if audit_log.reference_id do %>
+              (Ref: <%= audit_log.reference_id %>)
+            <% end %>
           </div>
         </div>
       </div>

--- a/priv/repo/migrations/20230801181852_add_reference_id_to_audit_logs.exs
+++ b/priv/repo/migrations/20230801181852_add_reference_id_to_audit_logs.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddReferenceIdToAuditLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_logs) do
+      add(:reference_id, :string)
+    end
+  end
+end

--- a/test/nerves_hub/audit_logs/audit_log_test.exs
+++ b/test/nerves_hub/audit_logs/audit_log_test.exs
@@ -9,12 +9,6 @@ defmodule NervesHub.AuditLogs.AuditLogTest do
   end
 
   describe "build" do
-    test "includes changes if present", %{device: device, user: user} do
-      params = %{tags: ["howdy"]}
-      al = AuditLog.build(user, device, :update, "updated", params)
-      assert al.changes == params
-    end
-
     test "can use supplied description", %{device: device, user: user} do
       description = "what just happened?!"
       al = AuditLog.build(user, device, :update, description, %{})

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -2,7 +2,6 @@ defmodule NervesHub.DevicesTest do
   use NervesHub.DataCase, async: false
 
   alias NervesHub.AuditLogs
-  alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.Deployments
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate
@@ -489,13 +488,6 @@ defmodule NervesHub.DevicesTest do
     for deployment <- deployments do
       assert deployment.firmware.product_id == product.id
     end
-  end
-
-  test "device_connected adds audit log", %{device: device} do
-    assert AuditLogs.logs_for(device) == []
-    Devices.device_connected(device)
-    assert [%AuditLog{description: desc}] = AuditLogs.logs_for(device)
-    assert desc =~ "device #{device.identifier} connected to the server"
   end
 
   test "delta_updatable?", %{

--- a/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
@@ -107,7 +107,6 @@ defmodule NervesHubWeb.API.DeploymentControllerTest do
 
       [audit_log] = AuditLogs.logs_for(deployment)
       assert audit_log.resource_type == Deployment
-      assert audit_log.changes == %{"is_active" => true}
     end
 
     test "renders errors when data is invalid", %{

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -254,7 +254,6 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       [audit_log_one, audit_log_two] = AuditLogs.logs_for(deployment)
 
       assert audit_log_one.resource_type == Deployment
-      assert Map.has_key?(audit_log_one.changes, "conditions")
 
       assert audit_log_two.description =~ ~r/removed all devices/
     end


### PR DESCRIPTION
Mostly around device connections. So we can tie device actions to a specific connection, like a connect and disconnect message.