### PR TITLE
Create a plug for local file uploads

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -21,6 +21,10 @@ case firmware_upload do
 
   "local" ->
     config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.File
+
+    config :nerves_hub, NervesHub.Firmwares.Upload.File,
+      enabled: true,
+      public_path: "/firmware"
 end
 
 config :nerves_hub, NervesHub.Mailer,

--- a/config/release.exs
+++ b/config/release.exs
@@ -43,10 +43,7 @@ case firmware_upload do
   "local" ->
     local_path = System.get_env("FIRMWARE_UPLOAD_PATH")
 
-    config :nerves_hub, NervesHub.Firmwares.Upload.File,
-      enabled: true,
-      local_path: local_path,
-      public_path: "/firmware"
+    config :nerves_hub, NervesHub.Firmwares.Upload.File, local_path: local_path
 end
 
 config :ex_aws, region: System.fetch_env!("AWS_REGION")

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -28,14 +28,10 @@ defmodule NervesHubWeb.Endpoint do
     only: ~w(css fonts images js favicon.ico robots.txt)
   )
 
-  file_upload_config = Application.compile_env(:nerves_hub, NervesHub.Firmwares.Upload.File, [])
+  firmware_upload = System.get_env("FIRMWARE_UPLOAD_BACKEND", "S3")
 
-  if Keyword.get(file_upload_config, :enabled, false) do
-    plug(
-      Plug.Static,
-      at: file_upload_config[:public_path],
-      from: file_upload_config[:local_path]
-    )
+  if firmware_upload == "local" do
+    plug(NervesHubWeb.Plugs.FileUpload)
   end
 
   # Code reloading can be explicitly enabled under the

--- a/lib/nerves_hub_web/plugs/file_upload.ex
+++ b/lib/nerves_hub_web/plugs/file_upload.ex
@@ -1,0 +1,22 @@
+defmodule NervesHubWeb.Plugs.FileUpload do
+  use NervesHubWeb, :plug
+
+  def init(_opts), do: []
+
+  def call(conn, _opts) do
+    file_upload_config = Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload.File, [])
+
+    if file_upload_config[:enabled] do
+      opts = [
+        at: file_upload_config[:public_path],
+        from: file_upload_config[:local_path]
+      ]
+
+      init = Plug.Static.init(opts)
+
+      Plug.Static.call(conn, init)
+    else
+      conn
+    end
+  end
+end


### PR DESCRIPTION
This previously wouldn't allow for running in single node mode without S3 because of a compile env warning.

To remove the Plug.Static from the endpoint because we need information determined at runtime (past compile time which is what this uses)