### PR TITLE
Add metrics filtering to devices query

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -215,6 +215,8 @@ defmodule NervesHub.Devices do
   defp filtering(query, filters) do
     Enum.reduce(filters, query, fn {key, value}, query ->
       case {key, value} do
+        # Filter values are empty strings as default,
+        # they should be ignored.
         {_, ""} ->
           query
 
@@ -286,7 +288,9 @@ defmodule NervesHub.Devices do
         {:metrics_value, _value} ->
           filter_on_metric(query, filters)
 
-        {_, _} ->
+        # Ignore any undefined filter.
+        # This will prevent error 500 responses on deprecated saved bookmarks etc.
+        _ ->
           query
       end
     end)

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -237,9 +237,6 @@ defmodule NervesHub.Devices do
             d.id in subquery(Connections.query_devices_with_connection_status(value))
           )
 
-        {:connection, _value} ->
-          where(query, [d], d.connection_status == ^String.to_atom(value))
-
         {:connection_type, value} ->
           where(query, [d], ^value in d.connection_types)
 

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -6,6 +6,7 @@ defmodule NervesHub.Devices.Device do
   alias NervesHub.Accounts.Org
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.DeviceMetric
   alias NervesHub.Deployments.Deployment
   alias NervesHub.Extensions.DeviceExtensionsSetting
   alias NervesHub.Firmwares.FirmwareMetadata
@@ -43,6 +44,7 @@ defmodule NervesHub.Devices.Device do
     embeds_one(:firmware_metadata, FirmwareMetadata, on_replace: :update)
     has_many(:device_certificates, DeviceCertificate, on_delete: :delete_all)
     has_many(:device_connections, DeviceConnection, on_delete: :delete_all)
+    has_many(:device_metrics, DeviceMetric, on_delete: :delete_all)
 
     field(:identifier, :string)
     field(:description, :string)

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
+  alias NervesHub.Devices.Metrics
   alias NervesHub.Firmwares
   alias NervesHub.Products.Product
   alias NervesHub.Tracker
@@ -33,7 +34,9 @@ defmodule NervesHubWeb.Live.Devices.Index do
     has_no_tags: false,
     alarm_status: "",
     alarm: "",
-    metrics: %{}
+    metrics_key: "",
+    metrics_operator: "gt",
+    metrics_value: ""
   }
 
   @filter_types %{
@@ -48,7 +51,9 @@ defmodule NervesHubWeb.Live.Devices.Index do
     has_no_tags: :boolean,
     alarm_status: :string,
     alarm: :string,
-    metrics: :map
+    metrics_key: :string,
+    metrics_operator: :string,
+    metrics_value: :string
   }
 
   @default_page 1
@@ -87,6 +92,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:device_tags, "")
     |> assign(:total_entries, 0)
     |> assign(:current_alarms, Alarms.get_current_alarm_types(product.id))
+    |> assign(:metrics_keys, Metrics.default_metric_types())
     |> subscribe_and_refresh_device_list_timer()
     |> ok()
   end
@@ -107,20 +113,6 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign_display_devices()
     |> noreply()
   end
-
-  defp filter_on_metrics_if_provided(filters, %{
-         "metric" => metric_type,
-         "metric_value" => metric_value,
-         "metric_operator" => operator
-       }) do
-    Map.put(filters, :metrics, %{
-      key: metric_type,
-      value: String.to_float(metric_value),
-      operator: String.to_existing_atom(operator)
-    })
-  end
-
-  defp filter_on_metrics_if_provided(filters, _), do: filters
 
   defp self_path(socket, extra) do
     params = Enum.into(stringify_keys(extra), socket.assigns.params)

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -108,11 +108,11 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> noreply()
   end
 
-  def filter_on_metrics_if_provided(filters, %{
-        "metric" => metric_type,
-        "metric_value" => metric_value,
-        "metric_operator" => operator
-      }) do
+  defp filter_on_metrics_if_provided(filters, %{
+         "metric" => metric_type,
+         "metric_value" => metric_value,
+         "metric_operator" => operator
+       }) do
     Map.put(filters, :metrics, %{
       key: metric_type,
       value: String.to_float(metric_value),
@@ -120,9 +120,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     })
   end
 
-  def filter_on_metrics_if_provided(filters, _) do
-    filters
-  end
+  defp filter_on_metrics_if_provided(filters, _), do: filters
 
   defp self_path(socket, extra) do
     params = Enum.into(stringify_keys(extra), socket.assigns.params)

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -155,6 +155,30 @@
             <div class="select-icon"></div>
           </div>
         </div>
+        <div class="form-group">
+          <label for="metrics">Metrics</label>
+          <div class="pos-rel">
+            <select name="metrics_key" id="metrics_key" class="form-control">
+              <option {selected?(@current_filters, :metrics_key, "")} value="">All</option>
+              <%= for key <- @metrics_keys do %>
+                <option {selected?(@current_filters, :metrics_key, Atom.to_string(key))}><%= Atom.to_string(key) %></option>
+              <% end %>
+            </select>
+            <div class="select-icon"></div>
+          </div>
+        </div>
+        <div :if={@current_filters.metrics_key != ""} class="form-group">
+          <label for="metrics_operator">Operator</label>
+          <select name="metrics_operator" id="metrics_operator" class="form-control">
+            <option {selected?(@current_filters, :metrics_operator, "gt")} value="gt">Greater Than</option>
+            <option {selected?(@current_filters, :metrics_operator, "lt")} value="lt">Less than</option>
+          </select>
+          <div class="select-icon"></div>
+        </div>
+        <div :if={@current_filters.metrics_key != ""} class="form-group">
+          <label for="metrics_value">Value</label>
+          <input type="number" name="metrics_value" id="metrics_value" class="form-control" value={@current_filters[:metrics_value]} phx-debounce="100" />
+        </div>
       </form>
       <button class="btn btn-secondary" type="button" phx-click="reset-filters">Reset Filters</button>
     </div>


### PR DESCRIPTION
Implements filtering on metric values.

What we want is to:
get all devices where the latest associated device metric for specified key is matching the provided filter (greater or less than X)

<s>The current query gives the latest device metric where the requirements are met, so if there are at least one metric report that match for a device, that device will be included in result, no matter the timestamp.</s>

Queries the latest inserted record for given metrics key, and checks if it matches the filter.

Includes a simple little functionality for testing in browser, just add params like `?metric=cpu_temp&metric_operator=gt&metric_value=37.0` to devices URL.