### PR TITLE
Don't send `:health_check` on device connect

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -99,8 +99,10 @@ defmodule NervesHubWeb.DeviceChannel do
 
     send(self(), :boot)
 
-    send(self(), :health_check)
-    schedule_health_check()
+    if device_health_check_enabled?() do
+      send(self(), :health_check)
+      schedule_health_check()
+    end
 
     {:noreply, socket}
   end


### PR DESCRIPTION
Devices with older NervesHubLink versions will crash because it doesn't know what a `check_health` message is and doesn't have the catch all. If the NervesHub instance has the feature disabled it will still send a message because this call was not checked for application config. If the instance does have it enabled then it will be scheduled and can start collecting health metrics as expected.