### PR TITLE
Split metrics into separate context

### DIFF
--- a/lib/nerves_hub/devices/device_metric.ex
+++ b/lib/nerves_hub/devices/device_metric.ex
@@ -1,0 +1,33 @@
+defmodule NervesHub.Devices.DeviceMetric do
+  use Ecto.Schema
+
+  alias Ecto.Changeset
+  import Ecto.Changeset
+
+  alias NervesHub.Devices.Device
+
+  @type t :: %__MODULE__{}
+  @required_params [:device_id, :key, :value]
+
+  schema "device_metrics" do
+    belongs_to(:device, Device)
+    field(:key, :string)
+    field(:value, :float)
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  def save(params) do
+    %__MODULE__{}
+    |> cast(params, @required_params)
+    |> validate_required(@required_params)
+    |> format_field(:key)
+  end
+
+  defp format_field(%Changeset{changes: %{key: key}} = cs, :key) do
+    # Just remove spaces for now.
+    formatted_key = String.replace(key, " ", "")
+
+    put_change(cs, :key, formatted_key)
+  end
+end

--- a/lib/nerves_hub/devices/metrics.ex
+++ b/lib/nerves_hub/devices/metrics.ex
@@ -4,6 +4,18 @@ defmodule NervesHub.Devices.Metrics do
   alias NervesHub.Devices.DeviceMetric
   alias NervesHub.Repo
 
+  @metric_types [
+    :cpu_temp,
+    :load_15min,
+    :load_1min,
+    :load_5min,
+    :size_mb,
+    :used_mb,
+    :used_percent
+  ]
+
+  def metric_types, do: @metric_types
+
   @doc """
   Get all metrics for device
   """
@@ -39,7 +51,7 @@ defmodule NervesHub.Devices.Metrics do
   @doc """
   Get specific key metrics for device within a specified time frame
   """
-  def get_device_metrics_by_key(device_id, key, time_unit, amount) do
+  def get_device_metrics_by_key(device_id, key, {time_unit, amount}) do
     DeviceMetric
     |> where(device_id: ^device_id)
     |> where(key: ^key)
@@ -67,12 +79,64 @@ defmodule NervesHub.Devices.Metrics do
     |> Repo.all()
   end
 
