### PR TITLE
set some tags before sending a sentry error

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -488,6 +488,15 @@ defmodule NervesHubWeb.DeviceChannel do
       "[DeviceChannel] Unhandled handle_in message! - #{inspect(msg)} - #{inspect(params)}"
     )
 
+    device = socket.assigns.device
+
+    Sentry.Context.set_tags_context(%{
+      device_identifier: device.identifier,
+      device_id: device.id,
+      product_id: device.product_id,
+      org_id: device.org_id
+    })
+
     _ =
       Sentry.capture_message("[DeviceChannel] Unhandled message!",
         extra: %{message: msg},


### PR DESCRIPTION
these tags help with filtering sentry errors