### PR TITLE
Optimize the queries needed for `Accounts.list_org_keys`

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -368,10 +368,22 @@ defmodule NervesHub.Accounts do
     |> Repo.insert()
   end
 
-  def list_org_keys(%Org{id: org_id}) do
+  def list_org_keys(org_or_org_id, load_created_by \\ true)
+
+  def list_org_keys(%Org{id: org_id}, load_created_by) do
+    list_org_keys(org_id, load_created_by)
+  end
+
+  def list_org_keys(org_id, load_created_by) do
     OrgKey
     |> where(org_id: ^org_id)
-    |> preload(:created_by)
+    |> then(fn query ->
+      if load_created_by do
+        preload(query, :created_by)
+      else
+        query
+      end
+    end)
     |> order_by(:id)
     |> Repo.all()
   end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -36,7 +36,6 @@ defmodule NervesHubWeb.DeviceChannel do
       device
       |> Devices.verify_deployment()
       |> Deployments.set_deployment()
-      |> Repo.preload(:org)
       |> deployment_preload()
 
     maybe_send_public_keys(device, socket, params)
@@ -507,7 +506,7 @@ defmodule NervesHubWeb.DeviceChannel do
   defp maybe_send_public_keys(device, socket, params) do
     Enum.each(["fwup_public_keys", "archive_public_keys"], fn key_type ->
       if params[key_type] == "on_connect" do
-        org_keys = NervesHub.Accounts.list_org_keys(device.org)
+        org_keys = NervesHub.Accounts.list_org_keys(device.org_id, false)
 
         push(socket, key_type, %{
           keys: Enum.map(org_keys, fn ok -> ok.key end)


### PR DESCRIPTION
- The Org related to the Device doesn't need to be preloaded
- Don't load the user (`created_by`) when sending the keys to devices