### PR TITLE
Rework duplicated connection handling

### DIFF
--- a/lib/nerves_hub/metrics.ex
+++ b/lib/nerves_hub/metrics.ex
@@ -21,6 +21,9 @@ defmodule NervesHub.Metrics do
          counter("nerves_hub.devices.connect.count", tags: [:env, :service]),
          counter("nerves_hub.devices.disconnect.count", tags: [:env, :service]),
          counter("nerves_hub.devices.duplicate_connection", tags: [:env, :service]),
+         counter("nerves_hub.devices.duplicate_connection.retries_exceeded",
+           tags: [:env, :service]
+         ),
          counter("nerves_hub.devices.deployment.changed.count", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.update.manual.count", tags: [:env, :service]),
          counter("nerves_hub.devices.deployment.update.automatic.count", tags: [:env, :service]),
@@ -163,6 +166,7 @@ defmodule NervesHub.DeviceReporter do
       [:nerves_hub, :devices, :connect],
       [:nerves_hub, :devices, :disconnect],
       [:nerves_hub, :devices, :duplicate_connection],
+      [:nerves_hub, :devices, :duplicate_connection, :retries_exceeded],
       [:nerves_hub, :devices, :update, :automatic]
     ]
   end
@@ -178,6 +182,19 @@ defmodule NervesHub.DeviceReporter do
   def handle_event([:nerves_hub, :devices, :duplicate_connection], _, metadata, _) do
     Logger.info("Device duplicate connection detected",
       event: "nerves_hub.devices.duplicate_connection",
+      ref_id: metadata[:ref_id],
+      identifier: metadata[:device][:identifier]
+    )
+  end
+
+  def handle_event(
+        [:nerves_hub, :devices, :duplicate_connection, :retries_exceeded],
+        _,
+        metadata,
+        _
+      ) do
+    Logger.info("Device duplicate connection retries exceeded",
+      event: "nerves_hub.devices.duplicate_connection.retries_exceeded",
       ref_id: metadata[:ref_id],
       identifier: metadata[:device][:identifier]
     )


### PR DESCRIPTION
Because items (in this case, devices) can only be removed from a Registry by the process that added them, the handling of duplicated connections and registry items has to change.

This PR adds a function before `:after_join` that checks for the device's existence in the registry. If the same device is found in the registry, the check is rescheduled to happen again in five seconds.

If the registry check fails three times, the connection is closed, forcing the device to reconnect and retrigger the broadcast which closes duplicate device connections again.

I've also added some metrics for the failed retries case.