### PR TITLE
Ignore unhandled messages in DeviceLink

### DIFF
--- a/lib/nerves_hub/devices/device_link.ex
+++ b/lib/nerves_hub/devices/device_link.ex
@@ -534,6 +534,20 @@ defmodule NervesHub.Devices.DeviceLink do
     {:stop, :normal, state}
   end
 
+  def handle_info(msg, state) do
+    # Ignore unhandled messages so that it doesn't crash the link process
+    # preventing cascading problems.
+    Logger.warning("[DeviceLink] Unhandled message! - #{inspect(msg)}")
+
+    _ =
+      Sentry.capture_message("[DeviceLink] Unhandled message!",
+        extra: %{message: msg},
+        result: :none
+      )
+
+    {:noreply, state}
+  end
+
   defp subscribe(topic) do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
   end

--- a/test/nerves_hub/devices/device_link_test.exs
+++ b/test/nerves_hub/devices/device_link_test.exs
@@ -491,6 +491,19 @@ defmodule NervesHub.DeviceLinkTest do
     assert {:stop, :normal, %{}} = DeviceLink.handle_info(:timeout_reconnect, %{})
   end
 
+  test "ignores unknown messages" do
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        # Prob good spot for prop test
+        DeviceLink.handle_info(12355, %{})
+        DeviceLink.handle_info("12355", %{})
+        DeviceLink.handle_info(:wat, %{})
+        DeviceLink.handle_info(nil, %{})
+      end)
+
+    assert log =~ ~r/Unhandled message!/
+  end
+
   defp create_device(context) do
     user = context[:user] || Fixtures.user_fixture()
     org = context[:org] || Fixtures.org_fixture(user)


### PR DESCRIPTION
Crashing DeviceLink could cause cascading problems. To fix that, this change ignores unhandled messages in `handle_info` and logs it