### PR TITLE
Remove the reconnect timer in DeviceLink

### DIFF
--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -32,11 +32,5 @@ defmodule NervesHubWeb.DeviceChannelTest do
     push_cb = :sys.get_state(socket.assigns.device_link_pid).push_cb
     push_cb.("howdy", %{})
     assert_push("howdy", %{})
-
-    # Socket close starts DeviceLink reconnect timer
-    link = socket.assigns.device_link_pid
-    Process.unlink(socket.channel_pid)
-    close(socket)
-    assert :sys.get_state(link).reconnect_timer
   end
 end


### PR DESCRIPTION
The connection between a DeviceLink and DeviceChannel is unreliable when there is a horde of devices trying to connect. A too large percentage of devices can think they have a DeviceLink but it terminated and didn't terminate the DeviceChannel. If we terminate faster, this may reduce the number of devices in this state.