### PR TITLE
Prewritten commands for a device

### DIFF
--- a/lib/nerves_hub/commands.ex
+++ b/lib/nerves_hub/commands.ex
@@ -1,0 +1,75 @@
+defmodule NervesHub.Commands.Command do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Products.Product
+
+  schema "commands" do
+    belongs_to(:product, Product)
+
+    field(:name, :string)
+    field(:text, :string)
+
+    timestamps()
+  end
+
+  def create_changeset(struct, params) do
+    struct
+    |> cast(params, [:name, :text])
+    |> validate_required([:name, :text])
+    |> validate_length(:name, lte: 255)
+    |> validate_change(:text, fn :text, text ->
+      if String.contains?(text, "\n") do
+        [text: "cannot contain newlines"]
+      else
+        []
+      end
+    end)
+  end
+
+  def update_changeset(struct, params) do
+    create_changeset(struct, params)
+  end
+end
+
+defmodule NervesHub.Commands do
+  import Ecto.Query
+
+  alias NervesHub.Commands.Command
+  alias NervesHub.Repo
+
+  def all_by_product(product) do
+    Command
+    |> where([c], c.product_id == ^product.id)
+    |> order_by(:name)
+    |> Repo.all()
+  end
+
+  def get!(id) do
+    Repo.get!(Command, id)
+  end
+
+  def get(product, id) do
+    case Repo.get_by(Command, id: id, product_id: product.id) do
+      nil ->
+        {:error, :not_found}
+
+      command ->
+        {:ok, command}
+    end
+  end
+
+  def create(product, params) do
+    product
+    |> Ecto.build_assoc(:commands)
+    |> Command.create_changeset(params)
+    |> Repo.insert()
+  end
+
+  def update(command, params) do
+    command
+    |> Command.update_changeset(params)
+    |> Repo.update()
+  end
+end

--- a/lib/nerves_hub/commands.ex
+++ b/lib/nerves_hub/commands.ex
@@ -73,3 +73,77 @@ defmodule NervesHub.Commands do
     |> Repo.update()
   end
 end
