### PR TITLE
Remove SYNC_NODES_OPTIONAL from runtime config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,22 +28,6 @@ dns_cluster_query =
 config :nerves_hub, dns_cluster_query: dns_cluster_query
 
 ##
-# Configure distributed erlang ports and nodes to connect to.
-#
-if System.get_env("RELEASE_MODE") do
-  node_list =
-    System.get_env("SYNC_NODES_OPTIONAL")
-    |> String.split(" ", trim: true)
-    |> Enum.map(&String.to_atom/1)
-
-  config :kernel,
-    sync_nodes_optional: node_list,
-    sync_nodes_timeout: 5000,
-    inet_dist_listen_min: 9100,
-    inet_dist_listen_max: 9155
-end
-
-##
 # Web and Device endpoints
 #
 if config_env() == :prod do

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,6 @@ defmodule NervesHub.MixProject do
         nerves_hub: [
           steps: [:assemble],
           include_executables_for: [:unix],
-          reboot_system_after_config: true,
           applications: [
             nerves_hub: :permanent
           ]


### PR DESCRIPTION
And remove the reboot_system_after_config option since we aren't adjusting the kernel config.

To be merged along with https://github.com/nerves-hub/nerves_hub_web/pull/1151