### PR TITLE
HTML/JS fixes

### DIFF
--- a/lib/nerves_hub_web/templates/layout/app.html.heex
+++ b/lib/nerves_hub_web/templates/layout/app.html.heex
@@ -1,70 +1,19 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
-    <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || "NervesHub" %>
-    </Phoenix.Component.live_title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/default.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/languages/bash.min.js"></script>
-    <script>hljs.highlightAll();</script>
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")}>
-
-    <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css" />
-    <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js"></script>
-    <script>
-    window.addEventListener("load", function(){
-    window.cookieconsent.initialise({
-      "palette": {
-        "popup": {
-          "background": "#343a40"
-        },
-        "button": {
-          "background": "#f1d600"
-        }
-      },
-      "position": "bottom",
-      "content": {
-        "message": "NervesHub uses cookies to ensure you get the best experience we can provide."
-      }
-    })});
-    </script>
-    <link href="https://fonts.googleapis.com/css?family=Audiowide" rel="stylesheet">
-  </head>
-
-  <body>
-    <div class="normal-wrapper">
-      <%= render("_navigation.html", assigns) %>
-      <main role="main" class="flex-column content-container">
-        <%= if Phoenix.Flash.get(@flash, :info) do %>
-          <div class="alert alert-info alert-dismissible">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <%= Phoenix.Flash.get(@flash, :info) %>
-          </div>
-        <% end %>
-        <%= if Phoenix.Flash.get(@flash, :error) do %>
-          <div class="alert alert-danger alert-dismissible">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <%= Phoenix.Flash.get(@flash, :error) %>
-          </div>
-        <% end %>
-        <%= render("_tabnav.html", conn: @conn) %>
-        <%= @inner_content %>
-      </main>
-    </div>
-
-    <%= render("_footer.html", conn: @conn) %>
-    <script>
-      window.userToken = "<%= assigns[:user_token] %>"
-      window.orgId = "<%= assigns[:org] && Map.get(assigns[:org], :id) %>"
-    </script>
-    <%= csrf_meta_tag() %>
-    <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}></script>
-  </body>
-</html>
+<div class="normal-wrapper">
+  <%= render("_navigation.html", assigns) %>
+  <main role="main" class="flex-column content-container">
+    <%= if Phoenix.Flash.get(@flash, :info) do %>
+      <div class="alert alert-info alert-dismissible">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <%= Phoenix.Flash.get(@flash, :info) %>
+      </div>
+    <% end %>
+    <%= if Phoenix.Flash.get(@flash, :error) do %>
+      <div class="alert alert-danger alert-dismissible">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <%= Phoenix.Flash.get(@flash, :error) %>
+      </div>
+    <% end %>
+    <%= render("_tabnav.html", conn: @conn) %>
+    <%= @inner_content %>
+  </main>
+</div>

--- a/lib/nerves_hub_web/templates/layout/root.html.heex
+++ b/lib/nerves_hub_web/templates/layout/root.html.heex
@@ -7,7 +7,13 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>NervesHub</title>
+    <Phoenix.Component.live_title>
+      <%= assigns[:page_title] || "NervesHub" %>
+    </Phoenix.Component.live_title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/languages/bash.min.js"></script>
+    <script>hljs.highlightAll();</script>
     <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")}>
 
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css" />
@@ -34,5 +40,14 @@
 
   <body>
     <%= @inner_content %>
+
+    <%= render("_footer.html", conn: @conn) %>
+
+    <script>
+      window.userToken = "<%= assigns[:user_token] %>"
+      window.orgId = "<%= assigns[:org] && Map.get(assigns[:org], :id) %>"
+    </script>
+    <%= csrf_meta_tag() %>
+    <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}></script>
   </body>
 </html>

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -83,7 +83,7 @@ defmodule NervesHubWeb.LayoutView do
 
     anchor = if opts.anchor, do: "##{opts.anchor}", else: ""
 
-    content_tag(:div, class: "btn-group btn-group-toggle", data: [toggle: "buttons"]) do
+    content_tag(:div, class: "btn-group btn-group-toggle") do
       opts
       |> Scrivener.HTML.raw_pagination_links(distance: Map.get(opts, :distance, 8))
       |> Enum.map(fn {text, page} ->
@@ -102,7 +102,7 @@ defmodule NervesHubWeb.LayoutView do
   def pagination_links(%{total_pages: _} = opts) do
     opts = Map.put_new(opts, :page_number, 1)
 
-    content_tag(:div, class: "btn-group btn-group-toggle", data: [toggle: "buttons"]) do
+    content_tag(:div, class: "btn-group btn-group-toggle") do
       opts
       |> Scrivener.HTML.raw_pagination_links(distance: Map.get(opts, :distance, 8))
       |> Enum.map(fn {text, page} ->


### PR DESCRIPTION
There was a bootstrap error in the web console related to the incorrect use of `data-toggle`. 
This was because the elements nested in the element which contains the `data-toggle="buttons"` must be checkboxes or radio buttons, not buttons. 

I've removed the `data-toggle` attribute, which fixes the js error, and everything is working as expected.

I also noticed that the generated output of visiting a page contained two `html` sections, including two `headers`, etc.

This was because the `app` template had a full page layout, and was being nested in the `root` template (which is standard for Phoenix).

I've removed the duplicate html in the `app` template.