### PR TITLE
Rate limit should be inclusive

### DIFF
--- a/lib/nerves_hub/rate_limit.ex
+++ b/lib/nerves_hub/rate_limit.ex
@@ -20,7 +20,7 @@ defmodule NervesHub.RateLimit do
 
     config = Application.get_env(:nerves_hub, __MODULE__)
 
-    result < config[:limit]
+    result <= config[:limit]
   end
 
   @doc false


### PR DESCRIPTION
If the limit is 1, then we'll never let devices in.