### PR TITLE
the start of a handy health check route for both endpoints

### DIFF
--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -15,6 +15,8 @@ defmodule NervesHubWeb.DeviceEndpoint do
     ]
   )
 
+  plug(NervesHubWeb.Plugs.ImAlive)
+
   plug(Sentry.PlugContext)
 
   plug(NervesHubWeb.Plugs.Logger)

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -49,6 +49,8 @@ defmodule NervesHubWeb.Endpoint do
   plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
   plug(NervesHubWeb.Plugs.Logger)
 
+  plug(NervesHubWeb.Plugs.ImAlive)
+
   plug(
     Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],

--- a/lib/nerves_hub_web/plugs/im_alive.ex
+++ b/lib/nerves_hub_web/plugs/im_alive.ex
@@ -1,0 +1,19 @@
+defmodule NervesHubWeb.Plugs.ImAlive do
+  @behaviour Plug
+  @moduledoc """
+  A simple plug to respond to health checks.
+  """
+
+  import Plug.Conn
+
+  def init(config), do: config
+
+  def call(%{request_path: "/status/alive"} = conn, _) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, "Hello Friend!")
+    |> halt
+  end
+
+  def call(conn, _), do: conn
+end


### PR DESCRIPTION
I use these for my deployments to Fly.io, which require a health check for blue green deployments 