### PR TITLE
Rename the manual push message for devices

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -230,10 +230,7 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   # manually pushed
-  def handle_info(
-        %Broadcast{event: "deployments/update", payload: %{deployment_id: nil} = payload},
-        socket
-      ) do
+  def handle_info(%Broadcast{event: "devices/update-manual", payload: payload}, socket) do
     :telemetry.execute([:nerves_hub, :devices, :update, :manual], %{count: 1})
     push(socket, "update", payload)
     {:noreply, socket}

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -235,7 +235,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
       firmware_meta: meta
     }
 
-    _ = NervesHubWeb.Endpoint.broadcast("device:#{device.id}", "deployments/update", payload)
+    _ = NervesHubWeb.Endpoint.broadcast("device:#{device.id}", "devices/update-manual", payload)
 
     socket
     |> assign(:device, device)


### PR DESCRIPTION
Split out of the same message that normal inflight deployments will send.

Breaking some things out of #1476 