### PR TITLE
Device link fixes

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -33,9 +33,5 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  def terminate(_reason, %{assigns: %{device_link_pid: link}}) do
-    DeviceLink.disconnect(link)
-  end
-
   def terminate(_reason, _state), do: :ok
 end


### PR DESCRIPTION
* Remove `DeviceLink.disconnect/1` from channel terminate
  * The device channel is monitored by DeviceLink. The extra call to `DeviceLink.disconnect/1` would sometimes timeout causing bigger issues with restarts elsewhere or race getting to the link process potentially producing DOWN messages after the monitor was cleared from link causing unmatched `handle_info` callbacks to be evaluated 
* Ignore messages from unknown socket in DeviceLink
  * TCP sockets have longer timeouts. There is a chance the old socket was still around when the new one started which could result in getting this message later than expected. For cases like that and when we no longer know the ref, simply ignore