### PR TITLE
Use unique channels to limit the chat to that device

### DIFF
--- a/assets/js/console.js
+++ b/assets/js/console.js
@@ -59,7 +59,7 @@ term.focus();
 let chatBody = document.getElementById('chat-body');
 let chatMessage = document.getElementById('chat-message');
 
-let channel = socket.channel('user_console', { device_id, product_id });
+let channel = socket.channel(`user:console:${device_id}`, {});
 
 channel
   .join()

--- a/lib/nerves_hub_web/channels/user_console_channel.ex
+++ b/lib/nerves_hub_web/channels/user_console_channel.ex
@@ -3,9 +3,8 @@ defmodule NervesHubWeb.UserConsoleChannel do
 
   alias Phoenix.Socket.Broadcast
 
-  def join("user_console", %{"device_id" => device_id, "product_id" => product_id}, socket) do
+  def join("user:console:" <> device_id, _, socket) do
     socket.endpoint.subscribe(console_topic(device_id))
-    socket.endpoint.subscribe("product:#{product_id}:devices")
     {:ok, assign(socket, :device_id, device_id)}
   end
 

--- a/lib/nerves_hub_web/channels/user_socket.ex
+++ b/lib/nerves_hub_web/channels/user_socket.ex
@@ -3,7 +3,7 @@ defmodule NervesHubWeb.UserSocket do
 
   alias NervesHub.Accounts
 
-  channel("user_console", NervesHubWeb.UserConsoleChannel)
+  channel("user:console:*", NervesHubWeb.UserConsoleChannel)
 
   def connect(%{"token" => token}, socket) do
     case Phoenix.Token.verify(socket, "user salt", token, max_age: 86400) do

--- a/lib/nerves_hub_web/templates/device/console.html.heex
+++ b/lib/nerves_hub_web/templates/device/console.html.heex
@@ -1,5 +1,4 @@
 <input id="device_id" hidden type="text" value={@device.id} />
-<input id="product_id" hidden type="text" value={@device.product_id} />
 
 <div class="desktop">
   <div class="box terminal">


### PR DESCRIPTION
It was a global chat previously, so any device could chat with another device. This limits to specific devices.