### PR TITLE
Only broadcast in `terminate/2` if the channel is joined

### DIFF
--- a/lib/nerves_hub_web/channels/user_console_channel.ex
+++ b/lib/nerves_hub_web/channels/user_console_channel.ex
@@ -64,11 +64,13 @@ defmodule NervesHubWeb.UserConsoleChannel do
   end
 
   def terminate(_reason, socket) do
-    _ =
-      broadcast(socket, "message", %{
-        name: socket.assigns.user.name,
-        event: "closed the console"
-      })
+    if socket.joined do
+      _ =
+        broadcast(socket, "message", %{
+          name: socket.assigns.user.name,
+          event: "closed the console"
+        })
+    end
 
     socket
   end


### PR DESCRIPTION
This fixes an error seen in Sentry where the socket isn't `joined`, possibly due to a socket termination.

https://github.com/phoenixframework/phoenix/blob/main/lib/phoenix/channel.ex#L698-L719

```
RuntimeError

push/3, reply/2, and broadcast/3 can only be called after the socket has finished joining.
To push a message on join, send to self and handle in handle_info/2. For example:

    def join(topic, auth_msg, socket) do
      ...
      send(self, :after_join)
      {:ok, socket}
    end

    def handle_info(:after_join, socket) do
      push(socket, "feed", %{list: feed_items(socket)})
      {:noreply, socket}
    end
```