### PR TITLE
Only render connection tooltip when timestamp is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/fixtures/ssl/device-root-ca.srl
 .vscode
 
 .env*
+.iex.exs

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,2 @@
+alias NervesHub.Devices
+alias NervesHub.Repo

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,2 +1,0 @@
-alias NervesHub.Devices
-alias NervesHub.Repo

--- a/lib/nerves_hub_web/components/device_header.ex
+++ b/lib/nerves_hub_web/components/device_header.ex
@@ -33,8 +33,8 @@ defmodule NervesHubWeb.Components.DeviceHeader do
       <div>
         <div class="help-text mb-1 tooltip-label help-tooltip">
           <span>Last connected</span>
-          <span class="tooltip-info"></span>
-          <span class="tooltip-text" id="connection-establisted-at-tooltip" phx-hook="LocalTime">
+          <span :if={@device.connection_established_at} class="tooltip-info"></span>
+          <span :if={@device.connection_established_at} class="tooltip-text" id="connection-establisted-at-tooltip" phx-hook="LocalTime">
             <%= @device.connection_established_at %>
           </span>
         </div>

--- a/lib/nerves_hub_web/components/device_header.ex
+++ b/lib/nerves_hub_web/components/device_header.ex
@@ -53,8 +53,8 @@ defmodule NervesHubWeb.Components.DeviceHeader do
       <div>
         <div class="help-text mb-1 tooltip-label help-tooltip">
           <span>Last seen</span>
-          <span class="tooltip-info"></span>
-          <span class="tooltip-text" id="connection-last-seen-at-tooltip" phx-hook="LocalTime">
+          <span :if={@device.connection_last_seen_at} class="tooltip-info"></span>
+          <span :if={@device.connection_last_seen_at} class="tooltip-text" id="connection-last-seen-at-tooltip" phx-hook="LocalTime">
             <%= @device.connection_last_seen_at %>
           </span>
         </div>

--- a/lib/nerves_hub_web/components/device_health/health_header.ex
+++ b/lib/nerves_hub_web/components/device_health/health_header.ex
@@ -44,8 +44,8 @@ defmodule NervesHubWeb.Components.HealthHeader do
       <div>
         <div class="help-text mb-1 tooltip-label help-tooltip">
           <span>Last connected</span>
-          <span class="tooltip-info"></span>
-          <span class="tooltip-text" id="connection-establisted-at-tooltip" phx-hook="LocalTime">
+          <span :if={@device.connection_established_at} class="tooltip-info"></span>
+          <span :if={@device.connection_established_at} class="tooltip-text" id="connection-establisted-at-tooltip" phx-hook="LocalTime">
             <%= @device.connection_established_at %>
           </span>
         </div>


### PR DESCRIPTION
Fixes javascript error yielded when device connection timestamp was missing.