### PR TITLE
Fwup metadata deduplication + tests

### DIFF
--- a/lib/nerves_hub/archives/archive.ex
+++ b/lib/nerves_hub/archives/archive.ex
@@ -5,6 +5,7 @@ defmodule NervesHub.Archives.Archive do
 
   alias NervesHub.Accounts.OrgKey
   alias NervesHub.Products.Product
+  alias NervesHub.Fwup.Metadata
 
   schema "archives" do
     belongs_to(:product, Product, where: [deleted_at: nil])
@@ -22,6 +23,10 @@ defmodule NervesHub.Archives.Archive do
     field(:vcs_identifier, :string)
 
     timestamps()
+  end
+
+  def create_changeset(archive, %Metadata{} = metadata) do
+    create_changeset(archive, Map.from_struct(metadata))
   end
 
   def create_changeset(archive, params) do

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -409,14 +409,6 @@ defmodule NervesHub.Firmwares do
     end
   end
 
-  defp get_metadata_req_header(conn, header) do
-    case Plug.Conn.get_req_header(conn, "x-nerveshub-#{header}") do
-      [] -> nil
-      ["" | _] -> nil
-      [value | _] -> value
-    end
-  end
-
   defp delta_updater() do
     Application.get_env(
       :nerves_hub,

--- a/lib/nerves_hub/fwup.ex
+++ b/lib/nerves_hub/fwup.ex
@@ -3,6 +3,11 @@ defmodule NervesHub.Fwup do
   Helpers for dealing with files created by FWUP.
   """
 
+  @required_metadata_keys [:architecture, :platform, :product, :uuid, :version]
+  @optional_metadata_keys [:author, :description, :misc, :vcs_identifier]
+
+  @metadata_regex Regex.compile!("meta-(?<key>[^\n]+)=\"(?<value>[^\n]+)\"")
+
   @doc """
   Decode and parse metadata from a FWUP file.
   """
@@ -12,28 +17,11 @@ defmodule NervesHub.Fwup do
           | {:error, :invalid_metadata}
   def metadata(file_path) do
     with {:ok, metadata} <- get_metadata(file_path),
-         {:ok, uuid} <- metadata_value(metadata, "meta-uuid"),
-         {:ok, architecture} <- metadata_value(metadata, "meta-architecture"),
-         {:ok, platform} <- metadata_value(metadata, "meta-platform"),
-         {:ok, product} <- metadata_value(metadata, "meta-product"),
-         {:ok, version} <- metadata_value(metadata, "meta-version"),
-         {:ok, author} <- metadata_value(metadata, "meta-author", nil),
-         {:ok, description} <- metadata_value(metadata, "meta-description", nil),
-         {:ok, misc} <- metadata_value(metadata, "meta-misc", nil),
-         {:ok, vcs_identifier} <- metadata_value(metadata, "meta-vcs-identifier", nil) do
-      metadata = %{
-        architecture: architecture,
-        author: author,
-        description: description,
-        misc: misc,
-        platform: platform,
-        product: product,
-        uuid: uuid,
-        vcs_identifier: vcs_identifier,
-        version: version
-      }
-
-      {:ok, metadata}
+         parsed_metadata <- parse_metadata(metadata),
+         {:ok, required_metadata} <- required_values(parsed_metadata),
+         optional_metadata <- optional_values(parsed_metadata),
+         complete <- Map.merge(required_metadata, optional_metadata) do
+      {:ok, complete}
     end
   end
 
@@ -47,25 +35,36 @@ defmodule NervesHub.Fwup do
     end
   end
 
-  defp metadata_value(metadata, key) when is_binary(key) do
-    {:ok, regex} = "#{key}=\"(?<value>[^\n]+)\"" |> Regex.compile()
+  defp parse_metadata(metadata) do
+    Regex.scan(@metadata_regex, metadata)
+    |> Enum.reduce(%{}, fn line, acc ->
+      [_, key, value] = line
 
-    case Regex.named_captures(regex, metadata) do
-      %{"value" => value} ->
-        {:ok, value}
+      key =
+        key
+        |> String.replace("-", "_")
+        |> String.to_atom()
 
-      _ ->
-        {:error, :invalid_metadata}
+      Map.put(acc, key, value)
+    end)
+  end
+
+  defp required_values(metadata) do
+    slice = Map.take(metadata, @required_metadata_keys)
+    slice_keys = Map.keys(slice)
+
+    if Enum.sort(slice_keys) == @required_metadata_keys do
+      {:ok, slice}
+    else
+      {:error, :invalid_metadata}
     end
   end
 
-  defp metadata_value(metadata, key, default) when is_binary(key) do
-    case metadata_value(metadata, key) do
-      {:ok, metadata_item} ->
-        {:ok, metadata_item}
+  defp optional_values(metadata) do
+    defaults = Map.new(@optional_metadata_keys, fn x -> {x, nil} end)
 
-      {:error, :invalid_metadata} ->
-        {:ok, default}
-    end
+    slice = Map.take(metadata, @optional_metadata_keys)
+
+    Map.merge(defaults, slice)
   end
 end

--- a/lib/nerves_hub/fwup.ex
+++ b/lib/nerves_hub/fwup.ex
@@ -3,8 +3,6 @@ defmodule NervesHub.Fwup do
   Helpers for dealing with files created by FWUP.
   """
 
-  @metadata_regex Regex.compile!("meta-(?<key>[^\n]+)=\"(?<value>[^\n]+)\"")
-
   defmodule Metadata do
     @enforce_keys [:architecture, :platform, :product, :uuid, :version]
     defstruct [
@@ -46,7 +44,7 @@ defmodule NervesHub.Fwup do
   end
 
   defp parse_metadata(metadata) do
-    Regex.scan(@metadata_regex, metadata)
+    Regex.scan(~r/meta-(?<key>[^\n]+)=\"(?<value>[^\n]+)\"/, metadata)
     |> Enum.reduce(%{}, fn line, acc ->
       [_, key, value] = line
 

--- a/test/nerves_hub/fwup_test.exs
+++ b/test/nerves_hub/fwup_test.exs
@@ -1,0 +1,43 @@
+defmodule NervesHub.FwupTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Fwup
+  alias NervesHub.Fixtures
+
+  test "retrieves all fwup metadata" do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user)
+
+    filepath = Fixtures.firmware_file_fixture(org_key, product)
+
+    assert {:ok, metadata} = Fwup.metadata(filepath)
+
+    assert "1.0.0" == metadata[:version]
+    assert "D " == metadata[:description]
+    assert "valid product" == metadata[:product]
+    assert "me" == metadata[:author]
+    assert is_binary(metadata[:uuid])
+    assert "x86_64" == metadata[:architecture]
+    assert Map.has_key?(metadata, :vcs_identifier)
+    assert nil == metadata[:vcs_identifier]
+    assert Map.has_key?(metadata, :misc)
+    assert nil == metadata[:misc]
+  end
+
+  test "returns :invalid_metadata" do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user)
+
+    filepath = Fixtures.firmware_file_fixture(org_key, product, %{platform: nil})
+
+    assert {:error, :invalid_metadata} == Fwup.metadata(filepath)
+  end
+
+  test "returns :invalid_fwup_file" do
+    assert {:error, :invalid_fwup_file} == Fwup.metadata("/bob")
+  end
+end

--- a/test/nerves_hub/fwup_test.exs
+++ b/test/nerves_hub/fwup_test.exs
@@ -2,37 +2,36 @@ defmodule NervesHub.FwupTest do
   use NervesHub.DataCase, async: true
 
   alias NervesHub.Fwup
+  alias NervesHub.Support.Fwup, as: SupportFwup
   alias NervesHub.Fixtures
 
-  test "retrieves all fwup metadata" do
+  test "retrieves all fwup metadata", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     org = Fixtures.org_fixture(user)
     product = Fixtures.product_fixture(user, org)
-    org_key = Fixtures.org_key_fixture(org, user)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
 
-    filepath = Fixtures.firmware_file_fixture(org_key, product)
+    filepath = Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir})
 
     assert {:ok, metadata} = Fwup.metadata(filepath)
 
