### PR TITLE
update footer links

### DIFF
--- a/lib/nerves_hub_web/templates/layout/_footer.html.heex
+++ b/lib/nerves_hub_web/templates/layout/_footer.html.heex
@@ -5,14 +5,10 @@
       <h6>Resources</h6>
       <a href="https://docs.nerves-hub.org/" target="_blank" rel="noopener noreferrer">Documentation</a>
       <a href="https://github.com/nerves-hub" target="_blank" rel="noopener noreferrer">Source code</a>
-      <a href="https://hexdocs.pm/nerves_hub/readme.html#content" target="_blank" rel="noopener noreferrer">HexDocs</a>
-      <a href={Routes.nerves_key_path(@conn, :index)}>NervesKey</a>
-      <a href="https://status.nerves-hub.org/" target="_blank" rel="noopener noreferrer">Status</a>
     </div>
     <div class="footer-nav help">
       <h6>Help</h6>
-      <a href="https://github.com/smartrent/nerves_hub_web/issues" target="_blank" rel="noopener noreferrer">Report an issue</a>
-      <a href="mailto:support@nerves-hub.org" target="_blank" rel="noopener noreferrer">Contact support</a>
+      <a href="https://github.com/nerves-hub/nerves_hub_web/issues" target="_blank" rel="noopener noreferrer">Report an issue</a>
     </div>
   </div>
   <div class="tos-grid">


### PR DESCRIPTION
- remove the status page link, which goes nowhere
- remove the support email link, GitHub issues are the preferred means of help
- link to this repos for the issues link, and not the smartrent repo, which 404s

and these last two might be a bit presumptuous 
- remove the `nerves_hub` hexdocs link
- and remove the nerves key link

these both are very specific and are better served by using the docs.