### PR TITLE
Don't require S3 access key id or secret access key

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -90,10 +90,13 @@ if config_env() == :prod do
       config :nerves_hub, NervesHub.Firmwares.Upload.S3,
         bucket: System.fetch_env!("S3_BUCKET_NAME")
 
-      config :ex_aws, :s3,
-        access_key_id: System.fetch_env!("S3_ACCESS_KEY_ID"),
-        secret_access_key: System.fetch_env!("S3_SECRET_ACCESS_KEY"),
-        bucket: System.fetch_env!("S3_BUCKET_NAME")
+      if System.get_env("S3_ACCESS_KEY_ID") do
+        config :ex_aws, :s3,
+          access_key_id: System.fetch_env!("S3_ACCESS_KEY_ID"),
+          secret_access_key: System.fetch_env!("S3_SECRET_ACCESS_KEY")
+      end
+
+      config :ex_aws, :s3, bucket: System.fetch_env!("S3_BUCKET_NAME")
 
       if region = System.get_env("S3_REGION") do
         config :ex_aws, :s3, region: region


### PR DESCRIPTION
Only load if provided, ECS uses role based permissions and this won't be set in that deployment environment.