### PR TITLE
remove use of `compiler_options`

### DIFF
--- a/test/support/default_mocks.ex
+++ b/test/support/default_mocks.ex
@@ -1,5 +1,3 @@
-Code.compiler_options(ignore_module_conflict: true)
-
 defmodule DefaultMocks do
   use ExUnit.CaseTemplate
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,5 +1,3 @@
-Code.compiler_options(ignore_module_conflict: true)
-
 defmodule NervesHub.Fixtures do
   alias NervesHub.Accounts
   alias NervesHub.Accounts.Org
@@ -14,10 +12,6 @@ defmodule NervesHub.Fixtures do
   alias NervesHub.Repo
   alias NervesHub.Support
   alias NervesHub.Support.Fwup
-
-  @after_compile {__MODULE__, :compiler_options}
-
-  def compiler_options(_, _), do: Code.compiler_options(ignore_module_conflict: false)
 
   @uploader Application.compile_env(:nerves_hub, :firmware_upload)
 

--- a/test/support/fwup.ex
+++ b/test/support/fwup.ex
@@ -1,5 +1,3 @@
-Code.compiler_options(ignore_module_conflict: true)
-
 defmodule NervesHub.Support.Fwup do
   @moduledoc """
   This module is intended to help with testing and development
@@ -13,10 +11,6 @@ defmodule NervesHub.Support.Fwup do
   make sure you pass unique names to avoid collisions if necessary.  This module
   takes little effort to avoid collisions on its own.
   """
-
-  @after_compile {__MODULE__, :compiler_options}
-
-  def compiler_options(_, _), do: Code.compiler_options(ignore_module_conflict: false)
 
   defmodule MetaParams do
     defstruct product: "nerves-hub",

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,4 +1,2 @@
-Code.compiler_options(ignore_module_conflict: true)
-
 Mox.defmock(NervesHub.DeltaUpdaterMock, for: NervesHub.Firmwares.DeltaUpdater)
 Mox.defmock(NervesHub.UploadMock, for: NervesHub.Firmwares.Upload)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,4 @@
 Logger.remove_backend(:console)
-Code.compiler_options(ignore_module_conflict: true)
 
 ExUnit.start(exclude: [:pending])
 


### PR DESCRIPTION
I was having issues with Elixir constantly recompiling files, and I think I tracked it down to this. 

Also, this feels a bit like a code smell.