### PR TITLE
Rely on the power of `Ecto.NoResultsError` for 404s

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,7 +2,6 @@ import '../css/app.scss'
 
 import 'phoenix_html'
 import 'bootstrap'
-import $ from 'jquery'
 import { Socket } from 'phoenix'
 import { LiveSocket } from 'phoenix_live_view'
 import Josh from 'joshjs'
@@ -72,7 +71,7 @@ window.addEventListener('phx:sharedsecret:clipcopy', event => {
   }
 })
 
-window.addEventListener('ca:edit:jitp', event => {
+window.addEventListener('ca:edit:jitp', () => {
   const checked = document.getElementById('jitp_toggle_ui').checked
 
   document.getElementById('jitp-delete').value = !checked
@@ -84,7 +83,7 @@ window.addEventListener('ca:edit:jitp', event => {
   }
 })
 
-window.addEventListener('ca:new:jitp', event => {
+window.addEventListener('ca:new:jitp', () => {
   const checked = document.getElementById('jitp_toggle_ui').checked
 
   document.getElementById('jitp_toggle').value = checked

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -346,7 +346,8 @@ if System.get_env("SENTRY_DSN_URL") do
     dsn: System.get_env("SENTRY_DSN_URL"),
     environment_name: System.get_env("DEPLOY_ENV", to_string(config_env())),
     enable_source_code_context: true,
-    root_source_code_path: File.cwd!()
+    root_source_code_path: [File.cwd!()],
+    before_send: {NervesHubWeb.SentryEventFilter, :filter_non_500}
 end
 
 config :nerves_hub, :statsd,

--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -126,18 +126,27 @@ defmodule NervesHub.Accounts do
     |> Repo.update()
   end
 
+  def get_org_user!(org, user) do
+    get_org_user_query(org, user)
+    |> Repo.one!()
+  end
+
   def get_org_user(org, user) do
+    get_org_user_query(org, user)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      org_user -> {:ok, org_user}
+    end
+  end
+
+  defp get_org_user_query(org, user) do
     OrgUser
     |> where([ou], ou.org_id == ^org.id)
     |> where([ou], ou.user_id == ^user.id)
     |> join(:inner, [ou], u in assoc(ou, :user), as: :user)
     |> preload([ou, user: user], user: user)
     |> Repo.exclude_deleted()
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      org_user -> {:ok, org_user}
-    end
   end
 
   def get_org_users(org) do

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -12,6 +12,10 @@ defmodule NervesHub.Application do
         raise "fwup could not be found in the $PATH. This is a requirement of NervesHubWeb and cannot start otherwise"
     end
 
+    :logger.add_handler(:my_sentry_handler, Sentry.LoggerHandler, %{
+      config: %{metadata: [:file, :line]}
+    })
+
     topologies = Application.get_env(:libcluster, :topologies, [])
 
     children =

--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -63,17 +63,16 @@ defmodule NervesHub.Deployments do
 
   def get_deployment!(deployment_id), do: Repo.get!(Deployment, deployment_id)
 
+  @spec get_by_product_and_name!(Product.t(), String.t()) :: Deployment.t()
+  def get_by_product_and_name!(product, name) do
+    get_by_product_and_name_query(product, name)
+    |> Repo.one!()
+  end
+
   @spec get_deployment_by_name(Product.t(), String.t()) ::
           {:ok, Deployment.t()} | {:error, :not_found}
-  def get_deployment_by_name(%Product{id: product_id}, deployment_name) do
-    from(
-      d in Deployment,
-      where: d.name == ^deployment_name,
-      join: f in assoc(d, :firmware),
-      where: f.product_id == ^product_id
-    )
-    |> Deployment.with_firmware()
-    |> Deployment.with_product()
+  def get_deployment_by_name(product, name) do
+    get_by_product_and_name_query(product, name)
     |> Repo.one()
     |> case do
       nil ->
@@ -82,6 +81,15 @@ defmodule NervesHub.Deployments do
       deployment ->
         {:ok, deployment}
     end
+  end
+
+  defp get_by_product_and_name_query(%Product{id: product_id}, name) do
+    Deployment
+    |> where(name: ^name)
+    |> where(product_id: ^product_id)
+    |> join(:left, [d], f in assoc(d, :firmware))
+    |> join(:left, [d], p in assoc(d, :product))
+    |> preload([d, f, p], firmware: f, product: p)
   end
 
   @spec delete_deployment(Deployment.t()) :: {:ok, Deployment.t()} | {:error, :not_found}
@@ -147,7 +155,7 @@ defmodule NervesHub.Deployments do
             # This opens up a minor optimization to preemptively set matching
             # devices to the new deployment all at once since the version
             # condition can be skipped.
-            # 
+            #
             # This also helps with offline devices by potentially reducing the
             # need to do the expensive deployment check on next connect which
             # reduces the load when a lot of devices come online at once.

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -116,10 +116,25 @@ defmodule NervesHub.Firmwares do
     Repo.get_by(Firmware, uuid: uuid)
   end
 
+  @spec get_firmware_by_product_and_uuid!(Product.t(), String.t()) :: Firmware.t()
+  def get_firmware_by_product_and_uuid!(product, uuid) do
+    get_firmware_by_product_and_uuid_query(product, uuid)
+    |> Repo.one!()
+  end
+
   @spec get_firmware_by_product_and_uuid(Product.t(), String.t()) ::
           {:ok, Firmware.t()}
           | {:error, :not_found}
-  def get_firmware_by_product_and_uuid(%Product{id: product_id}, uuid) do
+  def get_firmware_by_product_and_uuid(product, uuid) do
+    get_firmware_by_product_and_uuid_query(product, uuid)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      firmware -> {:ok, firmware}
+    end
+  end
+
+  defp get_firmware_by_product_and_uuid_query(%Product{id: product_id}, uuid) do
     from(
       f in Firmware,
       where: f.uuid == ^uuid,
@@ -127,11 +142,6 @@ defmodule NervesHub.Firmwares do
       preload: [product: p],
       where: p.id == ^product_id
     )
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
   end
 
   @spec create_firmware(

--- a/lib/nerves_hub/scripts.ex
+++ b/lib/nerves_hub/scripts.ex
@@ -15,6 +15,10 @@ defmodule NervesHub.Scripts do
     Repo.get!(Script, id)
   end
 
+  def get_by_product_and_id!(product, id) do
+    Repo.get_by!(Script, id: id, product_id: product.id)
+  end
+
   def get(product, id) do
     case Repo.get_by(Script, id: id, product_id: product.id) do
       nil ->

--- a/lib/nerves_hub_web.ex
+++ b/lib/nerves_hub_web.ex
@@ -131,6 +131,8 @@ defmodule NervesHubWeb do
 
       unquote(view_helpers())
 
+      on_mount(Sentry.LiveViewHook)
+
       def ok(socket), do: {:ok, socket}
       def noreply(socket), do: {:noreply, socket}
 

--- a/lib/nerves_hub_web/errors.ex
+++ b/lib/nerves_hub_web/errors.ex
@@ -1,19 +1,3 @@
 defmodule NervesHubWeb.NotFoundError do
   defexception message: "not found", plug_status: 404
 end
-
-defmodule NervesHubWeb.SentryEventFilter do
-  def filter_non_500(%Sentry.Event{original_exception: exception} = event) do
-    cond do
-      Plug.Exception.status(exception) < 500 ->
-        false
-
-      # Fall back to the default event filter.
-      Sentry.DefaultEventFilter.exclude_exception?(exception, event.source) ->
-        false
-
-      true ->
-        event
-    end
-  end
-end

--- a/lib/nerves_hub_web/errors.ex
+++ b/lib/nerves_hub_web/errors.ex
@@ -1,3 +1,19 @@
 defmodule NervesHubWeb.NotFoundError do
   defexception message: "not found", plug_status: 404
 end
+
+defmodule NervesHubWeb.SentryEventFilter do
+  def filter_non_500(%Sentry.Event{original_exception: exception} = event) do
+    cond do
+      Plug.Exception.status(exception) < 500 ->
+        false
+
+      # Fall back to the default event filter.
+      Sentry.DefaultEventFilter.exclude_exception?(exception, event.source) ->
+        false
+
+      true ->
+        event
+    end
+  end
+end

--- a/lib/nerves_hub_web/live/archives.ex
+++ b/lib/nerves_hub_web/live/archives.ex
@@ -28,7 +28,7 @@ defmodule NervesHubWeb.Live.Archives do
   defp apply_action(%{assigns: %{product: product}} = socket, :show, %{
          "archive_uuid" => archive_uuid
        }) do
-    {:ok, archive} = Archives.get(product, archive_uuid)
+    archive = Archives.get_by_product_and_uuid!(product, archive_uuid)
 
     socket
     |> page_title("Archive #{archive_uuid} - #{product.name}")

--- a/lib/nerves_hub_web/live/deployments/edit.ex
+++ b/lib/nerves_hub_web/live/deployments/edit.ex
@@ -10,10 +10,10 @@ defmodule NervesHubWeb.Live.Deployments.Edit do
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do
-    %{"name" => deployment_name} = params
+    %{"name" => name} = params
     %{product: product} = socket.assigns
 
-    {:ok, deployment} = Deployments.get_deployment_by_name(product, deployment_name)
+    deployment = Deployments.get_by_product_and_name!(product, name)
 
     archives = Archives.all_by_product(deployment.product)
     firmwares = Firmwares.get_firmwares_for_deployment(deployment)

--- a/lib/nerves_hub_web/live/deployments/show.ex
+++ b/lib/nerves_hub_web/live/deployments/show.ex
@@ -10,10 +10,10 @@ defmodule NervesHubWeb.Live.Deployments.Show do
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do
-    %{"name" => deployment_name} = params
+    %{"name" => name} = params
     %{product: product} = socket.assigns
 
-    {:ok, deployment} = Deployments.get_deployment_by_name(product, deployment_name)
+    deployment = Deployments.get_by_product_and_name!(product, name)
 
     logs =
       AuditLogs.logs_for_feed(deployment, %{

--- a/lib/nerves_hub_web/live/devices/settings.ex
+++ b/lib/nerves_hub_web/live/devices/settings.ex
@@ -9,8 +9,8 @@ defmodule NervesHubWeb.Live.Devices.Settings do
   alias NervesHub.Repo
 
   def mount(%{"device_identifier" => device_identifier}, _session, socket) do
-    {:ok, device} =
-      Devices.get_device_by_identifier(
+    device =
+      Devices.get_device_by_identifier!(
         socket.assigns.org,
         device_identifier,
         :device_certificates

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def mount(%{"device_identifier" => device_identifier}, _session, socket) do
     %{org: org, product: product} = socket.assigns
 
-    {:ok, device} = Devices.get_device_by_identifier(org, device_identifier)
+    device = Devices.get_device_by_identifier!(org, device_identifier)
 
     if connected?(socket) do
       socket.endpoint.subscribe("device:#{device.identifier}:internal")

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -28,7 +28,7 @@ defmodule NervesHubWeb.Live.Firmware do
   defp apply_action(%{assigns: %{product: product}} = socket, :show, %{
          "firmware_uuid" => firmware_uuid
        }) do
-    {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(product, firmware_uuid)
+    firmware = Firmwares.get_firmware_by_product_and_uuid!(product, firmware_uuid)
 
     socket
     |> page_title("Firmware #{firmware_uuid} - #{product.name}")

--- a/lib/nerves_hub_web/live/support_scripts/edit.ex
+++ b/lib/nerves_hub_web/live/support_scripts/edit.ex
@@ -10,7 +10,7 @@ defmodule NervesHubWeb.Live.SupportScripts.Edit do
         _session,
         %{assigns: %{product: product}} = socket
       ) do
-    {:ok, script} = Scripts.get(product, script_id)
+    script = Scripts.get_by_product_and_id!(product, script_id)
 
     socket
     |> page_title("Edit Support Script - #{socket.assigns.org.name}")

--- a/lib/nerves_hub_web/mounts/fetch_org_user.ex
+++ b/lib/nerves_hub_web/mounts/fetch_org_user.ex
@@ -6,8 +6,7 @@ defmodule NervesHubWeb.Mounts.FetchOrgUser do
   def on_mount(_, _, _, socket) do
     socket =
       assign_new(socket, :org_user, fn ->
-        {:ok, org_user} = Accounts.get_org_user(socket.assigns.org, socket.assigns.user)
-        org_user
+        Accounts.get_org_user!(socket.assigns.org, socket.assigns.user)
       end)
 
     {:cont, socket}

--- a/lib/nerves_hub_web/mounts/fetch_product.ex
+++ b/lib/nerves_hub_web/mounts/fetch_product.ex
@@ -9,6 +9,10 @@ defmodule NervesHubWeb.Mounts.FetchProduct do
         Enum.find(org.products, &(&1.name == product_name))
       end)
 
+    unless socket.assigns.product do
+      raise NervesHubWeb.NotFoundError
+    end
+
     {:cont, socket}
   end
 end

--- a/lib/nerves_hub_web/sentry_event_filter.ex
+++ b/lib/nerves_hub_web/sentry_event_filter.ex
@@ -1,0 +1,15 @@
+defmodule NervesHubWeb.SentryEventFilter do
+  def filter_non_500(%Sentry.Event{original_exception: exception} = event) do
+    cond do
+      Plug.Exception.status(exception) < 500 ->
+        false
+
+      # Fall back to the default event filter.
+      Sentry.DefaultEventFilter.exclude_exception?(exception, event.source) ->
+        false
+
+      true ->
+        event
+    end
+  end
+end

--- a/lib/nerves_hub_web/templates/error/500.html.heex
+++ b/lib/nerves_hub_web/templates/error/500.html.heex
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+
+    <title>Sorry, it's an unexpected error · NervesHub</title>
+    <link rel="stylesheet" href={Routes.static_path(NervesHubWeb.Endpoint, "/css/app.css")} />
+  </head>
+
+  <nav class="navbar navbar-expand navbar-dark fixed-top flex-md-nowrap p-0 flex-row justify-content-center">
+    <div class="content-container flex-row align-items-center justify-content-between h-100">
+      <a class="logo" href="/">
+        <img src="/images/logo.svg" alt="logo" />
+        <img src="/images/logo-no-text.svg" alt="logo" class="mobile-logo" />
+      </a>
+    </div>
+  </nav>
+
+  <body>
+    <div class="normal-wrapper">
+      <main role="main" class="flex-column content-container">
+        <div class="no-results-blowup-wrapper">
+          <img src="/images/product.svg" alt="No products" />
+          <p class="mt-8">Sorry, we tried to process your request but things didn't go so well.</p>
+          <p>Don't worry, we have sent an error report to the team and they are looking into it!</p>
+        </div>
+      </main>
+    </div>
+  </body>
+
+  <footer class="footer">
+    <div class="grid josh-js" data-josh-anim-name="fadeIn">
+      <img src="/images/logo.svg" alt="NervesHub Logo" class="footer-logo" />
+      <div class="footer-nav resources">
+        <h6>Resources</h6>
+        <a href="https://docs.nerves-hub.org/" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://github.com/nerves-hub" target="_blank" rel="noopener noreferrer">Source code</a>
+      </div>
+      <div class="footer-nav help">
+        <h6>Help</h6>
+        <a href="https://github.com/nerves-hub/nerves_hub_web/issues" target="_blank" rel="noopener noreferrer">Report an issue</a>
+      </div>
+    </div>
+  </footer>
+</html>

--- a/lib/nerves_hub_web/views/error_view.ex
+++ b/lib/nerves_hub_web/views/error_view.ex
@@ -1,13 +1,3 @@
 defmodule NervesHubWeb.ErrorView do
   use NervesHubWeb, :view
-
-  def render("500.html", _assigns) do
-    "Internal server error"
-  end
-
-  # In case no render clause matches or no
-  # template is found, let's render it as 500
-  def template_not_found(_template, assigns) do
-    render("500.html", assigns)
-  end
 end

--- a/test/nerves_hub_web/views/error_view_test.exs
+++ b/test/nerves_hub_web/views/error_view_test.exs
@@ -5,10 +5,7 @@ defmodule NervesHubWeb.ErrorViewTest do
   import Phoenix.View
 
   test "render 500.html" do
-    assert render_to_string(NervesHubWeb.ErrorView, "500.html", []) == "Internal server error"
-  end
-
-  test "render any other" do
-    assert render_to_string(NervesHubWeb.ErrorView, "505.html", []) == "Internal server error"
+    assert render_to_string(NervesHubWeb.ErrorView, "500.html", []) =~
+             "Sorry, we tried to process your request but things didn't go so well."
   end
 end


### PR DESCRIPTION
by using Ectos `!` functions, we can use Phoenix's error handling to show 404 pages.

This is cleaner, and follow convention.

This PR also includes some Sentry tidy ups, including the ignoring of all errors with a code below 500.