### PR TITLE
Change use of CPU metrics in health indicator

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -28,8 +28,10 @@ export default {
           "linear-gradient(180deg, rgba(16, 185, 129, 0.00) 18.75%, rgba(16, 185, 129, 0.04) 81.25%)",
         "health-warning":
           "linear-gradient(180deg, rgba(245, 158, 11, 0.00) 18.75%, rgba(245, 158, 11, 0.04) 81.25%), linear-gradient(180deg, rgba(63, 63, 70, 0.16) 0%, rgba(63, 63, 70, 0.24) 100%)",
-        "health-netural":
+        "health-neutral":
           "linear-gradient(180deg, rgba(99, 102, 241, 0.00) 18.75%, rgba(99, 102, 241, 0.04) 81.25%), linear-gradient(180deg, rgba(63, 63, 70, 0.16) 0%, rgba(63, 63, 70, 0.24) 100%)",
+        "health-plain":
+          "linear-gradient(180deg, rgba(99, 99, 99, 0.00) 18.75%, rgba(99, 99, 99, 0.04) 81.25%), linear-gradient(180deg, rgba(63, 63, 63, 0.16) 0%, rgba(63, 63, 63, 0.24) 100%)",
         "progress-glow":
           "radial-gradient(ellipse 80% 80% at 50% -10%, rgba(16, 185, 129, 0.3) 0, rgba(16, 185, 129, 0.0) 80%), radial-gradient(ellipse 50% 50% at 50% -10%, rgba(16, 185, 129, 0.3) 0, rgba(16, 185, 129, 0.0) 50%)",
         "example-map": "url('/images/mapbox-north-america-dummy.png')",

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -118,13 +118,16 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
               </div>
             </div>
           </div>
-          <div class="flex pt-2 px-4 pb-4 gap-2 items-center">
-            <div class="w-20 flex flex-col h-16 py-2 px-3 rounded border-b border-emerald-500 bg-health-good">
+          <div class="flex pt-2 px-4 pb-4 gap-2 items-center justify-items-stretch flex-wrap">
+            <div class="grow flex flex-col h-16 py-2 px-3 rounded border-b border-emerald-500 bg-health-good">
               <span class="text-xs text-zinc-400 tracking-wide">CPU</span>
-              <span :if={@latest_metrics["cpu_temp"]} class="text-xl leading-[30px] text-neutral-50">{round(@latest_metrics["cpu_temp"])}°</span>
+              <div :if={@latest_metrics["cpu_temp"]} class="flex justify-between items-end">
+                <span class="text-xl leading-[30px] text-neutral-50">{round(@latest_metrics["cpu_usage_percent"])}%</span>
+                <span class="text-base text-emerald-500">{round(@latest_metrics["cpu_temp"])}°</span>
+              </div>
               <span :if={!@latest_metrics["cpu_temp"]} class="text-xl leading-[30px] text-nerves-gray-500">NA</span>
             </div>
-            <div class="w-1/2 flex flex-col h-16 py-2 px-3 rounded border-b border-amber-500 bg-health-warning">
+            <div class="grow flex flex-col h-16 py-2 px-3 rounded border-b border-amber-500 bg-health-warning">
               <span class="text-xs text-zinc-400 tracking-wide">Memory used</span>
               <div :if={@latest_metrics["mem_used_mb"]} class="flex justify-between items-end">
                 <span class="text-xl leading-[30px] text-neutral-50">{round(@latest_metrics["mem_used_mb"])}MB</span>
@@ -134,7 +137,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
                 <span class="text-xl leading-[30px] text-nerves-gray-500">Not reported</span>
               </div>
             </div>
-            <div class="w-1/2 flex flex-col h-16 py-2 px-3 rounded border-b border-indigo-500 bg-health-netural">
+            <div class="grow flex flex-col h-16 py-2 px-3 rounded border-b border-indigo-500 bg-health-neutral">
               <span class="text-xs text-zinc-400 tracking-wide">Load avg</span>
               <div :if={@latest_metrics["load_1min"] || @latest_metrics["load_5min"] || @latest_metrics["load_15min"]} class="flex justify-between items-center">
                 <span :if={@latest_metrics["load_1min"]} class="text-xl leading-[30px] text-neutral-50">{@latest_metrics["load_1min"]}</span>


### PR DESCRIPTION
Add CPU percentage as the primary CPU indicator with temperature as secondary.

![Screenshot_20250121_092252](https://github.com/user-attachments/assets/88d8cb47-b2ef-4f61-a65d-2c08f660fb56)
