### PR TITLE
Allow setting role when inviting new user

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -440,7 +440,7 @@ defmodule NervesHub.Accounts do
   def add_or_invite_to_org(%{"email" => email} = params, org) do
     case get_user_by_email(email) do
       {:error, :not_found} -> invite(params, org)
-      {:ok, user} -> add_org_user(org, user, %{role: :admin})
+      {:ok, user} -> add_org_user(org, user, %{role: params["role"]})
     end
   end
 
@@ -507,7 +507,7 @@ defmodule NervesHub.Accounts do
 
     Repo.transaction(fn ->
       with {:ok, user} <- create_user(user_params),
-           {:ok, user} <- add_org_user(org, user, %{role: :admin}),
+           {:ok, user} <- add_org_user(org, user, %{role: invite.role}),
            {:ok, _invite} <- set_invite_accepted(invite) do
         # Repo.transaction will wrap this in an {:ok, user}
         user

--- a/lib/nerves_hub/accounts/invite.ex
+++ b/lib/nerves_hub/accounts/invite.ex
@@ -4,6 +4,7 @@ defmodule NervesHub.Accounts.Invite do
   import Ecto.Changeset
 
   alias NervesHub.Accounts.Org
+  alias NervesHub.Accounts.OrgUser
   alias __MODULE__
 
   @type t :: %__MODULE__{}
@@ -14,7 +15,7 @@ defmodule NervesHub.Accounts.Invite do
     field(:email, :string)
     field(:token, Ecto.UUID)
     field(:accepted, :boolean)
-    field(:role, Ecto.Enum, values: Ecto.Enum.values(NervesHub.Accounts.OrgUser, :role))
+    field(:role, Ecto.Enum, values: Ecto.Enum.values(OrgUser, :role))
 
     timestamps()
   end

--- a/lib/nerves_hub/accounts/invite.ex
+++ b/lib/nerves_hub/accounts/invite.ex
@@ -14,13 +14,14 @@ defmodule NervesHub.Accounts.Invite do
     field(:email, :string)
     field(:token, Ecto.UUID)
     field(:accepted, :boolean)
+    field(:role, Ecto.Enum, values: Ecto.Enum.values(NervesHub.Accounts.OrgUser, :role))
 
     timestamps()
   end
 
   def changeset(%Invite{} = invite, params) do
     invite
-    |> cast(params, [:email, :token, :org_id, :accepted])
-    |> validate_required([:email, :token, :org_id])
+    |> cast(params, [:email, :token, :org_id, :accepted, :role])
+    |> validate_required([:email, :token, :org_id, :role])
   end
 end

--- a/lib/nerves_hub/accounts/org_user.ex
+++ b/lib/nerves_hub/accounts/org_user.ex
@@ -11,7 +11,7 @@ defmodule NervesHub.Accounts.OrgUser do
     belongs_to(:org, Org, where: [deleted_at: nil])
     belongs_to(:user, User, where: [deleted_at: nil])
 
-    field(:role, Ecto.Enum, values: [:admin, :delete, :write, :read])
+    field(:role, Ecto.Enum, values: [:admin, :manage, :view])
     field(:deleted_at, :utc_datetime)
 
     timestamps()

--- a/lib/nerves_hub/accounts/user.ex
+++ b/lib/nerves_hub/accounts/user.ex
@@ -116,9 +116,8 @@ defmodule NervesHub.Accounts.User do
     |> preload(orgs: [:org_keys])
   end
 
-  def role_or_higher(:read), do: [:read, :write, :delete, :admin]
-  def role_or_higher(:write), do: [:write, :delete, :admin]
-  def role_or_higher(:delete), do: [:delete, :admin]
+  def role_or_higher(:view), do: [:view, :manage, :admin]
+  def role_or_higher(:manage), do: [:manage, :admin]
   def role_or_higher(:admin), do: [:admin]
 
   defp password_validations(%Changeset{} = changeset) do

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -25,7 +25,7 @@ defmodule NervesHub.Products do
         on: p.org_id == ou.org_id,
         where:
           p.org_id == ^org_id and ou.user_id == ^user_id and
-            ou.role in ^User.role_or_higher(:read),
+            ou.role in ^User.role_or_higher(:view),
         group_by: p.id
       )
 

--- a/lib/nerves_hub_web/controllers/api/ca_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/ca_certificate_controller.ex
@@ -5,9 +5,8 @@ defmodule NervesHubWeb.API.CACertificateController do
 
   action_fallback(NervesHubWeb.API.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:create])