+  def get_latest_metric(device_id) do
+    DeviceMetric
+    |> where(device_id: ^device_id)
+    |> order_by(desc: :inserted_at)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  def get_latest_metric(device_id, key) do
+    DeviceMetric
+    |> where(device_id: ^device_id)
+    |> where(key: ^key)
+    |> order_by(desc: :inserted_at)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  def get_latest_value(device_id, key) do
+    device_id
+    |> get_latest_metric(key)
+    |> get_value_or_nil()
+  end
+
+  def get_latest_timestamp_for_device(device_id) do
+    device_id
+    |> get_latest_metric()
+    |> case do
+      %DeviceMetric{inserted_at: timestamp} -> timestamp
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Get map with latest values for all metric types. Also includes timestamp.
+  """
+  def get_latest_metric_set_for_device(device_id) do
+    @metric_types
+    |> Enum.reduce(%{}, fn type, acc ->
+      Map.put(acc, type, get_latest_value(device_id, Atom.to_string(type)))
+    end)
+    |> Map.put(:timestamp, get_latest_timestamp_for_device(device_id))
+  end
+
+  defp get_value_or_nil(%DeviceMetric{value: value}), do: value
+  defp get_value_or_nil(_), do: nil
+
+  @doc """
+  Saves single metric.
+  """
   def save_metric(params) do
     params
     |> DeviceMetric.save()
     |> Repo.insert()
   end
 
+  @doc """
+  Saves map of metrics.
+  """
   def save_metrics(device_id, metrics) do
     Repo.transaction(fn ->
       Enum.map(metrics, fn {key, val} ->
@@ -81,6 +145,9 @@ defmodule NervesHub.Devices.Metrics do
     end)
   end
 
+  @doc """
+  Delete metrics after x days
+  """
   def truncate_device_metrics() do
     days_to_retain =
       Application.get_env(:nerves_hub, :device_health_days_to_retain)
@@ -88,7 +155,7 @@ defmodule NervesHub.Devices.Metrics do
     days_ago = DateTime.shift(DateTime.utc_now(), day: -days_to_retain)
 
     {count, _} =
-      DeviceMetrics
+      DeviceMetric
       |> where([dh], dh.inserted_at < ^days_ago)
       |> Repo.delete_all()
 

--- a/lib/nerves_hub/devices/metrics.ex
+++ b/lib/nerves_hub/devices/metrics.ex
@@ -1,0 +1,97 @@
+defmodule NervesHub.Devices.Metrics do
+  import Ecto.Query
+
+  alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Repo
+
+  @doc """
+  Get all metrics for device
+  """
+  def get_device_metrics(device_id) do
+    DeviceMetric
+    |> where(device_id: ^device_id)
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
+  end
+
+  @doc """
+  Get metrics by device within a specified time frame
+  """
+  def get_device_metrics(device_id, time_unit, amount) do
+    DeviceMetrics
+    |> where(device_id: ^device_id)
+    |> where([d], d.inserted_at > ago(^amount, ^time_unit))
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
+  end
+
+  @doc """
+  Get specific key metrics for device
+  """
+  def get_device_metrics_by_key(device_id, key) do
+    DeviceMetric
+    |> where(device_id: ^device_id)
+    |> where(key: ^key)
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
+  end
+
+  @doc """
+  Get specific key metrics for device within a specified time frame
+  """
+  def get_device_metrics_by_key(device_id, key, time_unit, amount) do
+    DeviceMetric
+    |> where(device_id: ^device_id)
+    |> where(key: ^key)
+    |> where([d], d.inserted_at > ago(^amount, ^time_unit))
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
+  end
+
+  def get_product_metrics_by_key(product_id, key) do
+    DeviceMetric
+    |> join(:left, [dm], d in assoc(dm, :device))
+    |> where([_, d], d.product_id == ^product_id)
+    |> where([dm, _], dm.key == ^key)
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
+  end
+
+  def get_product_metrics_by_key(product_id, key, time_unit, amount) do
+    DeviceMetric
+    |> join(:left, [dm], d in assoc(dm, :device))
+    |> where([_, d], d.product_id == ^product_id)
+    |> where([dm, _], dm.key == ^key)
+    |> where([d], d.inserted_at > ago(^amount, ^time_unit))
+    |> order_by(asc: :inserted_at)
+    |> Repo.all()
+  end
+
+  def save_metric(params) do
+    params
+    |> DeviceMetric.save()
+    |> Repo.insert()
+  end
+
+  def save_metrics(device_id, metrics) do
+    Repo.transaction(fn ->
+      Enum.map(metrics, fn {key, val} ->
+        save_metric(%{device_id: device_id, key: key, value: val})
+      end)
+    end)
+  end
+
+  def truncate_device_metrics() do
+    days_to_retain =
+      Application.get_env(:nerves_hub, :device_health_days_to_retain)
+
+    days_ago = DateTime.shift(DateTime.utc_now(), day: -days_to_retain)
+
+    {count, _} =
+      DeviceMetrics
+      |> where([dh], dh.inserted_at < ^days_ago)
+      |> Repo.delete_all()
+
+    {:ok, count}
+  end
+end

--- a/lib/nerves_hub/workers/device_health_truncation.ex
+++ b/lib/nerves_hub/workers/device_health_truncation.ex
@@ -1,6 +1,6 @@
 defmodule NervesHub.Workers.DeviceHealthTruncation do
   @moduledoc """
-  Remove old Device health reports.
+  Remove old Device health and metric reports.
 
   The number of days to keep is configured using the environment
   variable `HEALTH_CHECK_DAYS_TO_RETAIN`
@@ -13,6 +13,7 @@ defmodule NervesHub.Workers.DeviceHealthTruncation do
   @impl Oban.Worker
   def perform(_) do
     {:ok, _} = NervesHub.Devices.truncate_device_health()
+    {:ok, _} = NervesHub.Devices.Metrics.truncate_device_metrics()
 
     :ok
   end

--- a/lib/nerves_hub_web/components/device_health/health_header.ex
+++ b/lib/nerves_hub_web/components/device_health/health_header.ex
@@ -5,7 +5,7 @@ defmodule NervesHubWeb.Components.HealthHeader do
   attr(:product, :any)
   attr(:device, :any)
   attr(:status, :any)
-  attr(:latest_health, :any)
+  attr(:latest_health, :any, default: nil)
   attr(:health_check_timer, :any, default: nil)
 
   def render(assigns) do
