### PR TITLE
Use system CA certs explicitly for DB connections

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -221,12 +221,6 @@ if config_env() == :prod do
       ]
   end
 
-  #
-  # setup Erlang to use CAStore certs by default
-  #
-  :pubkey_os_cacerts.clear()
-  :pubkey_os_cacerts.load([CAStore.file_path()])
-
   database_ssl_opts =
     if System.get_env("DATABASE_PEM") do
       db_hostname_charlist =
@@ -247,7 +241,7 @@ if config_env() == :prod do
         server_name_indication: db_hostname_charlist
       ]
     else
-      []
+      [cacerts: :public_key.cacerts_get()]
     end
 
   databse_socket_options = if System.get_env("DATABASE_INET6") == "true", do: [:inet6], else: []


### PR DESCRIPTION
If other database SSL is not configured, use the `:public_key.cacerts_get()` function to load the system CA certs and explicitly use with DB connection.

Defaulting to `[]` effectively prevents any default system certs from being used. `:public_key.cacerts_get` is a preference here as well since some deployments load their specific CA store into the system path and may not be signed with globally registered CA in `CAStore` file. However, most systems include the same certificates as well anyway.