### PR TITLE
Remove action and params from audit logs

### DIFF
--- a/lib/nerves_hub/audit_logs.ex
+++ b/lib/nerves_hub/audit_logs.ex
@@ -6,20 +6,20 @@ defmodule NervesHub.AuditLogs do
   alias NervesHub.Repo
   alias NimbleCSV.RFC4180, as: CSV
 
-  def audit(actor, resource, action, description, params) do
-    AuditLog.build(actor, resource, action, description, params)
+  def audit(actor, resource, description) do
+    AuditLog.build(actor, resource, description)
     |> AuditLog.changeset()
     |> Repo.insert()
   end
 
-  def audit!(actor, resource, action, description, params \\ %{}) do
-    AuditLog.build(actor, resource, action, description, params)
+  def audit!(actor, resource, description) do
+    AuditLog.build(actor, resource, description)
     |> AuditLog.changeset()
     |> Repo.insert!()
   end
 
-  def audit_with_ref!(actor, resource, action, description, reference_id) do
-    AuditLog.build(actor, resource, action, description, reference_id, %{})
+  def audit_with_ref!(actor, resource, description, reference_id) do
+    AuditLog.build(actor, resource, description, reference_id)
     |> AuditLog.changeset()
     |> Repo.insert!()
   end

--- a/lib/nerves_hub/audit_logs/audit_log.ex
+++ b/lib/nerves_hub/audit_logs/audit_log.ex
@@ -2,30 +2,24 @@ defmodule NervesHub.AuditLogs.AuditLog do
   use Ecto.Schema
 
   import Ecto.Changeset
-  import EctoEnum
 
   alias NervesHub.Accounts.Org
   alias NervesHub.Types.Resource
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @required_params [
-    :action,
     :actor_id,
     :actor_type,
     :description,
-    :params,
     :resource_id,
     :resource_type,
     :org_id
   ]
   @optional_params [:reference_id]
 
-  defenum(Action, :action, [:create, :update, :delete])
-
   schema "audit_logs" do
     belongs_to(:org, Org, where: [deleted_at: nil])
 
-    field(:action, Action)
     field(:actor_id, :id)
     field(:actor_type, Resource)
     field(:description, :string)
@@ -37,37 +31,26 @@ defmodule NervesHub.AuditLogs.AuditLog do
     timestamps(type: :naive_datetime_usec, updated_at: false)
   end
 
-  def build(%actor_type{} = actor, %resource_type{} = resource, action, description, params) do
+  def build(%actor_type{} = actor, %resource_type{} = resource, description) do
     %__MODULE__{
-      action: action,
       actor_id: actor.id,
       actor_type: actor_type,
       description: description,
       resource_id: resource.id,
       resource_type: resource_type,
-      org_id: resource.org_id,
-      params: params
+      org_id: resource.org_id
     }
   end
 
-  def build(
-        %actor_type{} = actor,
-        %resource_type{} = resource,
-        action,
-        description,
-        reference_id,
-        params
-      ) do
+  def build(%actor_type{} = actor, %resource_type{} = resource, description, reference_id) do
     %__MODULE__{
-      action: action,
       actor_id: actor.id,
       actor_type: actor_type,
       description: description,
       resource_id: resource.id,
       resource_type: resource_type,
       org_id: resource.org_id,
-      reference_id: reference_id,
-      params: params
+      reference_id: reference_id
     }
   end
 

--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -147,7 +147,7 @@ defmodule NervesHub.Deployments do
           broadcast(:none, "deployments/changed", payload)
 
           description = "deployment #{deployment.name} conditions changed and removed all devices"
-          AuditLogs.audit!(deployment, deployment, :update, description)
+          AuditLogs.audit!(deployment, deployment, description)
         end
 
         # if is_active is false, wipe it out like above
@@ -163,7 +163,7 @@ defmodule NervesHub.Deployments do
             broadcast(deployment, "deployments/changed", payload)
 
             description = "deployment #{deployment.name} is inactive and removed all devices"
