### PR TITLE
Post an event when the console is closed

### DIFF
--- a/lib/nerves_hub_web/user_console_channel.ex
+++ b/lib/nerves_hub_web/user_console_channel.ex
@@ -28,6 +28,15 @@ defmodule NervesHubWeb.UserConsoleChannel do
     {:noreply, socket}
   end
 
+  def terminate(_reason, socket) do
+    broadcast(socket, "message", %{
+      username: socket.assigns.user.username,
+      event: "closed the console"
+    })
+
+    socket
+  end
+
   defp console_topic(device_id) do
     "console:#{device_id}"
   end


### PR DESCRIPTION
For other users to know when you've left (since we post when you join)

<img width="389" alt="Screenshot 2023-09-08 at 2 04 39 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/449228/3f58f72d-44b2-4eea-8046-c293c2ad3917">
