### PR TITLE
Increase the Orchestrator timer, and add a jitter

### DIFF
--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -109,8 +109,9 @@ defmodule NervesHub.Deployments.Orchestrator do
   def handle_continue(:boot, deployment) do
     _ = PubSub.subscribe(NervesHub.PubSub, "deployment:#{deployment.id}")
 
-    # trigger every 5 minutes as a back up
-    _ = :timer.send_interval(5 * 60 * 1000, :trigger)
+    # trigger every 10 minutes, plus a jitter between 1 and 5 seconds, as a back up
+    interval = (10 + :rand.uniform(10)) * 60 * 1000
+    _ = :timer.send_interval(interval, :trigger)
 
     deployment =
       deployment


### PR DESCRIPTION
This randomly spaces out the timers, which also reduces DB spikes. (minor spikes)