### PR TITLE
Batch insert device metrics

### DIFF
--- a/lib/nerves_hub/devices/metrics.ex
+++ b/lib/nerves_hub/devices/metrics.ex
@@ -173,11 +173,13 @@ defmodule NervesHub.Devices.Metrics do
   Saves map of metrics.
   """
   def save_metrics(device_id, metrics) do
-    Repo.transaction(fn ->
+    entries =
       Enum.map(metrics, fn {key, val} ->
-        save_metric(%{device_id: device_id, key: key, value: val})
+        DeviceMetric.save(%{device_id: device_id, key: key, value: val}).changes
+        |> Map.merge(%{inserted_at: {:placeholder, :now}})
       end)
-    end)
+
+    Repo.insert_all(DeviceMetric, entries, placeholders: %{now: DateTime.utc_now()})
   end
 
   @doc """

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -426,7 +426,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
     with {:health_report, {:ok, _}} <-
            {:health_report, Devices.save_device_health(device_health)},
-         {:metrics_report, {:ok, _}} <-
+         {:metrics_report, {_, _}} <-
            {:metrics_report, Metrics.save_metrics(socket.assigns.device.id, metrics)} do
       device_internal_broadcast!(socket.assigns.device, "health_check_report", %{})
     else

--- a/test/nerves_hub/device_metrics_test.exs
+++ b/test/nerves_hub/device_metrics_test.exs
@@ -46,8 +46,7 @@ defmodule NervesHub.DeviceMetricsTest do
         "used_percent" => 2
       }
 
-      assert {:ok, result} = Metrics.save_metrics(device.id, metrics)
-      assert length(result) == map_size(metrics)
+      assert {7, nil} = Metrics.save_metrics(device.id, metrics)
     end
   end
 

--- a/test/nerves_hub_web/live/devices/health_test.exs
+++ b/test/nerves_hub_web/live/devices/health_test.exs
@@ -37,7 +37,7 @@ defmodule NervesHubWeb.Devices.HealthTest do
       "used_percent" => 2
     }
 
-    assert {:ok, _} = Metrics.save_metrics(device.id, metrics)
+    assert {7, nil} = Metrics.save_metrics(device.id, metrics)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -249,7 +249,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "used_percent" => 60
       }
 
-      assert {:ok, _} = Metrics.save_metrics(device.id, metrics)
+      assert {7, nil} = Metrics.save_metrics(device.id, metrics)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -278,7 +278,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "used_percent" => 60
       }
 
-      assert {:ok, _} = Metrics.save_metrics(device.id, metrics)
+      assert {6, nil} = Metrics.save_metrics(device.id, metrics)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")


### PR DESCRIPTION
This decreases the metrics event processing time by half and reduces the number of Ecto queries, including no longer needing a transaction.

<img width="932" alt="Screenshot 2024-10-26 at 8 12 21 PM" src="https://github.com/user-attachments/assets/1826d063-f7d5-4a83-b5c3-c714922c59b1">

(the 3 and 12 relate to the number of telemetry spans)

(the 400,000 and 1,000,000 are the number of milliseconds used for processing)