@@ -66,13 +66,18 @@ defmodule NervesHubWeb.Components.HealthHeader do
           <span>Last reported</span>
           <span :if={@latest_health} class="tooltip-info"></span>
           <span :if={@latest_health} class="tooltip-text" id="last-reported-at-tooltip" phx-hook="LocalTime">
-            <%= @latest_health.inserted_at %>
+            <%= @latest_health.timestamp %>
           </span>
         </div>
         <p>
           <span :if={!@latest_health}>Never</span>
-          <time :if={@latest_health} id="last-reported-at" phx-hook="UpdatingTimeAgo" datetime={String.replace(DateTime.to_string(DateTime.truncate(@latest_health.inserted_at, :second)), " ", "T")}>
-            <%= Timex.from_now(@latest_health.inserted_at) %>
+          <time
+            :if={@latest_health.timestamp}
+            id="last-reported-at"
+            phx-hook="UpdatingTimeAgo"
+            datetime={String.replace(DateTime.to_string(DateTime.truncate(@latest_health.timestamp, :second)), " ", "T")}
+          >
+            <%= Timex.from_now(@latest_health.timestamp) %>
           </time>
         </p>
       </div>

--- a/lib/nerves_hub_web/live/devices/device_health.html.heex
+++ b/lib/nerves_hub_web/live/devices/device_health.html.heex
@@ -2,7 +2,7 @@
   <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}"} class="back-link">Back to
     device </.link>
 </div>
-<HealthHeader.render org={@org} product={@product} device={@device} status={@status} latest_health={@latest_health} health_check_timer={@health_check_timer} />
+<HealthHeader.render org={@org} product={@product} device={@device} status={@status} latest_health={@latest_metrics} health_check_timer={@health_check_timer} />
 
 <div class="divider"></div>
 
@@ -41,10 +41,10 @@
 
 <div class="row">
   <div class="col-lg-12">
-    <HealthSection.render title="Load Average - 1 min" svg={@graphs.load_1min} />
-    <HealthSection.render title="Load Average - 5 min" svg={@graphs.load_5min} />
-    <HealthSection.render title="Load Average - 15 min" svg={@graphs.load_15min} />
-    <HealthSection.render title="CPU Temperature in Celcius" svg={@graphs.cpu_temp} />
-    <HealthSection.render title="Memory Usage" svg={@graphs.used_mb} memory_size={@memory_size} memory_usage={@memory_usage} />
+    <HealthSection.render title="Load Average - 1 min" svg={@load_1min} />
+    <HealthSection.render title="Load Average - 5 min" svg={@load_5min} />
+    <HealthSection.render title="Load Average - 15 min" svg={@load_15min} />
+    <HealthSection.render title="CPU Temperature in Celcius" svg={@cpu_temp} />
+    <HealthSection.render title="Memory Usage" svg={@used_mb} memory_size={@latest_metrics.size_mb} memory_usage={@latest_metrics.used_percent} />
   </div>
 </div>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:status, Tracker.status(device))
     |> assign(:deployment, device.deployment)
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
-    |> assign(:health, Devices.get_latest_health(device.id))
+    |> assign(:latest_metrics, Devices.Metrics.get_latest_metric_set_for_device(device.id))
     |> schedule_health_check_timer()
     |> assign(:fwup_progress, nil)
     |> audit_log_assigns(1)

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -69,16 +69,6 @@
       </div>
 
       <DeviceLocation.render location={@device.connection_metadata["location"]} />
-
-      <%= if @health && @health.data["metadata"] do %>
-        <h3 class="mb-2">Metadata</h3>
-        <div class="display-box metrics">
-          <div :for={{key, value} <- @health.data["metadata"]} class="display-box-item">
-            <div class="help-text"><%= key |> String.replace("_", " ") |> String.capitalize() %></div>
-            <p><%= value %></p>
-          </div>
-        </div>
-      <% end %>
     </div>
 
     <div>
@@ -109,52 +99,50 @@
         </button>
       </div>
 
