### PR TITLE
sync a devices connection status

### DIFF
--- a/api-spec.yml
+++ b/api-spec.yml
@@ -1,7 +1,7 @@
-openapi: '3.0.2'
+openapi: "3.0.2"
 info:
   title: NervesHub Web
-  version: '2.0'
+  version: "2.0"
 servers:
   - url: http://localhost:4000/api
 security:
@@ -31,13 +31,25 @@ components:
     device:
       type: object
       properties:
+        connection_status:
+          type: string
+          example: "connected"
+        connection_established_at:
+          type: string
+          format: date-time
+        connection_disconnected_at:
+          type: string
+          format: date-time
+        connection_last_seen_at:
+          type: string
+          format: date-time
         deployment:
-          $ref: '#/components/schemas/deployment'
+          $ref: "#/components/schemas/deployment"
         description:
           type: string
           example: "A device"
         firmware_metadata:
-          $ref: '#/components/schemas/firmware_metadata'
+          $ref: "#/components/schemas/firmware_metadata"
         firmware_update_status:
           type: string
           enum: [latest, pending, updating]
@@ -162,7 +174,7 @@ paths:
             format: uuid
           required: true
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -176,8 +188,8 @@ paths:
                   `deployment` contains information about what firmware version and UUID should eventually be running on the device.
                 properties:
                   data:
-                    $ref: '#/components/schemas/device'
-        '404':
+                    $ref: "#/components/schemas/device"
+        "404":
           description: Not found
           content:
             application/json:
@@ -204,7 +216,7 @@ paths:
                   type: string
                   example: "kiosk"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -219,7 +231,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -229,7 +241,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/script'
+                      $ref: "#/components/schemas/script"
   /devices/{identifier}/scripts/{id}:
     post:
       summary: Trigger a script to run
@@ -243,7 +255,7 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: OK
           content:
             text/plain:
@@ -262,7 +274,7 @@ paths:
             type: string
             example: nerveshub
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -293,9 +305,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/firmware_key'
+              $ref: "#/components/schemas/firmware_key"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -303,12 +315,12 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/firmware_key'
+                    $ref: "#/components/schemas/firmware_key"
   /users/me:
     get:
       summary: View information about the authenticated user
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:

--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -200,7 +200,7 @@
 .device-meta-grid,
 .deployment-meta-grid {
   display: grid;
-  grid-template-columns: max-content max-content max-content 1fr;
+  grid-template-columns: max-content max-content max-content max-content 1fr;
   grid-column-gap: 5.5rem;
 
   @media (max-width: 900px) {

--- a/config/config.exs
+++ b/config/config.exs
@@ -53,17 +53,25 @@ config :nerves_hub, NervesHubWeb.Endpoint,
 #
 config :nerves_hub, NervesHub.Repo,
   queue_target: 500,
-  queue_interval: 5_000
+  queue_interval: 5_000,
+  migration_lock: :pg_advisory_lock
 
 config :nerves_hub, Oban,
   repo: NervesHub.ObanRepo,
   log: false,
-  queues: [delete_archive: 1, delete_firmware: 1, firmware_delta_builder: 2, truncate: 1],
+  queues: [
+    delete_archive: 1,
+    delete_firmware: 1,
+    device: 1,
+    firmware_delta_builder: 2,
+    truncate: 1
+  ],
   plugins: [
     # 1 week
     {Oban.Plugins.Pruner, max_age: 604_800},
     {Oban.Plugins.Cron,
      crontab: [
+       {"*/1 * * * *", NervesHub.Workers.CleanDeviceConnectionStates},
        {"0 * * * *", NervesHub.Workers.TruncateAuditLogs, max_attempts: 1},
        {"*/5 * * * *", NervesHub.Workers.ExpireInflightUpdates}
      ]}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -26,6 +26,8 @@ config :nerves_hub,
   ],
   device_deployment_change_jitter_seconds:
     String.to_integer(System.get_env("DEVICE_DEPLOYMENT_CHANGE_JITTER_SECONDS", "10")),
+  device_last_seen_update_interval_minutes:
+    String.to_integer(System.get_env("DEVICE_LAST_SEEN_UPDATE_INTERVAL_MINUTES", "5")),
   mapbox_access_token: System.get_env("MAPBOX_ACCESS_TOKEN")
 
 # only set this in :prod as not to override the :dev config

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -13,16 +13,19 @@ defmodule NervesHub.Devices.Device do
 
   @type t :: %__MODULE__{}
   @optional_params [
-    :last_communication,
     :description,
     :updates_enabled,
     :tags,
     :deleted_at,
     :update_attempts,
     :updates_blocked_until,
-    :connection_types,
     :connecting_code,
     :deployment_id,
+    :connection_status,
+    :connection_established_at,
+    :connection_disconnected_at,
+    :connection_last_seen_at,
+    :connection_types,
     :connection_metadata
   ]
   @required_params [:org_id, :product_id, :identifier]
@@ -36,12 +39,20 @@ defmodule NervesHub.Devices.Device do
 
     field(:identifier, :string)
     field(:description, :string)
-    field(:last_communication, :utc_datetime)
     field(:updates_enabled, :boolean, default: true)
     field(:tags, NervesHub.Types.Tag)
     field(:deleted_at, :utc_datetime)
     field(:update_attempts, {:array, :utc_datetime}, default: [])
     field(:updates_blocked_until, :utc_datetime)
+
+    field(:connection_status, Ecto.Enum,
+      values: [:connected, :disconnected, :not_seen],
+      default: :not_seen
+    )
+
+    field(:connection_established_at, :utc_datetime)
+    field(:connection_disconnected_at, :utc_datetime)
+    field(:connection_last_seen_at, :utc_datetime)
     field(:connection_types, {:array, Ecto.Enum}, values: [:cellular, :ethernet, :wifi])
     field(:connecting_code, :string)
     field(:connection_metadata, :map, default: %{})

--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -70,8 +70,8 @@ defmodule NervesHub.Tracker do
   online. If the device is online, it will send a connection state change of online.
   """
   def online?(device) do
-    _ = Phoenix.PubSub.broadcast(NervesHub.PubSub, "device:#{device.id}", :online?)
-    false
+    Phoenix.PubSub.broadcast(NervesHub.PubSub, "device:#{device.id}", :online?)
+    device.connection_status == :connected
   end
 
   @doc """

--- a/lib/nerves_hub/workers/clean_device_connection_states.ex
+++ b/lib/nerves_hub/workers/clean_device_connection_states.ex
@@ -1,0 +1,12 @@
+defmodule NervesHub.Workers.CleanDeviceConnectionStates do
+  use Oban.Worker,
+    max_attempts: 5,
+    queue: :device
+
+  @impl true
+  def perform(_) do
+    NervesHub.Devices.clean_connection_states()
+
+    :ok
+  end
+end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -30,7 +30,7 @@ defmodule NervesHubWeb.DeviceChannel do
     else
       err ->
         Logger.warning("[DeviceChannel] failure to connect - #{inspect(err)}")
-
+        Devices.device_disconnected(device)
         {:error, %{error: "could not connect"}}
     end
   end
@@ -140,12 +140,20 @@ defmodule NervesHubWeb.DeviceChannel do
         updating: false
       })
 
+    Process.send_after(self(), :update_connection_last_seen, last_seen_update_interval())
+
     socket =
       socket
       |> assign(:device, device)
       |> assign(:deployment_channel, deployment_channel)
       |> assign(:reference_id, ref_id)
 
+    {:noreply, socket}
+  end
+
+  def handle_info(:update_connection_last_seen, socket) do
+    {:ok, _device} = Devices.device_heartbeat(socket.assigns.device)
+    Process.send_after(self(), :update_connection_last_seen, last_seen_update_interval())
     {:noreply, socket}
   end
 
