### PR TITLE
Add a type to the `AuditLog` schema

### DIFF
--- a/lib/nerves_hub/audit_logs/audit_log.ex
+++ b/lib/nerves_hub/audit_logs/audit_log.ex
@@ -6,6 +6,8 @@ defmodule NervesHub.AuditLogs.AuditLog do
   alias NervesHub.Accounts.Org
   alias NervesHub.Types.Resource
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @required_params [
     :actor_id,


### PR DESCRIPTION
Resolves a warning coming from a function spec in the `AuditLogs.Templates` module using `AuditLog.t()`