### PR TITLE
Add script section to device UI

### DIFF
--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -58,6 +58,7 @@ defmodule NervesHub.Helpers.Authorization do
   def authorized?(:"support_script:create", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"support_script:update", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"support_script:delete", %OrgUser{role: role}), do: role_check(:manage, role)
+  def authorized?(:"support_script:run", %OrgUser{role: role}), do: role_check(:manage, role)
 
   defp role_check(required_role, user_role) do
     required_role

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -58,7 +58,7 @@ defmodule NervesHub.Helpers.Authorization do
   def authorized?(:"support_script:create", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"support_script:update", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"support_script:delete", %OrgUser{role: role}), do: role_check(:manage, role)
-  def authorized?(:"support_script:run", %OrgUser{role: role}), do: role_check(:manage, role)
+  def authorized?(:"support_script:run", %OrgUser{role: role}), do: role_check(:view, role)
 
   defp role_check(required_role, user_role) do
     required_role

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -96,6 +96,29 @@
         </div>
       <% end %>
     </div>
+
+    <div :if={@scripts != []}>
+      <h3 class="mb-2">Support Scripts</h3>
+
+      <div class="display-box">
+        <div :for={script <- @scripts} class="mb-2 pb-2 border-bottom border-dark">
+          <div class="flex-row align-items-center justify-content-between">
+            <div><%= script.name %></div>
+            <button class="btn btn-primary" phx-click="run-script" phx-value-script_id={script.id}>
+              Run
+            </button>
+          </div>
+          <div :if={@script_output.id == script.id} class="mt-2" phx-click="clear-script-output">
+            <code class="alarms-description color-white wb-ba ff-m"><%= @script_output.output %></code>
+          </div>
+        </div>
+        <div class="text-right">
+          <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts"}>
+            Add and edit scripts
+          </.link>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="col-lg-6">

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -101,15 +101,15 @@
       <h3 class="mb-2">Support Scripts</h3>
 
       <div class="display-box">
-        <div :for={script <- @scripts} class="mb-2 pb-2 border-bottom border-dark">
+        <div :for={{script, idx} <- @scripts} class="mb-2 pb-2 border-bottom border-dark">
           <div class="flex-row align-items-center justify-content-between">
             <div><%= script.name %></div>
-            <button class="btn btn-secondary" phx-click={if script.id == @script_output.id, do: "clear-script-output", else: "run-script"} phx-value-script_id={script.id}>
-              <%= if script.id == @script_output.id, do: "Close", else: "Run" %>
+            <button class="btn btn-secondary" disabled={script.output == running_script_placeholder()} phx-click={if script.output, do: "clear-script-output", else: "run-script"} phx-value-idx={idx}>
+              <%= script_button_text(script.output) %>
             </button>
           </div>
-          <div :if={@script_output.id == script.id} class="mt-2">
-            <code class="alarms-description color-white wb-ba ff-m"><%= @script_output.output %></code>
+          <div :if={script.output} class="mt-2">
+            <code class="alarms-description color-white wb-ba ff-m"><%= script.output %></code>
           </div>
         </div>
         <div class="text-right">

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -104,11 +104,11 @@
         <div :for={script <- @scripts} class="mb-2 pb-2 border-bottom border-dark">
           <div class="flex-row align-items-center justify-content-between">
             <div><%= script.name %></div>
-            <button class="btn btn-secondary" phx-click="run-script" phx-value-script_id={script.id}>
-              Run
+            <button class="btn btn-secondary" phx-click={if script.id == @script_output.id, do: "clear-script-output", else: "run-script"} phx-value-script_id={script.id}>
+              <%= if script.id == @script_output.id, do: "Close", else: "Run" %>
             </button>
           </div>
-          <div :if={@script_output.id == script.id} class="mt-2" phx-click="clear-script-output">
+          <div :if={@script_output.id == script.id} class="mt-2">
             <code class="alarms-description color-white wb-ba ff-m"><%= @script_output.output %></code>
           </div>
         </div>

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -104,7 +104,7 @@
         <div :for={script <- @scripts} class="mb-2 pb-2 border-bottom border-dark">
           <div class="flex-row align-items-center justify-content-between">
             <div><%= script.name %></div>
-            <button class="btn btn-primary" phx-click="run-script" phx-value-script_id={script.id}>
+            <button class="btn btn-secondary" phx-click="run-script" phx-value-script_id={script.id}>
               Run
             </button>
           </div>

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -392,6 +392,35 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     end
   end
 
+  describe "support scripts" do
+    test "no scripts available", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> refute_has("h3", text: "Support Scripts")
+    end
+
+    test "list scripts", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      {:ok, _command} =
+        NervesHub.Scripts.create(product, %{name: "MOTD", text: "NervesMOTD.print()"})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h3", text: "Support Scripts")
+      |> assert_has("div", text: "MOTD")
+      |> assert_has("button", text: "Run")
+    end
+  end
+
   def device_show_path(%{device: device, org: org, product: product}) do
     ~p"/org/#{org.name}/#{product.name}/devices/#{device.identifier}"
   end


### PR DESCRIPTION
Solves #1681 

Adds a simple section on device page for listing and running support scripts.

Not too much time spent on the looks since the whole UI is redesigned.