-            AuditLogs.audit!(deployment, deployment, :update, description)
+            AuditLogs.audit!(deployment, deployment, description)
           end
         end
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -40,7 +40,6 @@ defmodule NervesHubWeb.DeviceChannel do
         AuditLogs.audit_with_ref!(
           device,
           device,
-          :update,
           description,
           socket.assigns.reference_id
         )
@@ -70,7 +69,6 @@ defmodule NervesHubWeb.DeviceChannel do
           AuditLogs.audit_with_ref!(
             deployment,
             device,
-            :update,
             description,
             socket.assigns.reference_id
           )
@@ -226,7 +224,6 @@ defmodule NervesHubWeb.DeviceChannel do
         AuditLogs.audit_with_ref!(
           device,
           device,
-          :update,
           description,
           socket.assigns.reference_id
         )
@@ -237,7 +234,6 @@ defmodule NervesHubWeb.DeviceChannel do
         AuditLogs.audit_with_ref!(
           device,
           device,
-          :update,
           description,
           socket.assigns.reference_id
         )
@@ -292,7 +288,6 @@ defmodule NervesHubWeb.DeviceChannel do
           AuditLogs.audit_with_ref!(
             deployment,
             device,
-            :update,
             description,
             socket.assigns.reference_id
           )
@@ -383,7 +378,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
       description = "device #{device.identifier} disconnected from the server"
 
-      AuditLogs.audit_with_ref!(device, device, :update, description, reference_id)
+      AuditLogs.audit_with_ref!(device, device, description, reference_id)
 
       Registry.unregister(NervesHub.Devices, device.id)
       Tracker.offline(device)
@@ -462,7 +457,7 @@ defmodule NervesHubWeb.DeviceChannel do
       description =
         "device #{device.identifier} reloaded deployment and is attached to deployment #{device.deployment.name}"
 
-      AuditLogs.audit_with_ref!(device, device, :update, description, socket.assigns.reference_id)
+      AuditLogs.audit_with_ref!(device, device, description, socket.assigns.reference_id)
 
       DeviceLink.update_device(socket.assigns.device_link_pid, device)
 

--- a/lib/nerves_hub_web/controllers/api/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_controller.ex
@@ -33,9 +33,7 @@ defmodule NervesHubWeb.API.DeploymentController do
           AuditLogs.audit!(
             user,
             deployment,
-            :create,
-            "user #{user.username} created deployment #{deployment.name}",
-            params
+            "user #{user.username} created deployment #{deployment.name}"
           )
 
           conn
@@ -67,9 +65,7 @@ defmodule NervesHubWeb.API.DeploymentController do
       AuditLogs.audit!(
         user,
         deployment,
-        :update,
-        "user #{user.username} updated deployment #{deployment.name}",
-        deployment_params
+        "user #{user.username} updated deployment #{deployment.name}"
       )
 
       render(conn, "show.json", deployment: updated_deployment)

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -110,7 +110,7 @@ defmodule NervesHubWeb.API.DeviceController do
       {:ok, device} ->
         if Accounts.has_org_role?(device.org, user, :write) do
           message = "user #{user.username} rebooted device #{device.identifier}"
-          AuditLogs.audit!(user, device, :update, message, %{reboot: true})
+          AuditLogs.audit!(user, device, message)
 
           Endpoint.broadcast_from(self(), "device:#{device.id}", "reboot", %{})
 
@@ -198,7 +198,7 @@ defmodule NervesHubWeb.API.DeviceController do
           description =
             "user #{user.username} pushed firmware #{firmware.version} #{firmware.uuid} to device #{device.identifier}"
 
