### PR TITLE
Change pattern matching on headers for Device connection

### DIFF
--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -36,31 +36,31 @@ defmodule NervesHubWeb.DeviceSocket do
   end
 
   # Used by Devices connecting with HMAC Shared Secrets
-  def connect(_params, socket, headers) do
-    case Enum.find(headers.x_headers, fn {key, _} ->
-      key == "x-nh-signature"
-    end) do
-      nil -> {:error, :no_auth}
-      {_key, signature} ->
-        headers = Map.new(headers.x_headers)
+  def connect(_params, socket, %{x_headers: x_headers})
+      when is_list(x_headers) and length(x_headers) > 0 do
+    headers = Map.new(x_headers)
 
-        with true <- shared_secrets_enabled?(),
-            {:ok, key, salt, verification_opts} <- decode_from_headers(headers),
-            {:ok, auth} <- get_shared_secret_auth(key),
-            {:ok, identifier} <- Crypto.verify(auth.secret, salt, signature, verification_opts),
-            {:ok, device} <- get_or_maybe_create_device(auth, identifier) do
-          socket =
-            socket
-            |> assign(:device, device)
-            |> assign(:reference_id, generate_reference_id())
+    with true <- shared_secrets_enabled?(),
+         {:ok, key, salt, verification_opts} <- decode_from_headers(headers),
+         {:ok, auth} <- get_shared_secret_auth(key),
+         {:ok, signature} <- Map.fetch(headers, "x-nh-signature"),
+         {:ok, identifier} <- Crypto.verify(auth.secret, salt, signature, verification_opts),
+         {:ok, device} <- get_or_maybe_create_device(auth, identifier) do
+      socket =
+        socket
+        |> assign(:device, device)
+        |> assign(:reference_id, generate_reference_id())
 
-          {:ok, socket}
-        else
-          error ->
-            Logger.info("device authentication failed : #{inspect(error)}")
-            {:error, :invalid_auth}
-        end
+      {:ok, socket}
+    else
+      error ->
+        Logger.info("device authentication failed : #{inspect(error)}")
+        {:error, :invalid_auth}
     end
+  end
+
+  def connect(_params, _socket, _connect_info) do
+    {:error, :no_auth}
   end
 
   def id(%{assigns: %{device: device}}), do: "device_socket:#{device.id}"

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -372,7 +372,6 @@ defmodule NervesHubWeb.WebsocketTest do
       SocketClient.close(socket)
     end
 
-
     test "rejects expired signature", %{user: user} do
       org = Fixtures.org_fixture(user)
       product = Fixtures.product_fixture(user, org)

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -338,6 +338,41 @@ defmodule NervesHubWeb.WebsocketTest do
       SocketClient.close(socket)
     end
 
+    test "can register device with product key/secret, don't rely on header order", %{user: user} do
+      org = Fixtures.org_fixture(user)
+      product = Fixtures.product_fixture(user, org)
+      assert {:ok, auth} = Products.create_shared_secret_auth(product)
+
+      identifier = Ecto.UUID.generate()
+      refute Repo.get_by(Device, identifier: identifier)
+
+      opts = [
+        mint_opts: [protocols: [:http1]],
+        uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
+        headers: nh1_key_secret_headers(auth, identifier) |> Enum.reverse()
+      ]
+
+      params = %{
+        "nerves_fw_uuid" => Ecto.UUID.generate(),
+        "nerves_fw_product" => product.name,
+        "nerves_fw_architecture" => "arm64",
+        "nerves_fw_version" => "0.0.0",
+        "nerves_fw_platform" => "test_host"
+      }
+
+      {:ok, socket} = SocketClient.start_link(opts)
+      SocketClient.wait_connect(socket)
+      SocketClient.join(socket, "device", params)
+      SocketClient.wait_join(socket)
+
+      assert device = Repo.get_by(Device, identifier: identifier) |> Repo.preload(:org)
+
+      assert_online(device)
+
+      SocketClient.close(socket)
+    end
+
+
     test "rejects expired signature", %{user: user} do
       org = Fixtures.org_fixture(user)
       product = Fixtures.product_fixture(user, org)


### PR DESCRIPTION
The current way of matching was dependent on the order of headers in the list of tuples and I hit problems when testing other clients against it.