### PR TITLE
Clean stale `DeviceConnection`s

### DIFF
--- a/lib/nerves_hub/workers/clean_device_connection_states.ex
+++ b/lib/nerves_hub/workers/clean_device_connection_states.ex
@@ -3,9 +3,13 @@ defmodule NervesHub.Workers.CleanDeviceConnectionStates do
     max_attempts: 5,
     queue: :device
 
+  alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
+
   @impl true
   def perform(_) do
-    NervesHub.Devices.clean_connection_states()
+    Devices.clean_connection_states()
+    Connections.clean_stale_connections()
 
     :ok
   end


### PR DESCRIPTION
I noticed in the DB that we have several old/stale device connections. 

Upon looking into this more, I realised that when we added the `DeviceConnection` schema and relationships, we didn't add a way to clean the stale connections, which might linger due to unforeseen circumstances, like the app crashing.

