### PR TITLE
Fix the Dashboard map query and filtering

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -135,9 +135,8 @@ defmodule NervesHub.Devices do
 
   def get_minimal_device_location_by_product(product) do
     Device
-    |> join(:left, [d], dc in DeviceConnection, on: d.latest_connection_id == dc.id)
+    |> join(:inner, [d], dc in DeviceConnection, on: d.latest_connection_id == dc.id)
     |> where(product_id: ^product.id)
-    |> where(status: :provisioned)
     |> select([d, dc], %{
       id: d.id,
       identifier: d.identifier,

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -133,13 +133,11 @@ defmodule NervesHub.Devices do
     end)
   end
 
-  def get_minimal_device_location_by_org_id_and_product_id(org_id, product_id) do
+  def get_minimal_device_location_by_product(product) do
     Device
-    |> join(:inner, [d], dc in DeviceConnection, on: d.latest_connection_id == dc.id)
-    |> where(org_id: ^org_id)
-    |> where(product_id: ^product_id)
-    |> where([d], not is_nil(fragment("?->'location'->'latitude'", d.connection_metadata)))
-    |> where([d], not is_nil(fragment("?->'location'->'longitude'", d.connection_metadata)))
+    |> join(:left, [d], dc in DeviceConnection, on: d.latest_connection_id == dc.id)
+    |> where(product_id: ^product.id)
+    |> where(status: :provisioned)
     |> select([d, dc], %{
       id: d.id,
       identifier: d.identifier,

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -15,6 +15,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
+  alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Devices.Filtering
   alias NervesHub.Devices.InflightUpdate
@@ -142,7 +143,7 @@ defmodule NervesHub.Devices do
     |> select([d, dc], %{
       id: d.id,
       identifier: d.identifier,
-      connection_status: dc.connection_status,
+      connection_status: dc.status,
       latitude: fragment("?->'location'->'latitude'", d.connection_metadata),
       longitude: fragment("?->'location'->'longitude'", d.connection_metadata),
       firmware_uuid: fragment("?->'uuid'", d.firmware_metadata)

--- a/lib/nerves_hub_web/live/dashboard/index.ex
+++ b/lib/nerves_hub_web/live/dashboard/index.ex
@@ -89,8 +89,7 @@ defmodule NervesHubWeb.Live.Dashboard.Index do
     duration = t - socket.assigns.time
 
     if duration >= @delay do
-      devices =
-        Devices.get_minimal_device_location_by_org_id_and_product_id(org.id, product.id)
+      devices = Devices.get_minimal_device_location_by_product(product)
 
       latest_firmwares =
         Deployments.get_deployments_by_product(product)
@@ -141,7 +140,7 @@ defmodule NervesHubWeb.Live.Dashboard.Index do
     [new_marker | markers]
   end
 
-  defp generate_map_marker(%Device{} = _device, markers, _) do
+  defp generate_map_marker(_device, markers, _) do
     markers
   end
 

--- a/lib/nerves_hub_web/live/dashboard/index.ex
+++ b/lib/nerves_hub_web/live/dashboard/index.ex
@@ -3,7 +3,6 @@ defmodule NervesHubWeb.Live.Dashboard.Index do
 
   alias NervesHub.Deployments
   alias NervesHub.Devices
-  alias NervesHub.Devices.Device
 
   alias Phoenix.Socket.Broadcast
 
@@ -84,7 +83,7 @@ defmodule NervesHubWeb.Live.Dashboard.Index do
     end
   end
 
-  defp update_devices_and_markers(%{assigns: %{org: org, product: product}} = socket) do
+  defp update_devices_and_markers(%{assigns: %{product: product}} = socket) do
     t = time()
     duration = t - socket.assigns.time
 


### PR DESCRIPTION
- Include a missing alias, and fix the field used
- Fetch all devices for a product who have a 'latest connection' (ensuring they have, or are, connected to nerves hub)
- Remove the location where clauses (this is filtered later on)
- And adjust the `generate_map_marker` pattern match (the result isn't a Device)