@@ -507,8 +515,7 @@ defmodule NervesHubWeb.DeviceChannel do
       identifier: device.identifier
     })
 
-    {:ok, device} =
-      Devices.update_device(socket.assigns.device, %{last_communication: DateTime.utc_now()})
+    {:ok, device} = Devices.device_disconnected(device)
 
     Registry.unregister(NervesHub.Devices, device.id)
 
@@ -653,5 +660,10 @@ defmodule NervesHubWeb.DeviceChannel do
   defp device_deployment_change_jitter_ms() do
     jitter = Application.get_env(:nerves_hub, :device_deployment_change_jitter_seconds)
     :rand.uniform(jitter) * 1000
+  end
+
+  defp last_seen_update_interval() do
+    Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
+    |> :timer.minutes()
   end
 end

--- a/lib/nerves_hub_web/components/device_header.ex
+++ b/lib/nerves_hub_web/components/device_header.ex
@@ -33,29 +33,42 @@ defmodule NervesHubWeb.Components.DeviceHeader do
         </p>
       </div>
       <div>
+        <div class="help-text mb-1 tooltip-label help-tooltip">
+          <span>Last connected at</span>
+          <span class="tooltip-info"></span>
+          <span class="tooltip-text"><%= @device.connection_established_at %></span>
+        </div>
+        <p>
+          <%= if is_nil(@device.connection_established_at) do %>
+            Never
+          <% else %>
+            <%= DateTimeFormat.from_now(@device.connection_established_at) %>
+          <% end %>
+        </p>
+      </div>
+      <div>
+        <div class="help-text mb-1 tooltip-label help-tooltip">
+          <span>Last seen at</span>
+          <span class="tooltip-info"></span>
+          <span class="tooltip-text"><%= @device.connection_last_seen_at %></span>
+        </div>
+        <p>
+          <%= if is_nil(@device.connection_last_seen_at) do %>
+            Never
+          <% else %>
+            <%= DateTimeFormat.from_now(@device.connection_last_seen_at) %>
+          <% end %>
+        </p>
+      </div>
+      <div>
         <div class="help-text mb-1">Version</div>
         <%= if is_nil(@device.firmware_metadata) do %>
           <p>Unknown</p>
         <% else %>
           <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@device.firmware_metadata.uuid}"} class="badge ff-m mt-0">
-            <%= @device.firmware_metadata.version %>
-            <%= @device.firmware_metadata.uuid %>
+            <%= @device.firmware_metadata.version %> (<%= String.slice(@device.firmware_metadata.uuid, 0..7) %>)
           </.link>
         <% end %>
-      </div>
-      <div>
-        <div class="help-text mb-1 tooltip-label help-tooltip">
-          <span>Last Handshake</span>
-          <span class="tooltip-info"></span>
-          <span class="tooltip-text"><%= @device.last_communication %></span>
-        </div>
-        <p>
-          <%= if is_nil(@device.last_communication) do %>
-            Never
-          <% else %>
-            <%= DateTimeFormat.from_now(@device.last_communication) %>
-          <% end %>
-        </p>
       </div>
       <div>
         <div class="help-text">Firmware Updates</div>

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -55,6 +55,18 @@
           <input type="text" name="device_id" id="input_id" class="form-control" value={@current_filters["id"]} phx-debounce="500" />
         </div>
         <div class="form-group">
+          <label for="input_connection">Connection</label>
+          <div class="pos-rel">
+            <select name="connection" id="input_connection" class="form-control">
+              <option {selected?(@current_filters, "connection", "")} value="">All</option>
+              <option {selected?(@current_filters, "connection", "connected")} value="connected">Connected</option>
+              <option {selected?(@current_filters, "connection", "disconnected")} value="disconnected">Disconnected</option>
+              <option {selected?(@current_filters, "connection", "not_seen")} value="not_seen">Not Seen</option>
+            </select>
+            <div class="select-icon"></div>
+          </div>
+        </div>
+        <div class="form-group">
           <label for="connection_type">Connection Type</label>
           <div class="pos-rel">
             <select name="connection_type" id="connection_type" class="form-control">
