### PR TITLE
Relax restrictions when querying for eligible deployments

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -439,4 +439,22 @@ defmodule NervesHub.Deployments do
   defp ignore_same_deployment(query, %{deployment_id: deployment_id}) do
     where(query, [d], d.id != ^deployment_id)
   end
+
+  @doc """
+  Find all eligible deployments for a device, based on the firmware platform,
+  firmware architecture, and product.
+
+  This is purposefully less-strict then Deployments.matching_deployments/2
+  and should only be used when a human is choosing the deployment for a device.
+  """
+  @spec eligible_deployments(Device.t()) :: [Deployment.t()]
+  def eligible_deployments(device) do
+    Deployment
+    |> join(:inner, [d], assoc(d, :firmware), as: :firmware)
+    |> preload([_, firmware: f], firmware: f)
+    |> where([d, _], d.product_id == ^device.product_id)
+    |> where([d, firmware: f], f.platform == ^device.firmware_metadata.platform)
+    |> where([d, firmware: f], f.architecture == ^device.firmware_metadata.architecture)
+    |> Repo.all()
+  end
 end

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -56,7 +56,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> schedule_health_check_timer()
     |> assign(:fwup_progress, nil)
     |> audit_log_assigns(1)
-    |> assign(:eligible_deployments, Deployments.matching_deployments(device))
+    |> assign(:eligible_deployments, Deployments.eligible_deployments(device))
     |> ok()
   end
 
@@ -382,7 +382,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     socket
     |> assign(:device, device)
     |> assign(:deployment, nil)
-    |> assign(:eligible_deployments, Deployments.matching_deployments(device))
+    |> assign(:eligible_deployments, Deployments.eligible_deployments(device))
     |> put_flash(:info, "Device successfully removed from the deployment")
     |> noreply()
   end

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -241,6 +241,10 @@
           <span :if={is_nil(@deployment)} class="color-white-50">No Assigned Deployment</span>
         </div>
 
+        <div :if={Enum.empty?(@eligible_deployments) && is_nil(@device.deployment_id)}>
+          No Eligible Deployments
+        </div>
+
         <div :if={Enum.any?(@eligible_deployments) && is_nil(@device.deployment_id)}>
           <div class="help-text mb-1">
             Eligible Deployments

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -477,6 +477,20 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert Repo.reload(device) |> Map.get(:deployment_id)
       assert length(AuditLogs.logs_for(device)) == 1
     end
+
+    test "'no eligible deployments' text displays properly", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device,
+      deployment: deployment
+    } do
+      _ = Repo.delete!(deployment)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("div", text: "No Eligible Deployments")
+    end
   end
 
   def device_show_path(%{device: device, org: org, product: product}) do


### PR DESCRIPTION
Eligible deployments now only match against product, platform, and architecture. When there are no eligible deployments, helper text is displayed.