### PR TITLE
Remove `Application.load/1` in migrations

### DIFF
--- a/lib/nerves_hub/release/tasks.ex
+++ b/lib/nerves_hub/release/tasks.ex
@@ -8,8 +8,6 @@ defmodule NervesHub.Release.Tasks do
   ]
 
   def migrate() do
-    :ok = Application.load(@app)
-
     for repo <- Application.fetch_env!(@app, :ecto_repos) do
       {:ok, _, _} = Migrator.with_repo(repo, &Migrator.run(&1, :up, all: true), @migrate_opts)
     end
@@ -21,13 +19,10 @@ defmodule NervesHub.Release.Tasks do
   end
 
   def rollback(repo \\ NervesHub.Repo, version) do
-    :ok = Application.load(@app)
     {:ok, _, _} = Migrator.with_repo(repo, &Migrator.run(&1, :down, to: version), @migrate_opts)
   end
 
   def seed() do
-    :ok = Application.load(@app)
-
     with priv_path when is_list(priv_path) or is_binary(priv_path) <- :code.priv_dir(@app),
          seed_script = Path.join(priv_path, "repo/seeds.exs"),
          true <- File.exists?(seed_script),


### PR DESCRIPTION
We're running in a release and the match added for `Application.load`
will fail with `{:error, {:already_loaded, :nerves_hub}}` causing
migrations to fail.