### PR TITLE
Make it clear device has no active alarms

### DIFF
--- a/lib/nerves_hub/devices/alarms.ex
+++ b/lib/nerves_hub/devices/alarms.ex
@@ -68,7 +68,7 @@ defmodule NervesHub.Devices.Alarms do
     device.id
     |> Devices.get_latest_health()
     |> case do
-      %DeviceHealth{data: %{"alarms" => alarms}} when is_map(alarms) ->
+      %DeviceHealth{data: %{"alarms" => alarms}} when is_map(alarms) and map_size(alarms) > 0 ->
         for {alarm, description} <- alarms,
             do: {String.trim_leading(alarm, "Elixir."), description}
 

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -143,19 +143,21 @@
         </div>
       <% end %>
       <div>
-        <%= if @alarms do %>
-          <div class="device-health current-alarms">
-            <div class="callout">
-              <div class="help-text label">Current Alarms</div>
+        <div class="device-health current-alarms">
+          <div class="callout">
+            <%= if @alarms do %>
+              <div class="help-text label">Active Alarms</div>
               <div :for={{{alarm, description}, index} <- Enum.with_index(@alarms)}>
                 <div>
                   <span phx-click={JS.toggle_class("hidden", to: "#alarm-#{index}")} class={"badge #{if has_description?(description), do: "alarm-clickable"}"}><%= alarm %></span>
                 </div>
                 <code :if={has_description?(description)} id={"alarm-#{index}"} class="hidden alarms-description color-white wb-ba ff-m"><%= description %></code>
               </div>
-            </div>
+            <% else %>
+              <div class="help-text label">No active alarms</div>
+            <% end %>
           </div>
-        <% end %>
+        </div>
         <%= if (Enum.any?(Map.values(@latest_metrics))) do %>
           <div class="device-health">
             <%!-- Display CPU load averages as a group. --%>

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -308,7 +308,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "No health information has been received for this device.")
     end
 
-    test "has alarms", %{
+    test "has active alarms", %{
       conn: conn,
       org: org,
       product: product,
@@ -325,8 +325,33 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("h1", text: device.identifier)
       |> assert_has("div", text: "Health")
-      |> assert_has("div", text: "Current Alarms")
+      |> assert_has("div", text: "Active Alarms")
       |> assert_has("span", text: "SomeAlarm")
+    end
+
+    test "has no active alarms", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("div", text: "Health")
+      |> assert_has("div", text: "No active alarms")
+
+      assert {:ok, _} =
+               NervesHub.Devices.save_device_health(%{
+                 "device_id" => device.id,
+                 "data" => %{"alarms" => %{}}
+               })
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("div", text: "Health")
+      |> assert_has("div", text: "No active alarms")
     end
 
     test "full set of metrics", %{


### PR DESCRIPTION
Makes UI for device show "No active alarms" when that's the case.

Also adds test case for this.

In #1734 there's a suggestion of displaying a link to docs or code explaining how to setup alarms on devices, but I couldn't find any examples good enough. 