### PR TITLE
Add device extensions support

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -25,9 +25,6 @@ config :nerves_hub,
     username: System.get_env("ADMIN_AUTH_USERNAME"),
     password: System.get_env("ADMIN_AUTH_PASSWORD")
   ],
-  device_health_check_enabled: System.get_env("DEVICE_HEALTH_CHECK_ENABLED", "true") == "true",
-  device_health_check_interval_minutes:
-    String.to_integer(System.get_env("DEVICE_HEALTH_CHECK_INTERVAL_MINUTES", "60")),
   device_health_days_to_retain:
     String.to_integer(System.get_env("HEALTH_CHECK_DAYS_TO_RETAIN", "7")),
   device_deployment_change_jitter_seconds:
@@ -37,7 +34,18 @@ config :nerves_hub,
   deployment_calculator_interval_seconds:
     String.to_integer(System.get_env("DEPLOYMENT_CALCULATOR_INTERVAL_SECONDS", "3600")),
   mapbox_access_token: System.get_env("MAPBOX_ACCESS_TOKEN"),
-  dashboard_enabled: System.get_env("DASHBOARD_ENABLED", "false") == "true"
+  dashboard_enabled: System.get_env("DASHBOARD_ENABLED", "false") == "true",
+  extension_config: [
+    geo: [
+      # No interval, fetch geo on device connection by default
+      interval_minutes:
+        System.get_env("FEATURES_GEO_INTERVAL_MINUTES", "0") |> String.to_integer()
+    ],
+    health: [
+      interval_minutes:
+        System.get_env("FEATURES_HEALTH_INTERVAL_MINUTES", "60") |> String.to_integer()
+    ]
+  ]
 
 config :nerves_hub, :device_socket_drainer,
   batch_size: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_SIZE", "1000")),

--- a/config/test.exs
+++ b/config/test.exs
@@ -87,6 +87,8 @@ config :nerves_hub, NervesHub.SwooshMailer, adapter: Swoosh.Adapters.Test
 
 config :nerves_hub, NervesHub.RateLimit, limit: 100
 
+config :sentry, environment_name: :test
+
 config :phoenix_test, :endpoint, NervesHubWeb.Endpoint
 
 # Initialize plugs at runtime for faster test compilation

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1394,4 +1394,45 @@ defmodule NervesHub.Devices do
         "pending"
     end
   end
+
+  def enable_extension_setting(%Device{} = device, extension_string) do
+    device = get_device(device.id)
+
+    Device.changeset(device, %{"extensions" => %{extension_string => true}})
+    |> Repo.update()
+    |> tap(fn
+      {:ok, _} ->
+        topic = "device:#{device.id}:extensions"
+
+        NervesHubWeb.DeviceEndpoint.broadcast(topic, "attach", %{
+          "extensions" => [extension_string]
+        })
+
+      _ ->
+        :nope
+    end)
+  end
+
+  def disable_extension_setting(%Device{} = device, extension_string) do
+    device = get_device(device.id)
+
+    Device.changeset(device, %{"extensions" => %{extension_string => false}})
+    |> Repo.update()
+    |> tap(fn
+      {:ok, _} ->
+        topic = "device:#{device.id}:extensions"
+
+        NervesHubWeb.DeviceEndpoint.broadcast(topic, "detach", %{
+          "extensions" => [extension_string]
+        })
+
+      _ ->
+        :nope
+    end)
+  end
+
+  def preload_product(%Device{} = device) do
+    device
+    |> Repo.preload(:product)
+  end
 end

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Devices.Device do
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Deployments.Deployment
+  alias NervesHub.Extensions.ExtensionsSetting
   alias NervesHub.Firmwares.FirmwareMetadata
   alias NervesHub.Products.Product
 
@@ -71,12 +72,14 @@ defmodule NervesHub.Devices.Device do
     field(:connection_established_at, :utc_datetime)
     field(:connection_disconnected_at, :utc_datetime)
     field(:connection_last_seen_at, :utc_datetime)
+    embeds_one(:extensions, ExtensionsSetting, on_replace: :update)
   end
 
   def changeset(%Device{} = device, params) do
     device
     |> cast(params, @required_params ++ @optional_params)
     |> cast_embed(:firmware_metadata)
+    |> cast_embed(:extensions)
     |> validate_required(@required_params)
     |> validate_length(:tags, min: 1)
     |> unique_constraint(:identifier)

