### PR TITLE
Allow for the firmware file size limit to be configurable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -348,6 +348,10 @@ if config_env() == :prod do
   end
 end
 
+# Set a default max firmware upload size of 200MB for all environments
+config :nerves_hub, NervesHub.Firmwares.Upload,
+  max_size: System.get_env("FIRMWARE_UPLOAD_MAX_SIZE", "200000000") |> String.to_integer()
+
 ##
 # SMTP settings.
 #

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -144,7 +144,7 @@ defmodule NervesHub.Firmwares do
             Repo.rollback(error)
         end
       end,
-      timeout: 30_000
+      timeout: 60_000
     )
   end
 

--- a/lib/nerves_hub/firmwares/upload/s3.ex
+++ b/lib/nerves_hub/firmwares/upload/s3.ex
@@ -12,7 +12,7 @@ defmodule NervesHub.Firmwares.Upload.S3 do
   def upload_file(source_path, %{"s3_key" => s3_key}) do
     source_path
     |> S3.Upload.stream_file()
-    |> S3.upload(bucket(), s3_key)
+    |> S3.upload(bucket(), s3_key, timeout: 60_000)
     |> ExAws.request()
     |> case do
       {:ok, _} -> :ok

--- a/lib/nerves_hub_web/dymanic_config_multipart.ex
+++ b/lib/nerves_hub_web/dymanic_config_multipart.ex
@@ -1,0 +1,30 @@
+defmodule NervesHubWeb.DymanicConfigMultipart do
+  @moduledoc """
+  A wrapper around `Plug.Parsers.MULTIPART` which allows for the `:length` opt (max file size)
+  to be set during runtime.
+
+  This can later be expanded to allow for different file size limits based on the organization.
+
+  Thank you to https://hexdocs.pm/plug/Plug.Parsers.MULTIPART.html#module-dynamic-configuration
+  for the inspiration.
+  """
+
+  @multipart Plug.Parsers.MULTIPART
+
+  def init(opts) do
+    opts
+  end
+
+  def parse(conn, "multipart", subtype, headers, opts) do
+    opts = @multipart.init([length: max_file_size()] ++ opts)
+    @multipart.parse(conn, "multipart", subtype, headers, opts)
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts) do
+    {:next, conn}
+  end
+
+  defp max_file_size() do
+    Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
+  end
+end

--- a/lib/nerves_hub_web/dymanic_config_multipart.ex
+++ b/lib/nerves_hub_web/dymanic_config_multipart.ex
@@ -3,6 +3,8 @@ defmodule NervesHubWeb.DymanicConfigMultipart do
   A wrapper around `Plug.Parsers.MULTIPART` which allows for the `:length` opt (max file size)
   to be set during runtime.
 
+  This also restricts large file uploads to the firmware upload api route.
+
   This can later be expanded to allow for different file size limits based on the organization.
 
   Thank you to https://hexdocs.pm/plug/Plug.Parsers.MULTIPART.html#module-dynamic-configuration
@@ -16,7 +18,7 @@ defmodule NervesHubWeb.DymanicConfigMultipart do
   end
 
   def parse(conn, "multipart", subtype, headers, opts) do
-    opts = @multipart.init([length: max_file_size()] ++ opts)
+    opts = @multipart.init([length: max_file_size(conn)] ++ opts)
     @multipart.parse(conn, "multipart", subtype, headers, opts)
   end
 
@@ -24,7 +26,11 @@ defmodule NervesHubWeb.DymanicConfigMultipart do
     {:next, conn}
   end
 
-  defp max_file_size() do
-    Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
+  defp max_file_size(conn) do
+    if String.match?(conn.request_path, ~r/^\/api\/orgs\/\w+\/products\/\w+\/firmwares$/) do
+      Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
+    else
+      1_000_000
+    end
   end
 end

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -71,11 +71,9 @@ defmodule NervesHubWeb.Endpoint do
 
   plug(
     Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
+    parsers: [:urlencoded, NervesHubWeb.DymanicConfigMultipart, :json],
     pass: ["*/*"],
-    # 1GB
-    length: 1_073_741_824,
-    json_decoder: Jason
+    json_decoder: Phoenix.json_library()
   )
 
   plug(Sentry.PlugContext)

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -46,7 +46,7 @@ defmodule NervesHubWeb.Live.Firmware do
       accept: ~w(.fw),
       max_entries: 1,
       auto_upload: true,
-      max_file_size: 200_000_000,
+      max_file_size: max_file_size(),
       progress: &handle_progress/3
     )
     |> render_with(&upload_firmware_template/1)
@@ -192,5 +192,9 @@ defmodule NervesHubWeb.Live.Firmware do
   defp format_signed(%{org_key_id: org_key_id}, org_keys) do
     key = Enum.find(org_keys, &(&1.id == org_key_id))
     "#{key.name}"
+  end
+
+  defp max_file_size() do
+    Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
   end
 end


### PR DESCRIPTION
This allows for the firmware file size upload limit to be adjusted via runtime env var.

This also restrictions large file uploads to only the firmwares api route.

I'd also like this to be configurable per org, such that free users can only upload smaller firmware sizes, but thats for a different discussion.