### PR TITLE
Handle incoming files from NervesHubLink

### DIFF
--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -43,6 +43,21 @@ defmodule NervesHubWeb.ConsoleChannel do
     {:noreply, socket}
   end
 
+  def handle_in("file-data/start", payload, socket) do
+    socket.endpoint.broadcast_from!(self(), console_topic(socket), "file-data/start", payload)
+    {:noreply, socket}
+  end
+
+  def handle_in("file-data", payload, socket) do
+    socket.endpoint.broadcast_from!(self(), console_topic(socket), "file-data", payload)
+    {:noreply, socket}
+  end
+
+  def handle_in("file-data/stop", payload, socket) do
+    socket.endpoint.broadcast_from!(self(), console_topic(socket), "file-data/stop", payload)
+    {:noreply, socket}
+  end
+
   def handle_info({:after_join, _payload}, socket) do
     socket.endpoint.subscribe(console_topic(socket))
 


### PR DESCRIPTION
Server side to allow uploading files from devices to your open console page. This is handy for grabbing logs or binary files for inspection.

NHL PR: https://github.com/nerves-hub/nerves_hub_link/pull/130