@@ -78,19 +90,6 @@
             <div class="select-icon"></div>
           </div>
         </div>
-        <!--
-        <div class="form-group">
-          <label for="input_connection">Connection</label>
-          <div class="pos-rel">
-            <select name="connection" id="input_connection" class="form-control">
-              <option {selected?(@current_filters, "connection", "")} value="">All</option>
-              <option {selected?(@current_filters, "connection", "1")} value="1">Connected</option>
-              <option {selected?(@current_filters, "connection", "0")} value="0">Disconnected</option>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        -->
         <div class="form-group">
           <label for="input_firmware">Firmware</label>
           <div class="pos-rel">
@@ -237,7 +236,7 @@
             <%= if @device_statuses[device.identifier] == "online" do %>
               <img src="/images/icons/check.svg" alt="connected" class="table-icon" />
             <% else %>
-              <div title={"Last connected #{DateTimeFormat.from_now(device.last_communication)}"}>
+              <div title={if device.connection_last_seen_at, do: "Last seen at #{DateTimeFormat.from_now(device.connection_last_seen_at)}", else: "Not seen yet"} }>
                 <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
               </div>
             <% end %>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -212,7 +212,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   end
 
   defp audit_log_assigns(%{assigns: %{device: device}} = socket, page_number) do
-    logs = AuditLogs.logs_for_feed(device, %{page: page_number, page_size: 10})
+    logs = AuditLogs.logs_for_feed(device, %{page: page_number, page_size: 5})
 
     assign(socket, :audit_logs, logs)
   end

--- a/lib/nerves_hub_web/views/api/device_view.ex
+++ b/lib/nerves_hub_web/views/api/device_view.ex
@@ -21,7 +21,12 @@ defmodule NervesHubWeb.API.DeviceView do
       tags: device.tags,
       version: version(device),
       online: Tracker.sync_online?(device),
-      last_communication: last_communication(device),
+      connection_status: device.connection_status,
+      connection_established_at: device.connection_established_at,
+      connection_disconnected_at: device.connection_disconnected_at,
+      connection_last_seen_at: device.connection_last_seen_at,
+      # deprecated
+      last_communication: connection_last_seen_at(device),
       description: device.description,
       firmware_metadata: device.firmware_metadata,
       firmware_update_status: Devices.firmware_status(device),
@@ -45,6 +50,6 @@ defmodule NervesHubWeb.API.DeviceView do
   defp version(%{firmware_metadata: nil}), do: "unknown"
   defp version(%{firmware_metadata: %{version: vsn}}), do: vsn
 
-  defp last_communication(%{last_communication: nil}), do: "never"
-  defp last_communication(%{last_communication: dt}), do: to_string(dt)
+  defp connection_last_seen_at(%{connection_last_seen_at: nil}), do: "never"
+  defp connection_last_seen_at(%{connection_last_seen_at: dt}), do: to_string(dt)
 end

--- a/priv/repo/migrations/20240710220630_add_connection_information_to_devices.exs
+++ b/priv/repo/migrations/20240710220630_add_connection_information_to_devices.exs
@@ -1,0 +1,21 @@
+defmodule NervesHub.Repo.Migrations.AddConnectionInformationToDevices do
+  use Ecto.Migration
+
+  def up do
+    alter table(:devices) do
+      add(:connection_status, :string)
+      add(:connection_established_at, :utc_datetime)
+      add(:connection_disconnected_at, :utc_datetime)
+      add(:connection_last_seen_at, :utc_datetime)
+    end
+
+    flush()
+
+    execute("UPDATE devices SET connection_status = 'not_seen' WHERE last_communication IS NULL")
+    execute("UPDATE devices SET connection_status = 'disconnected', connection_established_at = last_communication, connection_disconnected_at = last_communication, connection_last_seen_at = last_communication WHERE last_communication IS NOT NULL")
+  end
+
+  def down do
+    raise "One way migration"
+  end
+end

