### PR TITLE
Protect against missing SKI

### DIFF
--- a/lib/nerves_hub/ssl.ex
+++ b/lib/nerves_hub/ssl.ex
@@ -51,7 +51,7 @@ defmodule NervesHub.SSL do
         # registration
         {:valid, state}
 
-      match?({:ok, _db_ca}, Devices.get_ca_certificate_by_ski(ski)) ->
+      is_binary(ski) and match?({:ok, _db_ca}, Devices.get_ca_certificate_by_ski(ski)) ->
         # Signer CA sent with the device certificate, but is an intermediary
         # so the chain is incomplete labeling it as unknown_ca.
         #


### PR DESCRIPTION
If a device certificate doesn't have an SKI, then the `NervesHub.SSL` verification function will fail silently and return `unknown_ca` making for confusing behavior.

This protects against `nil` and ensures an SKI is available to lookup when needed