### PR TITLE
device endpoint: redirect on 404

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,7 +12,9 @@ end
 config :nerves_hub,
   app: nerves_hub_app,
   deploy_env: System.get_env("DEPLOY_ENV", to_string(config_env())),
-  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org")
+  from_email: System.get_env("FROM_EMAIL", "no-reply@nerves-hub.org"),
+  device_endpoint_redirect:
+    System.get_env("DEVICE_ENDPOINT_REDIRECT", "https://docs.nerves-hub.org/")
 
 if level = System.get_env("LOG_LEVEL") do
   config :logger, level: String.to_atom(level)

--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -18,4 +18,6 @@ defmodule NervesHubWeb.DeviceEndpoint do
   plug(Sentry.PlugContext)
 
   plug(NervesHubWeb.Plugs.Logger)
+
+  plug(NervesHubWeb.Plugs.DeviceEndpointRedirect)
 end

--- a/lib/nerves_hub_web/plugs/device_endpoint_redirect.ex
+++ b/lib/nerves_hub_web/plugs/device_endpoint_redirect.ex
@@ -1,0 +1,18 @@
+defmodule NervesHubWeb.Plugs.DeviceEndpointRedirect do
+  use NervesHubWeb, :plug
+
+  require Logger
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    location = Application.get_env(:nerves_hub, :device_endpoint_redirect)
+
+    Logger.info("Invalid request to \"#{conn.request_path}\", redirecting to \"#{location}\"")
+
+    conn
+    |> put_resp_header("location", location)
+    |> send_resp(301, "")
+    |> halt
+  end
+end

--- a/test/nerves_hub_web/plugs/device_endpoint_redirect_test.exs
+++ b/test/nerves_hub_web/plugs/device_endpoint_redirect_test.exs
@@ -1,0 +1,13 @@
+defmodule NervesHubWeb.Plugs.DeviceEndpointRedirectTest do
+  use NervesHubWeb.ConnCase.Browser, async: true
+  use Plug.Test
+
+  @endpoint NervesHubWeb.DeviceEndpoint
+
+  test "redirect to docs.nerve-hub.org if the route isn't recognized" do
+    conn = get(build_conn(), "/somewhere")
+
+    assert Plug.Conn.get_resp_header(conn, "location") == ["https://docs.nerves-hub.org/"]
+    assert conn.halted
+  end
+end


### PR DESCRIPTION
this stops the following log lines in the device endpoint logs due to a route not being found:

```
[info] 02:21:22.472 [error] pid=<0.47185.0> Task #PID<0.47185.0> started from #PID<0.47180.0> terminating
[info] ** (Plug.Conn.NotSentError) a response was neither set nor sent from the connection
[info] (bandit 1.2.2) lib/bandit/pipeline.ex:147: Bandit.Pipeline.commit_response/1
[info] (bandit 1.2.2) lib/bandit/pipeline.ex:26: Bandit.Pipeline.run/6
[info] (bandit 1.2.2) lib/bandit/http2/stream_task.ex:69: Bandit.HTTP2.StreamTask.run/5
[info] (elixir 1.16.2) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
[info] Function: &Bandit.HTTP2.StreamTask.run/5
[info] Args: [%Bandit.HTTP2.Adapter{connection: #PID<0.47180.0>, transport_info: %Bandit.TransportInfo{secure?: true, sockname: {{172, 19, 6, 194}, 443}, peername: {{172, 16, 6, 194}, 56696}, peercert: nil}, stream_id: 15, end_stream: false, method: nil, content_encoding: "gzip", metrics: %{}, opts: []}, %Bandit.TransportInfo{secure?: true, sockname: {{172, 19, 6, 194}, 443}, peername: {{172, 16, 6, 194}, 56696}, peercert: nil}, [{":method", "GET"}, {":path", "/something"}, {":authority", "devices.nervescloud.com"}, {":scheme", "https"}, {"user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0"}, {"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"upgrade-insecure-requests", "1"}, {"sec-fetch-dest", "document"}, {"sec-fetch-mode", "navigate"}, {"sec-fetch-site", "none"}, {"sec-fetch-user", "?1"}, {"te", "trailers"}], {NervesHubWeb.DeviceEndpoint, []}, %Bandit.Telemetry{span_name: :request, telemetry_span_context: #Reference<0.2103422185.2080899073.189335>, start_time: -576407100767651567, start_metadata: %{telemetry_span_context: #Reference<0.2103422185.2080899073.189335>, stream_id: 15, connection_telemetry_span_context: #Reference<0.2103422185.2080899073.188876>}}]
[info] 02:21:22.474 [error] pid=<0.47180.0> mfa=Bandit.HTTP2.Stream.stream_terminated/2 Task for stream 15 crashed with {%Plug.Conn.NotSentError{message: "a response was neither set nor sent from the connection"}, [{Bandit.Pipeline, :commit_response, 1, [file: ~c"lib/bandit/pipeline.ex", line: 147, error_info: %{module: Exception}]}, {Bandit.Pipeline, :run, 6, [file: ~c"lib/bandit/pipeline.ex", line: 26]}, {Bandit.HTTP2.StreamTask, :run, 5, [file: ~c"lib/bandit/http2/stream_task.ex", line: 69]}, {Task.Supervised, :invoke_mfa, 2, [file: ~c"lib/task/supervised.ex", line: 101]}]} 
```