-  plug(:validate_role, [org: :read] when action in [:index, :show])
+  plug(:validate_role, [org: :manage] when action in [:create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   def index(%{assigns: %{org: org}} = conn, _params) do
     ca_certificates = Devices.get_ca_certificates(org)

--- a/lib/nerves_hub_web/controllers/api/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_controller.ex
@@ -8,9 +8,8 @@ defmodule NervesHubWeb.API.DeploymentController do
 
   action_fallback(NervesHubWeb.API.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:create, :update])
-  plug(:validate_role, [org: :read] when action in [:index, :show])
+  plug(:validate_role, [org: :manage] when action in [:create, :update, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   @whitelist_fields [:name, :org_id, :firmware_id, :conditions, :is_active]
 

--- a/lib/nerves_hub_web/controllers/api/device_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_certificate_controller.ex
@@ -6,9 +6,8 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
 
   action_fallback(NervesHubWeb.API.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:create])
-  plug(:validate_role, [org: :read] when action in [:index, :show])
+  plug(:validate_role, [org: :manage] when action in [:create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   def index(%{assigns: %{org: org}} = conn, %{"identifier" => identifier}) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier) do

--- a/lib/nerves_hub_web/controllers/api/firmware_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/firmware_controller.ex
@@ -5,9 +5,8 @@ defmodule NervesHubWeb.API.FirmwareController do
 
   action_fallback(NervesHubWeb.API.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:create])
-  plug(:validate_role, [org: :read] when action in [:index, :show])
+  plug(:validate_role, [org: :manage] when action in [:create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   def index(%{assigns: %{product: product}} = conn, _params) do
     firmwares = Firmwares.get_firmwares_by_product(product.id)

--- a/lib/nerves_hub_web/controllers/api/key_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/key_controller.ex
@@ -6,9 +6,8 @@ defmodule NervesHubWeb.API.KeyController do
 
   action_fallback(NervesHubWeb.API.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:create])
-  plug(:validate_role, [org: :read] when action in [:index, :show])
+  plug(:validate_role, [org: :manage] when action in [:create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   def index(%{assigns: %{org: org}} = conn, _params) do
     keys = Accounts.list_org_keys(org)

--- a/lib/nerves_hub_web/controllers/api/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/product_controller.ex
@@ -6,10 +6,8 @@ defmodule NervesHubWeb.API.ProductController do
 
   action_fallback(NervesHubWeb.API.FallbackController)
 
-  plug(:validate_role, [org: :read] when action in [:show])
-  plug(:validate_role, [org: :write] when action in [:create])
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :admin] when action in [:update])
+  plug(:validate_role, [org: :admin] when action in [:create, :delete, :update])
+  plug(:validate_role, [org: :view] when action in [:show])
 
   def index(%{assigns: %{user: user, org: org}} = conn, _params) do
     products = Products.get_products_by_user_and_org(user, org)

--- a/lib/nerves_hub_web/controllers/archive_controller.ex
+++ b/lib/nerves_hub_web/controllers/archive_controller.ex
@@ -4,9 +4,8 @@ defmodule NervesHubWeb.ArchiveController do
   alias NervesHub.Accounts
   alias NervesHub.Archives
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:new, :create])
-  plug(:validate_role, [org: :read] when action in [:index, :show])
+  plug(:validate_role, [org: :manage] when action in [:new, :create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   def index(conn, _params) do
     %{product: product} = conn.assigns
@@ -21,7 +20,7 @@ defmodule NervesHubWeb.ArchiveController do
 
     case Archives.get(uuid) do
       {:ok, archive} ->
-        if Accounts.has_org_role?(archive.product.org, user, :read) do
+        if Accounts.has_org_role?(archive.product.org, user, :view) do
           conn
           |> assign(:archive, archive)
           |> render("show.html")
@@ -45,7 +44,7 @@ defmodule NervesHubWeb.ArchiveController do
 
     case Archives.get(uuid) do
       {:ok, archive} ->
-        if Accounts.has_org_role?(archive.product.org, user, :read) do
+        if Accounts.has_org_role?(archive.product.org, user, :view) do
           redirect(conn, external: Archives.url(archive))
         else
           conn

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -9,9 +9,12 @@ defmodule NervesHubWeb.DeploymentController do
   alias NervesHub.Devices
   alias Ecto.Changeset
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:new, :create, :edit, :update, :toggle])
-  plug(:validate_role, [org: :read] when action in [:index, :show, :export_audit_logs])
+  plug(
+    :validate_role,
+    [org: :manage] when action in [:new, :create, :edit, :update, :delete, :toggle]
+  )
+
+  plug(:validate_role, [org: :view] when action in [:index, :show, :export_audit_logs])
 
   def index(%{assigns: %{org: _org, product: %{id: product_id}}} = conn, _params) do
     deployments = Deployments.get_deployments_by_product(product_id)

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -7,16 +7,14 @@ defmodule NervesHubWeb.DeviceController do
   alias NervesHubWeb.DeviceLive
   alias NervesHubWeb.Endpoint
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-
   plug(
     :validate_role,
-    [org: :write] when action in [:new, :create, :edit, :reboot, :toggle_updates]
+    [org: :manage] when action in [:new, :create, :edit, :delete, :reboot, :toggle_updates]
   )
 
   plug(
     :validate_role,
-    [org: :read]
+    [org: :view]
     when action in [:index, :console, :show, :download_certificate, :export_audit_logs]
   )
 

--- a/lib/nerves_hub_web/controllers/firmware_controller.ex
+++ b/lib/nerves_hub_web/controllers/firmware_controller.ex
@@ -7,9 +7,8 @@ defmodule NervesHubWeb.FirmwareController do
 
   action_fallback(NervesHubWeb.FallbackController)
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:upload, :do_upload])
-  plug(:validate_role, [org: :read] when action in [:index, :download])
+  plug(:validate_role, [org: :manage] when action in [:upload, :do_upload, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :download])
 
   def index(%{assigns: %{product: %{id: product_id}}} = conn, _params) do
     firmwares = Firmwares.get_firmwares_by_product(product_id)

