### PR TITLE
use `Signing Keys` instead of `Firmware Keys`

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -836,13 +836,13 @@ defmodule NervesHub.Devices do
   Move a device to a different product
 
   If the new target product is in a different organization, this will
-  attempt to also copy any firmware keys the device might be expecting
+  attempt to also copy any signing keys the device might be expecting
   to the new organization. However, it is best effort only.
 
   Moving a device will also trigger a deployment check to see if there
   is an update available from the new product/org for the device. It is
   up to the user to ensure the new device is configured with any new/different
-  firmware keys from the new org before moving otherwise the device
+  signing keys from the new org before moving otherwise the device
   might fail to update because of an unknown key.
   """
   @spec move(Device.t() | [Device.t()], Product.t(), User.t()) :: Repo.transaction()

--- a/lib/nerves_hub_web/controllers/org_key_controller.ex
+++ b/lib/nerves_hub_web/controllers/org_key_controller.ex
@@ -21,7 +21,7 @@ defmodule NervesHubWeb.OrgKeyController do
     case Accounts.create_org_key(org_key_params |> Enum.into(%{"org_id" => org.id})) do
       {:ok, _org_key} ->
         conn
-        |> put_flash(:info, "Firmware key created successfully.")
+        |> put_flash(:info, "Signing key created successfully.")
         |> redirect(to: Routes.org_key_path(conn, :index, org.name))
 
       {:error, %Ecto.Changeset{}} ->
@@ -54,7 +54,7 @@ defmodule NervesHubWeb.OrgKeyController do
          ) do
       {:ok, _org_key} ->
         conn
-        |> put_flash(:info, "Firmware key updated successfully.")
+        |> put_flash(:info, "Signing key updated successfully.")
         |> redirect(to: Routes.org_key_path(conn, :index, org.name))
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -67,7 +67,7 @@ defmodule NervesHubWeb.OrgKeyController do
 
     with {:ok, _org_key} <- Accounts.delete_org_key(org_key) do
       conn
-      |> put_flash(:info, "Firmware key deleted successfully.")
+      |> put_flash(:info, "Signing key deleted successfully.")
       |> redirect(to: Routes.org_key_path(conn, :index, org.name))
     else
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/nerves_hub_web/templates/firmware/index.html.heex
+++ b/lib/nerves_hub_web/templates/firmware/index.html.heex
@@ -25,7 +25,7 @@
         <th>Version</th>
         <th>Platform</th>
         <th>Architecture</th>
-        <th>Firmware key</th>
+        <th>Signing key</th>
         <th>Uploaded on</th>
         <th></th>
       </tr>
@@ -51,7 +51,7 @@
           <%= firmware.architecture %>
         </td>
         <td>
-          <div class="mobile-label help-text">Firmware key</div>
+          <div class="mobile-label help-text">Signing key</div>
           <div>
             <span class="badge"><%= format_signed(firmware, @org) %></span>
           </div>

--- a/lib/nerves_hub_web/templates/org_key/edit.html.heex
+++ b/lib/nerves_hub_web/templates/org_key/edit.html.heex
@@ -1,3 +1,3 @@
-<h1>Edit Firmware Key</h1>
+<h1>Edit Signing Key</h1>
 
 <%= render("form.html", Map.put(assigns, :action, Routes.org_key_path(@conn, :update, @org.name, @org_key))) %>

--- a/lib/nerves_hub_web/templates/org_key/form.html.heex
+++ b/lib/nerves_hub_web/templates/org_key/form.html.heex
@@ -23,7 +23,7 @@
       <%= link("Remove",
         to: Routes.org_key_path(@conn, :delete, @org.name, @org_key),
         method: :delete,
-        data: [confirm: "Are you sure you want to delete this firmware key? This can not be undone."],
+        data: [confirm: "Are you sure you want to delete this signing key? This can not be undone."],
         class: "btn btn-secondary"
       ) %>
       <%= submit("Save Changes", class: "btn btn-primary") %>

--- a/lib/nerves_hub_web/templates/org_key/index.html.heex
+++ b/lib/nerves_hub_web/templates/org_key/index.html.heex
@@ -1,13 +1,13 @@
 <div class="action-row">
-  <h1>Firmware Keys</h1>
-  <a class="btn btn-outline-light btn-action" aria-label="Add new firmware key" href={Routes.org_key_path(@conn, :new, @org.name)}>
+  <h1>Signing Keys</h1>
+  <a class="btn btn-outline-light btn-action" aria-label="Add new signing key" href={Routes.org_key_path(@conn, :new, @org.name)}>
     <span class="button-icon add"></span>
     <span class="action-text">Add Key</span>
   </a>
 </div>
 
 <div style="max-width: 650px">
-  <p class="p-small mb-3">Firmware keys refer to the raw or base64-encoded public and private keys used to sign and authenticate firmware files.</p>
+  <p class="p-small mb-3">Signing Keys are used to sign uploaded firmware, and verify the firmware on the device before the device is updated.</p>
 
   <%= for org_keys <- @org_keys do %>
     <a class="firmware-key box-item" href={Routes.org_key_path(@conn, :edit, @org.name, org_keys)}>
@@ -23,6 +23,6 @@
 </div>
 
 <%= link to: "https://docs.nerves-hub.org/nerves-hub/setup/firmware-signing-keys", class: "mt-3", target: "_blank", rel: "noopener noreferrer" do %>
-  <span>How to generate a firmware key</span>
+  <span>How to generate a signing key</span>
   <img src="/images/icons/arrow-forward-red.svg" alt="arrow" class="ml-2" />
 <% end %>

--- a/lib/nerves_hub_web/templates/org_key/new.html.heex
+++ b/lib/nerves_hub_web/templates/org_key/new.html.heex
@@ -1,3 +1,3 @@
-<h1>New Firmware Key</h1>
+<h1>New Signing Key</h1>
 
 <%= render("form.html", Map.put(assigns, :action, Routes.org_key_path(@conn, :create, @org.name))) %>

--- a/lib/nerves_hub_web/views/device_view.ex
+++ b/lib/nerves_hub_web/views/device_view.ex
@@ -68,9 +68,9 @@ defmodule NervesHubWeb.DeviceView do
     """
     This will move the selected device(s) to the #{product_name} product
 
