### PR TITLE
Set the channel name that libcluster_postgres uses

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -187,6 +187,7 @@ if config_env() == :prod do
     |> Keyword.merge(ssl: System.get_env("DATABASE_SSL", "true") == "true")
     |> Keyword.merge(ssl_opts: database_ssl_opts)
     |> Keyword.merge(parameters: [])
+    |> Keyword.merge(channel_name: "nerves_hub_clustering")
 
   config :libcluster,
     topologies: [


### PR DESCRIPTION
The default is a cleaned version of the cookie, which seems to be too long for postgres notify. Our cookie is 64 characters long, running a `NOTIFY` with a different 64 character long string also fails. To get around this we can manually set a cookie name.