### PR TITLE
Allow publishing docker images from PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           images: ghcr.io/nerves-hub/nerves-hub
           tags: |
             # short sha
-            type=sha,enable={{is_default_branch}},prefix=,suffix=,format=short
+            type=sha,prefix=,suffix=,format=short
             # branch image names, except for main
             type=ref,enable=${{ github.ref != format('refs/heads/{0}', 'main') }},event=branch
             # latest tag for main branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,27 @@ jobs:
             type=raw,enable={{is_default_branch}},value=latest
             # tag event (eg. "v1.2.3")
             type=ref,event=tag
+      
+      - name: Check if PR publish
+        if: ${{ github.event_name == 'pull_request' }}
+        id: pr_publish_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          commits=$(gh pr view ${{ github.head_ref }} --json commits --jq '.commits[] | .messageHeadline + " " + .messageBody')
+
+          if [[ $commits =~ \[publish\] ]]; then
+            echo "true"
+            echo "publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "false"
+            echo "publish=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' || github.ref_type == 'tag' }}
+          push: ${{ steps.pr_publish_check.outputs.publish == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is sometimes useful for testing PRs in external systems as needed

You can either manually trigger a publish in the `Actions` table and run the workflow for your branch or include `[publish]` in any commit message to have it sent through