### PR TITLE
Disable console button when device console is not available

### DIFF
--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -90,4 +90,26 @@ defmodule NervesHub.Tracker do
         false
     end
   end
+
+  @doc """
+  Check if a device's console channel is available.
+
+  Times out if console is unavailable.
+  """
+  def console_active?(device) do
+    _ =
+      Phoenix.PubSub.broadcast(
+        NervesHub.PubSub,
+        "device:console:#{device.id}",
+        {:active?, self()}
+      )
+
+    receive do
+      :active ->
+        true
+    after
+      500 ->
+        false
+    end
+  end
 end

--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -64,6 +64,12 @@ defmodule NervesHubWeb.ConsoleChannel do
 
     socket.endpoint.subscribe("device:console:#{socket.assigns.device.id}")
 
+    socket.endpoint.broadcast!(
+      "device:console:#{socket.assigns.device.id}:internal",
+      "console_joined",
+      %{}
+    )
+
     # now that the console is connected, push down the device's elixir, line by line
     device = socket.assigns.device
     device = Repo.preload(device, [:deployment])
@@ -99,6 +105,11 @@ defmodule NervesHubWeb.ConsoleChannel do
     lines = Enum.join(socket.assigns.buffer) <> socket.assigns.current_line
     send(pid, {:cache, lines})
 
+    {:noreply, socket}
+  end
+
+  def handle_info({:active?, pid}, socket) do
+    send(pid, :active)
     {:noreply, socket}
   end
 

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -23,6 +23,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
     if connected?(socket) do
       socket.endpoint.subscribe("device:#{device.identifier}:internal")
+      socket.endpoint.subscribe("device:console:#{device.id}:internal")
       socket.endpoint.subscribe("firmware")
     end
 
@@ -31,6 +32,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:tab_hint, :devices)
     |> assign(:device, device)
     |> assign(:status, Tracker.status(device))
+    |> assign(:console_active?, Tracker.console_active?(device))
     |> assign(:deployment, device.deployment)
     |> assign(:update_information, Devices.resolve_update(device))
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
@@ -68,11 +70,18 @@ defmodule NervesHubWeb.Live.Devices.Show do
     socket
     |> assign(:device, device)
     |> assign(:status, payload.status)
+    |> assign(:console_active?, Tracker.console_active?(device))
     |> assign(:fwup_progress, nil)
     |> assign(:update_information, Devices.resolve_update(device))
     |> then(fn socket ->
       if(payload.status == "online", do: clear_flash(socket), else: socket)
     end)
+    |> noreply()
+  end
+
+  def handle_info(%Broadcast{event: "console_joined"}, socket) do
+    socket
+    |> assign(:console_active?, true)
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -31,7 +31,7 @@
         <span class="button-icon identify"></span>
         <span class="action-text">Identify</span>
       </button>
-      <%= link(class: "btn btn-outline-light btn-action", aria_label: "Console", target: "_blank", to: Routes.device_path(@socket, :console, @org.name, @product.name, @device.identifier)) do %>
+      <%= link(class: "btn btn-outline-light btn-action #{unless (@console_active?), do: "disabled"}", aria_label: "Console", target: "_blank", to: Routes.device_path(@socket, :console, @org.name, @product.name, @device.identifier)) do %>
         <span class="button-icon console-icon"></span>
         <span class="action-text">Console</span>
       <% end %>

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -291,7 +291,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "CPU")
       |> assert_has("div", text: "Not reported")
       |> assert_has("span", text: "Last reported :")
-      |> assert_has("time", text: "now")
+      |> assert_has("time", text: "ago")
     end
   end
 


### PR DESCRIPTION
An attempt to solve https://github.com/nerves-hub/nerves_hub_web/issues/1519.

Explanation for disabled button is not added, we'd might wait with that until new UI is ready?

