### PR TITLE
Make sure the latest connection is loaded

### DIFF
--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -65,7 +65,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def handle_info(%Broadcast{event: "connection:heartbeat"}, socket) do
     %{device: device, org: org} = socket.assigns
 
-    {:ok, device} = Devices.get_device_by_identifier(org, device.identifier)
+    {:ok, device} = Devices.get_device_by_identifier(org, device.identifier, :latest_connection)
 
     socket
     |> assign(:device, device)


### PR DESCRIPTION
Fixes a UI issue where the connection status and information is removed after a device heartbeat occurs