### PR TITLE
Fetch the signing salt for the web socket connections from the config

### DIFF
--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -4,10 +4,14 @@ defmodule NervesHubWeb.Endpoint do
 
   alias NervesHub.Helpers.WebsocketConnectionError
 
+  def fetch_signing_salt() do
+    Application.get_env(:nerves_hub, __MODULE__)[:live_view][:signing_salt]
+  end
+
   @session_options [
     store: :cookie,
     key: "_nerves_hub_key",
-    signing_salt: "1CPjriVa"
+    signing_salt: {__MODULE__, :fetch_signing_salt, []}
   ]
 
   socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])


### PR DESCRIPTION
This approach is taken from https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-connect-info

```
Additionally, session_config may be a MFA, such as {MyAppWeb.Auth, :get_session_config, []}, 
to allow loading config in runtime.
```

This allows for the signing salt to not be published and shared between all running NervesHub installs.