### PR TITLE
Enforce TLS 1.2 for most backward compatibility

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -42,6 +42,7 @@ config :nerves_hub, NervesHubWeb.DeviceEndpoint,
     # See https://github.com/erlang/otp/issues/6492#issuecomment-1323874205
     #
     # certificate_authorities: false,
+    versions: [:"tlsv1.2"],
     verify: :verify_peer,
     verify_fun: {&NervesHubDevice.SSL.verify_fun/3, nil},
     fail_if_no_peer_cert: true,

--- a/config/release.exs
+++ b/config/release.exs
@@ -93,6 +93,7 @@ if nerves_hub_app in ["all", "device"] do
       # See https://github.com/erlang/otp/issues/6492#issuecomment-1323874205
       #
       # certificate_authorities: false,
+      versions: [:"tlsv1.2"],
       verify: :verify_peer,
       fail_if_no_peer_cert: true,
       keyfile: "/etc/ssl/#{host}-key.pem",

--- a/test/nerves_hub_device/ssl_test.exs
+++ b/test/nerves_hub_device/ssl_test.exs
@@ -163,7 +163,7 @@ defmodule NervesHubDevice.SSLTest do
       {:ok, db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
       {:ok, db_ca} = Devices.update_ca_certificate(db_ca, %{check_expiration: true})
       assert is_nil(db_ca.last_used)
-      assert {:fail, :invalid_issuer} = run_verify(context.cert2)
+      assert {:fail, :cert_expired} = run_verify(context.cert2)
       refute is_nil(Fixtures.reload(db_ca).last_used)
     end
 
@@ -220,7 +220,7 @@ defmodule NervesHubDevice.SSLTest do
       {:ok, db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
       {:ok, db_ca} = Devices.update_ca_certificate(db_ca, %{check_expiration: true})
       assert is_nil(db_ca.last_used)
-      assert {:fail, :invalid_issuer} = run_verify(context.unknown_cert)
+      assert {:fail, :cert_expired} = run_verify(context.unknown_cert)
       refute is_nil(Fixtures.reload(db_ca).last_used)
     end
 


### PR DESCRIPTION
Older versions of OTP that may be on devices have a harder time connecting to a server which allows TLS 1.3. For improved backwards compatibility, this sets the default TLS 1.2 for the DeviceEndpoint which should only have issues with devices using OTP 24.3.2 TLS v1.3