### PR TITLE
Don't show the orgs and projects drop down on the home page

### DIFF
--- a/lib/nerves_hub_web/templates/layout/_navigation.html.heex
+++ b/lib/nerves_hub_web/templates/layout/_navigation.html.heex
@@ -8,7 +8,7 @@
     <%= if logged_in?(@conn) do %>
       <ul class="navbar-nav mr-auto flex-grow">
         <li class="nav-item dropdown switcher">
-          <a class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <a :if={@conn.assigns[:org]} class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= if org = get_in(@conn.assigns, [:org]), do: org.name, else: @conn.assigns.user.username %><%= if product = product(@conn) do %> <span class="workspace-divider">:</span> <%= product.name %><% end %>
           </a>
 


### PR DESCRIPTION
This might be a bit nit picky of me, but it bugged me that on the home page, where you see your profile drop down at the top right, and your orgs in the main section, you are shown your username again in the nav bar, where the org drop down goes.

This PR hides the org drop down if an org hasn't been selected yet.

**What the nav bar looks like when you have selected an org to navigate to:**
<img width="1232" alt="Screenshot 2023-11-25 at 9 05 57 AM" src="https://github.com/nerves-hub/nerves_hub_web/assets/8701/9b9614d2-3d3c-448d-9269-88e8056eb7ac">

**What the nav looks like when you are on the home page (your username is in the nav bar twice)**
<img width="1178" alt="Screenshot 2023-11-25 at 9 06 44 AM" src="https://github.com/nerves-hub/nerves_hub_web/assets/8701/159ac14d-4a79-4310-81a5-af0c182ba4c4">

**After this PR**
<img width="1200" alt="Screenshot 2023-11-25 at 9 05 47 AM" src="https://github.com/nerves-hub/nerves_hub_web/assets/8701/0810008e-e6d9-4416-b9e7-c536a053d1ee">
