### PR TITLE
Open registration config tweak

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -111,3 +111,6 @@ config :nerves_hub, NervesHub.SwooshMailer, adapter: Swoosh.Adapters.Local
 config :nerves_hub, NervesHub.RateLimit, limit: 10
 
 config :sentry, environment_name: :development
+
+config :nerves_hub,
+  open_for_registrations: true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,8 +23,13 @@ config :nerves_hub,
   admin_auth: [
     username: System.get_env("ADMIN_AUTH_USERNAME"),
     password: System.get_env("ADMIN_AUTH_PASSWORD")
-  ],
-  open_for_registrations: System.get_env("OPEN_FOR_REGISTRATIONS", "false") == "true"
+  ]
+
+# only set this in :prod as not to override the :dev config
+if config_env() == :prod do
+  config :nerves_hub,
+    open_for_registrations: System.get_env("OPEN_FOR_REGISTRATIONS", "false") == "true"
+end
 
 if level = System.get_env("LOG_LEVEL") do
   config :logger, level: String.to_atom(level)


### PR DESCRIPTION
enable it in `:dev`, and only check the env var when the env is `:prod`