### PR TITLE
Remove audit and logger statement from extensions request check

### DIFF
--- a/lib/nerves_hub/audit_logs/templates/device_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/device_templates.ex
@@ -25,16 +25,6 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     AuditLogs.audit!(user, device, description)
   end
 
-  @spec audit_unsupported_api_version(Device.t()) :: AuditLog.t()
-  def audit_unsupported_api_version(device) do
-    description =
-      "Device #{device.identifier} could not get extensions: Unsupported API version."
-
-    Logger.info("[DeviceChannel] #{description}")
-
-    AuditLogs.audit!(device, device, description)
-  end
-
   ## Firmware and upgrades
 
   @spec audit_update_attempt(Device.t()) :: AuditLog.t()

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -67,8 +67,7 @@ defmodule NervesHubWeb.DeviceChannel do
     # Earlier versions of nerves_hub_link don't have a fallback for unknown messages,
     # so check version before requesting extensions
     if safe_to_request_extensions?(socket.assigns.device_api_version),
-      do: push(socket, "extensions:get", %{}),
-      else: DeviceTemplates.audit_unsupported_api_version(device)
+      do: push(socket, "extensions:get", %{})
 
     {:noreply, socket}
   end


### PR DESCRIPTION
Older versions of NervesHubLink would crash if an unknown messages was pushed down over the socket. Since extensions required a new message, this could fail badly on older devices and so a check was put in place to verify the Device API version NHL was reporting to know if it is safe to request extension info or not.

This removes the audit log _and_ logger statement that was happening when this safe check would not pass meaning the device version was too old to request. However, this happens with _every_ socket connection and can produce incredible amount of noise.

If that level of info is needed, I suggest a future change which shows the device version reported and what that means for support on the device (i.e. in the Device settings page perhaps?)