### PR TITLE
Update :env for statsd metrics to use DEPLOY_ENV

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,6 +3,8 @@ import Config
 # Start all of the applications
 config :nerves_hub, app: "all"
 
+config :nerves_hub, deploy_env: "dev"
+
 ssl_dir =
   (System.get_env("NERVES_HUB_CA_DIR") || Path.join([__DIR__, "../test/fixtures/ssl/"]))
   |> Path.expand()

--- a/config/release.exs
+++ b/config/release.exs
@@ -9,6 +9,8 @@ nerves_hub_app =
 
 config :nerves_hub, app: nerves_hub_app
 
+config :nerves_hub, deploy_env: System.get_env("DEPLOY_ENV")
+
 rate_limit = System.get_env("DEVICE_CONNECT_RATE_LIMIT", "100") |> String.to_integer()
 
 config :nerves_hub, NervesHub.RateLimit, limit: rate_limit

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,8 @@ import Config
 # Start all of the applications
 config :nerves_hub, app: "all"
 
+config :nerves_hub, deploy_env: "test"
+
 web_port = 5000
 
 config :bcrypt_elixir, log_rounds: 4

--- a/lib/nerves_hub/metrics.ex
+++ b/lib/nerves_hub/metrics.ex
@@ -41,7 +41,7 @@ defmodule NervesHub.Metrics do
          last_value("vm.memory.total", tags: [:env, :service])
        ],
        global_tags: [
-         env: Application.get_env(:nerves_hub, :env),
+         env: Application.get_env(:nerves_hub, :deploy_env),
          dyno: Application.get_env(:nerves_hub, :app),
          service: "nerves_hub"
        ]},


### PR DESCRIPTION
Instead of using the compile time environment, load it from the
environment variables.
