### PR TITLE
Fix crash when updating tags on device without firmware metadata

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -226,9 +226,10 @@ defmodule NervesHub.Deployments do
 
   Based on the product, firmware platform, firmware architecture, and device tags
   """
-  def alternate_deployments(%Device{firmware_metadata: nil}), do: []
+  def alternate_deployments(device, active \\ [true, false])
+  def alternate_deployments(%Device{firmware_metadata: nil}, _active), do: []
 
-  def alternate_deployments(device, active \\ [true, false]) do
+  def alternate_deployments(device, active) do
     Deployment
     |> join(:inner, [d], assoc(d, :firmware), as: :firmware)
     |> where([d], d.product_id == ^device.product_id)

--- a/test/nerves_hub/deployments_test.exs
+++ b/test/nerves_hub/deployments_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHub.DeploymentsTest do
   import Phoenix.ChannelTest
 
   alias NervesHub.Deployments
+  alias NervesHub.Devices.Device
   alias NervesHub.Fixtures
   alias Ecto.Changeset
 
@@ -323,5 +324,11 @@ defmodule NervesHub.DeploymentsTest do
       assert Enum.member?(deployments, low_deployment)
       refute Enum.member?(deployments, high_deployment)
     end
+  end
+
+  test "alternate_deployments/2 ignores device without firmware metadata" do
+    assert [] == Deployments.alternate_deployments(%Device{firmware_metadata: nil})
+    assert [] == Deployments.alternate_deployments(%Device{firmware_metadata: nil}, [true])
+    assert [] == Deployments.alternate_deployments(%Device{firmware_metadata: nil}, [false])
   end
 end


### PR DESCRIPTION
If a device has never connected, the `firmware_metadata` is `nil`. We were previously attempting to ignore this case before, but it would only apply if used as a single airily. If someone used `Deployments.alternate_deployment/2` without the default (like when updating tags on a device), the things would 💥 

This fixes the default definition so `firmware_metadata: nil` is properly skipped

<details><summary>Exception</summary>
<p>

```
Request: POST /org/poser/poser/devices/poser-bad
** (exit) an exception was raised:
    ** (KeyError) key :platform not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
        (nerves_hub 0.1.0) lib/nerves_hub/deployments.ex:238: NervesHub.Deployments.alternate_deployments/2
        (nerves_hub 0.1.0) lib/nerves_hub/deployments.ex:275: anonymous fn/2 in NervesHub.Deployments.set_deployment/1
        (opentelemetry 1.3.0) /Users/jonjon/code/nerves_hub_web/deps/opentelemetry/src/otel_tracer_default.erl:47: :otel_tracer_default.with_span/5
        (nerves_hub 0.1.0) lib/nerves_hub/devices.ex:499: NervesHub.Devices.update_device/3
        (ecto 3.10.3) lib/ecto/multi.ex:844: Ecto.Multi.apply_operation/5
        (elixir 1.15.4) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
        (ecto 3.10.3) lib/ecto/multi.ex:818: anonymous fn/5 in Ecto.Multi.apply_operations/5
        (ecto_sql 3.10.1) lib/ecto/adapters/sql.ex:1203: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
        (db_connection 2.5.0) lib/db_connection.ex:1630: DBConnection.run_transaction/4
        (ecto 3.10.3) lib/ecto/repo/transaction.ex:18: Ecto.Repo.Transaction.transaction/4
        (nerves_hub 0.1.0) lib/nerves_hub/devices.ex:832: NervesHub.Devices.update_device_with_audit/4
        (nerves_hub 0.1.0) lib/nerves_hub_web/controllers/device_controller.ex:86: NervesHubWeb.DeviceController.update/2
        (nerves_hub 0.1.0) lib/nerves_hub_web/controllers/device_controller.ex:1: NervesHubWeb.DeviceController.action/2
        (nerves_hub 0.1.0) lib/nerves_hub_web/controllers/device_controller.ex:1: NervesHubWeb.DeviceController.phoenix_controller_pipeline/2
        (phoenix 1.7.7) lib/phoenix/router.ex:430: Phoenix.Router.__call__/5
        (nerves_hub 0.1.0) lib/nerves_hub_web/endpoint.ex:1: NervesHubWeb.Endpoint.plug_builder_call/2
        (nerves_hub 0.1.0) deps/plug/lib/plug/debugger.ex:136: NervesHubWeb.Endpoint."call (overridable 3)"/2
        (nerves_hub 0.1.0) lib/nerves_hub_web/endpoint.ex:1: NervesHubWeb.Endpoint."call (overridable 4)"/2
        (nerves_hub 0.1.0) lib/nerves_hub_web/endpoint.ex:1: NervesHubWeb.Endpoint.call/2
        (phoenix 1.7.7) lib/phoenix/endpoint/sync_code_reload_plug.ex:22: Phoenix.Endpoint.SyncCodeReloadPlug.do_call/4
```

</p>
</details> 