### PR TITLE
Upload archives to a product

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -52,6 +52,13 @@ config :nerves_hub, NervesHub.Firmwares.Upload.File,
   local_path: Path.expand("tmp/firmware"),
   public_path: "/firmware"
 
+config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
+
+config :nerves_hub, NervesHub.Uploads.File,
+  enabled: true,
+  local_path: Path.expand("tmp/uploads"),
+  public_path: "/uploads"
+
 # config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: System.get_env("S3_BUCKET_NAME")
 
 config :nerves_hub, NervesHub.Repo, ssl: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -25,6 +25,12 @@ case firmware_upload do
     config :nerves_hub, NervesHub.Firmwares.Upload.File,
       enabled: true,
       public_path: "/firmware"
+
+    config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
+
+    config :nerves_hub, NervesHub.Uploads.File,
+      enabled: true,
+      public_path: "/uploads"
 end
 
 config :nerves_hub, NervesHub.Repo, pool_size: 20

--- a/config/release.exs
+++ b/config/release.exs
@@ -46,6 +46,8 @@ case firmware_upload do
     local_path = System.get_env("FIRMWARE_UPLOAD_PATH")
 
     config :nerves_hub, NervesHub.Firmwares.Upload.File, local_path: local_path
+
+    config :nerves_hub, NervesHub.Uploads.File, local_path: local_path
 end
 
 config :ex_aws, region: System.fetch_env!("AWS_REGION")

--- a/config/test.exs
+++ b/config/test.exs
@@ -48,6 +48,12 @@ config :nerves_hub, NervesHub.Firmwares.Upload.File,
   local_path: System.tmp_dir(),
   public_path: "/firmware"
 
+config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
+
+config :nerves_hub, NervesHub.Uploads.File,
+  local_path: System.tmp_dir(),
+  public_path: "/uploads"
+
 config :nerves_hub, NervesHub.Repo,
   ssl: false,
   pool: Ecto.Adapters.SQL.Sandbox

