### PR TITLE
Add a synchronous device online check

### DIFF
--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -56,4 +56,21 @@ defmodule NervesHub.Tracker do
     Phoenix.PubSub.broadcast(NervesHub.PubSub, "device:#{device.id}", :online?)
     false
   end
+
+  @doc """
+  Check if a device is currently online
+
+  If the device is not online this function will wait for a timeout before returning false
+  """
+  def sync_online?(device) do
+    Phoenix.PubSub.broadcast(NervesHub.PubSub, "device:#{device.id}", {:online?, self()})
+
+    receive do
+      :online ->
+        true
+    after
+      500 ->
+        false
+    end
+  end
 end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -290,6 +290,11 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
+  def handle_info({:online?, pid}, socket) do
+    send(pid, :online)
+    {:noreply, socket}
+  end
+
   def handle_info(%Broadcast{event: event, payload: payload}, socket) do
     # Forward broadcasts to the device for now
     push(socket, event, payload)

--- a/lib/nerves_hub_web/views/api/device_view.ex
+++ b/lib/nerves_hub_web/views/api/device_view.ex
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.API.DeviceView do
       identifier: device.identifier,
       tags: device.tags,
       version: version(device),
-      online: Tracker.online?(device),
+      online: Tracker.sync_online?(device),
       last_communication: last_communication(device),
       description: device.description,
       firmware_metadata: device.firmware_metadata,


### PR DESCRIPTION
The API doesn't have the ability to wait for a response async and needs to know before it can render the JSON. If the device is online this will be fast, if it's offline it will be slow because we're waiting for the timeout to occur.

The big question is how long should we wait before assuming the device is offline?