### PR TITLE
Always save/update the Devices connection status fields

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -602,13 +602,6 @@ defmodule NervesHub.Devices do
       connection_last_seen_at: DateTime.utc_now()
     })
     |> Repo.update()
-    |> case do
-      {:ok, device} ->
-        device
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
   end
 
   def device_heartbeat(device) do
@@ -620,13 +613,6 @@ defmodule NervesHub.Devices do
       connection_last_seen_at: DateTime.utc_now()
     })
     |> Repo.update()
-    |> case do
-      {:ok, device} ->
-        device
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
   end
 
   def device_disconnected(device) do
@@ -638,13 +624,6 @@ defmodule NervesHub.Devices do
       connection_last_seen_at: DateTime.utc_now()
     })
     |> Repo.update()
-    |> case do
-      {:ok, device} ->
-        device
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
   end
 
   defp clear_connection_information(device) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -593,40 +593,63 @@ defmodule NervesHub.Devices do
   end
 
   def device_connected(device) do
-    update_device(
-      device,
-      %{
-        connection_status: :connected,
-        connection_established_at: DateTime.utc_now(),
-        connection_disconnected_at: nil,
-        connection_last_seen_at: DateTime.utc_now()
-      },
-      broadcast: false
-    )
+    device
+    |> clear_connection_information()
+    |> Device.changeset(%{
+      connection_status: :connected,
+      connection_established_at: DateTime.utc_now(),
+      connection_disconnected_at: nil,
+      connection_last_seen_at: DateTime.utc_now()
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, device} ->
+        device
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def device_heartbeat(device) do
-    update_device(
-      device,
-      %{
-        connection_status: :connected,
-        connection_disconnected_at: nil,
-        connection_last_seen_at: DateTime.utc_now()
-      },
-      broadcast: false
-    )
+    device
+    |> clear_connection_information()
+    |> Device.changeset(%{
+      connection_status: :connected,
+      connection_disconnected_at: nil,
+      connection_last_seen_at: DateTime.utc_now()
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, device} ->
+        device
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   def device_disconnected(device) do
-    update_device(
-      device,
-      %{
-        connection_status: :disconnected,
-        connection_disconnected_at: DateTime.utc_now(),
-        connection_last_seen_at: DateTime.utc_now()
-      },
-      broadcast: false
-    )
+    device
+    |> clear_connection_information()
+    |> Device.changeset(%{
+      connection_status: :disconnected,
+      connection_disconnected_at: DateTime.utc_now(),
+      connection_last_seen_at: DateTime.utc_now()
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, device} ->
+        device
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defp clear_connection_information(device) do
+    %{device |
+      connection_status: nil,
+      connection_disconnected_at: "dummy",
+      connection_last_seen_at: nil
+    }
   end
 
   def clean_connection_states() do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -605,6 +605,7 @@ defmodule NervesHub.Devices do
     |> case do
       {:ok, device} ->
         device
+
       {:error, changeset} ->
         {:error, changeset}
     end
@@ -622,6 +623,7 @@ defmodule NervesHub.Devices do
     |> case do
       {:ok, device} ->
         device
+
       {:error, changeset} ->
         {:error, changeset}
     end
@@ -639,16 +641,18 @@ defmodule NervesHub.Devices do
     |> case do
       {:ok, device} ->
         device
+
       {:error, changeset} ->
         {:error, changeset}
     end
   end
 
   defp clear_connection_information(device) do
-    %{device |
-      connection_status: nil,
-      connection_disconnected_at: "dummy",
-      connection_last_seen_at: nil
+    %{
+      device
+      | connection_status: nil,
+        connection_disconnected_at: "dummy",
+        connection_last_seen_at: nil
     }
   end
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -152,13 +152,13 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   def handle_info(:update_connection_last_seen, %{assigns: %{device: device}} = socket) do
-    {:ok, _device} = Devices.device_heartbeat(device)
+    {:ok, device} = Devices.device_heartbeat(device)
 
     device_broadcast(device, "connection:heartbeat")
 
     Process.send_after(self(), :update_connection_last_seen, last_seen_update_interval())
 
-    {:noreply, socket}
+    {:noreply, assign(socket, :device, device)}
   end
 
   # We can save a fairly expensive query by checking the incoming deployment's payload


### PR DESCRIPTION
This short circuits Ecto change tracking by assigning dummy values before updating the data.

This is one part of the full fix related to a race condition in which two device connections could exist and both update the connection's status.

It could be argued that this isn't needed now that we are enforcing single connections per device, but I still think this is a good thing to have.