--- a/lib/nerves_hub/devices/metrics.ex
+++ b/lib/nerves_hub/devices/metrics.ex
@@ -6,6 +6,7 @@ defmodule NervesHub.Devices.Metrics do
 
   @default_metric_types [
     :cpu_temp,
+    :cpu_usage_percent,
     :load_15min,
     :load_1min,
     :load_5min,

--- a/lib/nerves_hub/extensions.ex
+++ b/lib/nerves_hub/extensions.ex
@@ -1,0 +1,68 @@
+defmodule NervesHub.Extensions do
+  @moduledoc """
+  An "extension" is an additional piece of functionality that we add onto the
+  existing connection between the device and the NervesHub service. They are
+  designed to be less important than firmware updates and requires both client
+  to report support and the server to enable support.
+
+  This is intended to ensure that:
+
+  - The service decides when activity should be taken by the device meaning
+    the fleet of devices will not inadvertently swarm the service with data.
+  - The service can turn off extensions in various ways to ensure that disruptive
+    extensions stop being enabled on subsequent connections.
+  - Use of extensions should have very little chance to disrupt the flow of a
+    critical firmware update.
+  """
+
+  @callback handle_in(event :: String.t(), Phoenix.Channel.payload(), Phoenix.Socket.t()) ::
+              {:noreply, Phoenix.Socket.t()}
+              | {:noreply, Phoenix.Socket.t(), timeout() | :hibernate}
+              | {:reply, Phoenix.Channel.reply(), Phoenix.Socket.t()}
+              | {:stop, reason :: term(), Phoenix.Socket.t()}
+              | {:stop, reason :: term(), Phoenix.Channel.reply(), Phoenix.Socket.t()}
+
+  @callback handle_info(msg :: term(), Phoenix.Socket.t()) ::
+              {:noreply, Phoenix.Socket.t()} | {:stop, reason :: term(), Phoenix.Socket.t()}
+
+  @callback attach(Phoenix.Socket.t()) :: {:noreply, Phoenix.Socket.t()}
+  @callback detach(Phoenix.Socket.t()) :: {:noreply, Phoenix.Socket.t()}
+  @callback description() :: String.t()
+
+  require Logger
+
+  @supported_extensions [:health, :geo]
+  @type extension() :: :health | :geo
+
+  @doc """
+  Get list of supported extensions as atoms with descriptive text.
+  """
+  @spec list() :: list(extension())
+  def list do
+    @supported_extensions
+  end
+
+  @spec module(extension()) :: module() | :unsupported
+  def module(:health), do: NervesHub.Extensions.Health
+  def module(:geo), do: NervesHub.Extensions.Geo
+  def module(_key), do: :unsupported
+
+  @spec module(extension(), String.t()) :: module() | :unsupported
+  def module(:health, ver) do
+    cond do
+      Version.match?(ver, "~> 0.0.1") -> NervesHub.Extensions.Health
+      true -> :unsupported
+    end
+  end
+
+  def module(:geo, ver) do
+    cond do
+      Version.match?(ver, "~> 0.0.1") -> NervesHub.Extensions.Geo
+      true -> :unsupported
+    end
+  end
+
+  def module(_key, _ver) do
+    :unsupported
+  end
+end

--- a/lib/nerves_hub/extensions/extensions_setting.ex
+++ b/lib/nerves_hub/extensions/extensions_setting.ex
@@ -1,0 +1,15 @@
+defmodule NervesHub.Extensions.ExtensionsSetting do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    field(:health, :boolean, default: nil)
+    field(:geo, :boolean, default: nil)
+  end
+
+  def changeset(setting, params) do
+    setting
+    |> cast(params, [:health, :geo])
+  end
+end

--- a/lib/nerves_hub/extensions/geo.ex
+++ b/lib/nerves_hub/extensions/geo.ex
@@ -1,0 +1,65 @@
+defmodule NervesHub.Extensions.Geo do
+  @behaviour NervesHub.Extensions
+
+  alias NervesHub.Devices
+
+  @impl NervesHub.Extensions
+  def description do
+    """
+    Reporting of GeoIP information or custom geo-location information sources
+    you've set up for your device.
+    """
+  end
+
+  @impl NervesHub.Extensions
+  def attach(socket) do
+    extension_config = Application.get_env(:nerves_hub, :extension_config)
+    geo_interval = get_in(extension_config, [:geo, :interval_minutes]) || 0
+
+    send(self(), {__MODULE__, :location_request})
+
+    socket =
+      if geo_interval > 0 do
+        timer =
+          geo_interval
+          |> :timer.minutes()
+          |> :timer.send_interval({__MODULE__, :location_request})
+
+        socket
+        |> Phoenix.Socket.assign(:geo_timer, timer)
+        |> Phoenix.Socket.assign(:geo_interval, geo_interval)
+      else
+        socket
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl NervesHub.Extensions
+  def detach(socket) do
+    _ = if socket.assigns[:geo_timer], do: :timer.cancel(socket.assigns.geo_timer)
+    {:noreply, Phoenix.Socket.assign(socket, :geo_timer, nil)}
+  end
+
+  @impl NervesHub.Extensions
+  def handle_in("location:update", location, %{assigns: %{device: device}} = socket) do
+    metadata = Map.put(device.connection_metadata, "location", location)
+
+    {:ok, device} = Devices.update_device(device, %{connection_metadata: metadata})
+
+    _ =
+      NervesHubWeb.DeviceEndpoint.broadcast(
+        "device:#{device.identifier}:internal",
+        "location:updated",
+        location
+      )
+
+    {:noreply, Phoenix.Socket.assign(socket, :device, device)}
+  end
+
+  @impl NervesHub.Extensions
+  def handle_info(:location_request, socket) do
+    Phoenix.Channel.push(socket, "geo:location:request", %{})
+    {:noreply, socket}
+  end
+end

--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -1,0 +1,115 @@
+defmodule NervesHub.Extensions.Health do
+  @behaviour NervesHub.Extensions
+
+  alias NervesHub.Devices
+  alias NervesHub.Devices.Metrics
+
+  require Logger
+
+  @impl NervesHub.Extensions
+  def description do
+    """
+    Reporting of fundamental device metrics, metadata, alarms and more.
+    Also supports custom metrics. Alarms require an alarm handler to be set.
+    """
+  end
+
+  @impl NervesHub.Extensions
+  def attach(socket) do
+    extension_config = Application.get_env(:nerves_hub, :extension_config, [])
+
+    health_interval =
+      case get_in(extension_config, [:health, :interval_minutes]) do
+        i when is_integer(i) and i > 0 -> i
+        _ -> 60
+      end
+
+    send(self(), {__MODULE__, :check})
+
+    socket =
+      if health_interval > 0 do
+        timer =
+          health_interval
+          |> :timer.minutes()
+          |> :timer.send_interval({__MODULE__, :check})
+
+        socket
+        |> Phoenix.Socket.assign(:health_interval, health_interval)
+        |> Phoenix.Socket.assign(:health_timer, timer)
+      else
+        socket
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl NervesHub.Extensions
+  def detach(socket) do
+    _ = if socket.assigns[:health_timer], do: :timer.cancel(socket.assigns.health_timer)
+    {:noreply, Phoenix.Socket.assign(socket, :health_timer, nil)}
+  end
+
+  @impl NervesHub.Extensions
+  def handle_in("report", %{"value" => device_status}, socket) do
+    device_meta =
+      for {key, val} <- Map.from_struct(socket.assigns.device.firmware_metadata),
+          into: %{},
+          do: {to_string(key), to_string(val)}
+
+    # Separate metrics from health report to store in metrics table
+    metrics = device_status["metrics"]
+
+    health_report =
+      device_status
+      |> Map.delete("metrics")
+      |> Map.put("metadata", Map.merge(device_status["metadata"], device_meta))
+
+    device_health = %{"device_id" => socket.assigns.device.id, "data" => health_report}
+
+    with {:health_report, {:ok, _}} <-
+           {:health_report, Devices.save_device_health(device_health)},
+         {:metrics_report, {count, _}} when count >= 0 <-
+           {:metrics_report, Metrics.save_metrics(socket.assigns.device.id, metrics)} do
+      device_internal_broadcast!(socket.assigns.device, "health_check_report", %{})
+    else
+      {:health_report, {:error, err}} ->
+        Logger.warning("Failed to save health check data: #{inspect(err)}")
+        log_to_sentry(socket.assigns.device, "[DeviceChannel] Failed to save health check data.")
+
+      {:metrics_report, {:error, err}} ->
+        Logger.warning("Failed to save metrics: #{inspect(err)}")
+        log_to_sentry(socket.assigns.device, "[DeviceChannel] Failed to save metrics.")
+    end
+
+    {:noreply, socket}
+  end
+
+  @impl NervesHub.Extensions
+  def handle_info(:check, socket) do
+    Phoenix.Channel.push(socket, "health:check", %{})
+    {:noreply, socket}
+  end
+
+  defp device_internal_broadcast!(device, event, payload) do
+    topic = "device:#{device.identifier}:extensions"
+    NervesHubWeb.DeviceEndpoint.broadcast_from!(self(), topic, event, payload)
+  end
+
+  defp log_to_sentry(device, msg_or_ex, extra \\ %{}) do
+    Sentry.Context.set_tags_context(%{
+      device_identifier: device.identifier,
+      device_id: device.id,
+      product_id: device.product_id,
+      org_id: device.org_id
+    })
+
+    _ =
+      if is_exception(msg_or_ex) do
+        Sentry.capture_exception(msg_or_ex, extra: extra, result: :none)
+      else
+        Sentry.capture_message(msg_or_ex, extra: extra, result: :none)
+      end
+
+    :ok
+  end
+end

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -269,4 +269,40 @@ defmodule NervesHub.Products do
       end
     end
   end
+
+  def enable_extension_setting(%Product{} = product, extension_string) do
+    product = get_product!(product.id)
+
+    Product.changeset(product, %{"extensions" => %{extension_string => true}})
+    |> Repo.update()
+    |> tap(fn
+      {:ok, _} ->
+        topic = "product:#{product.id}:extensions"
+
+        NervesHubWeb.DeviceEndpoint.broadcast(topic, "attach", %{
+          "extensions" => [extension_string]
+        })
+
+      _ ->
+        :nope
+    end)
+  end
+
+  def disable_extension_setting(%Product{} = product, extension_string) do
+    product = get_product!(product.id)
+
+    Product.changeset(product, %{"extensions" => %{extension_string => false}})
+    |> Repo.update()
+    |> tap(fn
+      {:ok, _} ->
+        topic = "product:#{product.id}:extensions"
+
+        NervesHubWeb.DeviceEndpoint.broadcast(topic, "detach", %{
+          "extensions" => [extension_string]
+        })
+
+      _ ->
+        :nope
+    end)
+  end
 end

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Products.Product do
   alias NervesHub.Scripts.Script
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
+  alias NervesHub.Extensions.ExtensionsSetting
   alias NervesHub.Firmwares.Firmware
   alias NervesHub.Products.SharedSecretAuth
 
@@ -31,6 +32,7 @@ defmodule NervesHub.Products.Product do
     field(:name, :string)
     field(:deleted_at, :utc_datetime)
     field(:delta_updatable, :boolean, default: false)
+    embeds_one(:extensions, ExtensionsSetting, on_replace: :update)
 
     timestamps()
   end
@@ -44,6 +46,7 @@ defmodule NervesHub.Products.Product do
   def changeset(product, params) do
     product
     |> cast(params, @required_params ++ @optional_params)
+    |> cast_embed(:extensions)
     |> update_change(:name, &trim/1)
     |> validate_required(@required_params)
     |> unique_constraint(:name, name: :products_org_id_name_index)

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -1,0 +1,134 @@
+defmodule NervesHubWeb.ExtensionsChannel do
+  use Phoenix.Channel
+
+  alias NervesHub.Extensions
+  alias Phoenix.Socket.Broadcast
+
+  require Logger
+
+  @impl Phoenix.Channel
+  def join("extensions", extension_versions, socket) do
+    extensions = parse_extensions(socket.assigns.device, extension_versions)
+    socket = assign(socket, :extensions, extensions)
+
+    attach_list = for {key, %{attach?: true}} <- extensions, do: key
+
+    if length(attach_list) > 0 do
+      send(self(), :init_extensions)
+    end
+
+    topic = "device:#{socket.assigns.device.id}:extensions"
+    NervesHubWeb.DeviceEndpoint.subscribe(topic)
+
+    {:ok, attach_list, socket}
+  end
+
+  defp parse_extensions(
+         %{extensions: device_extensions, product: %{extensions: product_extensions}},
+         extension_versions
+       ) do
+    allowed_extensions =
+      for {extension, true} <- Map.from_struct(product_extensions),
+          {^extension, device_enabled?} <- Map.from_struct(device_extensions),
+          device_enabled? != false,
+          do: extension
+
+    for {key_str, version} <- extension_versions, into: %{} do
+      meta =
+        case Version.parse(version) do
+          {:ok, ver} ->
+            extension = Enum.find(allowed_extensions, &(to_string(&1) == key_str))
+
+            if extension do
+              mod = Extensions.module(extension, ver)
+              %{attach?: Code.ensure_loaded?(mod), version: ver, module: mod, status: :detached}
+            else
+              %{attach?: false, version: version, module: nil, status: :detached}
+            end
+
+          _ ->
+            %{attach?: false, version: version, module: nil, status: :detached}
+        end
+
+      {key_str, meta}
+    end
+  end
+
+  @impl Phoenix.Channel
+  def handle_in(scoped_event, payload, socket) do
+    with [key, event] <- String.split(scoped_event, ":", parts: 2),
+         %{attach?: true, module: mod} <- socket.assigns.extensions[key] do
+      case event do
+        "attached" ->
+          update_in(socket.assigns.extensions[key], &%{&1 | status: :attached})
+          |> mod.attach()
+
+        "detached" ->
+          update_in(socket.assigns.extensions[key], &%{&1 | status: :detached})
+          |> mod.detach()
+
+        "error" ->
+          socket = update_in(socket.assigns.extensions[key], &%{&1 | status: :detached})
+          safe_handle_in(mod, event, payload, socket)
+
+        event ->
+          safe_handle_in(mod, event, payload, socket)
+      end
+    else
+      _ ->
+        # Unknown extension, tell device to detach it
+        {:reply, {:error, "detach"}, socket}
+    end
+  end
+
+  defp safe_handle_in(mod, event, payload, socket) do
+    mod.handle_in(event, payload, socket)
+  rescue
+    error ->
+      Logger.warning("#{inspect(mod)} failed to handle extension message - #{inspect(error)}")
+      log_to_sentry(socket.assigns.device, error)
+      {:noreply, socket}
+  end
+
+  @impl Phoenix.Channel
+  def handle_info(:init_extensions, socket) do
+    topic = "product:#{socket.assigns.device.product.id}:extensions"
+    NervesHubWeb.DeviceEndpoint.subscribe(topic)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(%Broadcast{event: event, payload: payload}, socket) do
+    push(socket, event, payload)
+    {:noreply, socket}
+  end
+
+  def handle_info({mod, msg}, socket) do
+    mod.handle_info(msg, socket)
+  rescue
+    error ->
+      Logger.warning("#{inspect(mod)} failed handle_info - #{inspect(error)}")
+      log_to_sentry(socket.assigns.device, error)
+      {:noreply, socket}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp log_to_sentry(device, msg_or_ex, extra \\ %{}) do
+    Sentry.Context.set_tags_context(%{
+      device_identifier: device.identifier,
+      device_id: device.id,
+      product_id: device.product_id,
+      org_id: device.org_id
+    })
+
+    _ =
+      if is_exception(msg_or_ex) do
+        Sentry.capture_exception(msg_or_ex, extra: extra, result: :none)
+      else
+        Sentry.capture_message(msg_or_ex, extra: extra, result: :none)
+      end
+
+    :ok
+  end
+end

--- a/lib/nerves_hub_web/components/utils.ex
+++ b/lib/nerves_hub_web/components/utils.ex
@@ -30,6 +30,14 @@ defmodule NervesHubWeb.Components.Utils do
     end
   end
 
+  def cpu_usage_percent_to_status(usage) do
+    case usage do
+      usage when usage < 80 -> ""
+      usage when usage < 90 -> "warn"
+      _ -> "danger"
+    end
+  end
+
   def memory_to_status(percent) do
     case percent do
       _ when percent > 80 -> "warn"

--- a/lib/nerves_hub_web/live/devices/settings.html.heex
+++ b/lib/nerves_hub_web/live/devices/settings.html.heex
@@ -66,6 +66,48 @@
 <div class="border-bottom border-dark mt-6 mb-4"></div>
 
 <div class="device-header-group">
+  <h3 class="mb-2">Extensions</h3>
+</div>
+
+<table :if={Enum.any?(@available_extensions)} class="table table-sm table-hover">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tr :for={{key, description} <- @available_extensions} class="item">
+    <td>
+      <input
+        id={"extension-#{key}"}
+        name={key}
+        type="checkbox"
+        class="checkbox"
+        disabled={Map.get(@device.product.extensions, key) != true}
+        checked={Map.get(@device.extensions, key, false) == true}
+        phx-click="update-extension"
+        phx-value-extension={key}
+        disabled={!authorized?(:"device:update", @org_user)}
+      />
+    </td>
+    <td class="ff-m">
+      <div class="mobile-label help-text">Name</div>
+      <%= key %>
+    </td>
+    <td>
+      <div class="mobile-label help-text">Description</div>
+      <p :if={Map.get(@device.product.extensions, key) != true}>
+        Extension is disabled at the product level.
+      </p>
+      <p><%= description %></p>
+    </td>
+  </tr>
+</table>
+
+<div class="border-bottom border-dark mt-6 mb-4"></div>
+
+<div class="device-header-group">
   <h3 class="mb-2">Certificates</h3>
   <%= if @toggle_upload do %>
     <button class="btn btn-primary" type="button" phx-click="toggle-upload" phx-value-toggle={to_string(@toggle_upload)}>
@@ -102,7 +144,7 @@
     </div>
   </div>
 <% end %>
-<table class="table table-sm table-hover">
+<table class="table table-sm table-hover certificates">
   <thead>
     <tr>
       <th>Serial</th>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -26,6 +26,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     if connected?(socket) do
       socket.endpoint.subscribe("device:#{device.identifier}:internal")
       socket.endpoint.subscribe("device:console:#{device.id}:internal")
+      socket.endpoint.subscribe("device:#{device.identifier}:extensions")
       socket.endpoint.subscribe("firmware")
     end
 

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -142,17 +142,39 @@
               </div>
             <% end %>
 
+            <%= if @latest_metrics.cpu_usage_percent do %>
+              <div class={"callout #{Utils.cpu_usage_percent_to_status(@latest_metrics.cpu_usage_percent)}"}>
+                <div class="help-text label">CPU use</div>
+                <%= round(@latest_metrics.cpu_usage_percent) %>%
+              </div>
+            <% else %>
+              <div class="callout">
+                <div class="help-text label">CPU use</div>
+                Not reported
+              </div>
+            <% end %>
+
             <%= if @latest_metrics.cpu_temp do %>
               <div class={"callout #{Utils.cpu_temp_to_status(@latest_metrics.cpu_temp)}"}>
-                <div class="help-text label">CPU</div>
+                <div class="help-text label">CPU temp</div>
                 <%= round(@latest_metrics.cpu_temp) %>°
               </div>
             <% end %>
 
             <%= for {key, val} <- @latest_custom_metrics do %>
               <div class="callout">
-                <div class="help-text label"><%= String.capitalize(key) %></div>
-                <%= val %>
+                <div class="help-text label">
+                  <%= key
+                  |> String.replace("_", " ")
+                  |> String.capitalize() %>
+                </div>
+                <%= cond do
+                  is_float(val) ->
+                    Float.round(val, 3)
+
+                  true ->
+                    val
+                end %>
               </div>
             <% end %>
           </div>

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -129,9 +129,67 @@
     </button>
   </div>
 <% else %>
-  <p class="h5 text-white font-weight-bold">This feature hasn't been enabled for this server.</p>
+  <p class="h5 text-white font-weight-bold">This extension hasn't been enabled for this server.</p>
   <p class="h5 text-white font-weight-bold">Please contact your system admin.</p>
 <% end %>
+
+<div class="border-bottom border-dark mt-5 mb-2"></div>
+
+<div class="container pl-0 mb-2">
+  <div class="row align-items-center">
+    <div class="col col-6">
+      <h3>Device Extensions</h3>
+    </div>
+    <div class="col col-2">
+      <span class="badge bg-warning">Experimental</span>
+    </div>
+  </div>
+</div>
+
+<p class="p-small">
+  Isolated channels for various device behaviours and extension messaging not crucial to firmware updates<br /> but are useful for managing, monitoring, and introspecting on wide fleets of devices.
+</p>
+<p class="p-small">
+  When enabled, NervesHub will request the extensions a device currently supports and then<br /> check against product and device settings to see if the extension should be attached to the connection.
+</p>
+<p class="p-small mb-3">
+  Extensions most be allowed at the product level. They can also be configured at the device level for more<br /> granular control when needed.
+</p>
+
+<table :if={Enum.any?(@available_extensions)} class="table table-sm table-hover">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tr :for={{key, description} <- @available_extensions} class="item">
+    <td>
+      <input
+        type="checkbox"
+        id={"extension-#{key}"}
+        name={key}
+        checked={Map.get(@product.extensions, key, false)}
+        phx-value-extension={key}
+        phx-click="update-extension"
+        disabled={!authorized?(:"product:update", @org_user)}
+        data-confirm={"Are you sure you want to enable #{key} for #{@product.name}?"}
+      />
+    </td>
+    <td class="ff-m">
+      <div class="mobile-label help-text">Name</div>
+
+      <label for={"extension-#{key}"}>
+        <%= String.capitalize(to_string(key)) %>
+      </label>
+    </td>
+    <td>
+      <div class="mobile-label help-text">Description</div>
+      <%= description %>
+    </td>
+  </tr>
+</table>
 
 <div class="border-bottom border-dark mt-5 mb-2"></div>
 

--- a/priv/repo/migrations/20241111221626_add_extensions.exs
+++ b/priv/repo/migrations/20241111221626_add_extensions.exs
@@ -1,0 +1,12 @@
+defmodule NervesHub.Repo.Migrations.AddExtensions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:products) do
+      add :extensions, :map, null: false, default: %{}
+    end
+    alter table(:devices) do
+      add :extensions, :map, null: false, default: %{}
+    end
+  end
+end

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -1,0 +1,227 @@
+defmodule NervesHubWeb.ExtensionsChannelTest do
+  use NervesHubWeb.ChannelCase
+  use DefaultMocks
+
+  alias NervesHub.Products
+  alias NervesHub.Fixtures
+  alias NervesHubWeb.DeviceChannel
+  alias NervesHubWeb.DeviceSocket
+  alias NervesHubWeb.ExtensionsChannel
+
+  test "joining device channel works without understanding extensions" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, _} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+  end
+
+  test "joining extensions channel suggests attaching geo and health" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, attach_list, _} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
+               "geo" => "0.0.1",
+               "health" => "0.0.1"
+             })
+
+    assert "health" in attach_list
+    assert "geo" in attach_list
+  end
+
+  test "joining extensions channel with unknown extensions is fine" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, ["health"], _} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
+               "goof" => "0.0.1",
+               "health" => "0.0.1"
+             })
+  end
+
+  test "product with extensions disabled does not suggest attaching anything" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    product = Products.get_product!(device.product_id)
+    Products.disable_extension_setting(product, "health")
+    Products.disable_extension_setting(product, "geo")
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, [], _} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
+               "geo" => "0.0.1",
+               "health" => "0.0.1"
+             })
+  end
+
+  test "product with only health suggests only health" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    product = Products.get_product!(device.product_id)
+    Products.disable_extension_setting(product, "geo")
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, ["health"], _} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
+               "geo" => "0.0.1",
+               "health" => "0.0.1"
+             })
+  end
+
+  test "attached health extension will receive request for health report" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, ["health"], socket} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{"health" => "0.0.1"})
+
+    push(socket, "health:attached")
+    assert_push("health:check", _)
+  end
+
+  test "attached geo extension will receive request for location update" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, ["geo"], socket} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{"geo" => "0.0.1"})
+
+    push(socket, "geo:attached")
+    assert_push("geo:location:request", _)
+  end
+
+  test "attached extensions will receive detach events on disabling at product level" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, attach_list, socket} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
+               "geo" => "0.0.1",
+               "health" => "0.0.1"
+             })
+
+    assert "health" in attach_list
+    assert "geo" in attach_list
+    push(socket, "health:attached")
+    push(socket, "geo:attached")
+    assert_push("geo:location:request", _)
+    assert_push("health:check", _)
+    product = Products.get_product!(device.product_id)
+    Products.disable_extension_setting(product, "geo")
+    assert_push("detach", %{"extensions" => ["geo"]})
+    Products.disable_extension_setting(product, "health")
+    assert_push("detach", %{"extensions" => ["health"]})
+  end
+
+  test "disabled extensions can be re-attached" do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment} = device_fixture(user, %{identifier: "123"})
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} = subscribe_and_join(socket, DeviceChannel, "device")
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, attach_list, socket} =
+             subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
+               "geo" => "0.0.1",
+               "health" => "0.0.1"
+             })
+
+    assert "health" in attach_list
+    assert "geo" in attach_list
+    push(socket, "health:attached")
+    push(socket, "geo:attached")
+    assert_push("geo:location:request", _)
+    assert_push("health:check", _)
+    product = Products.get_product!(device.product_id)
+    Products.disable_extension_setting(product, "geo")
+    assert_push("detach", %{"extensions" => ["geo"]})
+    Products.disable_extension_setting(product, "health")
+    assert_push("detach", %{"extensions" => ["health"]})
+    Products.enable_extension_setting(product, "geo")
+    assert_push("attach", %{"extensions" => ["geo"]})
+    Products.enable_extension_setting(product, "health")
+    assert_push("attach", %{"extensions" => ["health"]})
+  end
+
+  def device_fixture(user, device_params \\ %{}, org \\ nil) do
+    org = org || Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user)
+
+    firmware =
+      Fixtures.firmware_fixture(org_key, product, %{
+        version: "0.0.1"
+      })
+
+    deployment = Fixtures.deployment_fixture(org, firmware)
+
+    params = Enum.into(device_params, %{tags: ["beta", "beta-edge"]})
+
+    device =
+      Fixtures.device_fixture(
+        org,
+        product,
+        firmware,
+        params
+      )
+
+    {device, firmware, deployment}
+  end
+end

