### PR TITLE
Allow devices to have empty firmware when checking for deployments

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -463,6 +463,8 @@ defmodule NervesHub.Deployments do
   and should only be used when a human is choosing the deployment for a device.
   """
   @spec eligible_deployments(Device.t()) :: [Deployment.t()]
+  def eligible_deployments(%Device{firmware_metadata: nil}), do: []
+
   def eligible_deployments(device) do
     Deployment
     |> join(:inner, [d], assoc(d, :firmware), as: :firmware)

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -16,6 +16,25 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     Endpoint.subscribe("device:#{device.id}")
   end
 
+  describe "render liveview" do
+    test "render when device has no firmware", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      {:ok, device} =
+        Devices.create_device(%{
+          org_id: org.id,
+          product_id: product.id,
+          identifier: "no-firmware-device"
+        })
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: "no-firmware-device")
+    end
+  end
+
   describe "handle_event" do
     test "delete device", %{conn: conn, org: org, product: product, device: device} do
       conn


### PR DESCRIPTION
Fixes a bug (#1748 ) where the liveview crashes when trying to show a device without firmware metadata.