-      <div :if={!@health} class="display-box">
-        No health information have been received for this device.
-      </div>
-
-      <div>
-        <div :if={@health} class="device-health">
-          <div class="callouts">
-            <div :if={@health.data["metrics"] && @health.data["metrics"]["load_15min"]} class="callout">
-              <div class="help-text label">Load avg</div>
-              <%= @health.data["metrics"]["load_1min"] %> | <%= @health.data["metrics"]["load_5min"] %> | <%= @health.data["metrics"]["load_15min"] %>
-            </div>
-
-            <div :if={@health.data["metrics"] && @health.data["metrics"]["used_percent"]} class={"callout #{Utils.memory_to_status(60)}"} x>
-              <div class="help-text label">Memory used</div>
-              <%= round(@health.data["metrics"]["used_mb"]) %>MB (<%= round(@health.data["metrics"]["used_percent"]) %>%)
-            </div>
-            <div :if={!(@health.data["metrics"] && @health.data["metrics"]["used_percent"])} class="callout">
-              <div class="help-text label">Memory used</div>
-              Not reported
-            </div>
-
-            <div :if={@health.data["metrics"] && @health.data["metrics"]["cpu_temp"]} class={"callout #{Utils.cpu_temp_to_status(@health.data["metrics"]["cpu_temp"])}"}>
-              <div class="help-text label">CPU</div>
-              <%= round(@health.data["metrics"]["cpu_temp"]) %>°
-            </div>
-            <div :if={!(@health.data["metrics"] && @health.data["metrics"]["cpu_temp"])} class="callout">
-              <div class="help-text label">CPU</div>
-              Not reported
-            </div>
-          </div>
-
-          <%= if @health.data["metrics"] do %>
-            <div class="custom-metrics">
-              <div :for={{key, value} <- @health.data["metrics"]} class="metric">
-                <div class="help-text label"><%= key |> String.replace("_", " ") |> String.capitalize() %></div>
-                <%= value %>
-              </div>
-            </div>
-          <% end %>
+      <%= if (!Enum.any?(Map.values(@latest_metrics))) do %>
+        <div class="display-box">
+          No health information have been received for this device.
         </div>
+      <% end %>
+      <div>
+        <%= if (Enum.any?(Map.values(@latest_metrics))) do %>
+          <div :if={@latest_metrics.load_1min} class="device-health">
+            <div class="callout">
+              <div class="help-text label">Load avg</div>
+              <%= @latest_metrics.load_1min %> | <%= @latest_metrics.load_5min %> | <%= @latest_metrics.load_15min %>
+            </div>
 
-        <div :if={@health} class="flex-row justify-content-between">
+            <%= if @latest_metrics.used_mb do %>
+              <div class={"callout #{Utils.memory_to_status(60)}"} x>
+                <div class="help-text label">Memory used</div>
+                <%= round(@latest_metrics.used_mb) %>MB (<%= round(@latest_metrics.used_percent) %>%)
+              </div>
+            <% else %>
+              <div class="callout">
+                <div class="help-text label">Memory used</div>
+                Not reported
+              </div>
+            <% end %>
+
+            <%= if @latest_metrics.cpu_temp do %>
+              <div class={"callout #{Utils.cpu_temp_to_status(@latest_metrics.cpu_temp)}"}>
+                <div class="help-text label">CPU</div>
+                <%= round(@latest_metrics.cpu_temp) %>°
+              </div>
+            <% else %>
+              <div class="callout">
+                <div class="help-text label">CPU</div>
+                Not reported
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+
+        <div :if={Map.get(@latest_metrics, :timestamp)} class="flex-row justify-content-between">
           <div class="last-report">
             <span class="label pr-1">Last reported :</span>
-            <time id="health-reported-at" phx-hook="UpdatingTimeAgo" datetime={String.replace(DateTime.to_string(DateTime.truncate(@health.inserted_at, :second)), " ", "T")}>
-              <%= Timex.from_now(@health.inserted_at) %>
+            <time id="health-reported-at" phx-hook="UpdatingTimeAgo" datetime={String.replace(DateTime.to_string(DateTime.truncate(@latest_metrics.timestamp, :second)), " ", "T")}>
+              <%= Timex.from_now(@latest_metrics.timestamp) %>
             </time>
           </div>
           <div>

