### PR TITLE
Add minor deployment update optimization

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -143,6 +143,33 @@ defmodule NervesHub.Deployments do
           |> where([d], d.deployment_id == ^deployment.id)
           |> Repo.update_all(set: [deployment_id: nil])
 
+          if deployment.conditions["version"] in [nil, ""] and deployment.is_active do
+            # The version condition is the only one not done with the DB.
+            # This opens up a minor optimization to preemptively set matching
+            # devices to the new deployment all at once since the version
+            # condition can be skipped.
+            # 
+            # This also helps with offline devices by potentially reducing the
+            # need to do the expensive deployment check on next connect which
+            # reduces the load when a lot of devices come online at once.
+            Device
+            |> where([d], d.product_id == ^deployment.product_id)
+            |> where(
+              [d],
+              fragment("?->>'platform' = ?", d.firmware_metadata, ^deployment.firmware.platform)
+            )
+            |> where(
+              [d],
+              fragment(
+                "?->>'architecture' = ?",
+                d.firmware_metadata,
+                ^deployment.firmware.architecture
+              )
+            )
+            |> where([d], fragment("? <@ ?", ^deployment.conditions["tags"], d.tags))
+            |> Repo.update_all(set: [deployment_id: deployment.id])
+          end
+
           broadcast(deployment, "deployments/changed", payload)
           broadcast(:none, "deployments/changed", payload)
 


### PR DESCRIPTION
The version change is the limiting factor of when a device can be matched to a deployment fully in a db transaction. This adds a minor optimization to do the deployment calculation for devices in the DB when the deployment does not have a version condition.

Doing this also helps devices that might be offline when the deployment is updated by reducing the load of DB lookups when a device connects. It is especially useful for cases where many devices are coming online at once