--- a/lib/nerves_hub_web/controllers/org_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/org_certificate_controller.ex
@@ -5,9 +5,8 @@ defmodule NervesHubWeb.OrgCertificateController do
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.CACertificate.CSR
 
-  plug(:validate_role, [org: :delete] when action in [:delete])
-  plug(:validate_role, [org: :write] when action in [:new, :create])
-  plug(:validate_role, [org: :read] when action in [:index])
+  plug(:validate_role, [org: :manage] when action in [:new, :create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index])
 
   def index(%{assigns: %{org: org}} = conn, _params) do
     conn

--- a/lib/nerves_hub_web/controllers/org_key_controller.ex
+++ b/lib/nerves_hub_web/controllers/org_key_controller.ex
@@ -4,9 +4,8 @@ defmodule NervesHubWeb.OrgKeyController do
   alias NervesHub.Accounts
   alias NervesHub.Accounts.OrgKey
 
-  plug(:validate_role, [org: :read] when action in [:index, :show])
-  plug(:validate_role, [org: :write] when action in [:new, :create, :update, :edit])
-  plug(:validate_role, [org: :delete] when action in [:delete])
+  plug(:validate_role, [org: :manage] when action in [:new, :create, :update, :edit, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
 
   def index(%{assigns: %{org: org}} = conn, _params) do
     org_keys = Accounts.list_org_keys(org)

--- a/lib/nerves_hub_web/controllers/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/product_controller.ex
@@ -6,9 +6,8 @@ defmodule NervesHubWeb.ProductController do
 
   action_fallback(NervesHubWeb.FallbackController)
 
-  plug(:validate_role, [org: :write] when action in [:new, :create, :update])
-  plug(:validate_role, [org: :read] when action in [:index])
-  plug(:validate_role, [org: :delete] when action in [:delete])
+  plug(:validate_role, [org: :manage] when action in [:new, :create, :update, :delete])
+  plug(:validate_role, [org: :view] when action in [:index])
 
   def index(%{assigns: %{user: user, org: org}} = conn, _params) do
     products = Products.get_products_by_user_and_org(user, org)

--- a/lib/nerves_hub_web/templates/org/invite.html.heex
+++ b/lib/nerves_hub_web/templates/org/invite.html.heex
@@ -16,13 +16,10 @@
     <label for="role_input" class="tooltip-label h3 mb-1">
       <span>Role</span>
       <span class="tooltip-info"></span>
-      <span class="tooltip-text">User role can be changed from the command line</span>
+      <span class="tooltip-text">Defines the type of access this user has in this org</span>
     </label>
     <div class="pos-rel">
-      <select class="form-control" disabled id="role_input">
-        <option value="Admin">Admin</option>
-        <option value="Basic">Basic</option>
-      </select>
+      <%= select f, :role, NervesHubWeb.OrgUserView.role_options(), selected: :read, class: "form-control" %>
       <div class="select-icon"></div>
     </div>
   </div>

--- a/lib/nerves_hub_web/templates/org/invite.html.heex
+++ b/lib/nerves_hub_web/templates/org/invite.html.heex
@@ -19,7 +19,7 @@
       <span class="tooltip-text">Defines the type of access this user has in this org</span>
     </label>
     <div class="pos-rel">
-      <%= select f, :role, NervesHubWeb.OrgUserView.role_options(), selected: :read, class: "form-control" %>
+      <%= select(f, :role, NervesHubWeb.OrgUserView.role_options(), selected: :view, class: "form-control") %>
       <div class="select-icon"></div>
     </div>
   </div>

--- a/lib/nerves_hub_web/templates/org_user/edit.html.heex
+++ b/lib/nerves_hub_web/templates/org_user/edit.html.heex
@@ -1,5 +1,5 @@
 <h1>
-  Edit User Role
+  <%= @org_user.user.username %>
 </h1>
 
 <%= form_for @changeset, Routes.org_user_path(@conn, :update, @org.name, @org_user.user_id), fn f -> %>

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -151,7 +151,7 @@ defmodule NervesHubWeb.LayoutView do
          href: Routes.product_path(conn, :index, conn.assigns.org.name)
        }
      ] ++
