### PR TITLE
New UI : Device page improvements - part 3

### DIFF
--- a/assets/ui-rework/app.js
+++ b/assets/ui-rework/app.js
@@ -52,7 +52,7 @@ Hooks.DeviceLocationMap = {
 
     map.addControl(new mapboxgl.NavigationControl())
 
-    if (source != "") {
+    if ((source || "").toLowerCase() == "gps") {
       new mapboxgl.Marker({ color: "rgb(99 102 241)" })
         .setLngLat([centerLng, centerLat])
         .addTo(map)

--- a/assets/ui-rework/console.js
+++ b/assets/ui-rework/console.js
@@ -45,7 +45,7 @@ let term = new Terminal({
   cursorStyle: "bar",
   macOptionIsMeta: true,
   fontFamily: "Ubuntu Mono, courier-new, courier, monospace",
-  fontSize: 12,
+  fontSize: 14,
   theme: xtermjsTheme,
   scrollback: scrollback
 })

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,7 +43,9 @@ config :nerves_hub,
     ],
     health: [
       interval_minutes:
-        System.get_env("FEATURES_HEALTH_INTERVAL_MINUTES", "60") |> String.to_integer()
+        System.get_env("FEATURES_HEALTH_INTERVAL_MINUTES", "60") |> String.to_integer(),
+      ui_polling_seconds:
+        System.get_env("FEATURES_HEALTH_UI_POLLING_SECONDS", "60") |> String.to_integer()
     ]
   ],
   new_ui: System.get_env("NEW_UI_ENABLED", "true") == "true"

--- a/lib/mix/tasks/gen.metrics.ex
+++ b/lib/mix/tasks/gen.metrics.ex
@@ -44,12 +44,12 @@ defmodule Mix.Tasks.NervesHub.Gen.Metrics do
   def save_metrics(device_id, current_timestamp) do
     metrics = %{
       "cpu_temp" => Enum.random(1..100),
-      "load_15min" => :rand.uniform() |> Float.ceil(2),
       "load_1min" => :rand.uniform() |> Float.ceil(2),
       "load_5min" => :rand.uniform() |> Float.ceil(2),
-      "size_mb" => 7892,
-      "used_mb" => Enum.random(0..7892),
-      "used_percent" => Enum.random(0..100)
+      "load_15min" => :rand.uniform() |> Float.ceil(2),
+      "mem_size_mb" => 7892,
+      "mem_used_mb" => Enum.random(0..7892),
+      "mem_used_percent" => Enum.random(0..100)
     }
 
     Repo.transaction(fn ->

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -771,6 +771,7 @@ defmodule NervesHub.Devices do
     |> Ecto.Changeset.change()
     |> Ecto.Changeset.put_change(:deployment_id, deployment.id)
     |> Repo.update!()
+    |> Repo.preload(:deployment, force: true)
   end
 
   @spec clear_deployment(Device.t()) :: Device.t()
@@ -779,6 +780,7 @@ defmodule NervesHub.Devices do
     |> Ecto.Changeset.change()
     |> Ecto.Changeset.put_change(:deployment_id, nil)
     |> Repo.update!()
+    |> Repo.preload(:deployment, force: true)
   end
 
   @spec failure_threshold_met?(Device.t(), Deployment.t()) :: boolean()

--- a/lib/nerves_hub_web/components/device_page/activity.ex
+++ b/lib/nerves_hub_web/components/device_page/activity.ex
@@ -26,7 +26,7 @@ defmodule NervesHubWeb.Components.DevicePage.Activity do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col items-start justify-between gap-4">
+    <div class="h-full flex flex-col items-start justify-between gap-4">
       <div class="p-6 w-full">
         <div class="w-full flex flex-col bg-zinc-900 border border-zinc-700 rounded">
           <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -4,12 +4,15 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
   require Logger
 
   alias NervesHub.AuditLogs
+  alias NervesHub.Deployments
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
   alias NervesHub.Devices.Metrics
   alias NervesHub.Devices.UpdatePayload
   alias NervesHub.Firmwares
   alias NervesHub.Scripts
+
+  alias NervesHub.Repo
 
   alias NervesHubWeb.Components.NewUI.DeviceLocation
 

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -82,7 +82,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
           </div>
         </div>
 
-        <div :if={map_size(@latest_metrics) > 0 && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
+        <div :if={Enum.any?(@latest_metrics) && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
           <div class="h-14 pl-4 pr-3 flex items-center justify-between">
             <div class="text-neutral-50 font-medium leading-6">Health</div>
             <div class="flex items-center gap-2">

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -79,7 +79,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
           </div>
         </div>
 
-        <div :if={@latest_metrics && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
+        <div :if={map_size(@latest_metrics) > 0 && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
           <div class="h-14 pl-4 pr-3 flex items-center justify-between">
             <div class="text-neutral-50 font-medium leading-6">Health</div>
             <div class="flex items-center gap-2">
@@ -155,7 +155,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
           </div>
         </div>
 
-        <div :if={!@latest_metrics && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
+        <div :if={map_size(@latest_metrics) == 0 && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
           <div class="h-14 pl-4 pr-3 flex items-center justify-between">
             <div class="text-neutral-50 font-medium leading-6">Health</div>
           </div>

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -158,7 +158,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
           </div>
         </div>
 
-        <div :if={map_size(@latest_metrics) == 0 && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
+        <div :if={Enum.empty?(@latest_metrics) && @product.extensions.health && @device.extensions.health} class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
           <div class="h-14 pl-4 pr-3 flex items-center justify-between">
             <div class="text-neutral-50 font-medium leading-6">Health</div>
           </div>

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -257,6 +257,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
               data-confirm="Are you sure you want to remove the device from the deployment?"
               aria-label="Remove device from the assigned deployment"
               type="button"
+              phx-target={@myself}
               phx-click="remove-from-deployment"
             >
               <svg class="w-3 h-3" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -451,6 +452,20 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
     socket
     |> assign(:device, device)
     |> send_toast(:info, "Sending firmware update request.")
+    |> noreply()
+  end
+
+  def handle_event("remove-from-deployment", _, %{assigns: %{device: device}} = socket) do
+    device =
+      device
+      |> Devices.clear_deployment()
+      |> Repo.preload(:deployment)
+
+    socket
+    |> assign(:device, device)
+    |> assign(:deployment, nil)
+    |> assign(:eligible_deployments, Deployments.eligible_deployments(device))
+    |> send_toast(:info, "Device successfully removed from the deployment")
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/components/pager.ex
+++ b/lib/nerves_hub_web/components/pager.ex
@@ -40,7 +40,7 @@ defmodule NervesHubWeb.Components.Pager do
 
   def render_with_page_sizes(assigns) do
     ~H"""
-    <div class="sticky bottom-0 w-full flex flex-row border-0 bg-base-950 border-t border-t-base-700 px-6 py-4 z-10">
+    <div class="sticky bottom-0 h-16 w-full flex flex-row border-0 bg-base-950 border-t border-t-base-700 px-6 py-4 z-10">
       <%= for size <- @page_sizes do %>
         <button :if={size <= @pager.total_count} phx-click="set-paginate-opts" phx-value-page-size={size} phx-target={@target} class={"pager-button #{if size == @pager.page_size, do: "active-page"}"}>
           <%= size %>

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -30,6 +30,7 @@ defmodule NervesHubWeb.Helpers.Authorization do
 
   def authorized?(:"device:create", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"device:update", %OrgUser{role: role}), do: role_check(:manage, role)
+  def authorized?(:"device:set-deployment", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"device:push-update", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"device:toggle-updates", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"device:clear-penalty-box", %OrgUser{role: ur}), do: role_check(:manage, ur)

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -523,7 +523,7 @@
   </div>
 </div>
 
-<div class="sticky bottom-0 flex flex-row border-0 bg-base-950 border-t border-t-base-700 px-6 py-4 z-10">
+<div class="sticky bottom-0 h-16 flex flex-row border-0 bg-base-950 border-t border-t-base-700 px-6 py-4 z-10">
   <%= for size <- @paginate_opts.page_sizes do %>
     <button :if={size <= @total_entries} phx-click="set-paginate-opts" phx-value-page-size={size} class={"pager-button #{if size == @paginate_opts.page_size, do: "active-page"}"}>
       <%= size %>

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -525,7 +525,7 @@
 
 <div class="sticky bottom-0 flex flex-row border-0 bg-base-950 border-t border-t-base-700 px-6 py-4 z-10">
   <%= for size <- @paginate_opts.page_sizes do %>
-    <button phx-click="set-paginate-opts" phx-value-page-size={size} class={"pager-button #{if size == @paginate_opts.page_size, do: "active-page"}"}>
+    <button :if={size <= @total_entries} phx-click="set-paginate-opts" phx-value-page-size={size} class={"pager-button #{if size == @paginate_opts.page_size, do: "active-page"}"}>
       <%= size %>
     </button>
   <% end %>

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -224,12 +224,12 @@
     module={DetailsPage}
     id="device_details"
     device={@device}
-    deployment={@deployment}
     device_connection={@device_connection}
     auto_refresh_health={!!@health_check_timer}
     product={@product}
     org={@org}
     org_user={@org_user}
+    user={@user}
   />
 
   <.live_component :if={@tab == :health} module={HealthPage} id="device_health" device={@device} org={@org} product={@product} />

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -10,100 +10,63 @@
     <span class="text-zinc-50 font-semibold"><%= @device.identifier %></span>
   </div>
   <div class="flex items-center gap-2 ml-auto mr-6">
-    <%= if @device.deleted_at do %>
-      <button class="action-button" aria-label="Restore" type="button" phx-click="restore">
-        <span class="action-text">Restore</span>
-      </button>
-      <button class="action-button" aria-label="Destroy" type="button" phx-click="destroy" data-confirm="Are you sure?">
-        <span class="action-text">Destroy</span>
-      </button>
-    <% else %>
-      <button
-        class="box-content h-5 py-1.5 px-3 flex gap-2 justify-center items-center rounded border border-base-600 bg-zinc-800 text-sm font-medium text-zinc-300 disabled:text-zinc-500"
-        aria-label="Reboot device"
-        type="button"
-        phx-click="reboot"
-        data-confirm="Are you sure?"
-        disabled={disconnected?(@device_connection)}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-          <path
-            d="M14.4097 4.99992C15.7938 6.22149 16.6667 8.00876 16.6667 9.99992C16.6667 13.6818 13.6819 16.6666 10 16.6666C6.31814 16.6666 3.33337 13.6818 3.33337 9.99992C3.33337 8.00876 4.2063 6.22149 5.59033 4.99992M10 9.99992V3.33325"
-            stroke="#A1A1AA"
-            stroke-width="1.2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-        <span class="text-sm font-medium">Reboot</span>
-      </button>
-      <button
-        class="box-content h-5 py-1.5 px-3 flex gap-2 justify-center items-center rounded border border-base-600 bg-zinc-800 text-sm font-medium text-zinc-300 disabled:text-zinc-500"
-        aria-label="Reconnect device"
-        type="button"
-        phx-click="reconnect"
-        disabled={disconnected?(@device_connection)}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-          <path
-            d="M13.5714 11.4644C12.6574 10.5596 11.3947 9.99992 9.99996 9.99992C8.60523 9.99992 7.34254 10.5596 6.42853 11.4644M15.9523 9.10736C14.429 7.59933 12.3245 6.66659 9.99996 6.66659C7.67541 6.66659 5.57093 7.59933 4.04758 9.10736M18.3333 6.75034C16.2006 4.63909 13.2543 3.33325 9.99996 3.33325C6.74559 3.33325 3.79931 4.63909 1.66663 6.75034M11.6835 14.9999C11.6835 15.9204 10.9298 16.6666 9.99996 16.6666C9.07014 16.6666 8.31637 15.9204 8.31637 14.9999C8.31637 14.5397 8.50481 14.123 8.80948 13.8214C9.11415 13.5198 9.53505 13.3333 9.99996 13.3333C10.4649 13.3333 10.8858 13.5198 11.1904 13.8214C11.4951 14.123 11.6835 14.5397 11.6835 14.9999Z"
-            stroke="#A1A1AA"
-            stroke-width="1.2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-        <span class="text-sm font-medium">Reconnect</span>
-      </button>
-      <%!-- <.link
-          class="action-button disabled:bg-base-700 disabled:text-base-400"
-          disabled={!@console_active?}
-          aria_label="Console"
-          target="_blank"
-          navigate={Routes.device_path(@socket, :console, @org.name, @product.name, @device.identifier)}
-        >
-          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 16L21 16L21 4L3 4L3 16H12ZM12 16V20M12 20L16 20M12 20H8" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-          <span class="action-text">Console</span>
-        </.link> --%>
-      <button
-        class="box-content h-5 py-1.5 px-3 flex gap-2 justify-center items-center rounded border border-base-600 bg-zinc-800 text-sm font-medium text-zinc-300 disabled:text-zinc-500"
-        aria-label="Identify device"
-        type="button"
-        phx-click="identify"
-        disabled={disconnected?(@device_connection)}
-      >
-        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M10.0001 10.0001V10.0009M10.0001 1.66675V5.00008M10.0001 15.0001V18.3334M18.3334 10.0001H15.0001M5.00008 10.0001H1.66675M16.6667 10.0001C16.6667 13.682 13.682 16.6667 10.0001 16.6667C6.31818 16.6667 3.33341 13.682 3.33341 10.0001C3.33341 6.31818 6.31818 3.33341 10.0001 3.33341C13.682 3.33341 16.6667 6.31818 16.6667 10.0001Z"
-            stroke="#A1A1AA"
-            stroke-width="1.2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-        <span class="text-sm font-medium">Identify</span>
-      </button>
-      <%!-- <div class="relative px-4">
-          <a class="cursor-pointer" data-target="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" phx-click={show_menu("actions-top-row")}>
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-              <path
-                d="M9.1665 10C9.1665 10.2211 9.2543 10.433 9.41058 10.5893C9.56686 10.7456 9.77882 10.8334 9.99984 10.8334C10.2209 10.8334 10.4328 10.7456 10.5891 10.5893C10.7454 10.433 10.8332 10.2211 10.8332 10C10.8332 9.77903 10.7454 9.56707 10.5891 9.41079C10.4328 9.2545 10.2209 9.16671 9.99984 9.16671C9.77882 9.16671 9.56686 9.2545 9.41058 9.41079C9.2543 9.56707 9.1665 9.77903 9.1665 10ZM9.1665 15.8334C9.1665 16.0544 9.2543 16.2663 9.41058 16.4226C9.56686 16.5789 9.77882 16.6667 9.99984 16.6667C10.2209 16.6667 10.4328 16.5789 10.5891 16.4226C10.7454 16.2663 10.8332 16.0544 10.8332 15.8334C10.8332 15.6124 10.7454 15.4004 10.5891 15.2441C10.4328 15.0878 10.2209 15 9.99984 15C9.77882 15 9.56686 15.0878 9.41058 15.2441C9.2543 15.4004 9.1665 15.6124 9.1665 15.8334ZM9.1665 4.16671C9.1665 4.38772 9.2543 4.59968 9.41058 4.75596C9.56686 4.91224 9.77882 5.00004 9.99984 5.00004C10.2209 5.00004 10.4328 4.91224 10.5891 4.75596C10.7454 4.59968 10.8332 4.38772 10.8332 4.16671C10.8332 3.94569 10.7454 3.73373 10.5891 3.57745C10.4328 3.42117 10.2209 3.33337 9.99984 3.33337C9.77882 3.33337 9.56686 3.42117 9.41058 3.57745C9.2543 3.73373 9.1665 3.94569 9.1665 4.16671Z"
-                stroke="#A1A1AA"
-                stroke-width="1.2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </a>
-          <div class="absolute top-4 menu-box hidden min-w-48" id="actions-top-row" phx-click-away={hide_menu("actions-top-row")} phx-key="escape">
-            <button class="flex" aria-label="Delete" type="button" phx-click="delete" data-confirm="Are you sure?">
-              <span class="action-text">Delete</span>
-            </button>
-          </div>
-        </div> --%>
-    <% end %>
+    <button
+      class="box-content h-5 py-1.5 px-3 flex gap-2 justify-center items-center rounded border border-base-600 bg-zinc-800 text-sm font-medium text-zinc-300 disabled:text-zinc-500"
+      aria-label="Reboot device"
+      type="button"
+      phx-click="reboot"
+      data-confirm="Are you sure?"
+      disabled={disconnected?(@device_connection)}
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <path
+          d="M14.4097 4.99992C15.7938 6.22149 16.6667 8.00876 16.6667 9.99992C16.6667 13.6818 13.6819 16.6666 10 16.6666C6.31814 16.6666 3.33337 13.6818 3.33337 9.99992C3.33337 8.00876 4.2063 6.22149 5.59033 4.99992M10 9.99992V3.33325"
+          stroke="#A1A1AA"
+          stroke-width="1.2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span class="text-sm font-medium">Reboot</span>
+    </button>
+
+    <button
+      class="box-content h-5 py-1.5 px-3 flex gap-2 justify-center items-center rounded border border-base-600 bg-zinc-800 text-sm font-medium text-zinc-300 disabled:text-zinc-500"
+      aria-label="Reconnect device"
+      type="button"
+      phx-click="reconnect"
+      disabled={disconnected?(@device_connection)}
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <path
+          d="M13.5714 11.4644C12.6574 10.5596 11.3947 9.99992 9.99996 9.99992C8.60523 9.99992 7.34254 10.5596 6.42853 11.4644M15.9523 9.10736C14.429 7.59933 12.3245 6.66659 9.99996 6.66659C7.67541 6.66659 5.57093 7.59933 4.04758 9.10736M18.3333 6.75034C16.2006 4.63909 13.2543 3.33325 9.99996 3.33325C6.74559 3.33325 3.79931 4.63909 1.66663 6.75034M11.6835 14.9999C11.6835 15.9204 10.9298 16.6666 9.99996 16.6666C9.07014 16.6666 8.31637 15.9204 8.31637 14.9999C8.31637 14.5397 8.50481 14.123 8.80948 13.8214C9.11415 13.5198 9.53505 13.3333 9.99996 13.3333C10.4649 13.3333 10.8858 13.5198 11.1904 13.8214C11.4951 14.123 11.6835 14.5397 11.6835 14.9999Z"
+          stroke="#A1A1AA"
+          stroke-width="1.2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span class="text-sm font-medium">Reconnect</span>
+    </button>
+
+    <button
+      class="box-content h-5 py-1.5 px-3 flex gap-2 justify-center items-center rounded border border-base-600 bg-zinc-800 text-sm font-medium text-zinc-300 disabled:text-zinc-500"
+      aria-label="Identify device"
+      type="button"
+      phx-click="identify"
+      disabled={disconnected?(@device_connection)}
+    >
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M10.0001 10.0001V10.0009M10.0001 1.66675V5.00008M10.0001 15.0001V18.3334M18.3334 10.0001H15.0001M5.00008 10.0001H1.66675M16.6667 10.0001C16.6667 13.682 13.682 16.6667 10.0001 16.6667C6.31818 16.6667 3.33341 13.682 3.33341 10.0001C3.33341 6.31818 6.31818 3.33341 10.0001 3.33341C13.682 3.33341 16.6667 6.31818 16.6667 10.0001Z"
+          stroke="#A1A1AA"
+          stroke-width="1.2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span class="text-sm font-medium">Identify</span>
+    </button>
   </div>
   <div class="h-full border-l flex items-center justify-center border-base-700 bg-base-900">
     <a :if={Application.get_env(:nerves_hub, :new_ui)} href={"/ui/switch?return_to=#{@current_path}"} class="">

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -160,7 +160,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   end
 
   def handle_info(:check_health_interval, socket) do
-    timer_ref = Process.send_after(self(), :check_health_interval, 10_000)
+    timer_ref = Process.send_after(self(), :check_health_interval, health_polling_seconds())
 
     Health.request_health_check(socket.assigns.device)
 
@@ -588,5 +588,11 @@ defmodule NervesHubWeb.Live.Devices.Show do
     else
       "px-6 py-2 h-11 font-normal text-sm text-zinc-300 hover:border-b hover:border-indigo-500 relative -bottom-px"
     end
+  end
+
+  defp health_polling_seconds() do
+    Application.get_env(:nerves_hub, :extension_config, [])
+    |> get_in([:health, :ui_polling_seconds])
+    |> :timer.seconds()
   end
 end

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -67,8 +67,13 @@ defmodule NervesHubWeb.Live.Devices.Show do
   end
 
   def handle_info(:reload_device, socket) do
+    device =
+      socket.assigns.device
+      |> Repo.reload()
+      |> Repo.preload(:deployment)
+
     socket
-    |> assign(:device, Repo.reload(socket.assigns.device))
+    |> assign(:device, device)
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -66,6 +66,12 @@ defmodule NervesHubWeb.Live.Devices.Show do
     {:noreply, socket}
   end
 
+  def handle_info(:reload_device, socket) do
+    socket
+    |> assign(:device, Repo.reload(socket.assigns.device))
+    |> noreply()
+  end
+
   def handle_info(%Broadcast{topic: "firmware", event: "created"}, socket) do
     firmware = Firmwares.get_firmware_for_device(socket.assigns.device)
 


### PR DESCRIPTION
- Fully working 'delete', 'restore', and 'permanently delete' device UI/UX
- Fix some device location marker conditional logic
- Some small list pager UI issues squashed
- Allow for the health polling interval in the UI to be configured at runtime
- Added support for 'set deployment' to the details tab
- Fixed some UI updating issues with removing and setting deployments
- Fixed a bug with checking if a health report is empty