### PR TITLE
Order platform dropdown and add unknown platform as selection

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -154,6 +154,9 @@ defmodule NervesHub.Devices do
         {:firmware_version, value} ->
           where(query, [d], d.firmware_metadata["version"] == ^value)
 
+        {:platform, "Unknown"} ->
+          where(query, [d], is_nil(d.firmware_metadata["platform"]))
+
         {:platform, value} ->
           where(query, [d], d.firmware_metadata["platform"] == ^value)
 
@@ -1257,6 +1260,7 @@ defmodule NervesHub.Devices do
     |> select([d], fragment("?->>'platform'", d.firmware_metadata))
     |> distinct(true)
     |> where([d], d.product_id == ^product_id)
+    |> order_by([d], fragment("?->>'platform'", d.firmware_metadata))
     |> Repo.all()
   end
 

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -112,7 +112,7 @@
             <select name="platform" id="platform" class="form-control">
               <option {selected?(@current_filters, :platform, "")} value="">All</option>
               <%= for platform <- @platforms do %>
-                <option {selected?(@current_filters, :platform, platform)}><%= platform %></option>
+                <option {selected?(@current_filters, :platform, platform)}><%= if platform, do: platform, else: "Unknown" %></option>
               <% end %>
             </select>
             <div class="select-icon"></div>


### PR DESCRIPTION
Orders platform dropdown on device filtering (solves https://github.com/nerves-hub/nerves_hub_web/issues/1597).

Also replaces blank option with Unknown together with support for selecting unknown platform as filter.

From:
<img width="192" alt="image" src="https://github.com/user-attachments/assets/71077525-2c39-4218-b6a2-746aa52548cd">

To:
<img width="203" alt="image" src="https://github.com/user-attachments/assets/e1baa3ec-4801-4c3f-a4b6-c17dd80ea551">
