### PR TITLE
Show current alarms on device page

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -254,6 +254,19 @@ html body {
   flex-grow: 1;
 }
 
+.current-alarms>.callout {
+  width: 100%;
+}
+
+.alarms-description {
+  background-color: #24282a;
+  padding: 6px;
+}
+
+.alarm-clickable {
+  cursor: pointer;
+}
+
 .display-box.metrics {
   display: flex;
   flex-wrap: wrap;

--- a/lib/nerves_hub/devices/alarms.ex
+++ b/lib/nerves_hub/devices/alarms.ex
@@ -1,6 +1,7 @@
 defmodule NervesHub.Devices.Alarms do
   import Ecto.Query
   alias NervesHub.Repo
+  alias NervesHub.Devices
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceHealth
 
@@ -59,6 +60,15 @@ defmodule NervesHub.Devices.Alarms do
     |> query_current_alarms()
     |> select([a], count(a))
     |> Repo.one!()
+  end
+
+  def get_current_alarms_for_device(device) do
+    device.id
+    |> Devices.get_latest_health()
+    |> case do
+      %DeviceHealth{data: data} -> data["alarms"]
+      _ -> nil
+    end
   end
 
   @doc """

--- a/lib/nerves_hub/devices/alarms.ex
+++ b/lib/nerves_hub/devices/alarms.ex
@@ -66,8 +66,12 @@ defmodule NervesHub.Devices.Alarms do
     device.id
     |> Devices.get_latest_health()
     |> case do
-      %DeviceHealth{data: data} -> data["alarms"]
-      _ -> nil
+      %DeviceHealth{data: %{"alarms" => alarms}} when is_map(alarms) ->
+        for {alarm, description} <- alarms,
+            do: {String.trim_leading(alarm, "Elixir."), description}
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -365,10 +365,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     end
   end
 
-  defp format_alarm(alarm), do: String.trim_leading(alarm, "Elixir.")
-
-  defp has_description?(""), do: false
-  defp has_description?(description) when is_binary(description), do: true
-  # To cover for cases where alarm description is provided as an invalid type.
-  defp has_description?(_), do: false
+  defp has_description?(description) do
+    is_binary(description) and byte_size(description) > 0
+  end
 end

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
+  alias NervesHub.Devices.Alarms
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.UpdatePayload
   alias NervesHub.Firmwares
@@ -39,6 +40,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
     |> assign(:latest_metrics, Devices.Metrics.get_latest_metric_set_for_device(device.id))
     |> assign(:latest_custom_metrics, Devices.Metrics.get_latest_custom_metrics(device.id))
+    |> assign(:alarms, Alarms.get_current_alarms_for_device(device))
     |> assign_metadata()
     |> schedule_health_check_timer()
     |> assign(:fwup_progress, nil)
@@ -362,4 +364,11 @@ defmodule NervesHubWeb.Live.Devices.Show do
       device.connecting_code
     end
   end
+
+  defp format_alarm(alarm), do: String.trim_leading(alarm, "Elixir.")
+
+  defp has_description?(""), do: false
+  defp has_description?(description) when is_binary(description), do: true
+  # To cover for cases where alarm description is provided as an invalid type.
+  defp has_description?(_), do: false
 end

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -109,7 +109,7 @@
         </button>
       </div>
 
-      <%= unless (Enum.any?(Map.values(@latest_metrics)) or Enum.any?(Map.values(@latest_custom_metrics))) or @alarms do %>
+      <%= if (!Enum.any?(Map.values(@latest_metrics)) and !Enum.any?(Map.values(@latest_custom_metrics))) and !@alarms do %>
         <div class="display-box">
           No health information have been received for this device.
         </div>
@@ -121,7 +121,7 @@
               <div class="help-text label">Current Alarms</div>
               <div :for={{{alarm, description}, index} <- Enum.with_index(@alarms)}>
                 <div>
-                  <span phx-click={JS.toggle_class("hidden", to: "#alarm-#{index}")} class={"badge #{if has_description?(description), do: "alarm-clickable"}"}><%= format_alarm(alarm) %></span>
+                  <span phx-click={JS.toggle_class("hidden", to: "#alarm-#{index}")} class={"badge #{if has_description?(description), do: "alarm-clickable"}"}><%= alarm %></span>
                 </div>
                 <code :if={has_description?(description)} id={"alarm-#{index}"} class="hidden alarms-description color-white wb-ba ff-m"><%= description %></code>
               </div>

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -109,12 +109,25 @@
         </button>
       </div>
 
-      <%= if (!Enum.any?(Map.values(@latest_metrics)) or !Enum.any?(Map.values(@latest_custom_metrics))) do %>
+      <%= unless (Enum.any?(Map.values(@latest_metrics)) or Enum.any?(Map.values(@latest_custom_metrics))) or @alarms do %>
         <div class="display-box">
           No health information have been received for this device.
         </div>
       <% end %>
       <div>
+        <%= if @alarms do %>
+          <div class="device-health current-alarms">
+            <div class="callout">
+              <div class="help-text label">Current Alarms</div>
+              <div :for={{{alarm, description}, index} <- Enum.with_index(@alarms)}>
+                <div>
+                  <span phx-click={JS.toggle_class("hidden", to: "#alarm-#{index}")} class={"badge #{if has_description?(description), do: "alarm-clickable"}"}><%= format_alarm(alarm) %></span>
+                </div>
+                <code :if={has_description?(description)} id={"alarm-#{index}"} class="hidden alarms-description color-white wb-ba ff-m"><%= description %></code>
+              </div>
+            </div>
+          </div>
+        <% end %>
         <%= if (Enum.any?(Map.values(@latest_metrics))) do %>
           <div class="device-health">
             <div :if={@latest_metrics.load_1min} class="callout">

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -234,7 +234,28 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "No health information have been received for this device.")
     end
 
-    test "full set of information", %{
+    test "has alarms", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      device_health = %{
+        "device_id" => device.id,
+        "data" => %{"alarms" => %{"SomeAlarm" => "Some description"}}
+      }
+
+      assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("div", text: "Health")
+      |> assert_has("div", text: "Current Alarms")
+      |> assert_has("span", text: "SomeAlarm")
+    end
+
+    test "full set of metrics", %{
       conn: conn,
       org: org,
       product: product,


### PR DESCRIPTION
Display any current alarms for device.
Click on alarm to show description if provided.

