### PR TITLE
Add alternative way to get shared secret

### DIFF
--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -14,6 +14,7 @@ defmodule NervesHubWeb.Live.Product.Settings do
       |> assign(:shared_secrets, product.shared_secret_auths)
       |> assign(:shared_auth_enabled, DeviceSocket.shared_secrets_enabled?())
       |> assign(:form, to_form(Ecto.Changeset.change(product)))
+      |> assign(:show_shared_secret, nil)
 
     {:ok, socket}
   end
@@ -35,6 +36,12 @@ defmodule NervesHubWeb.Live.Product.Settings do
     socket
     |> assign(:shared_secrets, refreshed.shared_secret_auths)
     |> push_event("sharedsecret:created", %{})
+    |> noreply()
+  end
+
+  def handle_event("show-secret", %{"auth" => auth_id}, socket) do
+    socket
+    |> assign(:show_shared_secret, auth_id)
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -96,10 +96,17 @@
         <span class="deactivated"><%= if auth.deactivated_at, do: Date.to_string(auth.deactivated_at) %></span>
       </td>
       <td>
-        <input type="hidden" id={"shared-secret-#{auth.id}"} value={auth.secret} />
-        <button class="btn btn-secondary sharedsecret-clipcopy" value={auth.id} id={"shared-secret-#{auth.id}-button"} phx-hook="SharedSecretClipboardClick">
-          Copy Secret
-        </button>
+        <%= if @show_shared_secret == to_string(auth.id) do %>
+          <%= auth.secret %>
+        <% else %>
+          <input type="hidden" id={"shared-secret-#{auth.id}"} value={auth.secret} />
+          <button class="btn btn-secondary sharedsecret-clipcopy" value={auth.id} id={"shared-secret-#{auth.id}-button"} phx-hook="SharedSecretClipboardClick">
+            Copy Secret
+          </button>
+          <button class="btn btn-secondary sharedsecret-clipcopy" phx-value-auth={auth.id} id={"shared-secret-#{auth.id}-show"} phx-click="show-secret">
+            Show Secret
+          </button>
+        <% end %>
       </td>
       <td>
         <button


### PR DESCRIPTION
Exclusively a UI fix with the slightest security implication.

The Copy to clipboard way hasn't worked on Chromium for Linux in some time and this fix adds a way to show the secret as an option.

This has been reported by users running into it and wasting time using the wrong credentials. I've personally hit it about a million times.