-    Any existing firmware keys the devices may use will attempt to be migrated if they do not exist on the target organization.
+    Any existing signing keys the devices may use will attempt to be migrated if they do not exist on the target organization.
 
-    Moving devices may also trigger an update if there are matching deployments on the new product. It is up to the user to ensure any required firmware keys are on the device before migrating them to a new product with a new firmware or the device may fail to update.
+    Moving devices may also trigger an update if there are matching deployments on the new product. It is up to the user to ensure any required signing keys are on the device before migrating them to a new product with a new firmware or the device may fail to update.
 
     Do you wish to continue?
     """

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -154,7 +154,7 @@ defmodule NervesHubWeb.LayoutView do
        if NervesHub.Accounts.has_org_role?(org, user, :view) do
          [
            %{
-             title: "Firmware Keys",
+             title: "Signing Keys",
              active: "",
              href: Routes.org_key_path(conn, :index, conn.assigns.org.name)
            },

--- a/test/nerves_hub_web/controllers/org_key_controller_test.exs
+++ b/test/nerves_hub_web/controllers/org_key_controller_test.exs
@@ -9,14 +9,14 @@ defmodule NervesHubWeb.OrgKeyControllerTest do
   describe "index" do
     test "lists all org_keys", %{conn: conn, org: org} do
       conn = get(conn, Routes.org_key_path(conn, :index, org.name))
-      assert html_response(conn, 200) =~ "Firmware Keys"
+      assert html_response(conn, 200) =~ "Signing Keys"
     end
   end
 
   describe "new org_keys" do
     test "renders form", %{conn: conn, org: org} do
       conn = get(conn, Routes.org_key_path(conn, :new, org.name))
-      assert html_response(conn, 200) =~ "New Firmware Key"
+      assert html_response(conn, 200) =~ "New Signing Key"
     end
   end
 
@@ -41,7 +41,7 @@ defmodule NervesHubWeb.OrgKeyControllerTest do
     test "renders form for editing chosen org_keys", %{conn: conn, org: org} do
       org_key = Fixtures.org_key_fixture(org)
       conn = get(conn, Routes.org_key_path(conn, :edit, org.name, org_key))
-      assert html_response(conn, 200) =~ "Edit Firmware Key"
+      assert html_response(conn, 200) =~ "Edit Signing Key"
     end
   end
 
@@ -68,7 +68,7 @@ defmodule NervesHubWeb.OrgKeyControllerTest do
           org_key: @invalid_attrs
         )
 
-      assert html_response(conn, 200) =~ "Edit Firmware Key"
+      assert html_response(conn, 200) =~ "Edit Signing Key"
     end
   end
 


### PR DESCRIPTION
With the work going on with Archives, which also use the Firmware Keys for signing and validating the files, it was suggested by Jon to use `Signing Keys`.

This PR updates the Hub UI to use this terminology.