### PR TITLE
Add devices filter to list untagged devices

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -170,6 +170,13 @@ defmodule NervesHub.Devices do
             {:error, _} ->
               query
           end
+
+        {:has_no_tags, value} ->
+          if value do
+            where(query, [d], fragment("array_length(?, 1) = 0 or ? IS NULL", d.tags, d.tags))
+          else
+            query
+          end
       end
     end)
   end

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -24,7 +24,8 @@ defmodule NervesHubWeb.Live.Devices.Index do
     healthy: "",
     device_id: "",
     tag: "",
-    updates: ""
+    updates: "",
+    has_no_tags: false
   }
 
   @filter_types %{
@@ -35,7 +36,8 @@ defmodule NervesHubWeb.Live.Devices.Index do
     healthy: :string,
     device_id: :string,
     tag: :string,
-    updates: :string
+    updates: :string,
+    has_no_tags: :boolean
   }
 
   @default_page 1

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -118,6 +118,16 @@
           <label for="input_tags">Tags</label>
           <input type="text" name="tag" id="input_tags" class="form-control" value={@current_filters[:tag]} phx-debounce="500" />
         </div>
+        <div class="form-group">
+          <label for="has_no_tags">Untagged</label>
+          <div class="pos-rel">
+            <select name="has_no_tags" id="has_no_tags" class="form-control">
+              <option {selected?(@current_filters, :has_no_tags, false)} value="false">All</option>
+              <option {selected?(@current_filters, :has_no_tags, true)} value="true">Only untagged</option>
+            </select>
+            <div class="select-icon"></div>
+          </div>
+        </div>
       </form>
       <button class="btn btn-secondary" type="button" phx-click="reset-filters">Reset Filters</button>
     </div>

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -113,6 +113,21 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       refute render_change(view, "update-filters", %{"tag" => "doesntmatter"}) =~
                device2.identifier
     end
+
+    test "filters devices with only untagged", %{conn: conn, fixture: fixture} do
+      %{device: _device, firmware: firmware, org: org, product: product} = fixture
+
+      device2 = Fixtures.device_fixture(org, product, firmware, %{tags: nil})
+      device3 = Fixtures.device_fixture(org, product, firmware, %{tags: ["foo"]})
+
+      {:ok, view, html} = live(conn, device_index_path(fixture))
+      assert html =~ device2.identifier
+      assert html =~ device3.identifier
+
+      change = render_change(view, "update-filters", %{"has_no_tags" => "true"})
+      assert change =~ device2.identifier
+      refute change =~ device3.identifier
+    end
   end
 
   describe "bulk actions" do


### PR DESCRIPTION
If all deployments are tagged it becomes relevant to add tags to new devices. Finding devices which are untagged has been impossible using the current set of filters.

This adds a filter for Untagged devices.