### PR TITLE
Tell duplicate device connections to shutdown

### DIFF
--- a/lib/nerves_hub/metrics.ex
+++ b/lib/nerves_hub/metrics.ex
@@ -20,6 +20,7 @@ defmodule NervesHub.Metrics do
          # NervesHub
          counter("nerves_hub.devices.connect.count", tags: [:env, :service]),
          counter("nerves_hub.devices.disconnect.count", tags: [:env, :service]),
+         counter("nerves_hub.devices.duplicate_connection", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.changed.count", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.update.manual.count", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.update.automatic.count", tags: [:env, :service]),
@@ -161,6 +162,7 @@ defmodule NervesHub.DeviceReporter do
     [
       [:nerves_hub, :devices, :connect],
       [:nerves_hub, :devices, :disconnect],
+      [:nerves_hub, :devices, :duplicate_connection],
       [:nerves_hub, :devices, :update, :automatic]
     ]
   end
@@ -170,6 +172,14 @@ defmodule NervesHub.DeviceReporter do
       event: "nerves_hub.devices.connect",
       identifier: metadata[:identifier],
       firmware_uuid: metadata[:firmware_uuid]
+    )
+  end
+
+  def handle_event([:nerves_hub, :devices, :duplicate_connection], _, metadata, _) do
+    Logger.info("Device duplicate connection detected",
+      event: "nerves_hub.devices.duplicate_connection",
+      ref_id: metadata[:ref_id],
+      identifier: metadata[:device][:identifier]
     )
   end
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -91,7 +91,7 @@ defmodule NervesHubWeb.DeviceChannel do
     _ =
       NervesHubWeb.DeviceEndpoint.broadcast_from(
         self(),
-        "device:#{device.identifier}:internal",
+        "device:#{device.id}",
         "connected",
         %{}
       )

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -153,6 +153,11 @@ defmodule NervesHubWeb.DeviceChannel do
   # Listen for devices which have connected using the same device identifier
   # and trigger a clean shutdown
   def handle_info(%Broadcast{event: "connected"}, socket) do
+    :telemetry.execute([:nerves_hub, :devices, :duplicate_connection], %{}, %{
+      device: socket.assigns.device,
+      ref_id: socket.assigns.reference_id
+    })
+
     {:stop, :shutdown, socket}
   end
 


### PR DESCRIPTION
Its possible for websocket connections to be established to multiple devices using the same identifier. This either happens when a websocket connection dies (eg. network error) but the server takes a while to know about it and shut down the connection, while in the meantime the device has already reconnected. Its also possible to mess up your device settings and set the same identifier for multiple physical devices.

This PR send a PubSub event that a device has connected, and responds to the event by shutting down. I've used `broadcast_from` so `self()` doesn't get the `connected` message.