### PR TITLE
Remove `last_communication` and allow more migration control

### DIFF
--- a/lib/nerves_hub/release/tasks.ex
+++ b/lib/nerves_hub/release/tasks.ex
@@ -7,14 +7,25 @@ defmodule NervesHub.Release.Tasks do
     start_apps_before_migration: [:logger, :ssl, :postgrex, :ecto_sql]
   ]
 
-  def migrate() do
+  @doc """
+  Run the Ecto.Migrator for each defined repo
+
+  You can optionally pass options supported Ecto.Migrator.run/3 for each
+  repo in order to control the migration a bit more, like for specifying
+  a migration to stop at:
+
+    migrate([{NervesHub.Repo, [to: 20240806112233]}])
+  """
+  @spec migrate([{Ecto.Repo.t(), keyword()}]) :: [{:ok, [integer()], [atom()]} | {:error, term()}]
+  def migrate(opts \\ []) do
     for repo <- Application.fetch_env!(@app, :ecto_repos) do
-      {:ok, _, _} = Migrator.with_repo(repo, &Migrator.run(&1, :up, all: true), @migrate_opts)
+      run_opts = opts[repo] || [all: true]
+      {:ok, _, _} = Migrator.with_repo(repo, &Migrator.run(&1, :up, run_opts), @migrate_opts)
     end
   end
 
-  def migrate_and_seed() do
-    _ = migrate()
+  def migrate_and_seed(opts \\ []) do
+    _ = migrate(opts)
     seed()
   end
 

--- a/priv/repo/migrations/20240711034640_remove_last_communication_from_devices.exs
+++ b/priv/repo/migrations/20240711034640_remove_last_communication_from_devices.exs
@@ -1,0 +1,24 @@
+defmodule NervesHub.Repo.Migrations.RemoveLastCommunicationFromDevices do
+  use Ecto.Migration
+
+  # Since this removes a column, it should typically be applied in a separate
+  # deploy for multi-node setups in order to prevent errors between old nodes
+  # going down and new ones coming up.
+  #
+  # See https://fly.io/phoenix-files/migration-recipes/#removing-a-column
+  #
+  # You can accomplish this in releases with:
+  #   Nerves.Release.Tasks.migrate([{NervesHub.Repo, [to_exclusive: 20240711034640]}])
+
+  def up do
+    alter table(:devices) do
+      remove_if_exists :last_communication, :utc_datetime
+    end
+  end
+
+  def down do
+    alter table(:devices) do
+      add_if_not_exists :last_communication, :utc_datetime
+    end
+  end
+end


### PR DESCRIPTION
Adding the migration for removing `last_communication` which was included in https://github.com/nerves-hub/nerves_hub_web/pull/1386 and then removed by https://github.com/nerves-hub/nerves_hub_web/pull/1441 in order to support deploying the removal in a separate step following the guide in https://fly.io/phoenix-files/migration-recipes/#removing-a-column

This also adds more migration control for others using the mix release so that they can step through whatever migration versions needed, whether via commit isolation or manually utilizing the migration task.

This can be separated into 2 PRs, but they seemed related enough to review together