### PR TITLE
Change the org settings routes to be nested under `/orgs/:name`

### DIFF
--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -205,29 +205,6 @@ defmodule NervesHubWeb.Router do
 
     get("/online-devices", HomeController, :online_devices)
 
-    scope "/settings/:org_name" do
-      pipe_through(:org)
-
-      get("/", OrgController, :edit)
-      put("/", OrgController, :update)
-
-      get("/invite", OrgController, :invite)
-      post("/invite", OrgController, :send_invite)
-      delete("/invite/:token", OrgController, :delete_invite)
-      get("/certificates", OrgCertificateController, :index)
-      post("/certificates", OrgCertificateController, :create)
-      get("/certificates/new", OrgCertificateController, :new)
-      delete("/certificates/:serial", OrgCertificateController, :delete)
-      get("/certificates/:serial/edit", OrgCertificateController, :edit)
-      put("/certificates/:serial", OrgCertificateController, :update)
-      get("/users", OrgUserController, :index)
-      get("/users/:user_id", OrgUserController, :edit)
-      put("/users/:user_id", OrgUserController, :update)
-      delete("/users/:user_id", OrgUserController, :delete)
-
-      resources("/keys", OrgKeyController)
-    end
-
     scope "/account/:user_name" do
       get("/", AccountController, :edit)
       put("/", AccountController, :update)
@@ -251,6 +228,27 @@ defmodule NervesHubWeb.Router do
       get("/", ProductController, :index)
       get("/new", ProductController, :new)
       post("/", ProductController, :create)
+
+      scope "/settings" do
+        get("/", OrgController, :edit)
+        put("/", OrgController, :update)
+
+        get("/invite", OrgController, :invite)
+        post("/invite", OrgController, :send_invite)
+        delete("/invite/:token", OrgController, :delete_invite)
+        get("/certificates", OrgCertificateController, :index)
+        post("/certificates", OrgCertificateController, :create)
+        get("/certificates/new", OrgCertificateController, :new)
+        delete("/certificates/:serial", OrgCertificateController, :delete)
+        get("/certificates/:serial/edit", OrgCertificateController, :edit)
+        put("/certificates/:serial", OrgCertificateController, :update)
+        get("/users", OrgUserController, :index)
+        get("/users/:user_id", OrgUserController, :edit)
+        put("/users/:user_id", OrgUserController, :update)
+        delete("/users/:user_id", OrgUserController, :delete)
+
+        resources("/keys", OrgKeyController)
+      end
 
       scope "/:product_name" do
         pipe_through(:product)

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -123,22 +123,22 @@ defmodule NervesHubWeb.LayoutView do
     |> pagination_links()
   end
 
-  def sidebar_links(%{path_info: ["settings" | _tail]} = conn),
-    do: sidebar_settings(conn)
-
   def sidebar_links(%{path_info: ["account" | _tail]} = conn),
     do: sidebar_account(conn)
 
   def sidebar_links(%{path_info: ["org", "new"]}),
     do: []
 
-  def sidebar_links(%{path_info: ["org", _product_name]} = conn),
+  def sidebar_links(%{path_info: ["org", _org_name]} = conn),
     do: sidebar_settings(conn)
 
-  def sidebar_links(%{path_info: ["org", _product_name, "new"]} = conn),
+  def sidebar_links(%{path_info: ["org", _org_name, "new"]} = conn),
     do: sidebar_settings(conn)
 
-  def sidebar_links(%{path_info: ["org", _product_name | _tail]} = conn),
+  def sidebar_links(%{path_info: ["org", _org_name, "settings" | _tail]} = conn),
+    do: sidebar_settings(conn)
+
+  def sidebar_links(%{path_info: ["org", _org_name | _tail]} = conn),
     do: sidebar_org(conn)
 
   def sidebar_links(_conn), do: []


### PR DESCRIPTION
I found it a bit odd that Org settings were setup as `/settings/:org_name` instead of `/org/:org_name/settings`

This PR updates the routes to used the nested approach.