-       if NervesHub.Accounts.has_org_role?(org, user, :read) do
+       if NervesHub.Accounts.has_org_role?(org, user, :view) do
          [
            %{
              title: "Firmware Keys",

--- a/lib/nerves_hub_web/views/org_user_view.ex
+++ b/lib/nerves_hub_web/views/org_user_view.ex
@@ -4,14 +4,8 @@ defmodule NervesHubWeb.OrgUserView do
   alias NervesHub.Accounts.OrgUser
 
   def role_options() do
-    OrgUser
-    |> Ecto.Enum.mappings(:role)
-    |> Enum.map(fn {key, value} -> {format_option(value), key} end)
-  end
-
-  defp format_option(opt) do
-    opt
-    |> to_string()
-    |> String.capitalize()
+    for {key, value} <- Ecto.Enum.mappings(OrgUser, :role),
+        key in [:admin, :read],
+        do: {String.capitalize(value), key}
   end
 end

--- a/lib/nerves_hub_web/views/org_user_view.ex
+++ b/lib/nerves_hub_web/views/org_user_view.ex
@@ -5,7 +5,7 @@ defmodule NervesHubWeb.OrgUserView do
 
   def role_options() do
     for {key, value} <- Ecto.Enum.mappings(OrgUser, :role),
-        key in [:admin, :read],
+        key in [:admin, :manage, :view],
         do: {String.capitalize(value), key}
   end
 end

--- a/priv/repo/migrations/20231221104046_add_role_to_invite.exs
+++ b/priv/repo/migrations/20231221104046_add_role_to_invite.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddRoleToInvite do
+  use Ecto.Migration
+
+  def change do
+    alter table(:invites) do
+      add :role, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20231221105046_switch_role_to_varchar.exs
+++ b/priv/repo/migrations/20231221105046_switch_role_to_varchar.exs
@@ -1,0 +1,18 @@
+defmodule NervesHub.Repo.Migrations.SwitchRoleToVarchar do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE org_users ALTER COLUMN role TYPE varchar;"
+    execute "ALTER TABLE product_users ALTER COLUMN role TYPE varchar;"
+
+    execute "UPDATE org_users SET role = 'admin' WHERE role = 'delete';"
+    execute "UPDATE org_users SET role = 'manage' WHERE role = 'write';"
+    execute "UPDATE org_users SET role = 'view' WHERE role = 'read';"
+
+    execute "UPDATE product_users SET role = 'admin' WHERE role = 'delete';"
+    execute "UPDATE product_users SET role = 'manage' WHERE role = 'write';"
+    execute "UPDATE product_users SET role = 'view' WHERE role = 'read';"
+
+    execute "DROP TYPE role;"
+  end
+end

--- a/test/nerves_hub/accounts/accounts_test.exs
+++ b/test/nerves_hub/accounts/accounts_test.exs
@@ -223,7 +223,10 @@ defmodule NervesHub.AccountsTest do
     org = Fixtures.org_fixture(user)
 
     {:ok, %Invite{} = invite} =
-      Accounts.add_or_invite_to_org(%{"email" => "accepted_invite@test.org"}, org)
+      Accounts.add_or_invite_to_org(
+        %{"email" => "accepted_invite@test.org", "role" => "read"},
+        org
+      )
 
     assert {:ok, %OrgUser{}} =
              Accounts.create_user_from_invite(invite, org, %{
@@ -236,7 +239,10 @@ defmodule NervesHub.AccountsTest do
     org = Fixtures.org_fixture(user)
 
     {:ok, %Invite{} = invite} =
-      Accounts.add_or_invite_to_org(%{"email" => "failed_accepted_invite@test.org"}, org)
+      Accounts.add_or_invite_to_org(
+        %{"email" => "failed_accepted_invite@test.org", "role" => "read"},
+        org
+      )
 
     {:error, changeset} = Accounts.create_user_from_invite(invite, org, %{invalid: "params"})
     assert "can't be blank" in errors_on(changeset).password
@@ -246,9 +252,13 @@ defmodule NervesHub.AccountsTest do
   test "invite existing user", %{user: user} do
     org = Fixtures.org_fixture(user)
     new_user = Fixtures.user_fixture()
-    assert {:ok, %OrgUser{}} = Accounts.add_or_invite_to_org(%{"email" => new_user.email}, org)
 
-    {:error, changeset} = Accounts.add_or_invite_to_org(%{"email" => new_user.email}, org)
+    assert {:ok, %OrgUser{}} =
+             Accounts.add_or_invite_to_org(%{"email" => new_user.email, "role" => "read"}, org)
+
+    {:error, changeset} =
+      Accounts.add_or_invite_to_org(%{"email" => new_user.email, "role" => "read"}, org)
+
     assert "is already member" in errors_on(changeset).org_users
   end
 

--- a/test/nerves_hub/accounts/accounts_test.exs
+++ b/test/nerves_hub/accounts/accounts_test.exs
@@ -224,7 +224,7 @@ defmodule NervesHub.AccountsTest do
 
     {:ok, %Invite{} = invite} =
       Accounts.add_or_invite_to_org(
-        %{"email" => "accepted_invite@test.org", "role" => "read"},
+        %{"email" => "accepted_invite@test.org", "role" => "view"},
         org
       )
 
@@ -240,7 +240,7 @@ defmodule NervesHub.AccountsTest do
 
     {:ok, %Invite{} = invite} =
       Accounts.add_or_invite_to_org(
-        %{"email" => "failed_accepted_invite@test.org", "role" => "read"},
+        %{"email" => "failed_accepted_invite@test.org", "role" => "view"},
         org
       )
 
@@ -254,10 +254,10 @@ defmodule NervesHub.AccountsTest do
     new_user = Fixtures.user_fixture()
 
     assert {:ok, %OrgUser{}} =
-             Accounts.add_or_invite_to_org(%{"email" => new_user.email, "role" => "read"}, org)
+             Accounts.add_or_invite_to_org(%{"email" => new_user.email, "role" => "view"}, org)
 
     {:error, changeset} =
-      Accounts.add_or_invite_to_org(%{"email" => new_user.email, "role" => "read"}, org)
+      Accounts.add_or_invite_to_org(%{"email" => new_user.email, "role" => "view"}, org)
 
     assert "is already member" in errors_on(changeset).org_users
   end

--- a/test/nerves_hub/accounts/remove_account_test.exs
+++ b/test/nerves_hub/accounts/remove_account_test.exs
@@ -29,7 +29,10 @@ defmodule NervesHub.Accounts.RemoveAccountTest do
     Fixtures.firmware_delta_fixture(firmware1, firmware2)
 
     org2 = Fixtures.org_fixture(user, %{name: "Test-Org2"})
-    {:ok, invite} = Accounts.add_or_invite_to_org(%{"email" => "test@test.org"}, org2)
+
+    {:ok, invite} =
+      Accounts.add_or_invite_to_org(%{"email" => "test@test.org", "role" => "read"}, org2)
+
     params = %{username: "Test-User2", password: "Test-Password"}
     {:ok, org_user} = Accounts.create_user_from_invite(invite, org2, params)
 

--- a/test/nerves_hub/accounts/remove_account_test.exs
+++ b/test/nerves_hub/accounts/remove_account_test.exs
@@ -31,7 +31,7 @@ defmodule NervesHub.Accounts.RemoveAccountTest do
     org2 = Fixtures.org_fixture(user, %{name: "Test-Org2"})
 
     {:ok, invite} =
-      Accounts.add_or_invite_to_org(%{"email" => "test@test.org", "role" => "read"}, org2)
+      Accounts.add_or_invite_to_org(%{"email" => "test@test.org", "role" => "view"}, org2)
 
     params = %{username: "Test-User2", password: "Test-Password"}
     {:ok, org_user} = Accounts.create_user_from_invite(invite, org2, params)

--- a/test/nerves_hub/products/products_test.exs
+++ b/test/nerves_hub/products/products_test.exs
@@ -77,7 +77,7 @@ defmodule NervesHub.ProductsTest do
       product: product
     } do
       user = Fixtures.user_fixture()
-      Accounts.add_org_user(org, user, %{role: :read})
+      Accounts.add_org_user(org, user, %{role: :view})
       assert [^product] = Products.get_products_by_user_and_org(user, org)
     end
 

--- a/test/nerves_hub_web/controllers/account_controller_test.exs
+++ b/test/nerves_hub_web/controllers/account_controller_test.exs
@@ -9,7 +9,8 @@ defmodule NervesHubWeb.AccountControllerTest do
     test "renders invite creation form", %{
       conn: conn
     } do
-      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, conn.assigns.org)
+      {:ok, invite} =
+        Accounts.invite(%{"email" => "joe@example.com", "role" => "read"}, conn.assigns.org)
 
       conn = get(conn, Routes.account_path(conn, :invite, invite.token))
 
@@ -23,7 +24,7 @@ defmodule NervesHubWeb.AccountControllerTest do
       conn: conn
     } do
       org = conn.assigns.org
-      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com"}, org)
+      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com", "role" => "read"}, org)
 
       conn =
         post(

--- a/test/nerves_hub_web/controllers/account_controller_test.exs
+++ b/test/nerves_hub_web/controllers/account_controller_test.exs
@@ -10,7 +10,7 @@ defmodule NervesHubWeb.AccountControllerTest do
       conn: conn
     } do
       {:ok, invite} =
-        Accounts.invite(%{"email" => "joe@example.com", "role" => "read"}, conn.assigns.org)
+        Accounts.invite(%{"email" => "joe@example.com", "role" => "view"}, conn.assigns.org)
 
       conn = get(conn, Routes.account_path(conn, :invite, invite.token))
 
@@ -24,7 +24,7 @@ defmodule NervesHubWeb.AccountControllerTest do
       conn: conn
     } do
       org = conn.assigns.org
