### PR TITLE
Fix the oban config for the audit log truncation queue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -64,7 +64,9 @@ config :nerves_hub, Oban,
     delete_firmware: 1,
     device: 1,
     firmware_delta_builder: 2,
-    truncate: 1
+    truncate: 1,
+    # temporary, will remove in November
+    truncation: 1
   ],
   plugins: [
     # 1 week


### PR DESCRIPTION
This is fixing a mistake I introduced into the code base.

The Audit Log truncation worker is using a different name, which means we aren't actually processing this queue, and jobs are backing up.

This fixes it.

Sorry.