### PR TITLE
Delete Org + Product deletion validations + No default Org

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -58,29 +58,9 @@ defmodule NervesHub.Accounts do
   """
   @spec create_user(map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def create_user(user_params) do
-    org_params = %{name: user_params[:username]}
-
-    multi =
-      Multi.new()
-      |> Multi.insert(:user, User.creation_changeset(%User{}, user_params))
-      |> Multi.insert(:org, Org.creation_changeset(%Org{}, org_params))
-      |> Multi.insert(:org_user, fn %{user: user, org: org} ->
-        org_user = %OrgUser{
-          org_id: org.id,
-          user_id: user.id,
-          role: :admin
-        }
-
-        Org.add_user(org_user, %{})
-      end)
-
-    case Repo.transaction(multi) do
-      {:ok, result} ->
-        {:ok, result.user}
-
-      {:error, :user, changeset, _} ->
-        {:error, changeset}
-    end
+    %User{}
+    |> User.creation_changeset(user_params)
+    |> Repo.insert()
   end
 
   @doc """

--- a/lib/nerves_hub/accounts/org.ex
+++ b/lib/nerves_hub/accounts/org.ex
@@ -63,6 +63,12 @@ defmodule NervesHub.Accounts.Org do
     |> changeset(params)
   end
 
+  def delete_changeset(%Org{} = org) do
+    deleted_at = DateTime.truncate(DateTime.utc_now(), :second)
+
+    change(org, deleted_at: deleted_at)
+  end
+
   def with_org_keys(%Org{} = o) do
     o
     |> Repo.preload(:org_keys)

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -9,7 +9,6 @@ defmodule NervesHub.Products.Product do
   alias NervesHub.Devices.Device
   alias NervesHub.Firmwares.Firmware
   alias NervesHub.Products.SharedSecretAuth
-  alias NervesHub.Repo
 
   @required_params [:name, :org_id]
   @optional_params [:delta_updatable]
@@ -54,32 +53,12 @@ defmodule NervesHub.Products.Product do
     cast(product, params, @optional_params)
   end
 
-  def delete_changeset(product, params \\ %{}) do
+  def delete_changeset(product, _params \\ %{}) do
     deleted_at = DateTime.truncate(DateTime.utc_now(), :second)
 
     product
-    |> cast(params, @required_params ++ @optional_params)
-    |> no_soft_deleted_assoc(:devices, message: "Product has associated devices")
-    |> no_soft_deleted_assoc(:firmwares, message: "Product has associated firmwares")
+    |> change()
     |> put_change(:deleted_at, deleted_at)
-  end
-
-  defp no_soft_deleted_assoc(%{data: data} = changeset, assoc, opts) do
-    default_message = "is still associated with this entry"
-    message = Keyword.get(opts, :message, default_message)
-
-    empty? =
-      data
-      |> Repo.preload(assoc)
-      |> Map.get(assoc, [])
-      |> Enum.filter(&is_nil(Map.get(&1, :deleted_at)))
-      |> Enum.empty?()
-
-    if empty? do
-      changeset
-    else
-      add_error(changeset, assoc, message)
-    end
   end
 
   defp trim(string) when is_binary(string) do

--- a/lib/nerves_hub_web/components/navigation.ex
+++ b/lib/nerves_hub_web/components/navigation.ex
@@ -22,7 +22,7 @@ defmodule NervesHubWeb.Components.Navigation do
         </a>
 
         <%= if @user do %>
-          <ul class="navbar-nav mr-auto flex-grow">
+          <ul :if={Enum.any?(@user.orgs)} class="navbar-nav mr-auto flex-grow">
             <li class="nav-item dropdown switcher">
               <a class="nav-link dropdown-toggle org-select arrow-primary" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <%= if org = assigns[:org], do: org.name, else: "Select Org" %>

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Helpers.Authorization do
   end
 
   def authorized?(:update_organization, %OrgUser{role: ur}), do: role_check(:admin, ur)
+  def authorized?(:delete_organization, %OrgUser{role: ur}), do: role_check(:admin, ur)
 
   def authorized?(:save_signing_key, %OrgUser{role: ur}), do: role_check(:manage, ur)
   def authorized?(:delete_signing_key, %OrgUser{role: ur}), do: role_check(:manage, ur)