+
+defmodule NervesHub.Commands.Runner do
+  use GenServer
+
+  alias NervesHubWeb.Endpoint
+
+  defmodule State do
+    defstruct [:buffer, :clear?, :from, :receive_channel, :send_channel]
+  end
+
+  def send(device, command) do
+    {:ok, pid} = start_link(device)
+    GenServer.call(pid, {:send, command.text}, 10_000)
+  end
+
+  def start_link(device) do
+    GenServer.start_link(__MODULE__, device.id)
+  end
+
+  def init(device_id) do
+    state = %State{
+      buffer: <<>>,
+      clear?: true,
+      from: nil,
+      receive_channel: "user:console:#{device_id}",
+      send_channel: "device:console:#{device_id}"
+    }
+
+    {:ok, state}
+  end
+
+  def handle_call({:send, text}, from, state) do
+    text = ~s/IO.puts("[NERVESHUB:START]"); #{text}; IO.puts("[NERVESHUB:END]")/
+
+    text
+    |> String.graphemes()
+    |> Enum.map(fn character ->
+      Endpoint.broadcast_from!(self(), state.send_channel, "dn", %{"data" => character})
+    end)
+
+    Endpoint.subscribe(state.receive_channel)
+
+    Endpoint.broadcast_from!(self(), state.send_channel, "dn", %{"data" => "\r"})
+
+    {:noreply, %{state | from: from}}
+  end
+
+  def handle_info(%Phoenix.Socket.Broadcast{event: "up", payload: %{"data" => text}}, state) do
+    state = %{state | buffer: state.buffer <> text}
+
+    state =
+      if state.clear? && String.contains?(state.buffer, ~s/[NERVESHUB:END]/) do
+        %{state | buffer: <<>>, clear?: false}
+      else
+        state
+      end
+
+    if String.contains?(state.buffer, "[NERVESHUB:START]") &&
+         String.contains?(state.buffer, "[NERVESHUB:END]") do
+      buffer =
+        state.buffer
+        |> String.replace(~r/\A.+\[NERVESHUB:START\]\r\n/s, "")
+        |> String.replace(~r/\[NERVESHUB:END].+\z/s, "")
+
+      GenServer.reply(state.from, buffer)
+
+      {:stop, :normal, state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+end

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -4,6 +4,7 @@ defmodule NervesHub.Products.Product do
 
   alias NervesHub.Accounts.Org
   alias NervesHub.Archives.Archive
+  alias NervesHub.Commands.Command
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Firmwares.Firmware
@@ -20,6 +21,7 @@ defmodule NervesHub.Products.Product do
     has_many(:firmwares, Firmware)
     has_many(:jitp, CACertificate.JITP)
     has_many(:archives, Archive)
+    has_many(:commands, Command)
 
     has_many(:shared_secret_auths, SharedSecretAuth,
       preload_order: [desc: :deactivated_at, asc: :id]

--- a/lib/nerves_hub_web/controllers/api/command_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/command_controller.ex
@@ -1,0 +1,60 @@
+defmodule NervesHubWeb.API.CommandController do
+  use NervesHubWeb, :controller
+
+  alias NervesHub.Accounts
+  alias NervesHub.Commands
+  alias NervesHub.Devices
+
+  def index(conn, %{"identifier" => identifier}) do
+    %{user: user} = conn.assigns
+
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :view) do
+          conn
+          |> assign(:commands, Commands.all_by_product(device.product))
+          |> render("index.json")
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: read"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
+    end
+  end
+
+  def send(conn, %{"identifier" => identifier, "id" => id}) do
+    %{user: user} = conn.assigns
+
+    case Devices.get_by_identifier(identifier) do
+      {:ok, device} ->
+        if Accounts.has_org_role?(device.org, user, :view) do
+          case Commands.get(device.product, id) do
+            {:ok, command} ->
+              text(conn, Commands.Runner.send(device, command))
+
+            {:error, :not_found} ->
+              conn
+              |> put_status(404)
+              |> put_view(NervesHubWeb.API.ErrorView)
+              |> render(:"404")
+          end
+        else
+          conn
+          |> put_resp_header("content-type", "application/json")
+          |> send_resp(403, Jason.encode!(%{status: "missing required role: read"}))
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> put_view(NervesHubWeb.API.ErrorView)
+        |> render(:"404")
+    end
+  end
+end

--- a/lib/nerves_hub_web/controllers/command_controller.ex
+++ b/lib/nerves_hub_web/controllers/command_controller.ex
@@ -1,0 +1,105 @@
+defmodule NervesHubWeb.CommandController do
+  use NervesHubWeb, :controller
+
+  alias NervesHub.Commands
+  alias NervesHub.Repo
+
+  plug(:validate_role, [org: :manage] when action in [:new, :create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index])
+
+  def index(conn, _params) do
+    %{product: product} = conn.assigns
+
+    conn
+    |> assign(:commands, Commands.all_by_product(product))
+    |> render("index.html")
+  end
+
+  def new(conn, _params) do
+    changeset =
+      %Commands.Command{}
+      |> Commands.Command.create_changeset(%{})
+
+    conn
+    |> assign(:changeset, changeset)
+    |> render("new.html")
+  end
+
+  def create(conn, %{"command" => params}) do
+    %{org: org, product: product} = conn.assigns
+
+    case Commands.create(product, params) do
+      {:ok, _command} ->
+        conn
+        |> put_flash(:info, "Command created")
+        |> redirect(to: Routes.command_path(conn, :index, org.name, product.name))
+
+      {:error, changeset} ->
+        conn
+        |> assign(:changeset, changeset)
+        |> render("new.html")
+    end
+  end
+
+  def edit(conn, %{"id" => id}) do
+    %{org: org, product: product} = conn.assigns
+
+    case Commands.get(product, id) do
+      {:ok, command} ->
+        changeset = Commands.Command.update_changeset(command, %{})
+
+        conn
+        |> assign(:command, command)
+        |> assign(:changeset, changeset)
+        |> render("edit.html")
+
+      {:error, :not_found} ->
+        conn
+        |> put_flash(:error, "Not found")
+        |> redirect(to: Routes.command_path(conn, :index, org.name, product.name))
+    end
+  end
+
+  def update(conn, %{"id" => id, "command" => params}) do
+    %{org: org, product: product} = conn.assigns
+
+    case Commands.get(product, id) do
+      {:ok, command} ->
+        case Commands.update(command, params) do
+          {:ok, _command} ->
+            conn
+            |> put_flash(:info, "Command updated")
+            |> redirect(to: Routes.command_path(conn, :index, org.name, product.name))
+
+          {:error, changeset} ->
+            conn
+            |> assign(:command, command)
+            |> assign(:changeset, changeset)
+            |> render("edit.html")
+        end
+
+      {:error, :not_found} ->
+        conn
+        |> put_flash(:error, "Not found")
+        |> redirect(to: Routes.command_path(conn, :index, org.name, product.name))
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    %{org: org, product: product} = conn.assigns
+
+    case Commands.get(product, id) do
+      {:ok, command} ->
+        Repo.delete!(command)
+
+        conn
+        |> put_flash(:info, "Command deleted")
+        |> redirect(to: Routes.command_path(conn, :index, org.name, product.name))
+
+      {:error, :not_found} ->
+        conn
+        |> put_flash(:error, "Not found")
+        |> redirect(to: Routes.command_path(conn, :index, org.name, product.name))
+    end
+  end
+end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -75,6 +75,9 @@ defmodule NervesHubWeb.Router do
       post("/:identifier/code", DeviceController, :code)
       post("/:identifier/upgrade", DeviceController, :upgrade)
       delete("/:identifier/penalty", DeviceController, :penalty)
+
+      get("/:identifier/commands", CommandController, :index)
+      post("/:identifier/commands/:id", CommandController, :send)
     end
 
     scope "/" do

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -307,6 +307,8 @@ defmodule NervesHubWeb.Router do
           param: "uuid"
         )
 
