### PR TITLE
Add `Devices.SharedSecretAuth`

### DIFF
--- a/lib/nerves_hub/devices/shared_secret_auth.ex
+++ b/lib/nerves_hub/devices/shared_secret_auth.ex
@@ -1,0 +1,45 @@
+defmodule NervesHub.Devices.SharedSecretAuth do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Devices.Device
+  alias NervesHub.Products
+
+  @type t :: %__MODULE__{}
+
+  @key_prefix "nhd"
+
+  schema "device_shared_secret_auths" do
+    belongs_to(:device, Device)
+    belongs_to(:product_shared_secret_auth, Products.SharedSecretAuth)
+
+    field(:key, :string)
+    field(:secret, :string)
+
+    field(:deactivated_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  def create_changeset(%Device{id: device_id}, attrs \\ %{}) do
+    cast(%__MODULE__{device_id: device_id}, attrs, [:product_shared_secret_auth_id])
+    |> put_change(:key, "#{@key_prefix}_#{generate_token()}")
+    |> put_change(:secret, generate_token())
+    |> validate_required([:device_id, :key, :secret])
+    |> validate_format(:key, ~r/^#{@key_prefix}_[a-zA-Z0-9\-\/\+]{43}$/)
+    |> validate_format(:secret, ~r/^[a-zA-Z0-9\-\/\+]{43}$/)
+    |> foreign_key_constraint(:device_id)
+    |> foreign_key_constraint(:product_shared_secret_auth_id)
+    |> unique_constraint(:key)
+    |> unique_constraint(:secret)
+  end
+
+  def deactivate_changeset(%__MODULE__{} = auth) do
+    change(auth, %{deactivated_at: DateTime.truncate(DateTime.utc_now(), :second)})
+  end
+
+  defp generate_token() do
+    :crypto.strong_rand_bytes(32) |> Base.encode64(padding: false)
+  end
+end

--- a/priv/repo/migrations/20240107163347_create_device_shared_secret_auth.exs
+++ b/priv/repo/migrations/20240107163347_create_device_shared_secret_auth.exs
@@ -1,0 +1,20 @@
+defmodule NervesHub.Repo.Migrations.CreateDeviceSharedSecretAuth do
+  use Ecto.Migration
+
+  def change do
+    create table(:device_shared_secret_auths) do
+      add(:device_id, references(:devices), null: false)
+      add(:product_shared_secret_auth_id, references(:product_shared_secret_auth))
+
+      add(:key, :string, null: false)
+      add(:secret, :string, null: false)
+
+      add(:deactivated_at, :utc_datetime)
+
+      timestamps()
+    end
+
+    create index(:device_shared_secret_auths, [:key], unique: true)
+    create index(:device_shared_secret_auths, [:secret], unique: true)
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Firmwares
   alias NervesHub.Fixtures
+  alias NervesHub.Products
   alias NervesHub.Repo
   alias Ecto.Changeset
 
@@ -527,6 +528,17 @@ defmodule NervesHub.DevicesTest do
     refute Devices.matches_deployment?(%{device | tags: nil}, deployment)
     assert Devices.matches_deployment?(%{device | tags: nil}, nil_tags_deployment)
     assert Devices.matches_deployment?(device, nil_tags_deployment)
+  end
+
+  test "create shared secret auth with associated product shared secret auth", context do
+    {:ok, %{id: product_ssa_id}} = Products.create_shared_secret_auth(context.product)
+
+    assert {:ok, auth} =
+             Devices.create_shared_secret_auth(context.device, %{
+               product_shared_secret_auth_id: product_ssa_id
+             })
+
+    assert auth.product_shared_secret_auth_id == product_ssa_id
   end
 
   describe "tracking update attempts and verifying eligibility" do


### PR DESCRIPTION
Next part of #1136

Adds support for individual device secret auth. These can also be associated with a production shared secret auth to track when a device auth is created from the product auth (coming next). This will be helpful in the future to easily deactive all device tokens associated with a deactivated production token