### PR TITLE
Move some Deployment info around

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -37,12 +37,17 @@ defmodule NervesHub.Deployments do
     |> Map.new()
   end
 
-  @spec get_deployment_device_count(integer()) :: %{integer() => integer()}
+  @spec get_deployment_device_count(Deployment.t()) :: term() | nil
+  def get_deployment_device_count(%Deployment{id: id}) do
+    get_deployment_device_count(id)
+  end
+
+  @spec get_deployment_device_count(integer()) :: term() | nil
   def get_deployment_device_count(deployment_id) do
     Device
-    |> select([d], count(d.id))
     |> where([d], d.deployment_id == ^deployment_id)
-    |> Repo.one()
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
   end
 
   @spec get_deployments_by_firmware(integer()) :: [Deployment.t()]

--- a/lib/nerves_hub_web/live/deployments/edit.ex
+++ b/lib/nerves_hub_web/live/deployments/edit.ex
@@ -16,7 +16,7 @@ defmodule NervesHubWeb.Live.Deployments.Edit do
     deployment =
       Deployments.get_by_product_and_name!(product, name) |> NervesHub.Repo.preload(:firmware)
 
-    current_device_count = Deployments.get_deployment_device_count(deployment.id)
+    current_device_count = Deployments.get_deployment_device_count(deployment)
 
     archives = Archives.all_by_product(deployment.product)
     firmwares = Firmwares.get_firmwares_for_deployment(deployment)

--- a/lib/nerves_hub_web/live/deployments/show.ex
+++ b/lib/nerves_hub_web/live/deployments/show.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWeb.Live.Deployments.Show do
       |> Map.put(:anchor, "latest-activity")
 
     inflight_updates = Devices.inflight_updates_for(deployment)
-    current_device_count = Deployments.get_deployment_device_count(deployment.id)
+    current_device_count = Deployments.get_deployment_device_count(deployment)
 
     socket
     |> page_title("Deployment - #{deployment.name} - #{product.name}")

--- a/lib/nerves_hub_web/live/deployments/show.html.heex
+++ b/lib/nerves_hub_web/live/deployments/show.html.heex
@@ -34,6 +34,24 @@
       <%= if @deployment.is_active, do: "On", else: "Off" %>
     </p>
   </div>
+  <div>
+    <div class="help-text">Arch</div>
+    <p>
+      <%= @firmware.architecture %>
+    </p>
+  </div>
+  <div>
+    <div class="help-text">Platform</div>
+    <p>
+      <%= @firmware.platform %>
+    </p>
+  </div>
+  <div id="device-count">
+    <div class="help-text">Device count</div>
+    <p>
+      <%= @current_device_count %>
+    </p>
+  </div>
 </div>
 
 <div class="divider"></div>
@@ -50,10 +68,6 @@
               <%= firmware_summary(@firmware) %>
             </.link>
           </span>
-        </div>
-        <div>
-          <div class="help-text mb-1">Current device count</div>
-          <p><%= @current_device_count %></p>
         </div>
         <div class="row">
           <div class="col-lg-6 mb-1">


### PR DESCRIPTION
This moves some info from the body into the info bar under the deployment name.

I've also fixed the device count, which wasn't excluding deleted devices.

<img width="1156" alt="Screenshot 2025-01-07 at 4 30 01 PM" src="https://github.com/user-attachments/assets/8761a6ab-2e66-4011-bd48-f6130f1f8f15" />

