### PR TITLE
Clear inflight updates for unhealthy devices

### DIFF
--- a/lib/nerves_hub/deployments/orchestrator.ex
+++ b/lib/nerves_hub/deployments/orchestrator.ex
@@ -2,8 +2,8 @@ defmodule NervesHub.Deployments.Orchestrator do
   @moduledoc """
   Orchestration process to handle passing out updates to devices
 
-  When a deployment is updated, the orchestraor will tell every
-  device local to its node that there is a new update. This will
+  When a deployment is updated, the orchestrator will tell every
+  device local to its node that there is a new update. This
   hook will allow the orchestrator to start slowly handing out
   updates instead of blasting every device at once.
   """

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -865,8 +865,8 @@ defmodule NervesHub.Devices do
   end
 
   @doc """
-  Devices that haven't been automatically blocked are not in the penalty window
-  Devices that have a time greater than now are in the penalty window
+  Devices that haven't been automatically blocked are not in the penalty window.
+  Devices that have a time greater than now are in the penalty window.
   """
   def device_in_penalty_box?(device, now \\ DateTime.utc_now())
 
@@ -890,6 +890,8 @@ defmodule NervesHub.Devices do
         {:error, :up_to_date, device}
 
       updates_blocked?(device, now) ->
+        clear_inflight_update(device)
+
         {:error, :updates_blocked, device}
 
       failure_rate_met?(device, deployment) ->
@@ -904,6 +906,7 @@ defmodule NervesHub.Devices do
         """
 
         AuditLogs.audit!(deployment, device, description)
+        clear_inflight_update(device)
 
         {:ok, device} = update_device(device, %{updates_blocked_until: blocked_until})
 
@@ -921,6 +924,7 @@ defmodule NervesHub.Devices do
         """
 
         AuditLogs.audit!(deployment, device, description)
+        clear_inflight_update(device)
 
         {:ok, device} = update_device(device, %{updates_blocked_until: blocked_until})
 


### PR DESCRIPTION
Fixes #1617.

If we know a device is unhealthy, we want to clear inflight updates. This unblocks the orchestrator and allows it to continue updating as many devices as possible.