--- a/test/nerves_hub_web/live/devices/settings_test.exs
+++ b/test/nerves_hub_web/live/devices/settings_test.exs
@@ -36,7 +36,7 @@ defmodule NervesHubWeb.Live.Devices.SettingsTest do
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settings")
       # Device has 1 certificate as default
-      |> assert_has(".item", count: 1)
+      |> assert_has(".certificates .item", count: 1)
       |> click_button("#toggle-certificate-upload", "")
       |> unwrap(fn view ->
         file_input(view, ".import-pem", :certificate, [
@@ -51,16 +51,16 @@ defmodule NervesHubWeb.Live.Devices.SettingsTest do
       end)
       |> assert_has("div", text: "Certificate Upload Successful")
       |> assert_path("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settings")
-      |> assert_has(".item", count: 2)
+      |> assert_has(".certificates .item", count: 2)
     end
 
     test "can delete certificate", %{conn: conn, org: org, product: product, device: device} do
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settings")
       # Device has 1 certificate as default
-      |> assert_has(".item", count: 1)
+      |> assert_has(".certificates .item", count: 1)
       |> click_link("Delete")
-      |> refute_has(".item")
+      |> refute_has(".certificates .item")
     end
 
     test "can download certificate", %{conn: conn, org: org, product: product, device: device} do
@@ -68,7 +68,7 @@ defmodule NervesHubWeb.Live.Devices.SettingsTest do
         conn
         |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settings")
         # Device has 1 certificate as default
-        |> assert_has(".item", count: 1)
+        |> assert_has(".certificates .item", count: 1)
         |> click_link("Download")
 
       assert result.conn.resp_body =~ "-----BEGIN CERTIFICATE-----"

--- a/test/nerves_hub_web/live/product/settings_test.exs
+++ b/test/nerves_hub_web/live/product/settings_test.exs
@@ -51,7 +51,7 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/settings")
-      |> assert_has("p", text: "This feature hasn't been enabled for this server.")
+      |> assert_has("p", text: "This extension hasn't been enabled for this server.")
     end
 
     test "add shared secret", %{conn: conn, org: org, user: user} do

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -24,6 +24,14 @@ defmodule NervesHubWeb.ChannelCase do
 
       # The default endpoint for testing
       @endpoint NervesHubWeb.DeviceEndpoint
+
+      def subscribe_device_internal(device) do
+        Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.identifier}:internal")
+      end
+
+      def subscribe_extensions(device) do
+        Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.identifier}:extensions")
+      end
     end
   end
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -27,8 +27,12 @@ defmodule NervesHub.Fixtures do
     },
     is_active: false
   }
