### PR TITLE
Alter `:inet6` opt for Bandit

### DIFF
--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -101,7 +101,12 @@ defmodule NervesHubWeb.Endpoint do
 
     if config[:load_from_system_env] do
       port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
+
+      {:ok,
+       Keyword.put(config, :http,
+         thousand_island_options: [transport_options: [:inet6]],
+         port: port
+       )}
     else
       {:ok, config}
     end


### PR DESCRIPTION
`:inet6` needs to be passed to the ThousandIsland transport directly as the `Bandit.PhoenixAdapter` is unable to parse it from a mismatched proplist as it currently is