### PR TITLE
Allow database hostname without port

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -150,7 +150,7 @@ if config_env() == :prod do
   database_ssl_opts =
     if System.get_env("DATABASE_PEM") do
       db_hostname_charlist =
-        ~r/.*@(?<hostname>.*):\d{4}\/.*/
+        ~r/.*@(?<hostname>[^:\/]+)(?::\d+)?\/.*/
         |> Regex.named_captures(System.fetch_env!("DATABASE_URL"))
         |> Map.get("hostname")
         |> to_charlist()


### PR DESCRIPTION
This allow the hostname to not specify port (default 5432 for postgres) or a non standard port not necessarily for digits long.

![CleanShot 2024-03-04 at 13 16 39](https://github.com/nerves-hub/nerves_hub_web/assets/1312687/62fa87f7-0d18-4b8a-abc2-0e7f02d0bbde)
