### PR TITLE
Set a nil penalty timer in assigns

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -109,6 +109,7 @@ defmodule NervesHubWeb.DeviceChannel do
         socket
         |> assign(:device, device)
         |> assign(:update_started?, push_update?)
+        |> assign(:penalty_timer, nil)
         |> maybe_start_penalty_timer()
 
       send(self(), :boot)


### PR DESCRIPTION
`socket.assigns.penalty_timer` will error unless the key exists and is nil for the `if` check