### PR TITLE
prefer `tmp_dir` in tests

### DIFF
--- a/test/nerves_hub/archives_test.exs
+++ b/test/nerves_hub/archives_test.exs
@@ -6,18 +6,25 @@ defmodule NervesHub.ArchivesTest do
   alias NervesHub.Support
 
   describe "creating archives" do
-    test "success: on a product" do
+    @tag :tmp_dir
+    test "success: on a product", %{tmp_dir: tmp_dir} do
       user = Fixtures.user_fixture(%{name: "user"})
       org = Fixtures.org_fixture(user, %{name: "user"})
-      org_key = Fixtures.org_key_fixture(org, user)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
       product = Fixtures.product_fixture(user, org, %{name: "Hop"})
 
       {:ok, file_path} =
-        Support.Archives.create_signed_archive(org_key.name, "manifest", "signed-manifest", %{
-          platform: "generic",
-          architecture: "generic",
-          version: "0.1.0"
-        })
+        Support.Archives.create_signed_archive(
+          tmp_dir,
+          org_key.name,
+          "manifest",
+          "signed-manifest",
+          %{
+            platform: "generic",
+            architecture: "generic",
+            version: "0.1.0"
+          }
+        )
 
       {:ok, archive} = Archives.create(product, file_path)
 

--- a/test/nerves_hub/firmwares/firmwares_test.exs
+++ b/test/nerves_hub/firmwares/firmwares_test.exs
@@ -179,24 +179,28 @@ defmodule NervesHub.FirmwaresTest do
              ]) == {:ok, org_key}
     end
 
