### PR TITLE
New UI: Improve the readability of the device list progress bar

### DIFF
--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -172,6 +172,9 @@
                 <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
                   {device.identifier}
                 </.link>
+                <span :if={@progress[device.id]} class="flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
+                  <span class="text-xs text-zinc-300 tracking-tight">Updating: {@progress[device.id]}%</span>
+                </span>
               </div>
             </td>
 

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -173,7 +173,7 @@
                   {device.identifier}
                 </.link>
                 <span :if={@progress[device.id]} class="flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
-                  <span class="text-xs text-zinc-300 tracking-tight">Updating: {@progress[device.id]}%</span>
+                  <span class="text-xs text-zinc-300 tracking-tight">updating</span>
                 </span>
               </div>
             </td>

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -682,9 +682,10 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   defp progress_style(progress) do
     """
-     background-repeat: no-repeat;
-     background-image: radial-gradient(circle at 0%, rgba(16, 185, 129, 0.12) 0, rgba(16, 185, 129, 0.12) 60%, rgba(16, 185, 129, 0.0) 100%);
-     background-size: #{progress * 1.1}% 100%;
+     background-repeat: no-repeat, no-repeat;
+     background-image: linear-gradient(90deg, rgba(16, 185, 129, 1.00) 0%, rgba(16, 185, 129, 1.0) 100%),
+                        radial-gradient(circle at 0%, rgba(16, 185, 129, 0.12) 0, rgba(16, 185, 129, 0.12) 60%, rgba(16, 185, 129, 0.0) 100%);
+     background-size: #{progress}% 1px, #{progress * 1.1}% 100%;
     """
   end
 end

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -682,10 +682,9 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   defp progress_style(progress) do
     """
-     background-repeat: no-repeat, no-repeat;
-     background-image: linear-gradient(90deg, rgba(16, 185, 129, 1.00) 0%, rgba(16, 185, 129, 1.0) 100%),
-                       radial-gradient(ellipse 80% 80% at 50% -10%, rgba(16, 185, 129, 0.3) 0, rgba(16, 185, 129, 0.0) 80%);
-     background-size: #{progress}% 1px, #{progress}% 100%;
+     background-repeat: no-repeat;
+     background-image: radial-gradient(circle at 0%, rgba(16, 185, 129, 0.12) 0, rgba(16, 185, 129, 0.12) 60%, rgba(16, 185, 129, 0.0) 100%);
+     background-size: #{progress * 1.1}% 100%;
     """
   end
 end


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/6206bb99-05c1-4d64-9c85-f758f056f529

I felt the radial background was too muted, and it wasn't clear which device the solid green bar was for (think of a device that is half way down the list)

Now:

https://github.com/user-attachments/assets/034b7d83-8209-4048-bb28-61e5adf3a702

I've added a progress bar label, removed the top line, and tweaked the gradient a little