### PR TITLE
Use the correct channel when broascasting code to devices

### DIFF
--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -166,10 +166,12 @@ defmodule NervesHubWeb.API.DeviceController do
           body
           |> String.graphemes()
           |> Enum.map(fn character ->
-            Endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => character})
+            Endpoint.broadcast_from!(self(), "device:console:#{device.id}", "dn", %{
+              "data" => character
+            })
           end)
 
-          Endpoint.broadcast_from!(self(), "console:#{device.id}", "dn", %{"data" => "\r"})
+          Endpoint.broadcast_from!(self(), "device:console:#{device.id}", "dn", %{"data" => "\r"})
 
           send_resp(conn, 200, "Success")
         else


### PR DESCRIPTION
This changed recently and now matches this line https://github.com/nerves-hub/nerves_hub_web/blob/main/lib/nerves_hub_web/channels/console_channel.ex#L65