### PR TITLE
Update Sentry config for 10.x.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /build
 COPY --from=deps /build/deps deps
 COPY --from=assets /build/priv/static priv/static
 
-RUN mix do phx.digest, release nerves_hub --overwrite
+RUN mix do phx.digest, sentry.package_source_code, release nerves_hub --overwrite
 
 # Release Container
 FROM debian:buster-20230612 as release

--- a/config/release.exs
+++ b/config/release.exs
@@ -114,5 +114,4 @@ config :sentry,
   dsn: System.get_env("SENTRY_DSN_URL"),
   environment_name: System.get_env("DEPLOY_ENV"),
   enable_source_code_context: true,
-  root_source_code_path: File.cwd!(),
-  included_environments: ["prod", "production", "staging", "qa"]
+  root_source_code_path: File.cwd!()


### PR DESCRIPTION
Following the [Sentry 10.x upgrade guide](https://hexdocs.pm/sentry/upgrade-10-x.html)

* Runs `sentry.package_source_code` before the release
* Removes `included_environments`