--- a/priv/repo/migrations/20240905113948_create_device_metrics.exs
+++ b/priv/repo/migrations/20240905113948_create_device_metrics.exs
@@ -1,0 +1,17 @@
+defmodule NervesHub.Repo.Migrations.CreateDeviceMetrics do
+  use Ecto.Migration
+
+  def change do
+    create table(:device_metrics) do
+      add(:device_id, references(:devices), null: false)
+      add(:key, :string)
+      add(:value, :float)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create index(:device_metrics, [:device_id, :inserted_at])
+    create index(:device_metrics, [:key, :inserted_at])
+    create index(:device_metrics, [:inserted_at])
+  end
+end

--- a/test/nerves_hub/device_metrics_test.exs
+++ b/test/nerves_hub/device_metrics_test.exs
@@ -1,0 +1,97 @@
+defmodule NervesHub.DeviceMetricsTest do
+  use NervesHub.DataCase, async: false
+
+  alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Devices.Metrics
+  alias NervesHub.Fixtures
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    product2 = Fixtures.product_fixture(user, org, %{name: "Second product"})
+    org_key = Fixtures.org_key_fixture(org, user)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+    device = Fixtures.device_fixture(org, product, firmware)
+    device2 = Fixtures.device_fixture(org, product2, firmware)
+
+    {:ok, %{device: device, device2: device2, product: product, product2: product2}}
+  end
+
+  describe "saving metrics" do
+    test "save single metric", %{device: device} do
+      device_id = device.id
+      params = %{device_id: device_id, key: "cpu_temp", value: 42}
+
+      assert {:ok, %DeviceMetric{device_id: ^device_id, key: "cpu_temp", value: 42.0}} =
+               Metrics.save_metric(params)
+    end
+
+    test "save single metric, ensure formatting of key", %{device: device} do
+      device_id = device.id
+      params = %{device_id: device_id, key: "cpu_ temp", value: 42}
+
+      assert {:ok, %DeviceMetric{device_id: ^device_id, key: "cpu_temp", value: 42.0}} =
+               Metrics.save_metric(params)
+    end
+
+    test "save map of metrics", %{device: device} do
+      metrics = %{
+        "cpu_temp" => 41.381,
+        "load_15min" => 0.06,
+        "load_1min" => 0.55,
+        "load_5min" => 0.15,
+        "size_mb" => 7892,
+        "used_mb" => 172,
+        "used_percent" => 2
+      }
+
+      assert {:ok, result} = Metrics.save_metrics(device.id, metrics)
+      assert length(result) == map_size(metrics)
+    end
+  end
+
+  describe "get metrics for device" do
+    test "get device metrics for key", %{device: device, device2: device2} do
+      assert {:ok, %DeviceMetric{}} =
+               Metrics.save_metric(%{device_id: device.id, key: "cpu_temp", value: 42})
+
+      assert {:ok, %DeviceMetric{}} =
+               Metrics.save_metric(%{device_id: device2.id, key: "cpu_temp", value: 43})
+
+      res = Metrics.get_device_metrics_by_key(device.id, "cpu_temp")
+
+      # Assert result only include device metrics
+      assert length(res) == 1
+    end
+
+    test "assert no metrics gives empty list", %{device: device} do
+      assert [] = Metrics.get_device_metrics_by_key(device.id, "cpu_temp")
+    end
+
+    # test "get device metrics within time frame"
+  end
+
+  describe "get metrics for product" do
+    test "get product metrics by key", %{
+      device: device,
+      device2: device2,
+      product: product
+    } do
+      assert {:ok, %DeviceMetric{}} =
+               Metrics.save_metric(%{device_id: device.id, key: "cpu_temp", value: 42})
+
+      assert {:ok, %DeviceMetric{}} =
+               Metrics.save_metric(%{device_id: device.id, key: "load_1min", value: 1.2})
+
+      assert {:ok, %DeviceMetric{}} =
+               Metrics.save_metric(%{device_id: device2.id, key: "cpu_temp", value: 43})
+
+      res = Metrics.get_product_metrics_by_key(product.id, "cpu_temp")
+
+      # Assert metrics from devices belonging to other products are excluded,
+      # and that other metric keys are excluded
+      assert length(res) == 1
+    end
+  end
+end

--- a/test/nerves_hub/workers/device_health_truncation_test.exs
+++ b/test/nerves_hub/workers/device_health_truncation_test.exs
@@ -5,7 +5,7 @@ defmodule NervesHub.Workers.DeviceHealthTruncationTest do
   alias NervesHub.Devices
   alias NervesHub.Workers.DeviceHealthTruncation
 
