### PR TITLE
List outstanding invites for an organization

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -478,6 +478,22 @@ defmodule NervesHub.Accounts do
     end
   end
 
+  def get_invites_for_org(org) do
+    Invite
+    |> where([i], i.org_id == ^org.id)
+    |> where([i], i.accepted == false)
+    |> Repo.all()
+  end
+
+  def delete_invite(org, token) do
+    Invite
+    |> where([i], i.org_id == ^org.id)
+    |> where([i], i.token == ^token)
+    |> where([i], i.accepted == false)
+    |> Repo.one()
+    |> Repo.delete()
+  end
+
   @doc """
   Inserts a new user record, creating a org and adding a user to
   that new org if needed

--- a/lib/nerves_hub_web/controllers/org_controller.ex
+++ b/lib/nerves_hub_web/controllers/org_controller.ex
@@ -7,7 +7,7 @@ defmodule NervesHubWeb.OrgController do
   alias NervesHub.Accounts.{Invite, OrgKey, OrgUser}
   alias NervesHub.Mailer
 
-  plug(:validate_role, [org: :admin] when action in [:edit, :update, :invite])
+  plug(:validate_role, [org: :admin] when action in [:edit, :update, :invite, :delete_invite])
 
   def index(conn, _params) do
     render(conn, "index.html")
@@ -89,6 +89,20 @@ defmodule NervesHubWeb.OrgController do
           org: org,
           email: invite_params["email"]
         )
+    end
+  end
+
+  def delete_invite(%{assigns: %{org: org}} = conn, %{"token" => token}) do
+    case Accounts.delete_invite(org, token) do
+      {:ok, _} ->
+        conn
+        |> put_flash(:info, "Invite rescinded")
+        |> redirect(to: Routes.org_user_path(conn, :index, org.name))
+
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Invite failed to rescind")
+        |> redirect(to: Routes.org_user_path(conn, :index, org.name))
     end
   end
 end

--- a/lib/nerves_hub_web/controllers/org_user_controller.ex
+++ b/lib/nerves_hub_web/controllers/org_user_controller.ex
@@ -13,6 +13,7 @@ defmodule NervesHubWeb.OrgUserController do
     |> render(
       "index.html",
       org_users: Accounts.get_org_users(org),
+      invites: Accounts.get_invites_for_org(org),
       org: org
     )
   end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -213,6 +213,7 @@ defmodule NervesHubWeb.Router do
 
       get("/invite", OrgController, :invite)
       post("/invite", OrgController, :send_invite)
+      delete("/invite/:token", OrgController, :delete_invite)
       get("/certificates", OrgCertificateController, :index)
       post("/certificates", OrgCertificateController, :create)
       get("/certificates/new", OrgCertificateController, :new)

--- a/lib/nerves_hub_web/templates/org_user/index.html.heex
+++ b/lib/nerves_hub_web/templates/org_user/index.html.heex
@@ -1,3 +1,28 @@
+<%= if !Enum.empty?(@invites) do %>
+  <h1>Outstanding Invites</h1>
+
+  <table class="table table-sm table-hover">
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>Invite Link</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= for invite <- @invites do %>
+        <tr>
+          <td><%= invite.email %></td>
+          <td><pre style="background: white; margin: auto;"><%= Routes.account_url(@conn, :invite, invite.token) %></pre></td>
+          <td>
+            <%= link("Rescind", to: Routes.org_path(@conn, :delete_invite, @org.name, invite.token), method: :delete, class: "btn btn-outline-light") %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
 <div class="action-row">
   <h1>Users</h1>
   <a class="btn btn-outline-light btn-action" aria-label="Add new user" href={Routes.org_path(@conn, :invite, @org.name)}>


### PR DESCRIPTION
Allow to rescind outstanding invites to clear the list out.

This includes the invite link currently because email is being funky. This will eventually go away when we figure out what's going on.

<img width="1180" alt="Screenshot 2023-09-26 at 2 22 07 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/449228/9382f15b-fb96-415f-b79e-e9f6315973f5">