### PR TITLE
Ignore empty metrics map in health report

### DIFF
--- a/lib/nerves_hub/devices/metrics.ex
+++ b/lib/nerves_hub/devices/metrics.ex
@@ -148,6 +148,8 @@ defmodule NervesHub.Devices.Metrics do
   @doc """
   Saves map of metrics.
   """
+  def save_metrics(_device_id, metrics) when metrics == %{}, do: {:ok, 0}
+
   def save_metrics(device_id, metrics) do
     entries =
       Enum.map(metrics, fn {key, val} ->

--- a/lib/nerves_hub_web/live/devices/device_health.ex
+++ b/lib/nerves_hub_web/live/devices/device_health.ex
@@ -87,7 +87,7 @@ defmodule NervesHubWeb.Live.Devices.DeviceHealth do
     timer_ref = Process.send_after(self(), :check_health_interval, @check_health_interval)
 
     topic = "device:#{socket.assigns.device.id}:extensions"
-    NervesHubWeb.DeviceEndpoint.broadcast(topic, "health:check", %{})
+    socket.endpoint.broadcast(topic, "health:check", %{})
 
     socket
     |> assign(:health_check_timer, timer_ref)

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -126,9 +126,12 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def handle_info(:check_health_interval, socket) do
     timer_ref = Process.send_after(self(), :check_health_interval, 65_000)
 
-    socket.endpoint.broadcast("device:#{socket.assigns.device.id}", "check_health", %{})
+    topic = "device:#{socket.assigns.device.id}:extensions"
+    NervesHubWeb.DeviceEndpoint.broadcast(topic, "health:check", %{})
 
-    {:noreply, assign(socket, :health_check_timer, timer_ref)}
+    socket
+    |> assign(:health_check_timer, timer_ref)
+    |> noreply()
   end
 
   def handle_info(%Broadcast{event: "location:updated"}, socket) do

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -127,7 +127,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     timer_ref = Process.send_after(self(), :check_health_interval, 65_000)
 
     topic = "device:#{socket.assigns.device.id}:extensions"
-    NervesHubWeb.DeviceEndpoint.broadcast(topic, "health:check", %{})
+    socket.endpoint.broadcast(topic, "health:check", %{})
 
     socket
     |> assign(:health_check_timer, timer_ref)


### PR DESCRIPTION
Solves #1662.

Also, the deprecated broadcast topic for health checks is replaced with correct one.