### PR TITLE
Source a known env.sh if it is present

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,15 +1,12 @@
 #!/bin/sh
 
-# Sets and enables heart (recommended only in daemon mode)
-# case $RELEASE_COMMAND in
-#   daemon*)
-#     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
-#     export HEART_COMMAND
-#     export ELIXIR_ERL_OPTIONS="-heart"
-#     ;;
-#   *)
-#     ;;
-# esac
+# Allow overriding the file in a known location
+# Since this file's location changes with every version/commit
+if [[ -f "/etc/nerves_hub/env.sh" ]];
+then
+  source "/etc/nerves_hub/env.sh"
+  exit 0
+fi
 
 if [ "$APP_NAME" = "" ] || [ "$PRIVATE_IP" = "" ]
 then


### PR DESCRIPTION
Since we switched to `VERSION+SHA` it is more challenging to replace the env.sh file with a custom version. Sourcing a known file if present would help make things easier to override.