--- a/lib/nerves_hub_web/live/org/delete.ex
+++ b/lib/nerves_hub_web/live/org/delete.ex
@@ -1,0 +1,43 @@
+defmodule NervesHubWeb.Live.Org.Delete do
+  use NervesHubWeb, :updated_live_view
+
+  alias NervesHub.Accounts
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    socket
+    |> page_title("Delete Organization - #{socket.assigns.org.name}")
+    |> assign(:form, to_form(%{}))
+    |> ok()
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("delete", params, socket) do
+    authorized!(:delete_organization, socket.assigns.org_user)
+
+    if params["confirm_name"] == socket.assigns.org.name do
+      case Accounts.soft_delete_org(socket.assigns.org) do
+        {:ok, _org} ->
+          socket
+          |> put_flash(
+            :info,
+            "The Organization #{socket.assigns.org.name} has successfully been deleted"
+          )
+          |> push_navigate(to: ~p"/orgs")
+          |> noreply()
+
+        {:error, _changeset} ->
+          socket
+          |> put_flash(
+            :error,
+            "There was an error deleting the Organization #{socket.assigns.org.name}. Please contact support."
+          )
+          |> noreply()
+      end
+    else
+      socket
+      |> put_flash(:error, "Please type #{socket.assigns.org.name} to confirm.")
+      |> noreply()
+    end
+  end
+end

--- a/lib/nerves_hub_web/live/org/delete.html.heex
+++ b/lib/nerves_hub_web/live/org/delete.html.heex
@@ -1,0 +1,15 @@
+<h1>Are you absolutely sure?</h1>
+
+<p>Unexpected bad things will happen if you don’t read this!</p>
+<p>This action cannot be undone. This will permanently delete the <%= @org.name %> organization.</p>
+
+<.form :let={f} for={@form} phx-submit="delete">
+  <div class="form-group">
+    <label for="org_name_input">Please type <%= @org.name %> to confirm.</label>
+    <%= text_input(f, :confirm_name, class: "form-control", id: "org_name_input") %>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <%= submit("I understand the consequences, delete this organization.", class: "btn btn-primary") %>
+  </div>
+</.form>

--- a/lib/nerves_hub_web/live/org/settings.html.heex
+++ b/lib/nerves_hub_web/live/org/settings.html.heex
@@ -14,3 +14,9 @@
   </div>
   <%= submit("Save Changes", class: "btn btn-primary") %>
 </.form>
+
+<div class="border-bottom border-dark mt-5 mb-2"></div>
+
+<div>
+  <.link patch={~p"/org/#{@org.name}/settings/delete"} class="btn btn-primary">Delete Organization</.link>
+</div>

--- a/lib/nerves_hub_web/live/orgs/index.html.heex
+++ b/lib/nerves_hub_web/live/orgs/index.html.heex
@@ -1,17 +1,30 @@
-<h1 class="mt-2">My Organizations</h1>
-<div class="x3-grid">
-  <%= for org <- @user.orgs do %>
-    <%= link to: ~p"/org/#{org.name}", class: "grid-item" do %>
-      <h3><%= org.name %></h3>
-      <div class="flex-row">
-        <div>
-          <div class="help-text">Total Products</div>
-          <div class="flex-row mt-1 align-items-center">
-            <img src="/images/icons/product.svg" alt="products" class="mr-1" style="margin-top: -1px" />
-            <p><%= Enum.count(org.products) %></p>
+<%= if @user.orgs == [] do %>
+  <div class="no-results-blowup-wrapper">
+    <img src="/images/product.svg" alt="No organizations" />
+    <h3 style="margin-top: 2.75rem">You aren't a member of any organizations.</h3>
+    <div class="flex-row align-items-center mt-3">
+      <a class="btn btn-outline-light" aria-label="Create new organization" href={~p"/orgs/new"} role="button">
+        <span class="button-icon add"></span>
+        <span class="action-text">Create your first organization!</span>
+      </a>
+    </div>
+  </div>
+<% else %>
+  <h1 class="mt-2">My Organizations</h1>
+  <div class="x3-grid">
+    <%= for org <- @user.orgs do %>
+      <%= link to: ~p"/org/#{org.name}", class: "grid-item" do %>
+        <h3><%= org.name %></h3>
+        <div class="flex-row">
+          <div>
+            <div class="help-text">Total Products</div>
+            <div class="flex-row mt-1 align-items-center">
+              <img src="/images/icons/product.svg" alt="products" class="mr-1" style="margin-top: -1px" />
+              <p><%= Enum.count(org.products) %></p>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -236,6 +236,7 @@ defmodule NervesHubWeb.Router do
       live("/org/:org_name/settings/users/:user_id/edit", Live.Org.Users, :edit)
       live("/org/:org_name/settings/certificates", Live.Org.CertificateAuthorities, :index)
       live("/org/:org_name/settings/certificates/new", Live.Org.CertificateAuthorities, :new)
