### PR TITLE
Use the Endpoint from the `socket`

### DIFF
--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -177,7 +177,7 @@ defmodule NervesHubWeb.DeviceSocket do
 
   defp socket_and_assigns(socket, device) do
     # disconnect devices using the same identifier
-    _ = NervesHubWeb.DeviceEndpoint.broadcast("device_socket:#{device.id}", "disconnect", %{})
+    _ = socket.endpoint.broadcast_from(self(), "device_socket:#{device.id}", "disconnect", %{})
 
     socket =
       socket


### PR DESCRIPTION
Fixes an issue where the `DeviceSocket` is used by `Endpoint` but referencing `DeviceEndpoint` isn't available.

Also use `broadcast_from` as we don't need to send this message to the current pid.