### PR TITLE
When the console chat fills up we should scroll it

### DIFF
--- a/assets/css/_console.scss
+++ b/assets/css/_console.scss
@@ -47,14 +47,17 @@
       flex: 1;
       display: flex;
       flex-direction: column;
+      height: calc(100% - 28px);
+      position: relative;
 
       #chat-body {
         font-family: Montserrat, sans-serif;
         font-size: 16px;
         flex: 1;
         background: black;
-        height: 100%;
         color: white;
+        text-wrap: wrap;
+        overflow-y: scroll;
       }
 
       #chat-message {

--- a/assets/js/console.js
+++ b/assets/js/console.js
@@ -89,6 +89,7 @@ channel.on("message", payload => {
   } else if (payload.event) {
     chatBody.append(`${payload.username} ${payload.event}\n`);
   }
+  chatBody.scrollTop = chatBody.scrollHeight
 });
 
 chatBody.addEventListener("click", (e) => {

--- a/lib/nerves_hub_web/templates/device/console.html.heex
+++ b/lib/nerves_hub_web/templates/device/console.html.heex
@@ -15,9 +15,7 @@
     </div>
     <div class="body">
       <pre id="chat-body"></pre>
-      <div id="chat-text">
-        <input type="text" id="chat-message" />
-      </div>
+      <input type="text" id="chat-message" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
The chat window didn't have css set up to scroll messages so it just grew forever down the page.