### PR TITLE
Add audit logs when creating or updating script

### DIFF
--- a/lib/nerves_hub/audit_logs/templates/product_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/product_templates.ex
@@ -1,0 +1,23 @@
+defmodule NervesHub.AuditLogs.ProductTemplates do
+  alias NervesHub.AuditLogs
+  alias NervesHub.AuditLogs.AuditLog
+  alias NervesHub.Accounts.User
+  alias NervesHub.Products.Product
+  alias NervesHub.Scripts.Script
+
+  @spec audit_script_created(User.t(), Product.t(), Script.t()) :: AuditLog.t()
+  def audit_script_created(user, product, script) do
+    description =
+      "User #{user.name} created script named #{script.name} with id #{script.id} for product #{product.name}"
+
+    AuditLogs.audit!(user, product, description)
+  end
+
+  @spec audit_script_created(User.t(), Product.t(), Script.t()) :: AuditLog.t()
+  def audit_script_updated(user, product, script) do
+    description =
+      "User #{user.name} updated script named #{script.name} with id #{script.id} for product #{product.name}"
+
+    AuditLogs.audit!(user, product, description)
+  end
+end

--- a/lib/nerves_hub_web/live/support_scripts/edit.ex
+++ b/lib/nerves_hub_web/live/support_scripts/edit.ex
@@ -21,13 +21,15 @@ defmodule NervesHubWeb.Live.SupportScripts.Edit do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("update-script", %{"script" => script_params}, socket) do
-    authorized!(:"support_script:update", socket.assigns.org_user)
+  def handle_event(
+        "update-script",
+        %{"script" => script_params},
+        %{assigns: %{org: org, product: product, script: script, org_user: org_user}} = socket
+      ) do
+    authorized!(:"support_script:update", org_user)
 
-    %{org: org, product: product} = socket.assigns
-
-    case Scripts.update(socket.assigns.script, script_params) do
-      {:ok, _command} ->
+    case Scripts.update(script, org_user.user, script_params) do
+      {:ok, _script} ->
         socket
         |> put_flash(:info, "Support Script updated")
         |> send_toast(:info, "Support Script updated successfully.")

--- a/lib/nerves_hub_web/live/support_scripts/new.ex
+++ b/lib/nerves_hub_web/live/support_scripts/new.ex
@@ -14,13 +14,15 @@ defmodule NervesHubWeb.Live.SupportScripts.New do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("create-script", %{"script" => script_params}, socket) do
-    authorized!(:"support_script:create", socket.assigns.org_user)
+  def handle_event(
+        "create-script",
+        %{"script" => script_params},
+        %{assigns: %{org_user: org_user, org: org, product: product}} = socket
+      ) do
+    authorized!(:"support_script:create", org_user)
 
-    %{org: org, product: product} = socket.assigns
-
-    case Scripts.create(product, script_params) do
-      {:ok, _command} ->
+    case Scripts.create(product, org_user.user, script_params) do
+      {:ok, _script} ->
         socket
         |> put_flash(:info, "Support Script created")
         |> send_toast(:info, "Support Script created successfully.")

--- a/test/nerves_hub/scripts_test.exs
+++ b/test/nerves_hub/scripts_test.exs
@@ -12,15 +12,15 @@ defmodule NervesHub.ScriptsTest do
     %{user: user, org: org, product: product}
   end
 
-  describe "creating a command" do
-    test "successful", %{product: product} do
-      {:ok, command} =
-        Scripts.create(product, %{
+  describe "creating a script" do
+    test "successful", %{product: product, user: user} do
+      {:ok, script} =
+        Scripts.create(product, user, %{
           name: "MOTD",
           text: "NervesMOTD.print()"
         })
 
-      assert command.product_id == product.id
+      assert script.product_id == product.id
     end
   end
 end

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -540,10 +540,11 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       conn: conn,
       org: org,
       product: product,
-      device: device
+      device: device,
+      user: user
     } do
-      {:ok, _command} =
-        NervesHub.Scripts.create(product, %{name: "MOTD", text: "NervesMOTD.print()"})
+      {:ok, _script} =
+        NervesHub.Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")

--- a/test/nerves_hub_web/live/support_scripts_test.exs
+++ b/test/nerves_hub_web/live/support_scripts_test.exs
@@ -19,8 +19,13 @@ defmodule NervesHubWeb.Live.SupportScriptsTest do
       |> assert_has("h3", text: "#{product.name} doesn’t have any Support Scripts yet")
     end
 
-    test "shows all support scripts for a product", %{conn: conn, org: org, product: product} do
-      {:ok, _command} = Scripts.create(product, %{name: "MOTD", text: "NervesMOTD.print()"})
+    test "shows all support scripts for a product", %{
+      conn: conn,
+      org: org,
+      product: product,
+      user: user
+    } do
+      {:ok, _script} = Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/scripts")
@@ -29,8 +34,8 @@ defmodule NervesHubWeb.Live.SupportScriptsTest do
   end
 
   describe "delete" do
-    test "removes support script", %{conn: conn, org: org, product: product} do
-      {:ok, _command} = Scripts.create(product, %{name: "MOTD", text: "NervesMOTD.print()"})
+    test "removes support script", %{conn: conn, org: org, product: product, user: user} do
+      {:ok, _script} = Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/scripts")
@@ -59,8 +64,8 @@ defmodule NervesHubWeb.Live.SupportScriptsTest do
   end
 
   describe "edit" do
-    test "requires a name and text", %{conn: conn, org: org, product: product} do
-      {:ok, script} = Scripts.create(product, %{name: "MOTD", text: "NervesMOTD.print()"})
+    test "requires a name and text", %{conn: conn, org: org, product: product, user: user} do
+      {:ok, script} = Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/scripts/#{script.id}/edit")


### PR DESCRIPTION
Adds audit logging when a user creates or updates a script.

Adds a templates file for Product audit logging.

Adding the user as a parameter to creation and updates of scripts is also a preparation for #1799 :)