+        resources("/commands", CommandController)
+
         get("/archives/:uuid/download", ArchiveController, :download)
 
         scope "/deployments" do

--- a/lib/nerves_hub_web/templates/command/edit.html.eex
+++ b/lib/nerves_hub_web/templates/command/edit.html.eex
@@ -1,0 +1,20 @@
+<h1>Edit Command</h1>
+
+<%= form_for @changeset, Routes.command_path(@conn, :update, @org.name, @product.name, @command.id), [as: :command], fn f -> %>
+  <div class="form-group">
+    <label for="name_input">Command name</label>
+    <%= text_input(f, :name, class: "form-control", id: "name_input") %>
+    <div class="has-error"><%= error_tag(f, :name) %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="text_input">Command text</label>
+    <%= text_input(f, :text, class: "form-control", id: "text_input") %>
+    <div class="has-error"><%= error_tag(f, :text) %></div>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <a class="btn btn-secondary" href={Routes.command_path(@conn, :new, @org.name, @product.name)}>Back</a>
+    <%= submit("Save Changes", class: "btn btn-primary") %>
+  </div>
+<% end %>

--- a/lib/nerves_hub_web/templates/command/index.html.heex
+++ b/lib/nerves_hub_web/templates/command/index.html.heex
@@ -1,0 +1,51 @@
+<%= if @commands == [] do %>
+  <div class="no-results-blowup-wrapper">
+    <img src="/images/command.svg" alt="No commands" />
+    <h3 style="margin-top: 2.75rem"><%= @product.name %> doesn’t have any commands yet</h3>
+    <div class="flex-row align-items-center mt-3">
+      <a class="btn btn-outline-light" aria-label="Create command" href={Routes.command_path(@conn, :new, @org.name, @product.name)}>
+        <span class="action-text">Create Command</span>
+        <span class="button-icon add"></span>
+      </a>
+    </div>
+  </div>
+<% else %>
+  <div class="action-row">
+    <h1>Commands</h1>
+    <a class="btn btn-outline-light btn-action" aria-label="Create command" href={Routes.command_path(@conn, :new, @org.name, @product.name)}>
+      <span class="button-icon add"></span>
+      <span class="action-text">Create Command</span>
+    </a>
+  </div>
+
+  <table class="table">
+    <tr>
+      <th>Name</th>
+      <th>Text</th>
+      <th>Actions</th>
+    </tr>
+    <%= for command <- @commands do %>
+      <tr class="item">
+        <td>
+          <%= command.name %>
+        </td>
+        <td>
+          <pre><code><%= command.text %></code></pre>
+        </td>
+        <td class="actions">
+          <div class="mobile-label help-text">Actions</div>
+          <div class="dropdown options">
+            <a class="dropdown-toggle options" data-target="#" id={"command-#{command.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <div class="mobile-label pr-2">Open</div>
+              <img src="/images/icons/more.svg" alt="options" />
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+              <%= link("edit", class: "dropdown-item", to: Routes.command_path(@conn, :edit, @org.name, @product.name, command.id)) %>
+              <%= link("delete", class: "dropdown-item", method: :delete, to: Routes.command_path(@conn, :delete, @org.name, @product.name, command.id)) %>
+            </div>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/lib/nerves_hub_web/templates/command/new.html.heex
+++ b/lib/nerves_hub_web/templates/command/new.html.heex
@@ -1,0 +1,20 @@
+<h1>Add Command</h1>
+
+<%= form_for @changeset, Routes.command_path(@conn, :create, @org.name, @product.name), [as: :command], fn f -> %>
+  <div class="form-group">
+    <label for="name_input">Command name</label>
+    <%= text_input(f, :name, class: "form-control", id: "name_input") %>
+    <div class="has-error"><%= error_tag(f, :name) %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="text_input">Command text</label>
+    <%= text_input(f, :text, class: "form-control", id: "text_input") %>
+    <div class="has-error"><%= error_tag(f, :text) %></div>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <a class="btn btn-secondary" href={Routes.command_path(@conn, :new, @org.name, @product.name)}>Back</a>
+    <%= submit("Add Command", class: "btn btn-primary") %>
+  </div>
+<% end %>

--- a/lib/nerves_hub_web/views/api/command_view.ex
+++ b/lib/nerves_hub_web/views/api/command_view.ex
@@ -1,0 +1,17 @@
+defmodule NervesHubWeb.API.CommandView do
+  use NervesHubWeb, :api_view
+
+  def render("index.json", %{commands: commands}) do
+    %{
+      data: render_many(commands, __MODULE__, "command.json")
+    }
+  end
+
+  def render("command.json", %{command: command}) do
+    %{
+      id: command.id,
+      name: command.name,
+      text: command.text
+    }
+  end
+end

--- a/lib/nerves_hub_web/views/command_view.ex
+++ b/lib/nerves_hub_web/views/command_view.ex
@@ -1,0 +1,3 @@
+defmodule NervesHubWeb.CommandView do
+  use NervesHubWeb, :view
+end

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -205,6 +205,11 @@ defmodule NervesHubWeb.LayoutView do
           Routes.deployment_path(conn, :index, conn.assigns.org.name, conn.assigns.product.name)
       },
       %{
+        title: "Commands",
+        active: "",
+        href: Routes.command_path(conn, :index, conn.assigns.org.name, conn.assigns.product.name)
+      },
+      %{
         title: "Settings",
         active: "",
         href:

--- a/priv/repo/migrations/20240426144021_create_commands.exs
+++ b/priv/repo/migrations/20240426144021_create_commands.exs
@@ -1,0 +1,13 @@
+defmodule NervesHub.Repo.Migrations.CreateCommands do
+  use Ecto.Migration
+
+  def change do
+    create table(:commands) do
+      add(:product_id, references(:products), null: false)
+      add(:name, :string, null: false)
+      add(:text, :text, null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/test/nerves_hub/commands_test.exs
+++ b/test/nerves_hub/commands_test.exs
@@ -1,0 +1,38 @@
+defmodule NervesHub.CommandsTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.Commands
+  alias NervesHub.Fixtures
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+
+    %{user: user, org: org, product: product}
+  end
+
+  describe "creating a command" do
+    test "successful", %{product: product} do
+      {:ok, command} =
+        Commands.create(product, %{
+          name: "MOTD",
+          text: "NervesMOTD.print()"
+        })
+
+      assert command.product_id == product.id
+    end
+
+    test "no newline allowed", %{product: product} do
+      {:error, changeset} =
+        Commands.create(product, %{
+          name: "MOTD",
+          text: """
+          Hello there
+          """
+        })
+
+      assert changeset.errors[:text]
+    end
+  end
+end

--- a/test/nerves_hub_web/controllers/command_controller_test.exs
+++ b/test/nerves_hub_web/controllers/command_controller_test.exs
@@ -1,0 +1,72 @@
+defmodule NervesHubWeb.CommandControllerTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  alias NervesHub.Commands
+  alias NervesHub.Fixtures
+
+  setup %{user: user, org: org} do
+    [product: Fixtures.product_fixture(user, org)]
+  end
+
+  describe "new command" do
+    test "renders form with valid request params", %{conn: conn, org: org, product: product} do
+      new_conn = get(conn, Routes.command_path(conn, :new, org.name, product.name))
+
+      assert html_response(new_conn, 200) =~ "Add Command"
+    end
+  end
+
+  describe "create command" do
+    test "redirects to index when data is valid", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      params = %{
+        name: "MOTD",
+        text: "NervesMOTD.print()"
+      }
+
+      # check that we end up in the right place
+      conn =
+        post(conn, Routes.command_path(conn, :create, org.name, product.name), command: params)
+
+      assert redirected_to(conn, 302) =~
+               Routes.command_path(conn, :index, org.name, product.name)
+
+      conn = get(conn, Routes.command_path(conn, :index, org.name, product.name))
+      assert html_response(conn, 200) =~ params.name
+    end
+  end
+
+  describe "update command" do
+    test "redirects to listing when data is valid", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      {:ok, command} = Commands.create(product, %{name: "MOTD", text: "NervesMOTD>print()"})
+
+      params = %{
+        text: "NervesMOTD.print()"
+      }
+
+      conn =
+        put(conn, Routes.command_path(conn, :update, org.name, product.name, command.id),
+          command: params
+        )
+
+      assert redirected_to(conn) == Routes.command_path(conn, :index, org.name, product.name)
+      assert %{text: "NervesMOTD.print()"} = Commands.get!(command.id)
+    end
+  end
+
+  describe "delete product" do
+    test "deletes chosen product", %{conn: conn, org: org, product: product} do
+      {:ok, command} = Commands.create(product, %{name: "MOTD", text: "NervesMOTD.print()"})
+      path = Routes.command_path(conn, :delete, org.name, product.name, command.id)
+      conn = delete(conn, path)
+      assert redirected_to(conn) == Routes.command_path(conn, :index, org.name, product.name)
+    end
+  end
+end


### PR DESCRIPTION
Pre-written commands help enable self-service for support level users. Admins can create new commands that are sent via the console channel and the output is returned in an API response. Users can get access to the console in a very limited ability with this.