### PR TITLE
Fix broken paginator

### DIFF
--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -98,10 +98,9 @@ defmodule NervesHubWeb.Live.Devices.Index do
   end
 
   def handle_params(unsigned_params, _uri, socket) do
-    filters =
-      Map.merge(@default_filters, filter_changes(unsigned_params))
-
-    pagination_opts = Map.merge(socket.assigns.paginate_opts, pagination_changes(unsigned_params))
+    filters = Map.merge(@default_filters, filter_changes(unsigned_params))
+    changes = pagination_changes(unsigned_params)
+    pagination_opts = Map.merge(@default_pagination, changes)
 
     socket
     |> assign(:current_sort, Map.get(unsigned_params, "sort", "identifier"))

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -133,7 +133,7 @@ defmodule NervesHubWeb.LayoutView do
       Map.merge(opts, %{start_range: start_range, end_range: end_range, distance: distance})
 
     ~H"""
-    <div class="btn-group btn-group-toggle btn-group-gap">
+    <div :if={@total_pages > 0} class="btn-group btn-group-toggle btn-group-gap">
       <div :if={@start_range > 1}>
         <button class="btn btn-secondary btn-sm" phx-click="paginate" phx-value-page="1">1</button>
       </div>
@@ -147,9 +147,6 @@ defmodule NervesHubWeb.LayoutView do
       </div>
       <div :if={@total_pages > @distance}>
         <button class="btn btn-secondary btn-sm" phx-click="paginate" phx-value-page="…">…</button>
-      </div>
-      <div>
-        <button class="btn btn-secondary btn-sm" phx-click="paginate" phx-value-page={@total_pages}><%= @total_pages %></button>
       </div>
       <div :if={@page_number > 1}>
         <button class="btn btn-secondary btn-sm " phx-click="paginate" phx-value-page={@page_number - 1}>&lt;&lt;</button>

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -145,9 +145,14 @@ defmodule NervesHubWeb.LayoutView do
           <%= page %>
         </button>
       </div>
-      <div :if={@total_pages > @distance}>
-        <button class="btn btn-secondary btn-sm" phx-click="paginate" phx-value-page="…">…</button>
-      </div>
+      <%= if @total_pages > @distance do %>
+        <div>
+          <button class="btn btn-secondary btn-sm" phx-click="paginate" phx-value-page="…">…</button>
+        </div>
+        <div>
+          <button class="btn btn-secondary btn-sm" phx-click="paginate" phx-value-page={@total_pages}><%= @total_pages %></button>
+        </div>
+      <% end %>
       <div :if={@page_number > 1}>
         <button class="btn btn-secondary btn-sm " phx-click="paginate" phx-value-page={@page_number - 1}>&lt;&lt;</button>
       </div>


### PR DESCRIPTION
Solves #1678

- Reverts handling of pagination params in devices list that was broken due to a faulty rebase.
- Remove pagination button that displays total pages
- Only display pagination links if total pages is more than 0.