+      live("/org/:org_name/settings/delete", Live.Org.Delete)
 
       live(
         "/org/:org_name/settings/certificates/:serial/edit",

--- a/test/nerves_hub_web/controllers/api/product_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/product_controller_test.exs
@@ -77,22 +77,6 @@ defmodule NervesHubWeb.API.ProductControllerTest do
 
       assert response(conn, 403)
     end
-
-    test "product delete with associated firmwares", %{
-      conn: conn,
-      user: user,
-      org: org,
-      product: product
-    } do
-      # Create firmware for product
-      org_key = Fixtures.org_key_fixture(org, user)
-      firmware = Fixtures.firmware_fixture(org_key, product)
-      Fixtures.device_fixture(org, product, firmware)
-
-      conn = delete(conn, Routes.api_product_path(conn, :delete, org.name, product.name))
-
-      assert response(conn, 409)
-    end
   end
 
   describe "delete product roles" do

--- a/test/nerves_hub_web/live/orgs/index_test.exs
+++ b/test/nerves_hub_web/live/orgs/index_test.exs
@@ -1,18 +1,17 @@
 defmodule NervesHubWeb.Live.Orgs.IndexTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
-  #
-  # this is a UI/UX we should take into account
-  #
-  # describe "no org memberships" do
-  #   test "no orgs listed", %{conn: conn, org: org, user: user} do
-  #     {:ok, view, html} = live(conn, ~p"/orgs")
+  describe "no org memberships" do
+    test "no orgs listed" do
+      user = NervesHub.Fixtures.user_fixture()
 
-  #     assert html =~ "<h1 class=\"mt-2\">My Organizations</h1>"
-  #     assert html =~ "<h3>#{user.name}</h3>"
-  #     assert html =~ "<h3>#{org.name}</h3>"
-  #   end
-  # end
+      build_conn()
+      |> init_test_session(%{"auth_user_id" => user.id})
+      |> visit("/orgs")
+      |> assert_has("h3", text: "You aren't a member of any organizations.")
+      |> PhoenixTest.open_browser()
+    end
+  end
 
   describe "has orgs memberships" do
     test "all orgs listed", %{conn: conn, org: org, user: user} do

--- a/test/nerves_hub_web/live/orgs/index_test.exs
+++ b/test/nerves_hub_web/live/orgs/index_test.exs
@@ -9,16 +9,14 @@ defmodule NervesHubWeb.Live.Orgs.IndexTest do
       |> init_test_session(%{"auth_user_id" => user.id})
       |> visit("/orgs")
       |> assert_has("h3", text: "You aren't a member of any organizations.")
-      |> PhoenixTest.open_browser()
     end
   end
 
   describe "has orgs memberships" do
-    test "all orgs listed", %{conn: conn, org: org, user: user} do
+    test "all orgs listed", %{conn: conn, org: org} do
       conn
       |> visit("/orgs")
       |> assert_has("h1", text: "My Organizations")
-      |> assert_has("h3", text: user.username)
       |> assert_has("h3", text: org.name)
     end
   end

--- a/test/nerves_hub_web/live/product/settings_test.exs
+++ b/test/nerves_hub_web/live/product/settings_test.exs
@@ -33,51 +33,6 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
       product = NervesHub.Repo.reload(product)
       refute is_nil(product.deleted_at)
     end
-
-    test "shows an error if the product has a device", %{conn: conn, org: org, user: user} do
-      product = Fixtures.product_fixture(user, org, %{delta_updatable: false})
-
-      firmware =
-        org
-        |> Fixtures.org_key_fixture(user)
-        |> Fixtures.firmware_fixture(product)
-
-      Fixtures.device_fixture(org, product, firmware)
-
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/settings")
-      |> assert_has("h1", text: "Product Settings")
-      |> click_button("Remove Product")
-      |> assert_has("div",
-        text:
-          "There was an error deleting the Product. Please delete all Firmware and Devices first."
-      )
-      |> assert_path("/org/#{org.name}/#{product.name}/settings")
-
-      product = NervesHub.Repo.reload(product)
-      assert is_nil(product.deleted_at)
-    end
-
-    test "shows an error if the product has firmware", %{conn: conn, org: org, user: user} do
-      product = Fixtures.product_fixture(user, org, %{delta_updatable: false})
-
-      org
-      |> Fixtures.org_key_fixture(user)
-      |> Fixtures.firmware_fixture(product)
-
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/settings")
-      |> assert_has("h1", text: "Product Settings")
-      |> click_button("Remove Product")
-      |> assert_has("div",
-        text:
-          "There was an error deleting the Product. Please delete all Firmware and Devices first."
-      )
-      |> assert_path("/org/#{org.name}/#{product.name}/settings")
-
-      product = NervesHub.Repo.reload(product)
-      assert is_nil(product.deleted_at)
-    end
   end
 
   describe "shared secrets" do


### PR DESCRIPTION
- removes the default Org named after the user
- adds a UI for deleting an Org
- and removes the validations when deleting a Product
  - since Products are soft deleted, its better to keep the data around for x period of time
  - this 'cleanup' will be in a later PR