### PR TITLE
Add deployment information to the API response for devices

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -72,6 +72,7 @@ defmodule NervesHub.Devices do
     |> Repo.exclude_deleted()
     |> order_by(^sort_devices(sorting))
     |> filtering(filters)
+    |> preload(deployment: [:firmware])
     |> Repo.paginate(pagination)
   end
 
@@ -200,7 +201,7 @@ defmodule NervesHub.Devices do
         {:error, :not_found}
 
       device ->
-        {:ok, Repo.preload(device, [:org, :product])}
+        {:ok, Repo.preload(device, [:org, :product, deployment: [:firmware]])}
     end
   end
 

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -38,6 +38,8 @@ defmodule NervesHubWeb.API.DeviceController do
       |> Map.put("product_id", product.id)
 
     with {:ok, device} <- Devices.create_device(params) do
+      device = Repo.preload(device, deployment: [:firmware])
+
       conn
       |> put_status(:created)
       |> put_resp_header(
@@ -81,6 +83,8 @@ defmodule NervesHubWeb.API.DeviceController do
   def update(%{assigns: %{org: org}} = conn, %{"identifier" => identifier} = params) do
     with {:ok, device} <- Devices.get_device_by_identifier(org, identifier),
          {:ok, updated_device} <- Devices.update_device(device, params) do
+      updated_device = Repo.preload(updated_device, deployment: [:firmware])
+
       conn
       |> put_status(201)
       |> render("show.json", device: updated_device)
@@ -93,6 +97,8 @@ defmodule NervesHubWeb.API.DeviceController do
          {:ok, %DeviceCertificate{device_id: device_id}} <-
            Devices.get_device_certificate_by_x509(cert),
          {:ok, device} <- Devices.get_device_by_org(org, device_id) do
+      device = Repo.preload(device, deployment: [:firmware])
+
       conn
       |> put_status(200)
       |> render("show.json", device: device)

--- a/lib/nerves_hub_web/views/api/device_view.ex
+++ b/lib/nerves_hub_web/views/api/device_view.ex
@@ -25,8 +25,18 @@ defmodule NervesHubWeb.API.DeviceView do
       description: device.description,
       firmware_metadata: device.firmware_metadata,
       firmware_update_status: Devices.firmware_status(device),
+      deployment: render_one(device.deployment, __MODULE__, "deployment.json", as: :deployment),
       updates_enabled: device.updates_enabled,
       updates_blocked_until: device.updates_blocked_until
+    }
+  end
+
+  def render("deployment.json", %{deployment: deployment}) do
+    %{
+      firmware_uuid: deployment.firmware.uuid,
+      firmware_version: deployment.firmware.version,
+      is_active: deployment.is_active,
+      name: deployment.name
     }
   end
 


### PR DESCRIPTION
Surface the information for users to know what the device is expected to update to if the firmware update status is `pending`