### PR TITLE
Improve device buttons

### DIFF
--- a/assets/css/_buttons.scss
+++ b/assets/css/_buttons.scss
@@ -65,6 +65,10 @@ html {
       background-image: url("/images/icons/power.svg");
     }
 
+    &.reconnect {
+      background-image: url("/images/icons/reconnect.svg");
+    }
+
     &.identify {
       background-image: url("/images/icons/identify.svg");
     }

--- a/assets/static/images/icons/reconnect.svg
+++ b/assets/static/images/icons/reconnect.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" width="24px" height="24px">
+  <path stroke-linecap="round" stroke-linejoin="round" fill="#FFFFFF" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
+</svg>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -495,4 +495,8 @@ defmodule NervesHubWeb.Live.Devices.Show do
     do: "Run"
 
   defp script_button_text(_), do: "Close"
+
+  defp disconnected?(connection) do
+    is_nil(connection) || connection.status != :connected
+  end
 end

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -19,15 +19,15 @@
         <span class="action-text">Destroy</span>
       </button>
     <% else %>
-      <button class="btn btn-outline-light btn-action" aria-label="Reboot device" type="button" phx-click="reboot" data-confirm="Are you sure?">
+      <button class={["btn btn-outline-light btn-action", disconnected?(@device_connection) && "disabled"]} aria-label="Reboot device" type="button" phx-click="reboot" data-confirm="Are you sure?">
         <span class="button-icon power"></span>
         <span class="action-text">Reboot</span>
       </button>
-      <button class="btn btn-outline-light btn-action" aria-label="Reconnect device" type="button" phx-click="reconnect">
+      <button class={["btn btn-outline-light btn-action", disconnected?(@device_connection) && "disabled"]} aria-label="Reconnect device" type="button" phx-click="reconnect">
         <span class="button-icon reconnect"></span>
         <span class="action-text">Reconnect</span>
       </button>
-      <button class="btn btn-outline-light btn-action" aria-label="Identify device" type="button" phx-click="identify">
+      <button class={["btn btn-outline-light btn-action", disconnected?(@device_connection) && "disabled"]} aria-label="Identify device" type="button" phx-click="identify">
         <span class="button-icon identify"></span>
         <span class="action-text">Identify</span>
       </button>


### PR DESCRIPTION
Add an SVG for the 'reconnect' button, and disable `reboot`, `reconnect`, and `identify` if the device isn't connected.

<img width="930" alt="Screenshot 2025-01-07 at 3 38 57 PM" src="https://github.com/user-attachments/assets/a302d2b6-4014-412f-a08e-9eeff62c5d83" />
