### PR TITLE
Safe access when checking uuids in `Devices.firmware_status/1`

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1272,7 +1272,7 @@ defmodule NervesHub.Devices do
       is_nil(device.deployment_id) ->
         "latest"
 
-      device.firmware_metadata.uuid == device.deployment.firmware.uuid ->
+      get_in(device.firmware_metadata.uuid) == get_in(device.deployment.firmware.uuid) ->
         "latest"
 
       !Enum.empty?(device.update_attempts) ->

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -879,6 +879,17 @@ defmodule NervesHub.DevicesTest do
 
       assert Devices.firmware_status(device) == "pending"
     end
+
+    test "safe against missing metadata", %{device: device} do
+      # This is mostly for race conditions between finishing the DB write
+      # of related firmware metadata or deployment update and reading the
+      # record back in with a firmware_status (i.e via API request)
+      # In those rare cases we might have missing data and need to be able to
+      # handle it
+      missing_meta_device = %{device | deployment: nil, firmware_metadata: nil}
+
+      assert Devices.firmware_status(missing_meta_device) == "latest"
+    end
   end
 
   describe "inflight updates" do


### PR DESCRIPTION
This is mostly for race conditions between finishing the DB write of related firmware metadata or deployment update and reading the record back in with a firmware_status (i.e via API request) In those rare cases we might have missing data and need to be able to handle it

Discovered when hitting production with a series of API updates followed by reads