### PR TITLE
Remove inet6 option from the DeviceEndpoint

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -208,7 +208,6 @@ if config_env() == :prod do
             # See https://github.com/erlang/otp/issues/6492#issuecomment-1323874205
             #
             # certificate_authorities: false,
-            :inet6,
             versions: [:"tlsv1.2"],
             verify: :verify_peer,
             verify_fun: {&NervesHub.SSL.verify_fun/3, nil},


### PR DESCRIPTION
This doesn't appear to be an option in ThousandIsland and it's messing up starting the DeviceEndpoint because this needs to be a keyword list.

Update: it is an option deeper down in gen_tcp and ssl but something in Bandit is treating it as a keyword list still