### PR TITLE
Device channel fixes

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -381,7 +381,7 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  def handle_call("rebooting", _, socket) do
+  def handle_in("rebooting", _, socket) do
     {:noreply, socket}
   end
 

--- a/lib/nerves_hub_web/live/device_live/index.ex
+++ b/lib/nerves_hub_web/live/device_live/index.ex
@@ -299,6 +299,11 @@ defmodule NervesHubWeb.DeviceLive.Index do
     end
   end
 
+  # Unknown broadcasts get ignored, likely from the device:id:internal channel
+  def handle_info(%Broadcast{}, socket) do
+    {:noreply, socket}
+  end
+
   defp assign_display_devices(
          %{assigns: %{org: org, product: product, paginate_opts: paginate_opts}} = socket
        ) do


### PR DESCRIPTION
- The rebooting message is a handle_in. This was missed during the DeviceLink -> DeviceChannel reset
- Device Index should ignore unknown broadcasts. It's receiving the device internal channel now and should be skipped
except for connection changes