-    assert "1.0.0" == metadata[:version]
-    assert "D " == metadata[:description]
-    assert "valid product" == metadata[:product]
-    assert "me" == metadata[:author]
-    assert is_binary(metadata[:uuid])
-    assert "x86_64" == metadata[:architecture]
-    assert Map.has_key?(metadata, :vcs_identifier)
-    assert nil == metadata[:vcs_identifier]
-    assert Map.has_key?(metadata, :misc)
-    assert nil == metadata[:misc]
+    assert "1.0.0" == metadata.version
+    assert "D " == metadata.description
+    assert "valid product" == metadata.product
+    assert "me" == metadata.author
+    assert is_binary(metadata.uuid)
+    assert "x86_64" == metadata.architecture
+    assert nil == metadata.vcs_identifier
+    assert nil == metadata.misc
   end
 
-  test "returns :invalid_metadata" do
+  test "returns :invalid_metadata", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     org = Fixtures.org_fixture(user)
-    product = Fixtures.product_fixture(user, org)
-    org_key = Fixtures.org_key_fixture(org, user)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
 
-    filepath = Fixtures.firmware_file_fixture(org_key, product, %{platform: nil})
+    SupportFwup.create_firmware_with_invalid_metadata(tmp_dir, "unsigned")
+    {:ok, filepath} = SupportFwup.sign_firmware(tmp_dir, org_key.name, "unsigned", "signed")
 
     assert {:error, :invalid_metadata} == Fwup.metadata(filepath)
   end


### PR DESCRIPTION
This is for @fhunleth 

I removed the multiple Regex compiles and named captures and switched to a single compile and single run.

I also removed duplicated code in `Firmwares` which was doing the exact same thing, line for line.

And added tests.