### PR TITLE
Redirect past orgs page more conveniently

### DIFF
--- a/lib/nerves_hub_web/controllers/home_controller.ex
+++ b/lib/nerves_hub_web/controllers/home_controller.ex
@@ -4,7 +4,24 @@ defmodule NervesHubWeb.HomeController do
   def index(conn, _params) do
     case Map.has_key?(conn.assigns, :user) && !is_nil(conn.assigns.user) do
       true ->
-        render(conn, "index.html")
+        case conn.assigns[:orgs] do
+          # Single org, redirect
+          [org] ->
+            redirect(conn, to: Routes.product_path(conn, :index, org.name))
+
+          orgs when is_list(orgs) ->
+            # Redirect to last selected org if the user has made a selection in the past
+            if conn.assigns[:latest_org] &&
+                 Enum.any?(orgs, &(&1.name == conn.assigns[:latest_org])) do
+              redirect(conn, to: Routes.product_path(conn, :index, conn.assigns[:latest_org]))
+            else
+              render(conn, "index.html")
+            end
+
+          # Otherwise, just do the listing
+          _ ->
+            render(conn, "index.html")
+        end
 
       false ->
         redirect(conn, to: Routes.session_path(conn, :new))

--- a/lib/nerves_hub_web/controllers/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/product_controller.ex
@@ -11,7 +11,10 @@ defmodule NervesHubWeb.ProductController do
 
   def index(%{assigns: %{user: user, org: org}} = conn, _params) do
     products = Products.get_products_by_user_and_org(user, org)
-    render(conn, "index.html", products: products)
+
+    conn
+    |> put_session("latest_org", org.name)
+    |> render("index.html", products: products)
   end
 
   def new(conn, _params) do

--- a/lib/nerves_hub_web/plugs/fetch_user.ex
+++ b/lib/nerves_hub_web/plugs/fetch_user.ex
@@ -28,6 +28,7 @@ defmodule NervesHubWeb.Plugs.FetchUser do
             |> assign(:user, user)
             |> assign(:orgs, user.orgs)
             |> assign(:user_token, Phoenix.Token.sign(conn, "user salt", user.id))
+            |> assign(:latest_org, get_session(conn, "latest_org"))
 
           _ ->
             conn


### PR DESCRIPTION
Added two cases where we can skip the org page for the user:

1. The user only has one org.
2. The user has previously selected an org and we have it in session.