### PR TITLE
Use PR number when looking for publish commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,12 +136,13 @@ jobs:
             type=ref,event=tag
 
       - name: Check if PR publish
+        continue-on-error: true
         if: ${{ github.event_name == 'pull_request' }}
         id: pr_publish_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          commits=$(gh pr view ${{ github.head_ref }} --json commits --jq '.commits[] | .messageHeadline + " " + .messageBody')
+          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[] | .messageHeadline + " " + .messageBody')
 
           if [[ $commits =~ \[publish\] ]]; then
             echo "true"


### PR DESCRIPTION
This fixes an issue where jobs fail when built from forks which would have an incomplete ref. This changes to use the PR number instead which should get the details we need.

It also allows that step to fail to continue to job since it is such a specific, special case