### PR TITLE
Handle noproc error when a device comes online

### DIFF
--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -84,7 +84,14 @@ defmodule NervesHub.Tracker do
     pid = whereis(identifier)
 
     if pid != nil do
-      :ok = GenServer.stop(pid)
+      # If this happens to fail because the process is already dead,
+      # then goal achieved!
+      try do
+        :ok = GenServer.stop(pid)
+      catch
+        :exit, {:noproc, _} ->
+          :ok
+      end
 
       # we need to give time for the tracker shard to sync that
       # the device is now offline


### PR DESCRIPTION
When a device comes online, and they have multiple connections (e.g. wifi and cellular), the previous failed connection may terminate before the fallback connection fully comes online causing a noproc error.

This could happen by the tracker state being slightly out of date from replication across the cluster.