### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/node_modules/
+.git
+.idea #IntelliJ stuff
+_build
+deps
+tmp
+


### PR DESCRIPTION
The primary motivation for this change is to avoid issues that occur when building on a different platform than the dockerfile target. If the node_modules directory is copied as part of the docker build process, a native binary on the host system may already be present and it will conflict with, for example, a 64-bit linux target if your host system is, for example, a Mac.

It's possible to avoid this issue by writing more explicit copy commands in the dockerfile, but this adds more layers to the docker image which is undesirable when trying to minimize docker image size.

There's another pattern which we use in our own app, which uses an allow-list instead of an exclude-list:

````dockerignore
*

!apps/
!config/
!mix.exs
!mix.lock
!TAG.txt

**/.elixir_ls/
**/node_modules/
**/screenshots/
**/test/

**/*.iml
**/.DS_Store
````

However, I suspect this may be more confusing in a project with a large number of contributors, so I'm only disallowing a few items.