### PR TITLE
Don't `CTRL-L` on console start

### DIFF
--- a/assets/js/console.js
+++ b/assets/js/console.js
@@ -64,8 +64,6 @@ channel
   .join()
   .receive('ok', () => {
     console.log('JOINED')
-    // Push CTL-L to refresh form line
-    channel.push('dn', { data: '\f' })
     channel.push('window_size', { height: term.rows, width: term.cols })
   })
   .receive('error', () => {


### PR DESCRIPTION
In OTP 26, [`CTRL-L` now clears the screen](https://github.com/erlang/otp/commit/14555ef0440843a7ad1b879a15f9c6236fc597ca). If you (and others) are using a console page, the next person to reload the page will wipe the screen of all connected users with that page open.

Not sure why that was in there, so this removes that initial request so screens don't clear!
