### PR TITLE
dynamically update firmware selection on the Device page

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -159,6 +159,7 @@ defmodule NervesHub.Firmwares do
         with {:ok, params} <- build_firmware_params(org, filepath),
              {:ok, firmware} <- insert_firmware(params),
              :ok <- upload_file_2.(filepath, firmware.upload_metadata) do
+          NervesHubWeb.Endpoint.broadcast("firmware", "created", %{firmware: firmware})
           firmware
         else
           {:error, error} ->

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -19,6 +19,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
     if connected?(socket) do
       socket.endpoint.subscribe("device:#{device.identifier}:internal")
+      socket.endpoint.subscribe("firmware")
     end
 
     socket
@@ -30,6 +31,11 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
     |> audit_log_assigns(1)
     |> ok()
+  end
+
+  def handle_info(%Broadcast{topic: "firmware", event: "created"}, socket) do
+    firmware = Firmwares.get_firmware_for_device(socket.assigns.device)
+    {:noreply, assign(socket, :firmwares, firmware)}
   end
 
   def handle_info(%Broadcast{event: "connection:status", payload: payload}, socket) do

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
+  alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias NervesHubWeb.Endpoint
 
@@ -153,6 +154,29 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has(
         "img[src=\"https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v12/static/174.8185,-41.3159,10,0/463x250@2x?access_token=abc\"]"
       )
+    end
+  end
+
+  describe "firmware selection" do
+    test "updates when new firmware is available", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device,
+      org_key: org_key,
+      tmp_dir: tmp_dir
+    } do
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      session =
+        conn
+        |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+        |> assert_has("h1", text: device.identifier)
+        |> assert_has("option[value=\"#{firmware.uuid}\"]", text: firmware.version)
+
+      new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      assert_has(session, "option[value=\"#{new_firmware.uuid}\"]", text: new_firmware.version)
     end
   end
 


### PR DESCRIPTION
I was getting a little annoyed at having to refresh the Device show page when new firmware was uploaded (I was using "send update" a bit)

I've added support for updating this selection box without having to refresh the page. (plus tests)