### PR TITLE
Expect new errors when a device connects

### DIFF
--- a/lib/nerves_hub/metrics.ex
+++ b/lib/nerves_hub/metrics.ex
@@ -35,6 +35,7 @@ defmodule NervesHub.Metrics do
          counter("nerves_hub.rate_limit.rejected.count", tags: [:env, :service]),
          counter("nerves_hub.ssl.fail.count", tags: [:env, :service]),
          counter("nerves_hub.ssl.success.count", tags: [:env, :service]),
+         counter("nerves_hub.tracker.exception.count", tags: [:env, :service]),
          # General
          counter("phoenix.endpoint.start.count", tags: [:env, :service]),
          last_value("vm.memory.total", tags: [:env, :service])

--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -91,6 +91,9 @@ defmodule NervesHub.Tracker do
       catch
         :exit, {:noproc, _} ->
           :ok
+
+        :exit, {:shutdown, _} ->
+          :ok
       end
 
       # we need to give time for the tracker shard to sync that
@@ -123,8 +126,10 @@ defmodule NervesHub.Tracker do
   @doc false
   def await_offline(identifier, times \\ 0)
 
-  def await_offline(_identifier, times) when times >= 5 do
-    raise "Device did not go offline"
+  def await_offline(identifier, times) when times >= 5 do
+    raise NervesHub.Tracker.Exception,
+      identifier: identifier,
+      message: "Device did not go offline"
   end
 
   def await_offline(identifier, times) do

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -156,6 +156,11 @@ defmodule NervesHubWeb.DeviceChannel do
 
       {:noreply, socket}
     end)
+  rescue
+    NervesHub.Tracker.Exception ->
+      # Tracker had a problem, toss out the channel and let the device reconnect
+      :telemetry.execute([:nerves_hub, :tracker, :exception], %{count: 1})
+      {:stop, :normal, socket}
   end
 
   # We can save a fairly expensive query by checking the incoming deployment's payload


### PR DESCRIPTION
During a deploy we might trip the "device did not go offline" exception, so we can just expect this and start making metrics. It has thus far only triggered during a deploy.

Also expect a `{:shutdown, reason}` exit from stopping an existing device, this happens when a device has a flapping network connection that bounces between cell/wifi/ethernet quickly. Since the other process is dead anyways, ignore it, goal accomplished.