### PR TITLE
Stop the `updating` label from messing with the table column

### DIFF
--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -151,7 +151,7 @@
                 <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
                   {device.identifier}
                 </.link>
-                <span :if={@progress[device.id]} class="flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
+                <span class={["flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800", !@progress[device.id] && "invisible"]}>
                   <span class="text-xs text-zinc-300 tracking-tight">updating</span>
                 </span>
               </div>


### PR DESCRIPTION
The `invisible` CSS class keeps the element in the dom but just doesn't show it.

Its useful for cases where adding or removing it (or even using hidden) changes sizing and positioning of other elements.