-  test "delete device health entries older than 7 days", %{tmp_dir: dir} do
+  test "delete device health and metrics entries older than 7 days", %{tmp_dir: dir} do
     user = Fixtures.user_fixture()
     org = Fixtures.org_fixture(user)
     product = Fixtures.product_fixture(user, org)
@@ -16,18 +16,29 @@ defmodule NervesHub.Workers.DeviceHealthTruncationTest do
     for x <- 0..9 do
       days_ago = DateTime.shift(DateTime.utc_now(), day: -x)
 
-      inserted =
+      inserted_health =
         %{"device_id" => device.id, "data" => %{"literally_any_map" => "values"}}
         |> Devices.DeviceHealth.save()
         |> Ecto.Changeset.put_change(:inserted_at, days_ago)
         |> Repo.insert()
 
-      assert {:ok, %Devices.DeviceHealth{}} = inserted
+      assert {:ok, %Devices.DeviceHealth{}} = inserted_health
+
+      inserted_metric =
+        %{"device_id" => device.id, "key" => "cpu_temp", "value" => 41.381}
+        |> Devices.DeviceMetric.save()
+        |> Ecto.Changeset.put_change(:inserted_at, days_ago)
+        |> Repo.insert()
+
+      assert {:ok, %Devices.DeviceMetric{}} = inserted_metric
     end
 
     assert :ok = perform_job(DeviceHealthTruncation, %{})
 
     healths = Devices.get_device_health(device.id)
     assert 7 = Enum.count(healths)
+
+    metrics = Devices.Metrics.get_device_metrics(device.id)
+    assert 7 = Enum.count(metrics)
   end
 end

--- a/test/nerves_hub_web/controllers/api/key_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/key_controller_test.exs
@@ -69,7 +69,7 @@ defmodule NervesHubWeb.API.KeyControllerTest do
   end
 
   describe "delete key" do
-    setup [:create_key]
+    lo([:create_key])
 
     test "deletes chosen key", %{conn: conn, org: org, key: key} do
       conn = delete(conn, Routes.api_key_path(conn, :delete, org.name, key.name))

--- a/test/nerves_hub_web/controllers/api/key_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/key_controller_test.exs
@@ -69,7 +69,7 @@ defmodule NervesHubWeb.API.KeyControllerTest do
   end
 
   describe "delete key" do
-    lo([:create_key])
+    setup([:create_key])
 
     test "deletes chosen key", %{conn: conn, org: org, key: key} do
       conn = delete(conn, Routes.api_key_path(conn, :delete, org.name, key.name))

--- a/test/nerves_hub_web/live/devices/health_test.exs
+++ b/test/nerves_hub_web/live/devices/health_test.exs
@@ -1,8 +1,7 @@
 defmodule NervesHubWeb.Devices.HealthTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
-  alias NervesHub.Devices
-  alias NervesHubWeb.Live.Devices.DeviceHealth
+  alias NervesHub.Devices.Metrics
 
   alias NervesHubWeb.Endpoint
 
@@ -28,83 +27,20 @@ defmodule NervesHubWeb.Devices.HealthTest do
     product: product,
     device: device
   } do
