### PR TITLE
device console: authorization during channel join

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -181,6 +181,17 @@ defmodule NervesHub.Accounts do
     |> Repo.all()
   end
 
+  def find_org_user_with_device(user, device_id) do
+    OrgUser
+    |> join(:left, [ou], o in assoc(ou, :org))
+    |> join(:left, [ou, o], p in assoc(o, :products))
+    |> join(:left, [ou, o, p], d in assoc(p, :devices))
+    |> where([_, _, _, d], d.id == ^device_id)
+    |> where([ou], ou.user_id == ^user.id)
+    |> where([ou], is_nil(ou.deleted_at))
+    |> Repo.one()
+  end
+
   @doc """
   Authenticates a user by their email and password. Returns the user if the
   user is found and the password is correct, otherwise nil.

--- a/lib/nerves_hub_web/channels/user_console_channel.ex
+++ b/lib/nerves_hub_web/channels/user_console_channel.ex
@@ -1,12 +1,18 @@
 defmodule NervesHubWeb.UserConsoleChannel do
   use NervesHubWeb, :channel
 
+  alias NervesHub.Accounts
+  alias NervesHub.Helpers.Authorization
   alias Phoenix.Socket.Broadcast
 
   def join("user:console:" <> device_id, _, socket) do
-    topic = "device:console:#{device_id}"
-    Phoenix.PubSub.broadcast(NervesHub.PubSub, topic, {:connect, self()})
-    {:ok, assign(socket, :device_id, device_id)}
+    if authorized?(socket.assigns.user, device_id) do
+      topic = "device:console:#{device_id}"
+      Phoenix.PubSub.broadcast(NervesHub.PubSub, topic, {:connect, self()})
+      {:ok, assign(socket, :device_id, device_id)}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
   end
 
   def handle_in("message", payload, socket) do
@@ -64,5 +70,15 @@ defmodule NervesHubWeb.UserConsoleChannel do
     })
 
     socket
+  end
+
+  defp authorized?(user, device_id) do
+    case Accounts.find_org_user_with_device(user, device_id) do
+      nil ->
+        false
+
+      org_user ->
+        Authorization.authorized?(:device_console, org_user)
+    end
   end
 end

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -25,6 +25,8 @@ defmodule NervesHub.Helpers.Authorization do
   def authorized?(:update_product, %OrgUser{role: user_role}), do: role_check(:manage, user_role)
   def authorized?(:delete_product, %OrgUser{role: user_role}), do: role_check(:admin, user_role)
 
+  def authorized?(:device_console, %OrgUser{role: user_role}), do: role_check(:manage, user_role)
+
   defp role_check(required_role, user_role) do
     required_role
     |> User.role_or_higher()

--- a/test/nerves_hub/accounts/accounts_test.exs
+++ b/test/nerves_hub/accounts/accounts_test.exs
@@ -112,6 +112,20 @@ defmodule NervesHub.AccountsTest do
     assert {:error, :last_user} = Accounts.remove_org_user(org, user)
   end
 
+  test "find_org_user_with_device : fetch OrgUser for a user and device id" do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    user2 = Fixtures.user_fixture()
+
+    assert %OrgUser{} = Accounts.find_org_user_with_device(user, device.id)
+    assert nil == Accounts.find_org_user_with_device(user2, device.id)
+  end
+
   describe "authenticate" do
     setup do
       user_params = %{


### PR DESCRIPTION
A security issue was found with the `UserConsoleChannel` where an authorization check was missing during the channel join function.

Without this check, any authenticated user can connect to any connected device that has the remote console channel enabled.