-          AuditLogs.audit!(user, device, :update, description, %{firmware_uuid: firmware.uuid})
+          AuditLogs.audit!(user, device, description)
 
           payload = %UpdatePayload{
             update_available: true,

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -129,9 +129,7 @@ defmodule NervesHubWeb.DeploymentController do
         AuditLogs.audit!(
           user,
           deployment,
-          :create,
-          "user #{user.username} created deployment #{deployment.name}",
-          params
+          "user #{user.username} created deployment #{deployment.name}"
         )
 
         conn
@@ -200,9 +198,7 @@ defmodule NervesHubWeb.DeploymentController do
         AuditLogs.audit!(
           user,
           deployment,
-          :update,
-          "user #{user.username} updated deployment #{deployment.name}",
-          params
+          "user #{user.username} updated deployment #{deployment.name}"
         )
 
         conn
@@ -236,7 +232,7 @@ defmodule NervesHubWeb.DeploymentController do
 
     active_str = if value, do: "active", else: "inactive"
     description = "user #{user.username} marked deployment #{deployment.name} #{active_str}"
-    AuditLogs.audit!(user, deployment, :update, description, %{is_active: value})
+    AuditLogs.audit!(user, deployment, description)
 
     conn
     |> put_flash(:info, "Deployment set #{active_str}")
@@ -248,10 +244,7 @@ defmodule NervesHubWeb.DeploymentController do
 
     description = "user #{user.username} deleted deployment #{deployment.name}"
 
-    AuditLogs.audit!(user, deployment, :delete, description, %{
-      id: deployment.id,
-      name: deployment.name
-    })
+    AuditLogs.audit!(user, deployment, description)
 
     Deployments.delete_deployment(deployment)
 

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -109,13 +109,7 @@ defmodule NervesHubWeb.DeviceController do
   def reboot(conn, _params) do
     %{user: user, org: org, product: product, device: device} = conn.assigns
 
-    AuditLogs.audit!(
-      user,
-      device,
-      :update,
-      "user #{user.username} rebooted device #{device.identifier}",
-      %{reboot: true}
-    )
+    AuditLogs.audit!(user, device, "user #{user.username} rebooted device #{device.identifier}")
 
     Endpoint.broadcast_from!(self(), "device:#{device.id}", "reboot", %{})
 

--- a/lib/nerves_hub_web/live/device_live/show.ex
+++ b/lib/nerves_hub_web/live/device_live/show.ex
@@ -261,7 +261,7 @@ defmodule NervesHubWeb.DeviceLive.Show do
     description =
       "user #{user.username} pushed firmware #{firmware.version} #{firmware.uuid} to device #{device.identifier}"
 
-    AuditLogs.audit!(user, device, :update, description, %{firmware_uuid: firmware.uuid})
+    AuditLogs.audit!(user, device, description)
 
     payload = %UpdatePayload{
       update_available: true,
@@ -287,13 +287,7 @@ defmodule NervesHubWeb.DeviceLive.Show do
   end
 
   defp do_reboot(%{assigns: %{device: device, user: user}} = socket, :allowed) do
-    AuditLogs.audit!(
-      user,
-      device,
-      :update,
-      "user #{user.username} rebooted device #{device.identifier}",
-      %{reboot: true}
-    )
+    AuditLogs.audit!(user, device, "user #{user.username} rebooted device #{device.identifier}")
 
     socket.endpoint.broadcast_from(self(), "device:#{socket.assigns.device.id}", "reboot", %{})
 
@@ -306,12 +300,7 @@ defmodule NervesHubWeb.DeviceLive.Show do
     AuditLogs.audit!(
       user,
       device,
-      :update,
-      "user #{user.username} attempted to reboot device #{device.identifier}",
-      %{
-        reboot: false,
-        message: msg
-      }
+      "user #{user.username} attempted to reboot device #{device.identifier}"
     )
 
     {:noreply, put_flash(socket, :error, msg)}

--- a/lib/nerves_hub_web/templates/audit_log/_audit_log_feed.html.heex
+++ b/lib/nerves_hub_web/templates/audit_log/_audit_log_feed.html.heex
@@ -6,7 +6,7 @@
   <% else %>
     <%= for audit_log <- @audit_logs do %>
       <div class="audit-log-item" id={audit_log.id}>
-        <div class={"audit-action-icon icon-#{audit_log.action}"}></div>
+        <div class={"audit-action-icon icon-update"}></div>
         <div>
           <p class="audit-description"><%= audit_log.description %></p>
           <div class="help-text">

--- a/priv/repo/migrations/20190403164436_create_audit_logs.exs
+++ b/priv/repo/migrations/20190403164436_create_audit_logs.exs
@@ -1,15 +1,13 @@
 defmodule NervesHub.Repo.Migrations.CreateAuditLogs do
   use Ecto.Migration
 
-  alias NervesHub.AuditLogs.AuditLog.Action
-
   def change do
-    Action.create_type()
+    execute "create type action as enum ('create', 'update', 'delete');", "delete type action;"
 
     create table(:audit_logs, primary_key: false) do
       add(:id, :uuid, primary_key: true)
 
-      add(:action, Action.type(), null: false)
+      add(:action, :action, null: false)
       add(:actor_id, :id, null: false)
       add(:actor_type, :string, null: false)
       add(:params, :map, null: false)

--- a/priv/repo/migrations/20230801185335_null_true_on_action_and_params_for_audit_logs.exs
+++ b/priv/repo/migrations/20230801185335_null_true_on_action_and_params_for_audit_logs.exs
@@ -1,0 +1,10 @@
+defmodule NervesHub.Repo.Migrations.NullTrueOnActionAndParamsForAuditLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_logs) do
+      modify(:action, :action, null: true)
+      modify(:params, :jsonb, null: true)
+    end
+  end
+end

--- a/test/nerves_hub/audit_logs/audit_log_test.exs
+++ b/test/nerves_hub/audit_logs/audit_log_test.exs
@@ -11,9 +11,8 @@ defmodule NervesHub.AuditLogs.AuditLogTest do
   describe "build" do
     test "can use supplied description", %{device: device, user: user} do
       description = "what just happened?!"
-      al = AuditLog.build(user, device, :update, description, %{})
+      al = AuditLog.build(user, device, description)
       assert al.description == description
-      assert al.params == %{}
     end
   end
 end

--- a/test/nerves_hub/audit_logs_test.exs
+++ b/test/nerves_hub/audit_logs_test.exs
@@ -16,7 +16,7 @@ defmodule NervesHub.AuditLogsTest do
       Enum.map(0..5, fn days ->
         inserted_at = NaiveDateTime.add(now, -1 * days * 24 * 60 * 60, :second)
 
-        AuditLogs.audit!(%Device{id: 10}, %Device{id: 10, org_id: org.id}, :update, "Updating")
+        AuditLogs.audit!(%Device{id: 10}, %Device{id: 10, org_id: org.id}, "Updating")
         |> Ecto.Changeset.change(%{inserted_at: inserted_at})
         |> Repo.update!()
       end)
@@ -36,7 +36,7 @@ defmodule NervesHub.AuditLogsTest do
       Enum.map(0..11, fn _ ->
         inserted_at = NaiveDateTime.add(now, -1 * 5 * 24 * 60 * 60, :second)
 
-        AuditLogs.audit!(%Device{id: 10}, %Device{id: 10, org_id: org.id}, :update, "Updating")
+        AuditLogs.audit!(%Device{id: 10}, %Device{id: 10, org_id: org.id}, "Updating")
         |> Ecto.Changeset.change(%{inserted_at: inserted_at})
         |> Repo.update!()
       end)

--- a/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
@@ -55,8 +55,6 @@ defmodule NervesHubWeb.API.DeploymentControllerTest do
 
       [audit_log] = AuditLogs.logs_by(user)
       assert audit_log.resource_type == Deployment
-      assert audit_log.params["firmware_id"] == params.firmware_id
-      assert audit_log.params["name"] == params.name
     end
 
     test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -146,11 +146,7 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn = get(create_conn, redirect_path)
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Deployment created"
 
-      [%{resource_type: resource_type, params: params}] = AuditLogs.logs_by(fixture.user)
-      assert resource_type == Deployment
-      assert params["firmware_id"] == deployment_params.firmware_id
-      assert params["org_id"] == deployment_params.org_id
-      assert params["name"] == deployment_params.name
+      [%{resource_type: Deployment}] = AuditLogs.logs_by(fixture.user)
     end
   end
 


### PR DESCRIPTION
Nothing uses those fields and they just make the function call to audit logs very long.