### PR TITLE
Add a custom device transport for ThousandIsland

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -44,6 +44,7 @@ config :nerves_hub, NervesHubWeb.DeviceEndpoint,
     port: 4001,
     otp_app: :nerves_hub,
     thousand_island_options: [
+      transport_module: NervesHub.DeviceSSLTransport,
       transport_options: [
         # Enable client SSL
         # Older versions of OTP 25 may break using using devices

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -106,6 +106,7 @@ if config_env() == :prod do
         port: https_port,
         otp_app: :nerves_hub,
         thousand_island_options: [
+          transport_module: NervesHub.DeviceSSLTransport,
           transport_options: [
             # Enable client SSL
             # Older versions of OTP 25 may break using using devices

--- a/lib/nerves_hub/device_ssl_transport.ex
+++ b/lib/nerves_hub/device_ssl_transport.ex
@@ -1,0 +1,79 @@
+defmodule NervesHub.DeviceSSLTransport do
+  @moduledoc """
+  SSL transport for device certificate authentication
+
+  This transport exists to rate limit incoming SSL connections _before_ any
+  ssl work has started. This let's us shed incoming devices before we waste
+  a lot of resources on denying them midway through the SSL connection in
+  the `NervesHub.SSL.verify_fun/3`
+
+  See `handshake/1` for the main change. All other function are delegated back to
+  `ThousandIsland.Transports.SSL`
+  """
+
+  @behaviour ThousandIsland.Transport
+
+  @impl ThousandIsland.Transport
+  defdelegate listen(port, user_options), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate accept(listener_socket), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  def handshake(socket) do
+    if NervesHub.RateLimit.increment() do
+      :telemetry.execute([:nerves_hub, :rate_limit, :accepted], %{count: 1})
+
+      ThousandIsland.Transports.SSL.handshake(socket)
+    else
+      :telemetry.execute([:nerves_hub, :rate_limit, :rejected], %{count: 1})
+
+      {:error, :closed}
+    end
+  end
+
+  @impl ThousandIsland.Transport
+  defdelegate upgrade(socket, opts), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate controlling_process(socket, pid), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate recv(socket, length, timeout), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate send(socket, data), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate sendfile(socket, filename, offset, length), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate getopts(socket, options), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate setopts(socket, options), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate shutdown(socket, way), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate close(socket), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate sockname(socket), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate peername(socket), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate peercert(socket), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate secure?(), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate getstat(socket), to: ThousandIsland.Transports.SSL
+
+  @impl ThousandIsland.Transport
+  defdelegate negotiated_protocol(socket), to: ThousandIsland.Transports.SSL
+end

--- a/lib/nerves_hub/ssl.ex
+++ b/lib/nerves_hub/ssl.ex
@@ -1,7 +1,6 @@
 defmodule NervesHub.SSL do
   alias NervesHub.Devices
   alias NervesHub.Certificate
-  alias NervesHub.RateLimit
 
   @type pkix_path_validation_reason ::
           :cert_expired
@@ -34,15 +33,9 @@ defmodule NervesHub.SSL do
   # or the signer cert was included by the client and is valid
   # for the peer (device) cert
   def verify_fun(otp_cert, :valid_peer, state) do
-    if RateLimit.increment() do
-      :telemetry.execute([:nerves_hub, :rate_limit, :accepted], %{count: 1})
+    :telemetry.execute([:nerves_hub, :rate_limit, :accepted], %{count: 1})
 
-      do_verify(otp_cert, state)
-    else
-      :telemetry.execute([:nerves_hub, :rate_limit, :rejected], %{count: 1})
-
-      {:fail, :rate_limit}
-    end
+    do_verify(otp_cert, state)
   end
 
   def verify_fun(_certificate, :valid, state) do
@@ -50,38 +43,32 @@ defmodule NervesHub.SSL do
   end
 
   def verify_fun(otp_cert, {:bad_cert, err}, state) when err in [:unknown_ca, :cert_expired] do
-    if RateLimit.increment() do
-      :telemetry.execute([:nerves_hub, :rate_limit, :accepted], %{count: 1})
+    :telemetry.execute([:nerves_hub, :rate_limit, :accepted], %{count: 1})
 
-      aki = Certificate.get_aki(otp_cert)
-      ski = Certificate.get_ski(otp_cert)
+    aki = Certificate.get_aki(otp_cert)
+    ski = Certificate.get_ski(otp_cert)
 
-      cond do
-        aki == ski ->
-          # If the signer CA is also the root, then AKI == SKI. We can skip
-          # checking as it will be validated later on if the device needs
-          # registration
-          {:valid, state}
+    cond do
+      aki == ski ->
+        # If the signer CA is also the root, then AKI == SKI. We can skip
+        # checking as it will be validated later on if the device needs
+        # registration
+        {:valid, state}
 
-        is_binary(ski) and match?({:ok, _db_ca}, Devices.get_ca_certificate_by_ski(ski)) ->
-          # Signer CA sent with the device certificate, but is an intermediary
-          # so the chain is incomplete labeling it as unknown_ca.
-          #
-          # Since we have this CA registered, validate so we can move on to the device
-          # cert next and expiration will be checked later if registration of a new
-          # device cert needs to happen.
-          {:valid, state}
+      is_binary(ski) and match?({:ok, _db_ca}, Devices.get_ca_certificate_by_ski(ski)) ->
+        # Signer CA sent with the device certificate, but is an intermediary
+        # so the chain is incomplete labeling it as unknown_ca.
+        #
+        # Since we have this CA registered, validate so we can move on to the device
+        # cert next and expiration will be checked later if registration of a new
+        # device cert needs to happen.
+        {:valid, state}
 
-        true ->
-          # The signer CA was not included in the request, so this is most
-          # likely a device cert that needs verification. If it isn't, then
-          # this is some other unknown CA that will fail
-          do_verify(otp_cert, state)
-      end
-    else
-      :telemetry.execute([:nerves_hub, :rate_limit, :rejected], %{count: 1})
-
-      {:fail, :rate_limit}
+      true ->
+        # The signer CA was not included in the request, so this is most
+        # likely a device cert that needs verification. If it isn't, then
+        # this is some other unknown CA that will fail
+        do_verify(otp_cert, state)
     end
   end
 


### PR DESCRIPTION
Delegates to the SSL transport from ThousandIsland but adds rate limiting before the handshake. To forcefully close before SSL is allowed to start doing CPU intensive tasks.