-  @device_params %{tags: ["beta", "beta-edge"]}
-  @product_params %{name: "valid product", delta_updatable: true}
+  @device_params %{tags: ["beta", "beta-edge"], extensions: %{health: true, geo: true}}
+  @product_params %{
+    name: "valid product",
+    delta_updatable: true,
+    extensions: %{health: true, geo: true}
+  }
 
   defdelegate reload(record), to: Repo
 

--- a/test/support/socket_client.ex
+++ b/test/support/socket_client.ex
@@ -14,7 +14,7 @@ defmodule SocketClient do
   end
 
   def joined?(socket) do
-    GenServer.call(socket, :joined?)
+    GenServer.call(socket, :joined_device?)
   end
 
   def close(socket) do
@@ -27,6 +27,10 @@ defmodule SocketClient do
 
   def join_and_wait(socket, params \\ %{}) do
     GenServer.call(socket, {:join_and_wait, params})
+  end
+
+  def join_and_wait_extensions(socket, params \\ %{"geo" => "0.0.1", "health" => "0.0.1"}) do
+    GenServer.call(socket, {:join_and_wait_extensions, params})
   end
 
   def status(socket) do
@@ -107,7 +111,8 @@ defmodule SocketClient do
       new_socket()
       |> assign(:connected?, false)
       |> assign(:connecting?, true)