--- a/lib/nerves_hub/archives.ex
+++ b/lib/nerves_hub/archives.ex
@@ -1,0 +1,83 @@
+defmodule NervesHub.Archives do
+  @moduledoc """
+  Archives are extra fwup files that will be delivered to the device on connect
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias NervesHub.Archives.Archive
+  alias NervesHub.Fwup
+  alias NervesHub.Repo
+
+  def all_by_product(product) do
+    Archive
+    |> where([a], a.product_id == ^product.id)
+    |> Repo.all()
+  end
+
+  def get(uuid) when is_binary(uuid) do
+    case Repo.get_by(Archive, uuid: uuid) do
+      nil ->
+        {:error, :not_found}
+
+      archive ->
+        {:ok, Repo.preload(archive, product: [:org])}
+    end
+  end
+
+  def create(product, file_path) do
+    product = Repo.preload(product, org: [:org_keys])
+
+    with {:ok, org_key} <- validate_signature(product.org, file_path),
+         {:ok, metadata} <- Fwup.metadata(file_path) do
+      {:ok, archive} =
+        product
+        |> Ecto.build_assoc(:archives)
+        |> Map.put(:org_key_id, org_key.id)
+        |> Map.put(:size, :filelib.file_size(file_path))
+        |> Archive.create_changeset(metadata)
+        |> Repo.insert()
+
+      NervesHub.Uploads.upload(file_path, archive_path(archive))
+
+      {:ok, archive}
+    end
+  end
+
+  def url(archive) do
+    NervesHub.Uploads.url(archive_path(archive))
+  end
+
+  defp archive_path(archive) do
+    "/archives/#{archive.uuid}.fw"
+  end
+
+  def validate_signature(org, file_path) do
+    signed_key =
+      Enum.find(org.org_keys, fn %{key: key} ->
+        case System.cmd("fwup", ["--verify", "--public-key", key, "-i", file_path]) do
+          {_, 0} ->
+            true
+
+          # fwup returns a 1 for invalid signatures
+          {_, 1} ->
+            false
+
+          {text, code} ->
+            Logger.warning("fwup returned code #{code} with #{text}")
+
+            false
+        end
+      end)
+
+    case signed_key do
+      key when is_map(key) ->
+        {:ok, key}
+
+      nil ->
+        {:error, :invalid_signature}
+    end
+  end
+end

--- a/lib/nerves_hub/archives/archive.ex
+++ b/lib/nerves_hub/archives/archive.ex
@@ -1,0 +1,52 @@
+defmodule NervesHub.Archives.Archive do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Accounts.OrgKey
+  alias NervesHub.Products.Product
+
+  schema "archives" do
+    belongs_to(:product, Product, where: [deleted_at: nil])
+    belongs_to(:org_key, OrgKey)
+
+    field(:size, :integer)
+
+    field(:architecture, :string)
+    field(:author, :string)
+    field(:description, :string)
+    field(:misc, :string)
+    field(:platform, :string)
+    field(:uuid, Ecto.UUID)
+    field(:version, :string)
+    field(:vcs_identifier, :string)
+
+    timestamps()
+  end
+
+  def create_changeset(archive, params) do
+    archive
+    |> cast(params, [
+      :size,
+      :architecture,
+      :author,
+      :description,
+      :misc,
+      :platform,
+      :uuid,
+      :version,
+      :vcs_identifier
+    ])
+    |> validate_required([
+      :product_id,
+      :org_key_id,
+      :size,
+      :architecture,
+      :platform,
+      :uuid,
+      :version
+    ])
+    |> unique_constraint(:uuid, name: :archives_product_id_uuid_index)
+    |> foreign_key_constraint(:products)
+  end
+end

--- a/lib/nerves_hub/fwup.ex
+++ b/lib/nerves_hub/fwup.ex
@@ -1,0 +1,60 @@
+defmodule NervesHub.Fwup do
+  def metadata(file_path) do
+    with {:ok, metadata} <- get_metadata(file_path),
+         {:ok, uuid} <- metadata_value(metadata, "meta-uuid"),
+         {:ok, architecture} <- metadata_value(metadata, "meta-architecture"),
+         {:ok, platform} <- metadata_value(metadata, "meta-platform"),
+         {:ok, product} <- metadata_value(metadata, "meta-product"),
+         {:ok, version} <- metadata_value(metadata, "meta-version"),
+         {:ok, author} <- metadata_value(metadata, "meta-author", nil),
+         {:ok, description} <- metadata_value(metadata, "meta-description", nil),
+         {:ok, misc} <- metadata_value(metadata, "meta-misc", nil),
+         {:ok, vcs_identifier} <- metadata_value(metadata, "meta-vcs-identifier", nil) do
+      metadata = %{
+        architecture: architecture,
+        author: author,
+        description: description,
+        misc: misc,
+        platform: platform,
+        product: product,
+        uuid: uuid,
+        vcs_identifier: vcs_identifier,
+        version: version
+      }
+
+      {:ok, metadata}
+    end
+  end
+
+  def get_metadata(filepath) do
+    case System.cmd("fwup", ["-m", "-i", filepath]) do
+      {metadata, 0} ->
+        {:ok, metadata}
+
+      {error, _} ->
+        {:error, error}
+    end
+  end
+
+  def metadata_value(metadata, key) when is_binary(key) do
+    {:ok, regex} = "#{key}=\"(?<value>[^\n]+)\"" |> Regex.compile()
+
+    case Regex.named_captures(regex, metadata) do
+      %{"value" => value} ->
+        {:ok, value}
+
+      _ ->
+        {:error, {key, :not_found}}
+    end
+  end
+
+  def metadata_value(metadata, key, default) when is_binary(key) do
+    case metadata_value(metadata, key) do
+      {:ok, metadata_item} ->
+        {:ok, metadata_item}
+
+      {:error, {_, :not_found}} ->
+        {:ok, default}
+    end
+  end
+end

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -2,10 +2,11 @@ defmodule NervesHub.Products.Product do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias NervesHub.Devices.Device
   alias NervesHub.Accounts.Org
-  alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Archives.Archive
   alias NervesHub.Devices.CACertificate
+  alias NervesHub.Devices.Device
+  alias NervesHub.Firmwares.Firmware
   alias NervesHub.Repo
 
   @required_params [:name, :org_id]
@@ -17,6 +18,7 @@ defmodule NervesHub.Products.Product do
     has_many(:devices, Device, where: [deleted_at: nil])
     has_many(:firmwares, Firmware)
     has_many(:jitp, CACertificate.JITP)
+    has_many(:archives, Archive)
 
     belongs_to(:org, Org, where: [deleted_at: nil])
 

--- a/lib/nerves_hub/uploads.ex
+++ b/lib/nerves_hub/uploads.ex
@@ -1,0 +1,100 @@
+defmodule NervesHub.Uploads do
+  @callback delete(key :: String.t()) :: :ok | {:error, any()}
+
+  @callback upload(file :: File.io_device(), key :: String.t(), opts :: Keyword.t()) ::
+              :ok | {:error, any()}
+
+  @callback url(key :: String.t(), opts :: Keyword.t()) :: String.t()
+
+  def backend() do
+    Application.get_env(:nerves_hub, __MODULE__)[:backend]
+  end
+
+  def upload(file, key, opts \\ []) do
+    backend().upload(file, key, opts)
+  end
+
+  def url(key, opts \\ []) do
+    backend().url(key, opts)
+  end
+end
+
+defmodule NervesHub.Uploads.File do
+  @behaviour NervesHub.Uploads
+
+  def local_path() do
+    Application.get_env(:nerves_hub, __MODULE__)[:local_path]
+  end
+
+  @impl NervesHub.Uploads
+  def delete(key) do
+    path = Path.join(local_path(), key)
+    File.rm(path)
+
+    :ok
+  end
+
+  @impl NervesHub.Uploads
+  def upload(file_path, key, _opts) do
+    path = Path.join(local_path(), key)
+
+    dirname = Path.dirname(path)
+    File.mkdir_p(dirname)
+
+    case File.copy(file_path, path) do
+      {:ok, _} ->
+        :ok
+
+      _ ->
+        {:error, :uploading}
+    end
+  end
+
+  @impl NervesHub.Uploads
+  def url("/" <> key, opts), do: url(key, opts)
+
+  def url(key, _opts) do
+    "/uploads/#{key}"
+  end
+end
+
+defmodule NervesHub.Uploads.S3 do
+  @behaviour NervesHub.Uploads
+
+  alias ExAws.S3
+
+  def bucket() do
+    Application.get_env(:nerves_hub, __MODULE__)[:bucket]
+  end
+
+  @impl NervesHub.Uploads
+  def delete(key) do
+    bucket()
+    |> S3.delete_object(key)
+    |> ExAws.request()
+
+    :ok
+  end
+
+  @impl NervesHub.Uploads
+  def upload(file_path, key, opts) do
+    bucket()
+    |> S3.put_object(key, File.read!(file_path), Keyword.get(opts, :meta, []))
+    |> ExAws.request!()
+
+    :ok
+  end
+
+  @impl NervesHub.Uploads
+  def url(key, opts) do
+    case Keyword.has_key?(opts, :signed) do
+      true ->
+        config = ExAws.Config.new(:s3)
+        {:ok, url} = S3.presigned_url(config, :get, bucket(), key, opts[:signed])
+        url
+
+      false ->
+        "https://s3.amazonaws.com/#{bucket()}#{key}"
+    end
+  end
+end

--- a/lib/nerves_hub_web/controllers/archive_controller.ex
+++ b/lib/nerves_hub_web/controllers/archive_controller.ex
@@ -1,0 +1,87 @@
+defmodule NervesHubWeb.ArchiveController do
+  use NervesHubWeb, :controller
+
+  alias NervesHub.Accounts
+  alias NervesHub.Archives
+
+  plug(:validate_role, [org: :delete] when action in [:delete])
+  plug(:validate_role, [org: :write] when action in [:new, :create])
+  plug(:validate_role, [org: :read] when action in [:index, :show])
+
+  def index(conn, _params) do
+    %{product: product} = conn.assigns
+
+    conn
+    |> assign(:archives, Archives.all_by_product(product))
+    |> render("index.html")
+  end
+
+  def show(conn, %{"uuid" => uuid}) do
+    %{user: user} = conn.assigns
+
+    case Archives.get(uuid) do
+      {:ok, archive} ->
+        if Accounts.has_org_role?(archive.product.org, user, :read) do
+          conn
+          |> assign(:archive, archive)
+          |> render("show.html")
+        else
+          conn
+          |> put_status(404)
+          |> put_view(NervesHubWeb.ErrorView)
+          |> render(:"401")
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.ErrorView)
+        |> render(:"404")
+    end
+  end
+
+  def download(conn, %{"uuid" => uuid}) do
+    %{user: user} = conn.assigns
+
+    case Archives.get(uuid) do
+      {:ok, archive} ->
+        if Accounts.has_org_role?(archive.product.org, user, :read) do
+          redirect(conn, external: Archives.url(archive))
+        else
+          conn
+          |> put_status(404)
+          |> put_view(NervesHubWeb.ErrorView)
+          |> render(:"404")
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.ErrorView)
+        |> render(:"404")
+    end
+  end
+
+  def new(conn, _params) do
+    render(conn, "new.html")
+  end
+
+  def create(conn, %{"archive" => %{"file" => file}}) do
+    %{org: org, product: product} = conn.assigns
+
+    case Archives.create(product, file.path) do
+      {:ok, _archive} ->
+        conn
+        |> put_flash(:info, "Archive Uploaded")
+        |> redirect(to: Routes.archive_path(conn, :index, org.name, product.name))
+    end
+  end
+
+  def delete(conn, %{"uuid" => _uuid}) do
+    %{org: org, product: product} = conn.assigns
+
+    conn
+    |> put_flash(:info, "Archive Deleted")
+    |> redirect(to: Routes.archive_path(conn, :index, org.name, product.name))
+  end
+end

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -32,6 +32,7 @@ defmodule NervesHubWeb.Endpoint do
 
   if firmware_upload == "local" do
     plug(NervesHubWeb.Plugs.FileUpload)
+    plug(NervesHubWeb.Plugs.StaticUploads)
   end
 
   # Code reloading can be explicitly enabled under the

--- a/lib/nerves_hub_web/plugs/static_uploads.ex
+++ b/lib/nerves_hub_web/plugs/static_uploads.ex
@@ -1,0 +1,24 @@
+defmodule NervesHubWeb.Plugs.StaticUploads do
+  use NervesHubWeb, :plug
+
+  # This is for the NervesHub.Uploads style of uploads
+
+  def init(_opts), do: []
+
+  def call(conn, _opts) do
+    upload_config = Application.get_env(:nerves_hub, NervesHub.Uploads.File, [])
+
+    if upload_config[:enabled] do
+      opts = [
+        at: upload_config[:public_path],
+        from: upload_config[:local_path]
+      ]
+
+      init = Plug.Static.init(opts)
+
+      Plug.Static.call(conn, init)
+    else
+      conn
+    end
+  end
+end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -295,6 +295,13 @@ defmodule NervesHubWeb.Router do
           end
         end
 
+        resources("/archives", ArchiveController,
+          only: [:index, :show, :new, :create, :delete],
+          param: "uuid"
+        )
+
+        get("/archives/:uuid/download", ArchiveController, :download)
+
         scope "/deployments" do
           get("/", DeploymentController, :index)
           post("/", DeploymentController, :create)

--- a/lib/nerves_hub_web/templates/archive/index.html.heex
+++ b/lib/nerves_hub_web/templates/archive/index.html.heex
@@ -1,0 +1,85 @@
+<%= if @archives == [] do %>
+  <div class="no-results-blowup-wrapper">
+    <h3 style="margin-top: 2.75rem"><%= @product.name %> doesn’t have any archives yet</h3>
+    <div class="flex-row align-items-center mt-3">
+      <a class="btn btn-outline-light" aria-label="Upload archive" href={Routes.archive_path(@conn, :new, @org.name, @product.name)}>
+        <span class="button-icon add"></span>
+        <span class="action-text">Upload Archive</span>
+      </a>
+    </div>
+  </div>
+<% else %>
+  <div class="action-row">
+    <h1>Archive</h1>
+    <a class="btn btn-outline-light btn-action" aria-label="Upload archive" href={Routes.archive_path(@conn, :new, @org.name, @product.name)}>
+      <span class="button-icon add"></span>
+      <span class="action-text">Upload Archive</span>
+    </a>
+  </div>
+
+  <table class="table table-sm table-hover">
+    <thead>
+      <tr>
+        <th>UUID</th>
+        <th>Version</th>
+        <th>Platform</th>
+        <th>Architecture</th>
+        <th>Archive key</th>
+        <th>Uploaded on</th>
+        <th></th>
+      </tr>
+    </thead>
+    <%= for archive <- @archives do %>
+      <tr class="item">
+        <td>
+          <div class="mobile-label help-text">UUID</div>
+          <div>
+            <a href={Routes.archive_path(@conn, :show, @org.name, @product.name, archive.uuid)} class="badge ff-m"><%= archive.uuid %></a>
+          </div>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Version</div>
+          <%= archive.version %>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Platform</div>
+          <%= archive.platform %>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Architecture</div>
+          <%= archive.architecture %>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Archive key</div>
+          <div>
+            <span class="badge"><%= FirmwareView.format_signed(archive, @org) %></span>
+          </div>
+        </td>
+        <td>
+          <div class="mobile-label help-text">Uploaded on</div>
+          <div>
+            <%= if is_nil(archive.inserted_at) do %>
+              <span class="color-white-50">Never</span>
+            <% else %>
+              <span class="date-time"><%= archive.inserted_at %></span>
+            <% end %>
+          </div>
+        </td>
+        <td class="actions">
+          <div class="mobile-label help-text">Actions</div>
+          <div class="dropdown options">
+            <a class="dropdown-toggle options" href="#" id={archive.uuid} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <div class="mobile-label pr-2">Open</div>
+              <img src="/images/icons/more.svg" alt="options" />
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+              <%= link("Download", class: "dropdown-item", to: Routes.archive_path(@conn, :download, @org.name, @product.name, archive.uuid)) %>
+              <div class="dropdown-divider"></div>
+              <%= link "Delete", class: "dropdown-item", to: Routes.archive_path(@conn, :delete, @org.name, @product.name, archive.uuid), method: :delete, data: [confirm: "Are you sure you want to delete this archive? This can not be undone."] %>
+            </div>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/lib/nerves_hub_web/templates/archive/new.html.eex
+++ b/lib/nerves_hub_web/templates/archive/new.html.eex
@@ -1,0 +1,10 @@
+<%= form_for(@conn, Routes.archive_path(@conn, :create, @org.name, @product.name), [as: :archive, multipart: true], fn f -> %>
+  <div class="form-group custom-upload-group">
+    <label for="file_input" class="custom-upload-label not-selected">Click to upload file</label>
+    <%= file_input f, :file, required: true, id: "file_input", class: "custom-upload-input hidden" %>
+    <div class="has-error"><%= error_tag f, :file %></div>
+  </div>
+  <div class="button-submit-wrapper">
+    <%= submit "Upload Archive", class: "btn btn-primary" %>
+  </div>
+<% end) %>

--- a/lib/nerves_hub_web/templates/archive/show.html.eex
+++ b/lib/nerves_hub_web/templates/archive/show.html.eex
@@ -1,0 +1,62 @@
+<div class="action-row">
+  <%= link "All Archives", to: Routes.archive_path(@conn, :index, @org.name, @product.name), class: "back-link"%>
+  <div class="btn-group" role="group" aria-label="Device Actions">
+    <%= link(
+      class: "btn btn-outline-light btn-action",
+      aria_label: "Download",
+      to: Routes.archive_path(@conn, :download, @org.name, @product.name, @archive.uuid))
+      do %>
+      <span class="button-icon download"></span>
+      <span class="action-text">Download</span>
+    <% end %>
+    <%= link(
+      class: "btn btn-outline-light btn-action",
+      aria_label: "Delete",
+      to: Routes.archive_path(@conn, :delete, @org.name, @product.name, @archive.uuid),
+      method: :delete,
+      data: [confirm: "Are you sure you want to delete this archive? This can not be undone."])
+      do %>
+      <span class="button-icon delete"></span>
+      <span class="action-text">Delete</span>
+    <% end %>
+  </div>
+</div>
+
+<h1>Archive <%= @archive.version %></h1>
+
+<div class="firmware-meta-grid">
+  <div>
+    <div class="help-text">UUID</div>
+    <p class="ff-m"><%= @archive.uuid %></p>
+  </div>
+  <div>
+    <div class="help-text">Platform</div>
+    <p><%= @archive.platform %></p>
+  </div>
+  <div>
+    <div class="help-text">Architecture</div>
+    <p><%= @archive.architecture %></p>
+  </div>
+  <div class="gr-2">
+    <div class="help-text">Author</div>
+    <p><%= @archive.author %></p>
+  </div>
+  <div class="gr-2">
+    <div class="help-text">Uploaded On</div>
+    <p class="date-time">
+      <%= @archive.inserted_at %>
+    </p>
+  </div>
+  <div class="gr-2">
+    <div class="help-text">VCS ID</div>
+    <p class="ff-m">
+      <%= if is_nil(@archive.vcs_identifier) do %>
+        -
+      <% else %>
+        <%= @archive.vcs_identifier %>
+      <% end %>
+    </p>
+  </div>
+</div>
+
+<div class="divider"></div>

--- a/lib/nerves_hub_web/views/archive_view.ex
+++ b/lib/nerves_hub_web/views/archive_view.ex
@@ -1,0 +1,5 @@
+defmodule NervesHubWeb.ArchiveView do
+  use NervesHubWeb, :view
+
+  alias NervesHubWeb.FirmwareView
+end

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -194,6 +194,11 @@ defmodule NervesHubWeb.LayoutView do
         href: Routes.firmware_path(conn, :index, conn.assigns.org.name, conn.assigns.product.name)
       },
       %{
+        title: "Archives",
+        active: "",
+        href: Routes.archive_path(conn, :index, conn.assigns.org.name, conn.assigns.product.name)
+      },
+      %{
         title: "Deployments",
         active: "",
         href:

--- a/priv/repo/migrations/20231023200256_create_archives.exs
+++ b/priv/repo/migrations/20231023200256_create_archives.exs
@@ -1,0 +1,25 @@
+defmodule NervesHub.Repo.Migrations.CreateArchives do
+  use Ecto.Migration
+
+  def change do
+    create table(:archives) do
+      add(:product_id, references(:products), null: false)
+      add(:org_key_id, references(:org_keys), null: false)
+
+      add(:size, :integer, null: false)
+
+      add(:architecture, :string, null: false)
+      add(:author, :string)
+      add(:description, :text)
+      add(:misc, :text)
+      add(:platform, :string, null: false)
+      add(:uuid, :uuid, null: false)
+      add(:version, :string, null: false)
+      add(:vcs_identifier, :string)
+
+      timestamps()
+    end
+
+    create index(:archives, [:product_id, :uuid], unique: true)
+  end
+end

--- a/test/nerves_hub/archives_test.exs
+++ b/test/nerves_hub/archives_test.exs
@@ -1,0 +1,31 @@
+defmodule NervesHub.ArchivesTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.Archives
+  alias NervesHub.Fixtures
+  alias NervesHub.Support
+
+  describe "creating archives" do
+    test "success: on a product" do
+      user = Fixtures.user_fixture(%{name: "user"})
+      org = Fixtures.org_fixture(user, %{name: "user"})
+      org_key = Fixtures.org_key_fixture(org)
+      product = Fixtures.product_fixture(user, org, %{name: "Hop"})
+
+      {:ok, file_path} =
+        Support.Archives.create_signed_archive(org_key.name, "manifest", "signed-manifest", %{
+          platform: "generic",
+          architecture: "generic",
+          version: "0.1.0"
+        })
+
+      {:ok, archive} = Archives.create(product, file_path)
+
+      assert archive.org_key_id == org_key.id
+      assert archive.platform == "generic"
+      assert archive.architecture == "generic"
+      assert archive.version == "0.1.0"
+      assert archive.uuid
+    end
+  end
+end

--- a/test/nerves_hub_web/controllers/archive_controller_test.exs
+++ b/test/nerves_hub_web/controllers/archive_controller_test.exs
@@ -1,0 +1,58 @@
+defmodule NervesHubWeb.ArchiveControllerTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Support
+
+  setup %{user: user, org: org} do
+    [product: Fixtures.product_fixture(user, org)]
+  end
+
+  describe "new archive" do
+    test "renders form with valid request params", %{conn: conn, org: org, product: product} do
+      new_conn = get(conn, Routes.archive_path(conn, :new, org.name, product.name))
+
+      assert html_response(new_conn, 200) =~ "Upload Archive"
+    end
+  end
+
+  describe "create archive" do
+    test "redirects to show when data is valid", %{conn: conn, org: org, product: product} do
+      org_key = Fixtures.org_key_fixture(org)
+
+      {:ok, file_path} =
+        Support.Archives.create_signed_archive(org_key.name, "manifest", "signed-manifest", %{
+          platform: "generic",
+          architecture: "generic",
+          version: "0.1.0"
+        })
+
+      upload = %Plug.Upload{
+        path: file_path,
+        filename: Path.basename(file_path)
+      }
+
+      create_conn =
+        post(conn, Routes.archive_path(conn, :create, org.name, product.name),
+          archive: %{file: upload}
+        )
+
+      assert redirected_to(create_conn, 302)
+    end
+  end
+
+  describe "delete archive" do
+    test "deletes chosen archive", %{conn: conn, org: org, product: product} do
+      org_key = Fixtures.org_key_fixture(org)
+      archive = Fixtures.archive_fixture(org_key, product)
+
+      conn =
+        delete(
+          conn,
+          Routes.archive_path(conn, :delete, org.name, product.name, archive.uuid)
+        )
+
+      assert redirected_to(conn) == Routes.archive_path(conn, :index, org.name, product.name)
+    end
+  end
+end

--- a/test/support/archives.ex
+++ b/test/support/archives.ex
@@ -1,0 +1,79 @@
+defmodule NervesHub.Support.Archives do
+  defmodule MetaParams do
+    defstruct product: "nerves-hub",
+              description: "Manifest",
+              version: "1.0.0",
+              platform: "generic",
+              architecture: "generic",
+              author: "me"
+  end
+
+  def create_signed_archive(key_name, archive_name, output_name, meta_params \\ %{}) do
+    create_archive(archive_name, meta_params)
+    sign_archive(key_name, archive_name, output_name)
+  end
+
+  @doc """
+  Create an unsigned archive image, and return the path to that image.
+  """
+  def create_archive(archive_name, meta_params \\ %{}) do
+    conf_path = make_conf(struct(MetaParams, meta_params))
+    out_path = Path.join([System.tmp_dir(), archive_name <> ".fw"])
+    File.rm(out_path)
+
+    System.cmd("fwup", [
+      "-c",
+      "-f",
+      conf_path,
+      "-o",
+      out_path
+    ])
+
+    {:ok, out_path}
+  end
+
+  @doc """
+  Sign a archive image, and return the path to that image. The `archive_name`
+  argument must match the name of a archive created with `create_archive/2`.
+  """
+  def sign_archive(key_name, archive_name, output_name) do
+    dir = System.tmp_dir()
+    output_path = Path.join([dir, output_name <> ".fw"])
+
+    System.cmd(
+      "fwup",
+      [
+        "-S",
+        "-s",
+        Path.join([dir, key_name <> ".priv"]),
+        "-i",
+        Path.join([dir, archive_name <> ".fw"]),
+        "-o",
+        output_path
+      ],
+      stderr_to_stdout: true
+    )
+
+    {:ok, output_path}
+  end
+
+  def make_conf(metadata) do
+    path = Path.join([System.tmp_dir(), "#{Ecto.UUID.generate()}.conf"])
+    File.write!(path, build_conf(metadata))
+    path
+  end
+
+  def build_conf(metadata) do
+    """
+    meta-product = "#{metadata.product}"
+    meta-description = "#{metadata.description}"
+    meta-version = "#{metadata.version}"
+    meta-platform = "#{metadata.platform}"
+    meta-architecture = "#{metadata.architecture}"
+
+    file-resource manifest.json {
+      contents = "Hello"
+    }
+    """
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,19 +1,18 @@
 Code.compiler_options(ignore_module_conflict: true)
 
 defmodule NervesHub.Fixtures do
-  alias NervesHub.{
-    Accounts,
-    Accounts.Org,
-    Accounts.OrgKey,
-    Certificate,
-    Devices,
-    Deployments,
-    Firmwares,
-    Products,
-    Products.Product,
-    Repo
-  }
-
+  alias NervesHub.Accounts
+  alias NervesHub.Accounts.Org
+  alias NervesHub.Accounts.OrgKey
+  alias NervesHub.Archives
+  alias NervesHub.Certificate
+  alias NervesHub.Devices
+  alias NervesHub.Deployments
+  alias NervesHub.Firmwares
+  alias NervesHub.Products
+  alias NervesHub.Products.Product
+  alias NervesHub.Repo
+  alias NervesHub.Support
   alias NervesHub.Support.Fwup
 
   @after_compile {__MODULE__, :compiler_options}
@@ -180,6 +179,32 @@ defmodule NervesHub.Fixtures do
       |> Map.merge(params)
 
     Firmwares.create_firmware_transfer(params)
+  end
+
+  def archive_file_fixture(
+        %Accounts.OrgKey{} = org_key,
+        %Products.Product{} = product,
+        params \\ %{}
+      ) do
+    {:ok, filepath} =
+      Support.Archives.create_signed_archive(
+        org_key.name,
+        "unsigned-#{counter()}",
+        "signed-#{counter()}",
+        %{product: product.name} |> Enum.into(params)
+      )
+
+    filepath
+  end
+
+  def archive_fixture(
+        %Accounts.OrgKey{} = org_key,
+        %Products.Product{} = product,
+        params \\ %{}
+      ) do
+    filepath = archive_file_fixture(org_key, product, params)
+    {:ok, archive} = Archives.create(product, filepath)
+    archive
   end
 
   def deployment_fixture(%Org{} = org, %Firmwares.Firmware{} = firmware, params \\ %{}) do


### PR DESCRIPTION
Archives are extra firmware files that the device will be told about on connection. This can hold extra data that can be updated out of band from the main firmware.

This also includes a more generic style of uploading that we can convert the previous firmware uploads to in a separate PR. We would need to copy paste the uploader anyways so I went with a style I'm more comfortable with and have used in the past.