-      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com", "role" => "read"}, org)
+      {:ok, invite} = Accounts.invite(%{"email" => "joe@example.com", "role" => "view"}, org)
 
       conn =
         post(

--- a/test/nerves_hub_web/controllers/api/key_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/key_controller_test.exs
@@ -40,8 +40,8 @@ defmodule NervesHubWeb.API.KeyControllerTest do
   end
 
   describe "create keys roles" do
-    test "ok: org write", %{conn2: conn, org: org, user2: user} do
-      Accounts.add_org_user(org, user, %{role: :write})
+    test "ok: org manage", %{conn2: conn, org: org, user2: user} do
+      Accounts.add_org_user(org, user, %{role: :manage})
 
       name = "test"
       Fwup.gen_key_pair(name)
@@ -55,8 +55,8 @@ defmodule NervesHubWeb.API.KeyControllerTest do
       assert json_response(conn, 200)["data"]["name"] == name
     end
 
-    test "error: org read", %{conn2: conn, org: org, user2: user} do
-      Accounts.add_org_user(org, user, %{role: :read})
+    test "error: org view", %{conn2: conn, org: org, user2: user} do
+      Accounts.add_org_user(org, user, %{role: :view})
       name = "test"
       Fwup.gen_key_pair(name)
       pub_key = Fwup.get_public_key(name)
@@ -83,20 +83,14 @@ defmodule NervesHubWeb.API.KeyControllerTest do
   describe "delete key roles" do
     setup [:create_key]
 
-    test "ok: org delete", %{user2: user, conn2: conn, org: org, key: key} do
-      Accounts.add_org_user(org, user, %{role: :delete})
+    test "ok: org manage", %{user2: user, conn2: conn, org: org, key: key} do
+      Accounts.add_org_user(org, user, %{role: :manage})
       conn = delete(conn, Routes.api_key_path(conn, :delete, org.name, key.name))
       assert response(conn, 204)
     end
 
-    test "error: org write", %{user2: user, conn2: conn, org: org, key: key} do
-      Accounts.add_org_user(org, user, %{role: :write})
-      conn = delete(conn, Routes.api_key_path(conn, :delete, org.name, key.name))
-      assert json_response(conn, 403)["status"] != ""
-    end
-
-    test "error: org read", %{user2: user, conn2: conn, org: org, key: key} do
-      Accounts.add_org_user(org, user, %{role: :read})
+    test "error: org view", %{user2: user, conn2: conn, org: org, key: key} do
+      Accounts.add_org_user(org, user, %{role: :view})
       conn = delete(conn, Routes.api_key_path(conn, :delete, org.name, key.name))
       assert json_response(conn, 403)["status"] != ""
     end

--- a/test/nerves_hub_web/controllers/api/org_user_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/org_user_controller_test.exs
@@ -21,7 +21,7 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
   end
 
   describe "index roles" do
-    for role <- [:delete, :write, :read] do
+    for role <- [:manage, :view] do
       @role role
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
@@ -34,7 +34,7 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
 
   describe "add org_users" do
     test "renders org_user when data is valid", %{conn: conn, org: org, user2: user2} do
-      org_user = %{"username" => user2.username, "role" => "write"}
+      org_user = %{"username" => user2.username, "role" => "manage"}
       conn = post(conn, Routes.api_org_user_path(conn, :add, org.name), org_user)
       assert json_response(conn, 201)["data"]
 
@@ -57,7 +57,7 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
   end
 
   describe "add role" do
-    for role <- [:delete, :write, :read] do
+    for role <- [:manage, :view] do
       @role role
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
@@ -89,7 +89,7 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
   end
 
   describe "remove role" do
-    for role <- [:delete, :write, :read] do
+    for role <- [:manage, :view] do
       @role role
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
@@ -105,18 +105,20 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
 
     test "renders org_user when data is valid", %{conn: conn, org: org, user2: user} do
       conn =
-        put(conn, Routes.api_org_user_path(conn, :update, org.name, user.username), role: "write")
+        put(conn, Routes.api_org_user_path(conn, :update, org.name, user.username),
+          role: "manage"
+        )
 
-      assert json_response(conn, 200)["data"]["role"] == "write"
+      assert json_response(conn, 200)["data"]["role"] == "manage"
 
       path = Routes.api_org_user_path(conn, :show, org.name, user.username)
       conn = get(conn, path)
-      assert json_response(conn, 200)["data"]["role"] == "write"
+      assert json_response(conn, 200)["data"]["role"] == "manage"
     end
   end
 
   describe "update role" do
-    for role <- [:delete, :write, :read] do
+    for role <- [:manage, :view] do
       @role role
 
       test "error: org #{@role}", %{conn2: conn, org: org, user2: user} do
@@ -124,7 +126,7 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
 
         conn =
           put(conn, Routes.api_org_user_path(conn, :update, org.name, user.username),
-            role: "write"
+            role: "manage"
           )
 
         assert json_response(conn, 403)["status"] != ""

--- a/test/nerves_hub_web/controllers/api/product_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/product_controller_test.exs
@@ -42,11 +42,11 @@ defmodule NervesHubWeb.API.ProductControllerTest do
   end
 
   describe "create products roles" do
-    test "ok: org write", %{user2: user, conn2: conn, org: org} do
+    test "ok: org manage", %{user2: user, conn2: conn, org: org} do
       name = "test"
       product = %{name: name}
 
-      Accounts.add_org_user(org, user, %{role: :write})
+      Accounts.add_org_user(org, user, %{role: :admin})
 
       conn = post(conn, Routes.api_product_path(conn, :create, org.name), product)
       assert json_response(conn, 201)["data"]
@@ -59,7 +59,7 @@ defmodule NervesHubWeb.API.ProductControllerTest do
       name = "test"
       product = %{name: name}
 
-      Accounts.add_org_user(org, user, %{role: :read})
+      Accounts.add_org_user(org, user, %{role: :view})
 
       conn = post(conn, Routes.api_product_path(conn, :create, org.name), product)
       assert json_response(conn, 403)["status"] != ""
@@ -98,7 +98,7 @@ defmodule NervesHubWeb.API.ProductControllerTest do
     setup [:create_product]
 
     test "ok: org delete", %{user2: user, conn2: conn, org: org, product: product} do
-      Accounts.add_org_user(org, user, %{role: :delete})
+      Accounts.add_org_user(org, user, %{role: :admin})
 
       conn = delete(conn, Routes.api_product_path(conn, :delete, org.name, product.name))
       assert response(conn, 204)
@@ -109,14 +109,14 @@ defmodule NervesHubWeb.API.ProductControllerTest do
     end
 
     test "error: org delete", %{user2: user, conn2: conn, org: org, product: product} do
-      Accounts.add_org_user(org, user, %{role: :read})
+      Accounts.add_org_user(org, user, %{role: :view})
 
       conn = delete(conn, Routes.api_product_path(conn, :delete, org.name, product.name))
       assert json_response(conn, 403)["status"] != ""
     end
 
     test "error: org read", %{user2: user, conn2: conn, org: org, product: product} do
-      Accounts.add_org_user(org, user, %{role: :read})
+      Accounts.add_org_user(org, user, %{role: :view})
 
       conn = delete(conn, Routes.api_product_path(conn, :delete, org.name, product.name))
       assert json_response(conn, 403)["status"] != ""

--- a/test/nerves_hub_web/controllers/org_controller_test.exs
+++ b/test/nerves_hub_web/controllers/org_controller_test.exs
@@ -79,7 +79,7 @@ defmodule NervesHubWeb.OrgControllerTest do
     test "sends invite when user does not exist", %{conn: conn, org: org} do
       conn =
         post(conn, Routes.org_path(conn, :send_invite, org.name),
-          invite: %{email: "nunya@bid.ness", role: :read}
+          invite: %{email: "nunya@bid.ness", role: :view}
         )
 
       assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
@@ -94,7 +94,7 @@ defmodule NervesHubWeb.OrgControllerTest do
 
       conn =
         post(conn, Routes.org_path(conn, :send_invite, org.name),
-          invite: %{email: user.email, role: :read}
+          invite: %{email: user.email, role: :view}
         )
 
       assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
@@ -111,7 +111,7 @@ defmodule NervesHubWeb.OrgControllerTest do
     } do
       conn =
         post(conn, Routes.org_path(conn, :send_invite, org.name),
-          invite: %{email: user.email, role: :read}
+          invite: %{email: user.email, role: :view}
         )
 
       assert html_response(conn, 200) =~ user.email

