### PR TITLE
Remove the load balancer from the application tree

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -26,7 +26,6 @@ defmodule NervesHub.Application do
         metrics(deploy_env()) ++
         [
           NervesHub.RateLimit,
-          NervesHub.LoadBalancer,
           NervesHub.Repo,
           NervesHub.ObanRepo,
           {Phoenix.PubSub, name: NervesHub.PubSub},


### PR DESCRIPTION
This used tracker shards to collection device information and needs to be updated for another method before being useful for detecting load