### PR TITLE
remove an unused alias in `seeds.exs`

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 # The seeds are run on every deploy. Therefore, it is important
 # that first check to see if the data you are trying to insert
 # has been run yet.
-alias NervesHub.{Accounts, Accounts.User, Repo, Firmwares}
+alias NervesHub.{Accounts, Accounts.User, Repo}
 
 defmodule NervesHub.SeedHelpers do
   alias NervesHub.Fixtures


### PR DESCRIPTION
while running the seeds I saw:

```
warning: unused alias Firmwares
  priv/repo/seeds.exs:16
```

this fixes the warning.