--- a/test/nerves_hub_web/controllers/org_controller_test.exs
+++ b/test/nerves_hub_web/controllers/org_controller_test.exs
@@ -79,7 +79,7 @@ defmodule NervesHubWeb.OrgControllerTest do
     test "sends invite when user does not exist", %{conn: conn, org: org} do
       conn =
         post(conn, Routes.org_path(conn, :send_invite, org.name),
-          invite: %{email: "nunya@bid.ness"}
+          invite: %{email: "nunya@bid.ness", role: :read}
         )
 
       assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
@@ -93,7 +93,9 @@ defmodule NervesHubWeb.OrgControllerTest do
       user = Fixtures.user_fixture(%{email: "who@der.com"})
 
       conn =
-        post(conn, Routes.org_path(conn, :send_invite, org.name), invite: %{email: user.email})
+        post(conn, Routes.org_path(conn, :send_invite, org.name),
+          invite: %{email: user.email, role: :read}
+        )
 
       assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
 
@@ -108,7 +110,9 @@ defmodule NervesHubWeb.OrgControllerTest do
       user: user
     } do
       conn =
-        post(conn, Routes.org_path(conn, :send_invite, org.name), invite: %{email: user.email})
+        post(conn, Routes.org_path(conn, :send_invite, org.name),
+          invite: %{email: user.email, role: :read}
+        )
 
       assert html_response(conn, 200) =~ user.email
       assert html_response(conn, 200) =~ "is already member"

