### PR TITLE
API improvements for JITP

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -390,6 +390,13 @@ defmodule NervesHub.Devices do
     |> Ecto.build_assoc(:ca_certificates)
     |> CACertificate.changeset(params)
     |> Repo.insert()
+    |> case do
+      {:ok, ca_certificate} ->
+        {:ok, Repo.preload(ca_certificate, jitp: :product)}
+
+      err ->
+        err
+    end
   end
 
   @spec create_ca_certificate_from_x509(Org.t(), X509.Certificate.t(), binary() | nil) ::

--- a/lib/nerves_hub_web/controllers/api/ca_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/ca_certificate_controller.ex
@@ -33,7 +33,8 @@ defmodule NervesHubWeb.API.CACertificateController do
            not_before: not_before,
            not_after: not_after,
            der: X509.Certificate.to_der(cert),
-           description: Map.get(params, "description")
+           description: Map.get(params, "description"),
+           jitp: params["jitp"]
          },
          {:ok, ca_certificate} <- Devices.create_ca_certificate(org, params) do
       conn

--- a/lib/nerves_hub_web/views/api/ca_certificate_view.ex
+++ b/lib/nerves_hub_web/views/api/ca_certificate_view.ex
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.API.CACertificateView do
   use NervesHubWeb, :api_view
 
+  alias NervesHub.Devices.CACertificate.JITP
   alias NervesHubWeb.API.CACertificateView
 
   def render("index.json", %{ca_certificates: ca_certificates}) do
@@ -16,7 +17,18 @@ defmodule NervesHubWeb.API.CACertificateView do
       serial: ca_certificate.serial,
       not_before: ca_certificate.not_before,
       not_after: ca_certificate.not_after,
-      description: ca_certificate.description
+      description: ca_certificate.description,
+      jitp: maybe_add_jitp(ca_certificate.jitp)
     }
   end
+
+  defp maybe_add_jitp(%JITP{} = jitp) do
+    %{
+      product_name: jitp.product.name,
+      tags: jitp.tags,
+      description: jitp.description
+    }
+  end
+
+  defp maybe_add_jitp(_), do: nil
 end


### PR DESCRIPTION
Alternate implementation for #880

* Add `jitp` to CACertificate API response
* Support `jitp` in API CACertificate create 