### PR TITLE
Remove connect/disconnect messages from the audit logs

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -76,7 +76,9 @@ defmodule NervesHubWeb.DeviceChannel do
     end
 
     ## After join
-    :telemetry.execute([:nerves_hub, :devices, :connect], %{count: 1})
+    :telemetry.execute([:nerves_hub, :devices, :connect], %{count: 1}, %{
+      identifier: device.identifier
+    })
 
     # local node tracking
     Registry.update_value(NervesHub.Devices, device.id, fn value ->
@@ -383,8 +385,10 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  def terminate(_reason, socket) do
-    :telemetry.execute([:nerves_hub, :devices, :disconnect], %{count: 1})
+  def terminate(_reason, %{assigns: %{device: device}} = socket) do
+    :telemetry.execute([:nerves_hub, :devices, :disconnect], %{count: 1}, %{
+      identifier: device.identifier
+    })
 
     {:ok, device} =
       Devices.update_device(socket.assigns.device, %{last_communication: DateTime.utc_now()})

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -38,15 +38,6 @@ defmodule NervesHubWeb.DeviceChannel do
   def handle_info({:after_join, params}, %{assigns: %{device: device}} = socket) do
     socket = assign(socket, :device_api_version, Map.get(params, "device_api_version", "1.0.0"))
 
-    description = "device #{device.identifier} connected to the server"
-
-    AuditLogs.audit_with_ref!(
-      device,
-      device,
-      description,
-      socket.assigns.reference_id
-    )
-
     device =
       device
       |> Devices.verify_deployment()
@@ -398,11 +389,8 @@ defmodule NervesHubWeb.DeviceChannel do
     {:ok, device} =
       Devices.update_device(socket.assigns.device, %{last_communication: DateTime.utc_now()})
 
-    description = "device #{device.identifier} disconnected from the server"
-
-    AuditLogs.audit_with_ref!(device, device, description, socket.assigns.reference_id)
-
     Registry.unregister(NervesHub.Devices, device.id)
+
     Tracker.offline(device)
 
     :ok

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -4,7 +4,6 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   import TrackerHelper
 
-  alias NervesHub.AuditLogs
   alias NervesHub.Devices
   alias NervesHub.Fixtures
   alias NervesHubWeb.DeviceChannel
@@ -33,28 +32,6 @@ defmodule NervesHubWeb.DeviceChannelTest do
     {:ok, _, _socket} = subscribe_and_join(socket, DeviceChannel, "device")
 
     assert_online(device)
-  end
-
-  test "device disconnected adds audit log" do
-    user = Fixtures.user_fixture()
-    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
-    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
-
-    {:ok, socket} =
-      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
-
-    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
-
-    Process.unlink(socket.channel_pid)
-
-    close(socket)
-
-    disconnect_log =
-      Enum.find(AuditLogs.logs_for(device), fn audit_log ->
-        audit_log.description == "device #{device.identifier} disconnected from the server"
-      end)
-
-    assert disconnect_log
   end
 
   test "update_available on connect" do


### PR DESCRIPTION
It's a very large portion of what's in the audit logs table. We should probably be storing these in another way because devices tend to flap online/offline enough with LTE connections.