--- a/test/nerves_hub_web/controllers/org_user_controller_test.exs
+++ b/test/nerves_hub_web/controllers/org_user_controller_test.exs
@@ -36,14 +36,14 @@ defmodule NervesHubWeb.OrgUserControllerTest do
     test "updates role and redirects", %{conn: conn, org: org, user2: user} do
       conn =
         put(conn, Routes.org_user_path(conn, :update, org.name, user.id), %{
-          org_user: %{role: "write"}
+          org_user: %{role: "manage"}
         })
 
       assert redirected_to(conn) == Routes.org_user_path(conn, :index, org.name)
 
       conn = get(conn, Routes.org_user_path(conn, :index, org.name))
       assert html_response(conn, 200) =~ "Role updated"
-      assert html_response(conn, 200) =~ "write"
+      assert html_response(conn, 200) =~ "manage"
     end
 
     test "shows error", %{conn: conn, org: org, user2: user} do

--- a/test/nerves_hub_web/live/device_live_show_test.exs
+++ b/test/nerves_hub_web/live/device_live_show_test.exs
@@ -32,7 +32,7 @@ defmodule NervesHubWeb.DeviceLiveShowTest do
 
       Repo.preload(user, :org_users)
       |> Map.get(:org_users)
-      |> Enum.map(&NervesHub.Accounts.change_org_user_role(&1, :read))
+      |> Enum.map(&NervesHub.Accounts.change_org_user_role(&1, :view))
 
       {:ok, view, _html} = live(conn, device_show_path(fixture))
 

--- a/test/nerves_hub_web/views/org_user_view_test.exs
+++ b/test/nerves_hub_web/views/org_user_view_test.exs
@@ -7,8 +7,6 @@ defmodule NervesHubWeb.OrgUserViewTest do
     test "a list of formatted tuples is returned" do
       assert OrgUserView.role_options() == [
                {"Admin", :admin},
-               {"Delete", :delete},
-               {"Write", :write},
                {"Read", :read}
              ]
     end

--- a/test/nerves_hub_web/views/org_user_view_test.exs
+++ b/test/nerves_hub_web/views/org_user_view_test.exs
@@ -7,7 +7,8 @@ defmodule NervesHubWeb.OrgUserViewTest do
     test "a list of formatted tuples is returned" do
       assert OrgUserView.role_options() == [
                {"Admin", :admin},
-               {"Read", :read}
+               {"Manage", :manage},
+               {"View", :view}
              ]
     end
   end


### PR DESCRIPTION
Adds `role` to the invite stored for new users so they are created with the expected role.

<img width="1058" alt="image" src="https://github.com/nerves-hub/nerves_hub_web/assets/11321326/05efd3b4-7935-4cbd-8f02-26344f79859d">