--- a/priv/repo/migrations/20240711034526_add_connection_status_index_to_devices.exs
+++ b/priv/repo/migrations/20240711034526_add_connection_status_index_to_devices.exs
@@ -1,0 +1,8 @@
+defmodule NervesHub.Repo.Migrations.AddConnectionStatusIndexToDevices do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def change do
+    create index("devices", [:connection_status], concurrently: true)
+  end
+end

--- a/priv/repo/migrations/20240711034640_remove_last_communication_from_devices.exs
+++ b/priv/repo/migrations/20240711034640_remove_last_communication_from_devices.exs
@@ -1,0 +1,13 @@
+defmodule NervesHub.Repo.Migrations.RemoveLastCommunicationFromDevices do
+  use Ecto.Migration
+
+  def up do
+    alter table(:devices) do
+      remove :last_communication, :utc_datetime
+    end
+  end
+
+  def down do
+    raise "One way migration"
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -43,7 +43,7 @@ defmodule NervesHub.SeedHelpers do
       conditions: %{"version" => "< 1.0.0", "tags" => ["beta"]}
     })
 
-    Fixtures.device_fixture(org, product, firmwares |> elem(1), %{last_communication: DateTime.utc_now()})
+    Fixtures.device_fixture(org, product, firmwares |> elem(1), %{connection_last_seen_at: DateTime.utc_now()})
   end
 
   def nerves_team_seed(root_user_params) do

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -881,21 +881,104 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
-  describe "inflight updates" do
-    test "clears expired inflight updates", %{device: device, deployment: deployment} do
-      deployment = Repo.preload(deployment, :firmware)
-      Fixtures.inflight_update(device, deployment)
-      assert {0, _} = Devices.delete_expired_inflight_updates()
+  describe "updates connection details" do
+    test "marks a device as connected", %{org: org, product: product, firmware: firmware} do
+      device = Fixtures.device_fixture(org, product, firmware)
 
-      Devices.clear_inflight_update(device)
+      {:ok, updated} = Devices.device_connected(device)
 
-      expires_at =
-        DateTime.utc_now()
-        |> DateTime.shift(hour: -1)
-        |> DateTime.truncate(:second)
+      assert updated.connection_status == :connected
+      assert recent_datetime(updated.connection_established_at)
+      assert recent_datetime(updated.connection_last_seen_at)
+      assert updated.connection_disconnected_at == nil
+    end
 