-    device_health = %{
-      "device_id" => device.id,
-      "data" => %{
-        "metrics" => %{
-          "cpu_temp" => 41.381,
-          "load_15min" => 0.06,
-          "load_1min" => 0.55,
-          "load_5min" => 0.15,
-          "size_mb" => 7892,
-          "used_mb" => 172,
-          "used_percent" => 2
-        },
-        "timestamp" => "2024-08-26T15:44:18.295149Z"
-      }
+    metrics = %{
+      "cpu_temp" => 41.381,
+      "load_15min" => 0.06,
+      "load_1min" => 0.55,
+      "load_5min" => 0.15,
+      "size_mb" => 7892,
+      "used_mb" => 172,
+      "used_percent" => 2
     }
 
-    assert {:ok, %Devices.DeviceHealth{}} = Devices.save_device_health(device_health)
+    assert {:ok, _} = Metrics.save_metrics(device.id, metrics)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
     |> assert_has("svg")
-  end
-
-  test "assert health data without metrics doesn't crash liveview", %{
-    conn: conn,
-    org: org,
-    product: product,
-    device: device
-  } do
-    device_health = %{
-      "device_id" => device.id,
-      "data" => %{
-        "timestamp" => "2024-08-26T15:44:18.295149Z"
-      }
-    }
-
-    assert {:ok, %Devices.DeviceHealth{}} = Devices.save_device_health(device_health)
-
-    conn
-    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
-    |> assert_has(".metrics-text", text: "No data for selected period")
-  end
-
-  test "assert metrics with nil data is rejected", %{
-    device: device
-  } do
-    valid_data = %{
-      "device_id" => device.id,
-      "data" => %{
-        "metrics" => %{
-          "cpu_temp" => 41.381,
-          "load_15min" => 0.06,
-          "load_1min" => 0.55,
-          "load_5min" => 0.15,
-          "size_mb" => 7892,
-          "used_mb" => 172,
-          "used_percent" => 2
-        },
-        "timestamp" => "2024-08-26T15:44:18.295149Z"
-      }
-    }
-
-    invalid_data = %{
-      "device_id" => device.id,
-      "data" => %{
-        "timestamp" => "2024-08-26T15:44:18.295149Z"
-      }
-    }
-
-    assert {:ok, %Devices.DeviceHealth{}} = Devices.save_device_health(valid_data)
-    assert {:ok, %Devices.DeviceHealth{}} = Devices.save_device_health(invalid_data)
-
-    metrics =
-      device.id
-      |> Devices.get_device_health()
-      |> DeviceHealth.organize_data()
-
-    assert length(metrics.cpu_temp) == 1
   end
 end

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
+  alias NervesHub.Devices.Metrics
   alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias NervesHubWeb.Endpoint
@@ -238,28 +239,24 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      device_health = %{
-        "device_id" => device.id,
-        "data" => %{
-          "metrics" => %{
-            "load_1min" => "0.00",
-            "load_5min" => "0.00",
-            "load_15min" => "0.00",
-            "used_percent" => 60,
-            "used_mb" => 100,
-            "cpu_temp" => 30
-          }
-        }
+      metrics = %{
+        "cpu_temp" => 30,
+        "load_15min" => 0.00,
+        "load_1min" => 0.00,
+        "load_5min" => 0.00,
+        "size_mb" => 7892,
+        "used_mb" => 100,
+        "used_percent" => 60
       }
 
-      assert {:ok, %Devices.DeviceHealth{}} = Devices.save_device_health(device_health)
+      assert {:ok, _} = Metrics.save_metrics(device.id, metrics)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("h1", text: device.identifier)
       |> assert_has("div", text: "Health")
       |> assert_has("div", text: "Load avg")
-      |> assert_has("div", text: "0.00 | 0.00 | 0.00")
+      |> assert_has("div", text: "0.0 | 0.0 | 0.0")
       |> assert_has("div", text: "Memory used")
       |> assert_has("div", text: "100MB (60%)")
       |> assert_has("div", text: "CPU")
@@ -272,27 +269,23 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      device_health = %{
-        "device_id" => device.id,
-        "data" => %{
-          "metrics" => %{
-            "load_1min" => "0.00",
-            "load_5min" => "0.00",
-            "load_15min" => "0.00",
-            "used_percent" => 60,
-            "used_mb" => 100
-          }
-        }
+      metrics = %{
+        "load_15min" => 0.00,
+        "load_1min" => 0.00,
+        "load_5min" => 0.00,
+        "size_mb" => 7892,
+        "used_mb" => 100,
+        "used_percent" => 60
       }
 
-      assert {:ok, %Devices.DeviceHealth{}} = Devices.save_device_health(device_health)
+      assert {:ok, _} = Metrics.save_metrics(device.id, metrics)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("h1", text: device.identifier)
       |> assert_has("div", text: "Health")
       |> assert_has("div", text: "Load avg")
-      |> assert_has("div", text: "0.00 | 0.00 | 0.00")
+      |> assert_has("div", text: "0.0 | 0.0 | 0.0")
       |> assert_has("div", text: "Memory used")
       |> assert_has("div", text: "100MB (60%)")
       |> assert_has("div", text: "CPU")


### PR DESCRIPTION
Adds context for metrics, and support to liveviews to use metrics instead of health report (for metrics purposes).

No visual changes are made, the Contex graphs are still used but with a new data fetching approach which will make it easier to create more varied graphs from here, even for product metrics.