-      |> assign(:joined?, false)
+      |> assign(:joined_device?, false)
+      |> assign(:joined_extensions?, false)
       |> assign(:reply, nil)
       |> assign(:received_update?, false)
       |> assign(:update, nil)
@@ -132,16 +137,29 @@ defmodule SocketClient do
   end
 
   @impl true
-  def handle_join(_channel, reply, socket) do
+  def handle_join("device", reply, socket) do
     socket =
       socket
-      |> assign(:joined?, true)
+      |> assign(:joined_device?, true)
+      |> assign(:reply, reply)
+
+    {:ok, socket}
+  end
+
+  def handle_join("extensions", reply, socket) do
+    socket =
+      socket
+      |> assign(:joined_extensions?, true)
       |> assign(:reply, reply)
 
     {:ok, socket}
   end
 
   @impl true
+  def handle_message("device", "extensions:get", _message, socket) do
+    {:ok, socket}
+  end
+
   def handle_message("device", "update", message, socket) do
     socket =
       socket
@@ -160,7 +178,7 @@ defmodule SocketClient do
     {:ok, socket}
   end
 
-  def handle_message("device", "check_health", %{}, socket) do
+  def handle_message("extensions", "health:check", %{}, socket) do
     socket =
       socket
       |> assign(:receive_check_helth?, true)