-      Fixtures.inflight_update(device, deployment, %{"expires_at" => expires_at})
-      assert {1, _} = Devices.delete_expired_inflight_updates()
+    test "marks a device as disconnected", %{org: org, product: product, firmware: firmware} do
+      device = Fixtures.device_fixture(org, product, firmware)
+
+      {:ok, updated} = Devices.device_connected(device)
+      {:ok, again} = Devices.device_disconnected(updated)
+
+      assert again.connection_status == :disconnected
+      assert recent_datetime(again.connection_established_at)
+      assert recent_datetime(again.connection_last_seen_at)
+      assert recent_datetime(again.connection_disconnected_at)
+    end
+
+    test "marks a devices last seen information", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      device = Fixtures.device_fixture(org, product, firmware)
+
+      {:ok, updated} = Devices.device_heartbeat(device)
+
+      assert updated.connection_status == :connected
+      assert recent_datetime(updated.connection_last_seen_at)
+      assert updated.connection_disconnected_at == nil
+    end
+  end
+
+  defp recent_datetime(datetime) do
+    DateTime.diff(DateTime.utc_now(), datetime, :second) <= 5
+  end
+
+  describe "clean up device connection statuses" do
+    test "don't change the connection status of devices with a recent heartbeat", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      Fixtures.device_fixture(org, product, firmware, %{
+        connection_status: :connected,
+        connection_established_at: DateTime.shift(DateTime.utc_now(), minute: -10),
+        connection_last_seen_at: DateTime.shift(DateTime.utc_now(), minute: -1)
+      })
+
+      Fixtures.device_fixture(org, product, firmware, %{
+        connection_status: :connected,
+        connection_established_at: DateTime.shift(DateTime.utc_now(), minute: -9),
+        connection_last_seen_at: DateTime.shift(DateTime.utc_now(), minute: -2)
+      })
+
+      Fixtures.device_fixture(org, product, firmware, %{
+        connection_status: :connected,
+        connection_established_at: DateTime.shift(DateTime.utc_now(), minute: -11),
+        connection_last_seen_at: DateTime.shift(DateTime.utc_now(), minute: -1)
+      })
+
+      assert Devices.connected_count(product) == 3
+      Devices.clean_connection_states()
+      assert Devices.connected_count(product) == 3
+    end
+
+    test "clean connection status of devices not seen recently", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      Fixtures.device_fixture(org, product, firmware, %{
+        connection_status: :connected,
+        connection_established_at: DateTime.shift(DateTime.utc_now(), minute: -10),
+        connection_last_seen_at: DateTime.shift(DateTime.utc_now(), minute: -1)
+      })
+
+      Fixtures.device_fixture(org, product, firmware, %{
+        connection_status: :connected,
+        connection_established_at: DateTime.shift(DateTime.utc_now(), minute: -25),
+        connection_last_seen_at: DateTime.shift(DateTime.utc_now(), minute: -15)
+      })
+
+      Fixtures.device_fixture(org, product, firmware, %{
+        connection_status: :connected,
+        connection_established_at: DateTime.shift(DateTime.utc_now(), minute: -47),
+        connection_last_seen_at: DateTime.shift(DateTime.utc_now(), minute: -9)
+      })
+
+      assert Devices.connected_count(product) == 3
+      Devices.clean_connection_states()
+      assert Devices.connected_count(product) == 1
     end
   end
 

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -575,7 +575,7 @@ defmodule NervesHubWeb.WebsocketTest do
         |> NervesHub.Repo.get(device.id)
         |> NervesHub.Repo.preload(:org)
 
-      assert Time.diff(DateTime.utc_now(), device.last_communication) < 2
+      assert Time.diff(DateTime.utc_now(), device.connection_last_seen_at) < 2
 
       SocketClient.close(socket)
     end
@@ -662,7 +662,7 @@ defmodule NervesHubWeb.WebsocketTest do
 
       assert_connection_change()
 
-      assert Time.diff(DateTime.utc_now(), updated_device.last_communication) < 2
+      assert Time.diff(DateTime.utc_now(), updated_device.connection_last_seen_at) < 2
 
       SocketClient.close(socket)
     end


### PR DESCRIPTION
- sync when a device establishes a connection, when it disconnects, and its 'heartbeat' (powered by the device channel)
- sync 'connected', 'disconnected', and 'not_seen' based on the device connecting, disconnecting, and the heartbeat
- add a connection status filter to the device list
- an oban worker that runs each minute to clean up device connection statuses if they haven't been seen in 6 minutes (configurable)
- updated the device show UI to include the last connected at and last seen at

This change will mean that each connected device will write to the devices table once each 5 minutes (configurable) based on a heartbeat timer in `DeviceChannel`. 

While this change isn't expected to be a performance issue, the impact is a little unknown. For example, 100,000 devices updating every 5 minutes would mean 333 DB updates every second. It's very likely the `DEVICE_LAST_SEEN_UPDATE_INTERVAL_MINUTES` environment variable will need to be tweaked to find the right setting for a platform's installation.

<img width="1182" alt="Screenshot 2024-07-11 at 4 23 35 PM" src="https://github.com/nerves-hub/nerves_hub_web/assets/8701/db52d198-1326-402b-82d9-1e5fdc929b05">
