### PR TITLE
Scripts should use a text area

### DIFF
--- a/lib/nerves_hub_web/live/support_scripts/edit.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/edit.html.heex
@@ -9,7 +9,7 @@
 
   <div class="form-group">
     <label for="text_input">Script text</label>
-    <%= text_input(f, :text, class: "form-control", id: "text_input") %>
+    <%= textarea(f, :text, rows: 5, class: "form-control", id: "text_input") %>
     <div class="has-error"><%= error_tag(f, :text) %></div>
   </div>
 

--- a/lib/nerves_hub_web/live/support_scripts/new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/new.html.heex
@@ -9,7 +9,7 @@
 
   <div class="form-group">
     <label for="text_input">Script text</label>
-    <%= text_input(f, :text, class: "form-control", id: "text_input") %>
+    <%= textarea(f, :text, rows: 5, class: "form-control", id: "text_input") %>
     <div class="has-error"><%= error_tag(f, :text) %></div>
   </div>
 


### PR DESCRIPTION
Since scripts can include line breaks the new/edit forms should use textareas to allow for easy editing.