@@ -177,8 +195,12 @@ defmodule SocketClient do
     {:reply, socket.assigns.connecting?, socket}
   end
 
-  def handle_call(:joined?, _from, socket) do
-    {:reply, socket.assigns.joined?, socket}
+  def handle_call(:joined_device?, _from, socket) do
+    {:reply, socket.assigns.joined_device?, socket}
+  end
+
+  def handle_call(:joined_extensions?, _from, socket) do
+    {:reply, socket.assigns.joined_extensions?, socket}
   end
 
   def handle_call(:received_archive?, _from, socket) do
@@ -202,11 +224,20 @@ defmodule SocketClient do
     {:reply, socket.assigns.reply, socket}
   end
 
-  def handle_call({:join, channel, params}, _from, socket) do
+  def handle_call({:join, "device", params}, _from, socket) do
     socket =
       socket
-      |> assign(:joined?, false)
-      |> Slipstream.join(channel, params)
+      |> assign(:joined_device?, false)
+      |> Slipstream.join("device", params)
+
+    {:reply, :ok, socket}
+  end
+
+  def handle_call({:join, "extensions", params}, _from, socket) do
+    socket =
+      socket
+      |> assign(:joined_extensions?, false)
+      |> Slipstream.join("extensions", params)
 
     {:reply, :ok, socket}
   end
