### PR TITLE
Variant of the progress bar tweaks

### DIFF
--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -173,7 +173,7 @@
                   {device.identifier}
                 </.link>
                 <span :if={@progress[device.id]} class="flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
-                  <span class="text-xs text-zinc-300 tracking-tight">Updating: {@progress[device.id]}%</span>
+                  <span class="text-xs text-zinc-300 tracking-tight">updating</span>
                 </span>
               </div>
             </td>

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -682,9 +682,10 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   defp progress_style(progress) do
     """
-     background-repeat: no-repeat;
-     background-image: radial-gradient(circle at 0%, rgba(16, 185, 129, 0.12) 0, rgba(16, 185, 129, 0.12) 60%, rgba(16, 185, 129, 0.0) 100%);
-     background-size: #{progress * 1.1}% 100%;
+     background-repeat: no-repeat, no-repeat;
+     background-image: linear-gradient(90deg, rgba(16, 185, 129, 1.00) 0%, rgba(16, 185, 129, 1.0) 100%),
+                        radial-gradient(circle at 0%, rgba(16, 185, 129, 0.12) 0, rgba(16, 185, 129, 0.12) 60%, rgba(16, 185, 129, 0.0) 100%);
+     background-size: #{progress}% 1px, #{progress * 1.1}% 100%;
     """
   end
 end


### PR DESCRIPTION
If you can't tell I really like the thin progress bar :D 

![Screenshot_20250123_095813](https://github.com/user-attachments/assets/6b6065f4-40d7-4825-9dbe-a0f2a055ec3f)

This uses the fix of the background from: https://github.com/nerves-hub/nerves_hub_web/pull/1814

But it also uses the thin stripe.

For simplicity I cut the % display in the label. I think the label is helpful but it was making the whole table jiggle and it would be a bunch of faffing about to make it behave nice.