### PR TITLE
add support for devices checking if an update is available

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -400,6 +400,20 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
+  def handle_in("check_update_available", _params, socket) do
+    device =
+      socket.assigns.device
+      |> Devices.verify_deployment()
+      |> Deployments.set_deployment()
+      |> Repo.preload(:org)
+      |> Repo.preload(deployment: [:archive, :firmware])
+
+    # Let the orchestrator handle this going forward ?
+    update_payload = Devices.resolve_update(device)
+
+    {:reply, {:ok, update_payload}, socket}
+  end
+
   def handle_in("rebooting", _, socket) do
     {:noreply, socket}
   end

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -104,6 +104,32 @@ defmodule NervesHubWeb.DeviceChannelTest do
     assert_push("update", %{})
   end
 
+  test "devices can request available updates via check_update_available" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    assert {:ok, device} = Devices.update_device(device, %{deployment_id: deployment.id})
+    assert device.updates_enabled
+
+    params =
+      for {k, v} <- Map.from_struct(device.firmware_metadata), into: %{} do
+        case k do
+          :uuid -> {"nerves_fw_uuid", Ecto.UUID.generate()}
+          _ -> {"nerves_fw_#{k}", v}
+        end
+      end
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, %{}, socket} = subscribe_and_join(socket, DeviceChannel, "device", params)
+
+    ref = push(socket, "check_update_available", %{"value" => 10})
+
+    assert_reply(ref, :ok, %NervesHub.Devices.UpdatePayload{update_available: true})
+  end
+
   test "the first fwup_progress marks an update as happening" do
     user = Fixtures.user_fixture()
     {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})


### PR DESCRIPTION
this is related to https://github.com/nerves-hub/nerves_hub_link/issues/47

**open questions:**

do we want to add an audit log for this?

should the event name be something more like `update:check` or `update:check_available`?