### PR TITLE
Move the device drainer config to be under `websocket`

### DIFF
--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -5,13 +5,13 @@ defmodule NervesHubWeb.DeviceEndpoint do
   socket(
     "/socket",
     NervesHubWeb.DeviceSocketCertAuth,
-    drainer: [
-      batch_size: 500,
-      batch_interval: 1_000,
-      shutdown: 30_000
-    ],
     websocket: [
-      connect_info: [:peer_data, :x_headers]
+      connect_info: [:peer_data, :x_headers],
+      drainer: [
+        batch_size: 500,
+        batch_interval: 1_000,
+        shutdown: 30_000
+      ]
     ]
   )
 


### PR DESCRIPTION
Upon reading the docs again, the config should not be at the top level of the socket call.