### PR TITLE
When updating a deployment don't clear existing devices' deployment

### DIFF
--- a/test/nerves_hub/deployments_test.exs
+++ b/test/nerves_hub/deployments_test.exs
@@ -125,7 +125,7 @@ defmodule NervesHub.DeploymentsTest do
       assert_broadcast("deployments/update", %{}, 500)
     end
 
-    test "changing tags resets device's deployments and causes a recalculation", state do
+    test "changing tags sends an update broadcast", state do
       %{firmware: firmware, org: org, product: product} = state
 
       deployment =
@@ -147,44 +147,6 @@ defmodule NervesHub.DeploymentsTest do
         Deployments.update_deployment(deployment, %{conditions: %{"tags" => ["beta"]}})
 
       assert deployment.conditions == %{"tags" => ["beta"]}
-
-      device_one = Repo.reload(device_one)
-      refute device_one.deployment_id
-      device_two = Repo.reload(device_two)
-      refute device_two.deployment_id
-
-      assert_broadcast("deployments/changed", %{}, 500)
-    end
-
-    test "changing tags with empty version causes recalculation", state do
-      %{firmware: firmware, org: org, product: product} = state
-
-      deployment =
-        Fixtures.deployment_fixture(org, firmware, %{name: "name", conditions: %{tags: ["alpha"]}})
-
-      {:ok, deployment} = Deployments.update_deployment(deployment, %{is_active: true})
-
-      device_one = Fixtures.device_fixture(org, product, firmware, %{tags: ["alpha"]})
-      device_two = Fixtures.device_fixture(org, product, firmware, %{tags: ["beta"]})
-
-      device_one = Deployments.set_deployment(device_one)
-      assert device_one.deployment_id == deployment.id
-      device_two = Deployments.set_deployment(device_two)
-      refute device_two.deployment_id == deployment.id
-
-      Phoenix.PubSub.subscribe(NervesHub.PubSub, "deployment:#{deployment.id}")
-
-      {:ok, deployment} =
-        Deployments.update_deployment(deployment, %{
-          conditions: %{"tags" => ["beta"], "version" => ""}
-        })
-
-      assert deployment.conditions == %{"tags" => ["beta"], "version" => ""}
-
-      device_one = Repo.reload(device_one)
-      refute device_one.deployment_id
-      device_two = Repo.reload(device_two)
-      assert device_two.deployment_id
 
       assert_broadcast("deployments/changed", %{}, 500)
     end
@@ -219,11 +181,6 @@ defmodule NervesHub.DeploymentsTest do
       assert deployment.conditions == %{"tags" => ["beta"]}
 
       assert_broadcast("deployments/changed", %{}, 500)
-
-      device_one = Repo.reload(device_one)
-      refute device_one.deployment_id
-      device_two = Repo.reload(device_two)
-      refute device_two.deployment_id
     end
   end
 

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -258,7 +258,7 @@ defmodule NervesHubWeb.DeploymentControllerTest do
 
       assert audit_log_one.resource_type == Deployment
 
-      assert audit_log_two.description =~ ~r/removed all devices/
+      assert audit_log_two.description =~ ~r/conditions changed/
     end
   end
 


### PR DESCRIPTION
When we have very large deployments we can run into timeouts as all of the devices recalculate at the same time. Instead let the device channel recalculate and generally sit and do nothing