### PR TITLE
Ignore some otel logging metadata

### DIFF
--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -11,7 +11,10 @@ defmodule NervesHub.Logger do
     :time,
     :gl,
     :ansi_color,
-    :__sentry__
+    :__sentry__,
+    :otel_trace_id,
+    :otel_span_id,
+    :otel_trace_flags
   ]
 
   def format(level, message, timestamp, metadata) do


### PR DESCRIPTION
This cleans up our logs a little bit