### PR TITLE
More logging around device events

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,9 @@
 import Config
 
 # Configures Elixir's Logger
-config :logger, :console,
-  format: "$time $metadata level=$level $message\n",
-  metadata: [:user_id, :request_id, :trace_id, :span_id]
+config :logger, :default_formatter,
+  format: {NervesHub.LoggerFormatter, :format},
+  metadata: :all
 
 config :phoenix,
   json_library: Jason,

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -794,6 +794,11 @@ defmodule NervesHub.Devices do
   end
 
   def firmware_update_successful(device) do
+    :telemetry.execute([:nerves_hub, :devices, :update, :successful], %{count: 1}, %{
+      identifier: device.identifier,
+      firmware_uuid: device.firmware_metadata.uuid
+    })
+
     description =
       "device #{device.identifier} firmware set to version #{device.firmware_metadata.version} (#{device.firmware_metadata.uuid})"
 

--- a/lib/nerves_hub/logger_formatter.ex
+++ b/lib/nerves_hub/logger_formatter.ex
@@ -1,0 +1,7 @@
+defmodule NervesHub.LoggerFormatter do
+  @pattern Logger.Formatter.compile("$time [$level] $metadata$message\n")
+  def format(level, message, timestamp, metadata) do
+    metadata = Keyword.drop(metadata, [:line, :file, :domain, :application])
+    Logger.Formatter.format(@pattern, level, message, timestamp, metadata)
+  end
+end

--- a/lib/nerves_hub/metrics.ex
+++ b/lib/nerves_hub/metrics.ex
@@ -119,6 +119,7 @@ defmodule NervesHub.Metrics.Reporters do
   def handle_continue(:initialize, state) do
     reporters = [
       NervesHub.EctoReporter,
+      NervesHub.DeviceReporter,
       NervesHub.NodeReporter
     ]
 
@@ -150,6 +151,49 @@ defmodule NervesHub.EctoReporter do
   # No queue time
   def handle_event([:nerves_hub, :repo, :query], _, _, _) do
     :ok
+  end
+end
+
+defmodule NervesHub.DeviceReporter do
+  require Logger
+
+  def events() do
+    [
+      [:nerves_hub, :devices, :connect],
+      [:nerves_hub, :devices, :disconnect],
+      [:nerves_hub, :devices, :update, :automatic]
+    ]
+  end
+
+  def handle_event([:nerves_hub, :devices, :connect], _, metadata, _) do
+    Logger.info("Device connected",
+      event: "nerves_hub.devices.connect",
+      identifier: metadata[:identifier],
+      firmware_uuid: metadata[:firmware_uuid]
+    )
+  end
+
+  def handle_event([:nerves_hub, :devices, :disconnect], _, metadata, _) do
+    Logger.info("Device disconnected",
+      event: "nerves_hub.devices.disconnect",
+      identifier: metadata[:identifier]
+    )
+  end
+
+  def handle_event([:nerves_hub, :devices, :update, :automatic], _, metadata, _) do
+    Logger.info("Device received update",
+      event: "nerves_hub.devices.update.automatic",
+      identifier: metadata[:identifier],
+      firmware_uuid: metadata[:firmware_uuid]
+    )
+  end
+
+  def handle_event([:nerves_hub, :devices, :update, :successful], _, metadata, _) do
+    Logger.info("Device updated firmware",
+      event: "nerves_hub.devices.update.successful",
+      identifier: metadata[:identifier],
+      firmware_uuid: metadata[:firmware_uuid]
+    )
   end
 end
 


### PR DESCRIPTION
Add logging to devices connecting, disconnecting, receiving an update, and successfully updating. Outputs metadata as key/value pairs for parsing with something like datadog.