### PR TITLE
Allow unprovisioned devices to set deployments

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -703,9 +703,10 @@ defmodule NervesHub.Devices do
   @doc """
   Resolve an update for the device's deployment
   """
-  def resolve_update(%{deployment_id: nil}) do
-    %UpdatePayload{update_available: false}
-  end
+  @spec resolve_update(Device.t()) :: UpdatePayload.t()
+  def resolve_update(%{status: :registered}), do: %UpdatePayload{update_available: false}
+
+  def resolve_update(%{deployment_id: nil}), do: %UpdatePayload{update_available: false}
 
   def resolve_update(device) do
     deployment = Repo.preload(device.deployment, [:firmware])

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -511,14 +511,11 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:audit_pager, audit_pager)
   end
 
-  defp assign_deployments(%{assigns: %{device: device, product: product}} = socket) do
-    deployments =
-      if device.status == :provisioned,
-        do: Deployments.eligible_deployments(device),
-        else: Deployments.get_deployments_by_product(product)
+  defp assign_deployments(%{assigns: %{device: %{status: :provisioned} = device}} = socket),
+    do: assign(socket, deployments: Deployments.eligible_deployments(device))
 
-    assign(socket, deployments: deployments)
-  end
+  defp assign_deployments(%{assigns: %{product: product}} = socket),
+    do: assign(socket, deployments: Deployments.get_deployments_by_product(product))
 
   defp connecting_code(device) do
     if device.deployment && device.deployment.connecting_code do

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -252,14 +252,14 @@
 
         <div :if={Enum.any?(@deployments) && is_nil(@device.deployment_id)}>
           <div class="help-text mb-1">
-            <%= if @device.status == :provisioned, do: "Eligible Deployments", else: "Product Deployments" %>
+            {if @device.status == :provisioned, do: "Eligible Deployments", else: "Product Deployments"}
           </div>
           <form phx-submit="set-deployment">
             <div class="flex-row justify-content-between">
               <select name="deployment_id" class="form-control">
                 <option value="">Select a deployment</option>
                 <%= for deployment <- @deployments do %>
-                  <option value={deployment.id}><%= deployment.name %> - <%= deployment.firmware.platform %>, <%= deployment.firmware.architecture %></option>
+                  <option value={deployment.id}>{deployment.name} - {deployment.firmware.platform}, {deployment.firmware.architecture}</option>
                 <% end %>
               </select>
               <button class="btn btn-secondary ml-2">Set</button>

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -240,23 +240,26 @@
               </button>
             </div>
           </div>
+          <div :if={@device.status == :registered} class="mt-1">
+            Device will be removed from the deployment upon connection if the aarch and platform doesn't match.
+          </div>
           <span :if={is_nil(@deployment)} class="color-white-50">No Assigned Deployment</span>
         </div>
 
-        <div :if={Enum.empty?(@eligible_deployments) && is_nil(@device.deployment_id)}>
+        <div :if={Enum.empty?(@deployments) && is_nil(@device.deployment_id) && @device.status == :provisioned}>
           No Eligible Deployments
         </div>
 
-        <div :if={Enum.any?(@eligible_deployments) && is_nil(@device.deployment_id)}>
+        <div :if={Enum.any?(@deployments) && is_nil(@device.deployment_id)}>
           <div class="help-text mb-1">
-            Eligible Deployments
+            <%= if @device.status == :provisioned, do: "Eligible Deployments", else: "Product Deployments" %>
           </div>
           <form phx-submit="set-deployment">
             <div class="flex-row justify-content-between">
               <select name="deployment_id" class="form-control">
                 <option value="">Select a deployment</option>
-                <%= for deployment <- @eligible_deployments do %>
-                  <option value={deployment.id}>{deployment.name}</option>
+                <%= for deployment <- @deployments do %>
+                  <option value={deployment.id}><%= deployment.name %> - <%= deployment.firmware.platform %>, <%= deployment.firmware.architecture %></option>
                 <% end %>
               </select>
               <button class="btn btn-secondary ml-2">Set</button>

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -23,7 +23,7 @@ defmodule NervesHub.DevicesTest do
     org_key = Fixtures.org_key_fixture(org, user)
     firmware = Fixtures.firmware_fixture(org_key, product)
     deployment = Fixtures.deployment_fixture(org, firmware, %{is_active: true})
-    device = Fixtures.device_fixture(org, product, firmware)
+    device = Fixtures.device_fixture(org, product, firmware, %{status: :provisioned})
     device2 = Fixtures.device_fixture(org, product, firmware)
     device3 = Fixtures.device_fixture(org, product, firmware)
     ca_fix = Fixtures.ca_certificate_fixture(org)


### PR DESCRIPTION
Allows for unprovisioned devices to list and set deployments belonging to product. (#1760)

- List all product deployments instead of eligible deployments when device status is `:registered`
- When a deployment is set, an info text tells the user it will be removed from device if firmware and aarch don't match on connection
- Add test for this case
- Set device to `:provisioned` when testing eligible deployments