+    @tag :tmp_dir
     test "returns {:error, :invalid_signature} when signature fails", %{
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       {:ok, signed_path} = Fwup.create_signed_firmware(org_key.name, "unsigned", "signed")
-      other_org_key = Fixtures.org_key_fixture(org, user)
+      other_org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
 
       assert Firmwares.verify_signature(signed_path, [other_org_key]) ==
                {:error, :invalid_signature}
     end
 
+    @tag :tmp_dir
     test "returns {:error, :invalid_signature} on corrupt files", %{
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       {:ok, signed_path} = Fwup.create_signed_firmware(org_key.name, "unsigned", "signed")
 
-      {:ok, corrupt_path} = Fwup.corrupt_firmware_file(signed_path)
+      {:ok, corrupt_path} = Fwup.corrupt_firmware_file(signed_path, tmp_dir)
 
       assert Firmwares.verify_signature(corrupt_path, [
                org_key

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -856,16 +856,17 @@ defmodule NervesHubWeb.WebsocketTest do
   end
 
   describe "archives" do
-    test "on connect receive an archive", %{user: user} do
+    @tag :tmp_dir
+    test "on connect receive an archive", %{user: user, tmp_dir: tmp_dir} do
       org = Fixtures.org_fixture(user)
-      org_key = Fixtures.org_key_fixture(org, user)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
 
       {device, firmware} = device_fixture(user, %{identifier: @valid_serial}, org)
 
       firmware = Repo.preload(firmware, [:product])
       product = firmware.product
 
-      archive = Fixtures.archive_fixture(org_key, product)
+      archive = Fixtures.archive_fixture(tmp_dir, org_key, product)
 
       deployment =
         Fixtures.deployment_fixture(org, firmware, %{

--- a/test/nerves_hub_web/controllers/archive_controller_test.exs
+++ b/test/nerves_hub_web/controllers/archive_controller_test.exs
@@ -21,16 +21,23 @@ defmodule NervesHubWeb.ArchiveControllerTest do
       conn: conn,
       user: user,
       org: org,
-      product: product
+      product: product,
+      tmp_dir: tmp_dir
     } do
-      org_key = Fixtures.org_key_fixture(org, user)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
 
       {:ok, file_path} =
-        Support.Archives.create_signed_archive(org_key.name, "manifest", "signed-manifest", %{
-          platform: "generic",
-          architecture: "generic",
-          version: "0.1.0"
-        })
+        Support.Archives.create_signed_archive(
+          tmp_dir,
+          org_key.name,
+          "manifest",
+          "signed-manifest",
+          %{
+            platform: "generic",
+            architecture: "generic",
+            version: "0.1.0"
+          }
+        )
 
       upload = %Plug.Upload{
         path: file_path,
@@ -47,9 +54,15 @@ defmodule NervesHubWeb.ArchiveControllerTest do
   end
 
   describe "delete archive" do
-    test "deletes chosen archive", %{conn: conn, user: user, org: org, product: product} do
-      org_key = Fixtures.org_key_fixture(org, user)
-      archive = Fixtures.archive_fixture(org_key, product)
+    test "deletes chosen archive", %{
+      conn: conn,
+      user: user,
+      org: org,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      archive = Fixtures.archive_fixture(tmp_dir, org_key, product)
 
       conn =
         delete(

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -17,10 +17,11 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
-      firmware = Fixtures.firmware_fixture(org_key, product)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
       conn =
         get(
@@ -51,10 +52,11 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
-      Fixtures.firmware_fixture(org_key, product)
+      Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       conn = get(conn, Routes.deployment_path(conn, :new, org.name, product.name))
 
       assert html_response(conn, 200) =~ "Add Deployment"
@@ -85,13 +87,15 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
 
       firmware =
         Fixtures.firmware_fixture(org_key, product, %{
-          version: "relatively unusual version"
+          version: "relatively unusual version",
+          dir: tmp_dir
         })
 
       deployment_params = %{
@@ -155,10 +159,11 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
-      firmware = Fixtures.firmware_fixture(org_key, product)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =
@@ -176,10 +181,11 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
-      firmware = Fixtures.firmware_fixture(org_key, product)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =
@@ -214,10 +220,11 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
-      firmware = Fixtures.firmware_fixture(org_key, product)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =
@@ -260,10 +267,11 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org)
-      firmware = Fixtures.firmware_fixture(org_key, product)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       deployment = Fixtures.deployment_fixture(org, firmware)
 
       conn =

--- a/test/nerves_hub_web/controllers/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/firmware_controller_test.exs
@@ -38,13 +38,17 @@ defmodule NervesHubWeb.FirmwareControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product_name = "cool product"
       product = Fixtures.product_fixture(user, org, %{name: product_name})
 
       {:ok, signed_firmware_path} =
-        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{product: product_name})
+        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{
+          product: product_name,
+          dir: tmp_dir
+        })
 
       upload = %Plug.Upload{
         path: signed_firmware_path,
@@ -70,14 +74,15 @@ defmodule NervesHubWeb.FirmwareControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org, %{name: "starter"})
 
       {:ok, signed_firmware_path} =
         Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{product: "starter"})
 
-      {:ok, corrupt_firmware_path} = Fwup.corrupt_firmware_file(signed_firmware_path)
+      {:ok, corrupt_firmware_path} = Fwup.corrupt_firmware_file(signed_firmware_path, tmp_dir)
 
       upload = %Plug.Upload{
         path: corrupt_firmware_path,
@@ -125,12 +130,16 @@ defmodule NervesHubWeb.FirmwareControllerTest do
       conn: conn,
       user: user,
       org: org,
-      org_key: org_key
+      org_key: org_key,
+      tmp_dir: tmp_dir
     } do
       product = Fixtures.product_fixture(user, org, %{name: "non-matching name"})
 
       {:ok, signed_firmware_path} =
-        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{product: "name"})
+        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{
+          product: "name",
+          dir: tmp_dir
+        })
 
       upload = %Plug.Upload{
         path: signed_firmware_path,

--- a/test/nerves_hub_web/live/org/certificate_authorities_test.exs
+++ b/test/nerves_hub_web/live/org/certificate_authorities_test.exs
@@ -19,7 +19,6 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
   end
 
   describe "new" do
-    @tag :tmp_dir
     test "CA is created on success", %{conn: conn, org: org, tmp_dir: tmp_dir} do
       conn =
         conn
@@ -55,7 +54,6 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
                Devices.get_ca_certificate_by_serial(serial)
     end
 
-    @tag :tmp_dir
     test "renders errors when cert is invalid", %{conn: conn, org: org, tmp_dir: tmp_dir} do
       conn =
         conn
@@ -83,7 +81,6 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       assert [] = Devices.get_ca_certificates(org)
     end
 
-    @tag :tmp_dir
     test "renders errors when csr is invalid", %{conn: conn, org: org, tmp_dir: tmp_dir} do
       conn =
         conn
@@ -115,7 +112,6 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       assert [] = Devices.get_ca_certificates(org)
     end
 
-    @tag :tmp_dir
     @tag timeout: :infinity
     test "create with JITP", %{conn: conn, user: user, org: org, tmp_dir: tmp_dir} do
       product = Fixtures.product_fixture(user, org)

--- a/test/support/archives.ex
+++ b/test/support/archives.ex
@@ -8,17 +8,17 @@ defmodule NervesHub.Support.Archives do
               author: "me"
   end
 
-  def create_signed_archive(key_name, archive_name, output_name, meta_params \\ %{}) do
-    create_archive(archive_name, meta_params)
-    sign_archive(key_name, archive_name, output_name)
+  def create_signed_archive(dir, key_name, archive_name, output_name, meta_params \\ %{}) do
+    create_archive(dir, archive_name, meta_params)
+    sign_archive(dir, key_name, archive_name, output_name)
   end
 
   @doc """
   Create an unsigned archive image, and return the path to that image.
   """
-  def create_archive(archive_name, meta_params \\ %{}) do
+  def create_archive(dir, archive_name, meta_params \\ %{}) do
     conf_path = make_conf(struct(MetaParams, meta_params))
-    out_path = Path.join([System.tmp_dir(), archive_name <> ".fw"])
+    out_path = Path.join([dir, archive_name <> ".fw"])
     File.rm(out_path)
 
     System.cmd("fwup", [
@@ -36,8 +36,7 @@ defmodule NervesHub.Support.Archives do
   Sign a archive image, and return the path to that image. The `archive_name`
   argument must match the name of a archive created with `create_archive/2`.
   """
-  def sign_archive(key_name, archive_name, output_name) do
-    dir = System.tmp_dir()
+  def sign_archive(dir, key_name, archive_name, output_name) do
     output_path = Path.join([dir, output_name <> ".fw"])
 
     System.cmd(

--- a/test/support/browser_case.ex
+++ b/test/support/browser_case.ex
@@ -16,8 +16,10 @@ defmodule NervesHubWeb.ConnCase.Browser do
       import Phoenix.LiveViewTest
       import PhoenixTest
 
-      setup do
-        fixture = Fixtures.standard_fixture()
+      @moduletag :tmp_dir
+
+      setup context do
+        fixture = Fixtures.standard_fixture(context.tmp_dir)
 
         %{org: org, org_key: org_key, user: user} = fixture
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -72,10 +72,11 @@ defmodule NervesHub.Fixtures do
     org
   end
 
-  def org_key_fixture(%Accounts.Org{} = org, %Accounts.User{} = user) do
+  def org_key_fixture(%Accounts.Org{} = org, %Accounts.User{} = user, dir \\ System.tmp_dir()) do
     fwup_key_name = "org_key-#{counter()}"
-    Fwup.gen_key_pair(fwup_key_name)
-    key = Fwup.get_public_key(fwup_key_name)
+
+    Fwup.gen_key_pair(fwup_key_name, dir)
+    key = Fwup.get_public_key(fwup_key_name, dir)
 
     params = %{
       org_id: org.id,
@@ -180,12 +181,14 @@ defmodule NervesHub.Fixtures do
   end
 
   def archive_file_fixture(
+        dir,
         %Accounts.OrgKey{} = org_key,
         %Products.Product{} = product,
         params \\ %{}
       ) do
     {:ok, filepath} =
       Support.Archives.create_signed_archive(
+        dir,
         org_key.name,
         "unsigned-#{counter()}",
         "signed-#{counter()}",
@@ -196,11 +199,12 @@ defmodule NervesHub.Fixtures do
   end
 
   def archive_fixture(
+        dir,
         %Accounts.OrgKey{} = org_key,
         %Products.Product{} = product,
         params \\ %{}
       ) do
-    filepath = archive_file_fixture(org_key, product, params)
+    filepath = archive_file_fixture(dir, org_key, product, params)
     {:ok, archive} = Archives.create(product, filepath)
     archive
   end
@@ -365,13 +369,13 @@ defmodule NervesHub.Fixtures do
     %{fixture | db_cert: db_cert}
   end
 
-  def standard_fixture() do
+  def standard_fixture(dir \\ System.tmp_dir()) do
     user_name = "Jeff"
     user = user_fixture(%{name: user_name})
     org = org_fixture(user, %{name: user_name})
     product = product_fixture(user, org, %{name: "Hop"})
-    org_key = org_key_fixture(org, user)
-    firmware = firmware_fixture(org_key, product)
+    org_key = org_key_fixture(org, user, dir)
+    firmware = firmware_fixture(org_key, product, %{dir: dir})
     deployment = deployment_fixture(org, firmware)
     device = device_fixture(org, product, firmware)
     %{db_cert: device_certificate} = device_certificate_fixture(device)


### PR DESCRIPTION
this adds the `:tmp_dir` tag on a module level for all `BrowserCase` test files