### PR TITLE
Remove drainer config from device endpoint

### DIFF
--- a/lib/nerves_hub_web/device_endpoint.ex
+++ b/lib/nerves_hub_web/device_endpoint.ex
@@ -12,11 +12,6 @@ defmodule NervesHubWeb.DeviceEndpoint do
     NervesHubWeb.DeviceSocket,
     websocket: [
       connect_info: [:peer_data, :x_headers],
-      drainer: [
-        batch_size: 500,
-        batch_interval: 1_000,
-        shutdown: 30_000
-      ],
       error_handler: {WebsocketConnectionError, :handle_error, []}
     ]
   )
@@ -26,11 +21,6 @@ defmodule NervesHubWeb.DeviceEndpoint do
     NervesHubWeb.DeviceSocket,
     websocket: [
       connect_info: [:peer_data, :x_headers],
-      drainer: [
-        batch_size: 500,
-        batch_interval: 1_000,
-        shutdown: 30_000
-      ],
       error_handler: {WebsocketConnectionError, :handle_error, []}
     ]
   )

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -21,11 +21,6 @@ defmodule NervesHubWeb.Endpoint do
     NervesHubWeb.DeviceSocket,
     websocket: [
       connect_info: [:x_headers],
-      drainer: [
-        batch_size: 500,
-        batch_interval: 1_000,
-        shutdown: 30_000
-      ],
       error_handler: {WebsocketConnectionError, :handle_error, []}
     ]
   )


### PR DESCRIPTION
It seems to be in the wrong spot per the docs for `socket/3`