### PR TITLE
Remove `firmware:<uuid>` topic from DeviceChannel

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -20,14 +20,6 @@ defmodule NervesHubWeb.DeviceChannel do
   require Logger
   require OpenTelemetry.Tracer, as: Tracer
 
-  def join("firmware:" <> fw_uuid, params, socket) do
-    with {:ok, certificate} <- get_certificate(socket),
-         {:ok, device} <- Devices.get_device_by_certificate(certificate) do
-      params = Map.put_new(params, "nerves_fw_uuid", fw_uuid)
-      join("device", params, assign(socket, :device, device))
-    end
-  end
-
   def join("device", params, %{assigns: %{device: device}} = socket) do
     Tracer.with_span "DeviceChannel.join" do
       with {:ok, device} <- update_metadata(device, params),

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -81,13 +81,6 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  def join("device", params, socket) do
-    with {:ok, certificate} <- get_certificate(socket),
-         {:ok, device} <- Devices.get_device_by_certificate(certificate) do
-      join("device", params, assign(socket, :device, device))
-    end
-  end
-
   def handle_in("fwup_progress", %{"value" => percent}, socket) do
     device = socket.assigns.device
 
@@ -380,10 +373,6 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   def terminate(_reason, _state), do: :ok
-
-  defp get_certificate(%{assigns: %{certificate: certificate}}), do: {:ok, certificate}
-
-  defp get_certificate(_), do: {:error, :no_device_or_org}
 
   # The reported firmware is the same as what we already know about
   def update_metadata(%Device{firmware_metadata: %{uuid: uuid}} = device, %{

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -6,7 +6,6 @@ defmodule NervesHubWeb.DeviceSocket do
   ## Channels
   # channel "room:*", NervesHubWeb.RoomChannel
   channel("console", NervesHubWeb.ConsoleChannel)
-  channel("firmware:*", NervesHubWeb.DeviceChannel)
   channel("device", NervesHubWeb.DeviceChannel)
 
   # Socket params are passed from the client and can

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -10,25 +10,25 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   test "basic connection to the channel" do
     user = Fixtures.user_fixture()
-    {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
-    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
     assert socket
   end
 
   test "presence connection information" do
     user = Fixtures.user_fixture()
-    {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
-    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
 
     # Make sure the channel has performed it's after join
     _ = :sys.get_state(socket.channel_pid)
@@ -41,13 +41,13 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   test "device disconnected adds audit log" do
     user = Fixtures.user_fixture()
-    {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
-    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
 
     Process.unlink(socket.channel_pid)
 
@@ -63,28 +63,28 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   test "update_available on connect" do
     user = Fixtures.user_fixture()
-    {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
     {:ok, join_reply, _socket} =
-      subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
+      subscribe_and_join(socket, DeviceChannel, "device")
 
     assert join_reply.update_available == false
   end
 
   test "the first fwup_progress marks an update as happening" do
     user = Fixtures.user_fixture()
-    {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
     {:ok, _join_reply, socket} =
-      subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
+      subscribe_and_join(socket, DeviceChannel, "device")
 
     push(socket, "fwup_progress", %{"value" => 10})
 
@@ -96,14 +96,14 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   test "set connection types for the device" do
     user = Fixtures.user_fixture()
-    {device, firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
     {:ok, _join_reply, socket} =
-      subscribe_and_join(socket, DeviceChannel, "firmware:#{firmware.uuid}")
+      subscribe_and_join(socket, DeviceChannel, "device")
 
     push(socket, "connection_types", %{"value" => ["ethernet", "wifi"]})
 

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -153,25 +153,6 @@ defmodule NervesHubWeb.WebsocketTest do
       SocketClient.close(socket)
     end
 
-    test "Can connect and authenticate to channel using firmware topic", %{user: user} do
-      {device, firmware} = device_fixture(user, %{identifier: @valid_serial})
-
-      Fixtures.device_certificate_fixture(device)
-      {:ok, socket} = SocketClient.start_link(@socket_config)
-      SocketClient.wait_connect(socket)
-      SocketClient.join(socket, "firmware:#{firmware.uuid}")
-      SocketClient.wait_join(socket)
-
-      device =
-        NervesHub.Repo.get(Device, device.id)
-        |> NervesHub.Repo.preload(:org)
-
-      assert Tracker.online?(device)
-      refute_receive({"presence_diff", _})
-
-      SocketClient.close(socket)
-    end
-
     test "already registered expired certificate without signer CA can connect", %{user: user} do
       org = Fixtures.org_fixture(user, %{name: "custom_ca_test"})
       {device, _firmware} = device_fixture(user, %{identifier: @valid_serial}, org)


### PR DESCRIPTION
This topic was used in the earliest version of NervesHub and the device client connection. However, the lib it was used in ([`nerves_hub`](https://github.com/nerves-hub/nerves_hub)) has been deprecated since 2020-04-14. The last version of that lib to use this topic was [v0.4.0](https://github.com/nerves-hub/nerves_hub/releases/tag/v0.4.0) published 2019-02-14. The latest version available in Hex is v0.7.4 released 2019-06-21.

Since this was completely replaced by `nerves_hub_link` and it's been 4 years, I think it's safe to remove support for this topic which we don't have intentions on reusing in 2.0