### PR TITLE
Show helpful message when uploading duplicate firmware

### DIFF
--- a/lib/nerves_hub_web/live/firmware_templates/upload_firmware_template.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/upload_firmware_template.html.heex
@@ -9,7 +9,14 @@
     <.live_file_input upload={@uploads.firmware} required />
 
     <div class="has-error">
-      <span :if={@error_message} class="help-block"><%= @error_message %></span>
+      <span :if={@error_message} class="help-block">
+        <%= case @error_code do %>
+          <% :duplicate_firmware -> %>
+            <%= @error_message %> <a href={"/org/#{@org.name}/#{@product.name}/firmware/#{@uuid}"} target="_blank">View Firmware</a>
+          <% _ -> %>
+            <%= @error_message %>
+        <% end %>
+      </span>
     </div>
 
     <div :for={entry <- @uploads.firmware.entries} class="mt-1">


### PR DESCRIPTION
Fixes #1473.

This adds an error clause to provide helpful feedback when uploading firmware that has already been uploaded. [There's already a test for this constraint](https://github.com/nerves-hub/nerves_hub_web/blob/b7efd90ff828c0a6ee52b0b40ba3065cd68b6985/test/nerves_hub/firmwares_test.exs#L53), but let me know if a LiveView test is wanted/needed.

![CleanShot 2024-11-01 at 08 35 36](https://github.com/user-attachments/assets/50dfc16d-5c64-4401-bd2d-d759fd04ad4b)
