### PR TITLE
fixes a Sentry warning when running the tests

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -99,4 +99,4 @@ else
   config :opentelemetry, tracer: :otel_tracer_noop, traces_exporter: :none
 end
 
-config :sentry, environment_name: "developent"
+config :sentry, environment_name: :developent

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -99,4 +99,4 @@ else
   config :opentelemetry, tracer: :otel_tracer_noop, traces_exporter: :none
 end
 
-config :sentry, environment_name: :developent
+config :sentry, environment_name: :development

--- a/config/test.exs
+++ b/config/test.exs
@@ -85,6 +85,4 @@ config :opentelemetry, :processors,
     exporter: {:otel_exporter_tab, []}
   }
 
-config :sentry,
-  environment_name: :test,
-  included_environments: []
+config :sentry, environment_name: :test


### PR DESCRIPTION
When running the tests I came across:

```
warning: :included_environments option is deprecated. Use :dsn to control whether to send events to Sentry.
  (nimble_options 1.0.2) lib/nimble_options.ex:556: NimbleOptions.validate_value/3
  (nimble_options 1.0.2) lib/nimble_options.ex:542: NimbleOptions.validate_option/3
  (nimble_options 1.0.2) lib/nimble_options.ex:524: NimbleOptions.reduce_options/2
  (elixir 1.15.4) lib/enum.ex:4830: Enumerable.List.reduce/3
  (elixir 1.15.4) lib/enum.ex:2564: Enum.reduce_while/3
  (nimble_options 1.0.2) lib/nimble_options.ex:517: NimbleOptions.validate_options/2
```

This PR fixes the issue, and brings `dev.exs` and `test.exs` Sentry config inline with each other.