### PR TITLE
Start tls_certificate_check before migrating

### DIFF
--- a/lib/nerves_hub/release/tasks.ex
+++ b/lib/nerves_hub/release/tasks.ex
@@ -8,6 +8,8 @@ defmodule NervesHub.Release.Tasks do
   ]
 
   def migrate() do
+    :ok = Application.ensure_started(:tls_certificate_check)
+
     Application.load(@app)
 
     for repo <- Application.fetch_env!(@app, :ecto_repos) do


### PR DESCRIPTION
This is used in the runtime.exs configuration and needs to be started before we load the nerves_hub application