### PR TITLE
Have the ssl process hibernate after 15s

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -123,7 +123,8 @@ if config_env() == :prod do
             fail_if_no_peer_cert: true,
             keyfile: keyfile,
             certfile: certfile,
-            cacertfile: CAStore.file_path()
+            cacertfile: CAStore.file_path(),
+            hibernate_after: 15_000
           ]
         ]
       ]


### PR DESCRIPTION
Tell the ssl_gen_statem process to hibernate after 15s of no activity, this will force a GC sweep and keep memory low. Otherwise there's a memory leak that was discovered with `:recon.bin_leak/1`. Running `:recon.bin_leak/1` on a two node cluster and 5k sockets recovered 2GB of memory per node. No memory leak was noticed with this setting and the same amount of devices.