@@ -218,7 +249,20 @@ defmodule SocketClient do
       |> join("device", params)
       |> await_join!("device")
       |> assign(:connected?, true)
-      |> assign(:joined?, true)
+      |> assign(:joined_device?, true)
+      |> assign(:reply, %{})
+
+    {:reply, :ok, socket}
+  end
+
+  def handle_call({:join_and_wait_extensions, params}, _from, socket) do
+    socket =
+      socket
+      |> await_connect!()
+      |> join("extensions", params)
+      |> await_join!("extensions")
+      |> assign(:connected?, true)
+      |> assign(:joined_extensions?, true)
       |> assign(:reply, %{})
 
     {:reply, :ok, socket}


### PR DESCRIPTION
Start of device extensions which allow for specialized functionality on device to report data and interactions safely outside the update mechanism.

Requires https://github.com/nerves-hub/nerves_hub_link/pull/228

Based on conversations the last while, these are some of the core design decisions so far:
* NervesHub selectively tells a device what extensions to enable
* Extensions are off by default on device
* Extensions should have no affect on socket connectivity or ability to update a device

With that in mind, this is the basic communication cycle for supporting extensions on device.

```mermaid
sequenceDiagram
    participant Device as Device (NHL)
    participant NH as NervesHub

    Device ->> NH: Connect
    NH ->> NH: Check `extensions_allowed?`
    NH ->> Device: Send "extensions:get"
    Device ->> NH: Join "extensions" channel with [%{<extension> => <version>}]
    NH ->> NH: Determine extensions to enable based on report
    NH ->> Device: Send "extensions:enable" to with list of extensions to enable

    loop For each extension to enable
        Device ->> NH: Report "<extension_name>:<event>" where event is enabled or error
    end
```

TODO: All the bits to selectively decide what extensions can be enabled for a device