### PR TITLE
Deployment calculator fixes around which devices are looked at

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -282,8 +282,14 @@ defmodule NervesHub.Deployments do
         device_id: d.id,
         inserted_at: ^DateTime.utc_now()
       })
-      |> where([d], d.deployment_id == ^deployment.id)
-      |> or_where([d], is_nil(d.deployment_id) and d.product_id == ^deployment.product_id)
+      |> where([d], not is_nil(d.connection_last_seen_at))
+      |> where(
+        [d],
+        d.deployment_id == ^deployment.id or
+          (is_nil(d.deployment_id) and d.product_id == ^deployment.product_id)
+      )
+      |> where([d], d.firmware_metadata["platform"] == ^deployment.firmware.platform)
+      |> where([d], d.firmware_metadata["architecture"] == ^deployment.firmware.architecture)
 
     Repo.insert_all(InflightDeploymentCheck, query)
   end

--- a/test/nerves_hub/deployments/calculator_test.exs
+++ b/test/nerves_hub/deployments/calculator_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
 
   alias NervesHub.Deployments
   alias NervesHub.Deployments.Calculator
+  alias NervesHub.Devices
   alias NervesHub.Fixtures
   alias NervesHub.Repo
 
@@ -18,6 +19,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
       deployment = %{deployment | firmware: firmware}
 
       device = Fixtures.device_fixture(org, product, firmware, %{tags: ["rpi"]})
+      {:ok, device} = Devices.device_connected(device)
 
       Deployments.create_inflight_checks(deployment)
 
@@ -38,6 +40,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
       deployment = %{deployment | firmware: firmware}
 
       device = Fixtures.device_fixture(org, product, firmware, %{tags: ["rpi"]})
+      {:ok, device} = Devices.device_connected(device)
       device = Deployments.set_deployment(device)
       assert device.deployment_id == deployment.id
 
@@ -66,6 +69,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
         Deployments.update_deployment(original_deployment, %{is_active: true})
 
       device = Fixtures.device_fixture(org, product, firmware, %{tags: ["rpi"]})
+      {:ok, device} = Devices.device_connected(device)
       device = Deployments.set_deployment(device)
       assert device.deployment_id == original_deployment.id
 
@@ -80,7 +84,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
 
       Deployments.create_inflight_checks(deployment)
 
-      assert :skipped = Calculator.process_next_device(deployment)
+      assert :none_found = Calculator.process_next_device(deployment)
 
       device = Repo.reload(device)
       assert device.deployment_id == original_deployment.id
@@ -102,6 +106,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
       {:ok, deployment} = Deployments.update_deployment(deployment, %{is_active: true})
 
       device = Fixtures.device_fixture(org, product, firmware, %{tags: ["rpi"]})
+      {:ok, device} = Devices.device_connected(device)
       device = Deployments.set_deployment(device)
       assert device.deployment_id == deployment.id
 
@@ -126,6 +131,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
       deployment = %{deployment | firmware: firmware}
 
       device = Fixtures.device_fixture(org, product, firmware, %{tags: ["rpi"]})
+      {:ok, device} = Devices.device_connected(device)
       device = Deployments.set_deployment(device)
       assert device.deployment_id == deployment.id
 
@@ -147,7 +153,7 @@ defmodule NervesHub.Deployments.CalculatorTest do
       firmware = Fixtures.firmware_fixture(org_key, product)
       deployment = Fixtures.deployment_fixture(org, firmware)
 
-      assert :skipped = Calculator.process_next_device(deployment)
+      assert :none_found = Calculator.process_next_device(deployment)
     end
   end
 end


### PR DESCRIPTION
- Skip any device that hasn't connected previously, which also means they don't have firmware metadata to look at
- If a device has a deployment that doesn't match the inflight check's deployment, return a different value than `:skipped` to avoid waiting 15s before processing the next device