### PR TITLE
Improve the Device Registry name

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -24,7 +24,7 @@ defmodule NervesHub.Application do
         {Ecto.Migrator,
          repos: Application.fetch_env!(:nerves_hub, :ecto_repos),
          skip: Application.get_env(:nerves_hub, :database_auto_migrator) != true},
-        {Registry, keys: :unique, name: NervesHub.Devices},
+        {Registry, keys: :unique, name: NervesHub.Devices.Registry},
         {Finch, name: Swoosh.Finch}
       ] ++
         metrics(deploy_env()) ++

--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -65,7 +65,7 @@ defmodule NervesHub.Deployments.Orchestrator do
     }
 
     devices =
-      Registry.select(NervesHub.Devices, [
+      Registry.select(NervesHub.Devices.Registry, [
         {{:_, :_, :"$1"}, match_conditions, [match_return]}
       ])
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -67,10 +67,10 @@ defmodule NervesHubWeb.DeviceChannel do
 
     # local node tracking
     # lets make sure we deregister any other connected devices using the same device id
-    :ok = Registry.unregister(NervesHub.Devices, device.id)
+    :ok = Registry.unregister(NervesHub.Devices.Registry, device.id)
 
     {:ok, _pid} =
-      Registry.register(NervesHub.Devices, device.id, %{
+      Registry.register(NervesHub.Devices.Registry, device.id, %{
         deployment_id: device.deployment_id,
         firmware_uuid: get_in(device, [Access.key(:firmware_metadata), Access.key(:uuid)]),
         updates_enabled: device.updates_enabled && !Devices.device_in_penalty_box?(device),
@@ -218,7 +218,7 @@ defmodule NervesHubWeb.DeviceChannel do
     )
 
     {_, _} =
-      Registry.update_value(NervesHub.Devices, device.id, fn value ->
+      Registry.update_value(NervesHub.Devices.Registry, device.id, fn value ->
         Map.put(value, :deployment_id, device.deployment_id)
       end)
 
@@ -300,7 +300,7 @@ defmodule NervesHubWeb.DeviceChannel do
     device = Repo.reload(device)
 
     {_, _} =
-      Registry.update_value(NervesHub.Devices, device.id, fn value ->
+      Registry.update_value(NervesHub.Devices.Registry, device.id, fn value ->
         Map.merge(value, %{
           updates_enabled: device.updates_enabled && !Devices.device_in_penalty_box?(device)
         })
@@ -375,7 +375,7 @@ defmodule NervesHubWeb.DeviceChannel do
     })
 
     {_, _} =
-      Registry.update_value(NervesHub.Devices, device.id, fn value ->
+      Registry.update_value(NervesHub.Devices.Registry, device.id, fn value ->
         Map.merge(value, %{updates_enabled: updates_enabled})
       end)
 
@@ -437,7 +437,7 @@ defmodule NervesHubWeb.DeviceChannel do
       {:ok, device} = Devices.update_attempted(device)
 
       {_, _} =
-        Registry.update_value(NervesHub.Devices, device.id, fn value ->
+        Registry.update_value(NervesHub.Devices.Registry, device.id, fn value ->
           Map.put(value, :updating, true)
         end)
 
@@ -563,7 +563,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
     {:ok, device} = Devices.device_disconnected(device)
 
-    Registry.unregister(NervesHub.Devices, device.id)
+    Registry.unregister(NervesHub.Devices.Registry, device.id)
 
     Tracker.offline(device)
 
@@ -674,7 +674,7 @@ defmodule NervesHubWeb.DeviceChannel do
     AuditLogs.audit_with_ref!(device, device, description, socket.assigns.reference_id)
 
     {_, _} =
-      Registry.update_value(NervesHub.Devices, device.id, fn value ->
+      Registry.update_value(NervesHub.Devices.Registry, device.id, fn value ->
         Map.put(value, :deployment_id, device.deployment_id)
       end)
 
@@ -702,7 +702,7 @@ defmodule NervesHubWeb.DeviceChannel do
       subscribe(deployment_channel)
 
       {_, _} =
-        Registry.update_value(NervesHub.Devices, device.id, fn value ->
+        Registry.update_value(NervesHub.Devices.Registry, device.id, fn value ->
           Map.merge(value, %{
             deployment_id: device.deployment_id
           })


### PR DESCRIPTION
There is naming conflict with the Devices context, which is confusing at times.