### PR TITLE
fix: script list api endpoint

### DIFF
--- a/lib/nerves_hub_web/views/api/script_view.ex
+++ b/lib/nerves_hub_web/views/api/script_view.ex
@@ -3,15 +3,15 @@ defmodule NervesHubWeb.API.ScriptView do
 
   def render("index.json", %{scripts: scripts}) do
     %{
-      data: render_many(scripts, __MODULE__, "command.json")
+      data: render_many(scripts, __MODULE__, "script.json")
     }
   end
 
-  def render("command.json", %{command: command}) do
+  def render("script.json", %{script: script}) do
     %{
-      id: command.id,
-      name: command.name,
-      text: command.text
+      id: script.id,
+      name: script.name,
+      text: script.text
     }
   end
 end


### PR DESCRIPTION
Hello! Noticed this got missed in the rename while trying to use the API.

## Before
<img width="1394" alt="Screenshot 2024-05-08 at 12 33 34 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/51095001/3a4db380-3e9a-40ea-8c57-29f123b019b6">

## After
<img width="1395" alt="Screenshot 2024-05-08 at 12 33 52 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/51095001/b51d9127-ee5e-4da8-9d36-a09c9d992d9b">
