### PR TITLE
Add jitter to devices' setting their deployment on deployment change

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -172,10 +172,24 @@ defmodule NervesHubWeb.DeviceChannel do
         %{assigns: %{device: device}} = socket
       ) do
     if device_matches_deployment_payload?(device, payload) do
-      {:noreply, assign_deployment(socket, payload)}
+      if timer = Map.get(socket.assigns, :assign_deployment_timer) do
+        Process.cancel_timer(timer)
+      end
+
+      # jitter over five minutes to attempt to not slam the database when
+      # any matching devices go to set their deployment. This is for very large
+      # deployments, to prevent ecto pool contention.
+      jitter = :rand.uniform(300) * 1000
+      timer = Process.send_after(self(), {:assign_deployment, payload}, jitter)
+      {:noreply, assign(socket, :assign_deployment_timer, timer)}
     else
       {:noreply, socket}
     end
+  end
+
+  def handle_info({:assign_deployment, payload}, socket) do
+    socket = assign(socket, :assign_deployment_timer, nil)
+    {:noreply, assign_deployment(socket, payload)}
   end
 
   def handle_info(
@@ -186,9 +200,10 @@ defmodule NervesHubWeb.DeviceChannel do
       :telemetry.execute([:nerves_hub, :devices, :deployment, :changed], %{count: 1})
       {:noreply, assign_deployment(socket, payload)}
     else
-      # jitter over a minute but spaced out to attempt to not
-      # slam the database when all devices check
-      jitter = :rand.uniform(30) * 2 * 1000
+      # jitter over five minutes to attempt to not slam the database when
+      # any matching devices go to resolve their deployment. This is for very large
+      # deployments, to prevent ecto pool contention.
+      jitter = :rand.uniform(300) * 1000
       Process.send_after(self(), :resolve_changed_deployment, jitter)
       {:noreply, socket}
     end

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -239,6 +239,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
     socket_alpha = :sys.get_state(socket_alpha.channel_pid)
     assert is_nil(socket_alpha.assigns.device.deployment_id)
 
+    # skip the jitter
+    send(socket_beta.channel_pid, :resolve_changed_deployment)
     socket_beta = :sys.get_state(socket_beta.channel_pid)
     refute is_nil(socket_beta.assigns.device.deployment_id)
   end


### PR DESCRIPTION
If we have a large fleet of devices, we could cause cascading ecto pool issues if thousands+ of devices go to set their deployment at the same time. Jitter over 5 minutes to help avoid slamming the pool. Also space out resolving a deployment for attached devices over the same time frame.