### PR TITLE
add python 3.10.13 to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 nodejs 16.18.1
+python 3.10.13
 elixir 1.16.0-otp-26
 erlang 26.2.1


### PR DESCRIPTION
The `mix assets.compile` fails using python 3.11 and 3.12
```
...
npm ERR! ValueError: invalid mode: 'rU' while trying to load binding.gyp
npm ERR! gyp ERR! configure error 
npm ERR! gyp ERR! stack Error: `gyp` failed with exit code: 1
...
```

Using 3.10 fixes the error