### PR TITLE
Fix an issue with fwup progress not being shown

### DIFF
--- a/lib/nerves_hub_web/components/device_header.ex
+++ b/lib/nerves_hub_web/components/device_header.ex
@@ -83,17 +83,6 @@ defmodule NervesHubWeb.Components.DeviceHeader do
         </p>
       </div>
     </div>
-
-    <%= if Map.has_key?(assigns, :fwup_progress) && assigns.fwup_progress do %>
-      <div class="help-text mt-3">Progress</div>
-      <div class="progress device-show">
-        <div class="progress-bar" role="progressbar" style={"width: #{@fwup_progress}%"}>
-          <%= @fwup_progress %>%
-        </div>
-      </div>
-    <% end %>
-
-    <div class="divider"></div>
     """
   end
 end

--- a/lib/nerves_hub_web/components/fwup_progress.ex
+++ b/lib/nerves_hub_web/components/fwup_progress.ex
@@ -1,0 +1,16 @@
+defmodule NervesHubWeb.Components.FwupProgress do
+  use NervesHubWeb, :component
+
+  attr(:fwup_progress, :any)
+
+  def render(assigns) do
+    ~H"""
+    <div class="help-text mt-3">Progress</div>
+    <div class="progress device-show">
+      <div class="progress-bar" role="progressbar" style={"width: #{@fwup_progress}%"}>
+        <%= @fwup_progress %>%
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   alias NervesHub.Tracker
 
   alias NervesHubWeb.Components.DeviceHeader
+  alias NervesHubWeb.Components.FwupProgress
   alias NervesHubWeb.Components.DeviceLocation
 
   alias Phoenix.Socket.Broadcast
@@ -28,6 +29,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:status, Tracker.status(device))
     |> assign(:deployment, device.deployment)
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
+    |> assign(:fwup_progress, nil)
     |> audit_log_assigns(1)
     |> ok()
   end
@@ -49,7 +51,14 @@ defmodule NervesHubWeb.Live.Devices.Show do
   end
 
   def handle_info(%Broadcast{event: "fwup_progress", payload: payload}, socket) do
-    {:noreply, assign(socket, :fwup_progress, payload.percent)}
+    if payload.percent == 100 do
+      socket
+      |> put_flash(:info, "Update complete: The device will reboot shortly.")
+      |> assign(:fwup_progress, nil)
+      |> noreply()
+    else
+      {:noreply, assign(socket, :fwup_progress, payload.percent)}
+    end
   end
 
   # Ignore unknown messages

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -47,6 +47,9 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:device, device)
     |> assign(:status, payload.status)
     |> assign(:fwup_progress, nil)
+    |> then(fn socket ->
+      if(payload.status == "online", do: clear_flash(socket), else: socket)
+    end)
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -53,6 +53,10 @@
 
 <DeviceHeader.render org={@org} product={@product} device={@device} status={@status} />
 
+<FwupProgress.render :if={assigns.fwup_progress} fwup_progress={@fwup_progress} />
+
+<div class="divider"></div>
+
 <div class="row">
   <div class="col-lg-6">
     <div>


### PR DESCRIPTION
During the move to LiveView I borked a condition check for showing the Fwup progress.

This PR fixes the issues, adds tests, and improves the message. 

(when the progress hits 100, the bar is hidden and a flash is shown saying that the device is about to reboot)

<img width="1199" alt="Screenshot 2024-07-15 at 5 50 01 PM" src="https://github.com/user-attachments/assets/e667836e-fd37-4816-8118-4f4650cb8728">
