### PR TITLE
Remove Ecto from the InflightUpdate expiry worker

### DIFF
--- a/lib/nerves_hub/devices/inflight_update.ex
+++ b/lib/nerves_hub/devices/inflight_update.ex
@@ -1,9 +1,14 @@
 defmodule NervesHub.Devices.InflightUpdate do
   use Ecto.Schema
 
+  import Ecto.Changeset
+
   alias NervesHub.Devices.Device
+  alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Deployments.Deployment
   alias NervesHub.Firmwares.Firmware
+
+  @required_params [:device_id, :deployment_id, :firmware_id, :firmware_uuid, :expires_at]
 
   schema "inflight_updates" do
     belongs_to(:device, Device)
@@ -15,5 +20,14 @@ defmodule NervesHub.Devices.InflightUpdate do
     field(:expires_at, :utc_datetime)
 
     timestamps(updated_at: false)
+  end
+
+  def create_changeset(params) do
+    %InflightUpdate{}
+    |> cast(params, @required_params)
+    |> validate_required(@required_params)
+    |> unique_constraint(:deployment_id,
+      name: :inflight_updates_device_id_deployment_id_index
+    )
   end
 end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -881,6 +881,24 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
+  describe "inflight updates" do
+    test "clears expired inflight updates", %{device: device, deployment: deployment} do
+      deployment = Repo.preload(deployment, :firmware)
+      Fixtures.inflight_update(device, deployment)
+      assert {0, _} = Devices.delete_expired_inflight_updates()
+
+      Devices.clear_inflight_update(device)
+
+      expires_at =
+        DateTime.utc_now()
+        |> DateTime.shift(hour: -1)
+        |> DateTime.truncate(:second)
+
+      Fixtures.inflight_update(device, deployment, %{"expires_at" => expires_at})
+      assert {1, _} = Devices.delete_expired_inflight_updates()
+    end
+  end
+
   defp update_firmware_uuid(device, uuid) do
     firmware_metadata = %{
       architecture: "x86_64",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -5,6 +5,7 @@ defmodule NervesHub.Fixtures do
   alias NervesHub.Archives
   alias NervesHub.Certificate
   alias NervesHub.Devices
+  alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Deployments
   alias NervesHub.Firmwares
   alias NervesHub.Products
@@ -364,6 +365,26 @@ defmodule NervesHub.Fixtures do
       |> Repo.update()
 
     %{fixture | db_cert: db_cert}
+  end
+
+  def inflight_update(device, deployment, params \\ %{}) do
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.shift(hour: 1)
+      |> DateTime.truncate(:second)
+
+    defaults = %{
+      "device_id" => device.id,
+      "deployment_id" => deployment.id,
+      "firmware_id" => deployment.firmware_id,
+      "firmware_uuid" => deployment.firmware.uuid,
+      "expires_at" => expires_at
+    }
+
+    defaults
+    |> Map.merge(params)
+    |> InflightUpdate.create_changeset()
+    |> Repo.insert()
   end
 
   def standard_fixture(dir \\ System.tmp_dir()) do


### PR DESCRIPTION
The Oban worker that cleans up expired `InflightUpdate`s should not be using Ecto directly.

This PR also moves the changeset for creating `InflightUpdate`s to `InflightUpdate`, and adds a test for `delete_expired_inflight_updates/0` which the Oban worker now uses.