### PR TITLE
Set fullsweep_after on device channel

### DIFF
--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -12,7 +12,8 @@ defmodule NervesHubWeb.DeviceEndpoint do
     NervesHubWeb.DeviceSocket,
     websocket: [
       connect_info: [:peer_data, :x_headers],
-      error_handler: {WebsocketConnectionError, :handle_error, []}
+      error_handler: {WebsocketConnectionError, :handle_error, []},
+      fullsweep_after: 0
     ]
   )
 
@@ -21,7 +22,8 @@ defmodule NervesHubWeb.DeviceEndpoint do
     NervesHubWeb.DeviceSocket,
     websocket: [
       connect_info: [:peer_data, :x_headers],
-      error_handler: {WebsocketConnectionError, :handle_error, []}
+      error_handler: {WebsocketConnectionError, :handle_error, []},
+      fullsweep_after: 0
     ]
   )
 


### PR DESCRIPTION
Remove drainer since it seems to be in the wrong spot and there's a default for it anyways