### PR TITLE
Configure Phoenix socket drainer for devices

### DIFF
--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -5,6 +5,11 @@ defmodule NervesHubWeb.DeviceEndpoint do
   socket(
     "/socket",
     NervesHubWeb.DeviceSocketCertAuth,
+    drainer: [
+      batch_size: 500,
+      batch_interval: 1_000,
+      shutdown: 30_000
+    ],
     websocket: [
       connect_info: [:peer_data, :x_headers]
     ]


### PR DESCRIPTION
https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-common-configuration

This should shed devices in a more controlled manner than dropping all N sockets at the same time when a SIGTERM is received.