### PR TITLE
Filter out deleted users from the list of org users

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -149,6 +149,8 @@ defmodule NervesHub.Accounts do
       where: ou.org_id == ^org.id,
       order_by: [desc: ou.role]
     )
+    |> join(:inner, [ou], u in assoc(ou, :user), as: :user)
+    |> where([ou, user: user], is_nil(user.deleted_at))
     |> OrgUser.with_user()
     |> Repo.exclude_deleted()
     |> Repo.all()


### PR DESCRIPTION
If a user is deleted and the org_user row still exists, this will create a 500 error on the listing page because the preload for the user doesn't load the user.