### PR TITLE
Wrap the deployment orchestrator with traces

### DIFF
--- a/lib/nerves_hub/metrics.ex
+++ b/lib/nerves_hub/metrics.ex
@@ -27,6 +27,8 @@ defmodule NervesHub.Metrics do
          counter("nerves_hub.devices.deployment.update.manual.count", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.update.automatic.count", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.penalty_box.check.count", tags: [:env, :service]),
+         counter("nerves_hub.deployments.trigger_update.count", tags: [:env, :service]),
+         counter("nerves_hub.deployments.trigger_update.device.count", tags: [:env, :service]),
          counter("nerves_hub.devices.jitp.created.count", tags: [:env, :service]),
          counter("nerves_hub.device_certificates.created.count", tags: [:env, :service]),
          last_value("nerves_hub.devices.online.count", tags: [:env, :service, :node]),


### PR DESCRIPTION
And also export simple metrics around how often a trigger happens and how many devices are happening.