### PR TITLE
New UI: Add support for creating deployments

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -301,6 +301,11 @@ defmodule NervesHub.Deployments do
     :ok
   end
 
+  @spec new_deployment() :: Changeset.t()
+  def new_deployment() do
+    Ecto.Changeset.change(%Deployment{})
+  end
+
   @spec change_deployment(Deployment.t(), map()) :: Changeset.t()
   def change_deployment(deployment, params) do
     Deployment.changeset(deployment, params)

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -23,12 +23,48 @@ defmodule NervesHub.Firmwares do
 
   defp firmware_upload_config(), do: Application.fetch_env!(:nerves_hub, :firmware_upload)
 
+  @spec count(%Product{}) :: non_neg_integer()
+  def count(product) do
+    Firmware
+    |> where([f], f.product_id == ^product.id)
+    |> Repo.aggregate(:count)
+  end
+
+  @spec get_unique_platforms(%Product{}) :: [String.t()]
+  def get_unique_platforms(product) do
+    Firmware
+    |> select([f], f.platform)
+    |> distinct(true)
+    |> where([f], f.product_id == ^product.id)
+    |> Repo.all()
+  end
+
+  @spec get_unique_architectures(%Product{}) :: [String.t()]
+  def get_unique_architectures(product) do
+    Firmware
+    |> select([f], f.architecture)
+    |> distinct(true)
+    |> where([f], f.product_id == ^product.id)
+    |> Repo.all()
+  end
+
   @spec get_firmwares_by_product(integer()) :: [Firmware.t()]
   def get_firmwares_by_product(product_id) do
     Firmware
     |> where([f], f.product_id == ^product_id)
     |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
     |> with_product()
+    |> Repo.all()
+  end
+
+  @spec get_firmwares(%Product{}, String.t(), String.t()) :: [Firmware.t()]
+  def get_firmwares(product, platform, architecture) do
+    Firmware
+    |> where([f], f.product_id == ^product.id)
+    |> where([f], f.platform == ^platform)
+    |> where([f], f.architecture == ^architecture)
+    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
+    |> limit(25)
     |> Repo.all()
   end
 

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -23,14 +23,14 @@ defmodule NervesHub.Firmwares do
 
   defp firmware_upload_config(), do: Application.fetch_env!(:nerves_hub, :firmware_upload)
 
-  @spec count(%Product{}) :: non_neg_integer()
+  @spec count(Product.t()) :: non_neg_integer()
   def count(product) do
     Firmware
     |> where([f], f.product_id == ^product.id)
     |> Repo.aggregate(:count)
   end
 
-  @spec get_unique_platforms(%Product{}) :: [String.t()]
+  @spec get_unique_platforms(Product.t()) :: [String.t()]
   def get_unique_platforms(product) do
     Firmware
     |> select([f], f.platform)
@@ -39,7 +39,7 @@ defmodule NervesHub.Firmwares do
     |> Repo.all()
   end
 
-  @spec get_unique_architectures(%Product{}) :: [String.t()]
+  @spec get_unique_architectures(Product.t()) :: [String.t()]
   def get_unique_architectures(product) do
     Firmware
     |> select([f], f.architecture)
@@ -57,7 +57,7 @@ defmodule NervesHub.Firmwares do
     |> Repo.all()
   end
 
-  @spec get_firmwares(%Product{}, String.t(), String.t()) :: [Firmware.t()]
+  @spec get_firmwares(Product.t(), String.t(), String.t()) :: [Firmware.t()]
   def get_firmwares(product, platform, architecture) do
     Firmware
     |> where([f], f.product_id == ^product.id)

--- a/lib/nerves_hub_web/live/deployments/index-new.html.heex
+++ b/lib/nerves_hub_web/live/deployments/index-new.html.heex
@@ -17,7 +17,7 @@
   <div class="flex items-center h-[90px] gap-4 px-6 py-7 border-b border-[#3F3F46] text-sm font-medium">
     <h1 class="text-xl leading-[30px] font-semibold text-neutral-50">All Deployments</h1>
     <div class="rounded-sm bg-zinc-800 text-xs text-zinc-300 px-1.5 py-0.5 mr-auto">{@pager_meta.total_count}</div>
-    <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/new"} aria-label="Add a new deployment">
+    <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/newz"} aria-label="Add a new deployment">
       <.icon name="add" /> Create Deployment
     </.button>
   </div>

--- a/lib/nerves_hub_web/live/deployments/newz.ex
+++ b/lib/nerves_hub_web/live/deployments/newz.ex
@@ -8,7 +8,7 @@ defmodule NervesHubWeb.Live.Deployments.Newz do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, %{assigns: %{product: product}} = socket) do
-    if Firmwares.count(socket.assigns.product) == 0 do
+    if Firmwares.count(product) == 0 do
       socket
       |> assign(:firmware_required, true)
       |> ok()

--- a/lib/nerves_hub_web/live/deployments/newz.ex
+++ b/lib/nerves_hub_web/live/deployments/newz.ex
@@ -1,0 +1,163 @@
+defmodule NervesHubWeb.Live.Deployments.Newz do
+  use NervesHubWeb, :updated_live_view
+
+  alias NervesHub.AuditLogs.DeploymentTemplates
+  alias NervesHub.Deployments
+  alias NervesHub.Firmwares
+  alias NervesHub.Firmwares.Firmware
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, %{assigns: %{product: product}} = socket) do
+    if Firmwares.count(socket.assigns.product) == 0 do
+      socket
+      |> assign(:firmware_required, true)
+      |> ok()
+    else
+      platforms = Firmwares.get_unique_platforms(product)
+
+      socket
+      |> page_title("New Deployment - #{socket.assigns.product.name}")
+      |> sidebar_tab(:deployments)
+      |> assign(:firmware_required, false)
+      |> assign(:platforms, platforms)
+      |> assign(:architectures, [])
+      |> assign(:platform, nil)
+      |> assign(:architecture, nil)
+      |> assign(:firmwares, [])
+      |> assign(:form, to_form(Deployments.new_deployment()))
+      |> ok()
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("platform-selected", %{"deployment" => %{"platform" => platform}}, socket) do
+    authorized!(:"deployment:create", socket.assigns.org_user)
+
+    %{product: product} = socket.assigns
+
+    architectures = Firmwares.get_unique_architectures(product)
+
+    socket
+    |> assign(:platform, platform)
+    |> assign(:architectures, architectures)
+    |> assign(:architecture, nil)
+    |> assign(:firmwares, [])
+    |> noreply()
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event(
+        "architecture-selected",
+        %{"deployment" => %{"architecture" => architecture}},
+        socket
+      ) do
+    authorized!(:"deployment:create", socket.assigns.org_user)
+
+    %{product: product} = socket.assigns
+
+    firmwares =
+      Firmwares.get_firmwares(product, socket.assigns.platform, architecture)
+
+    socket
+    |> assign(:firmwares, firmwares)
+    |> assign(:architecture, architecture)
+    |> noreply()
+  end
+
+  # @impl Phoenix.LiveView
+  def handle_event("create-deployment", %{"deployment" => params}, socket) do
+    authorized!(:"deployment:create", socket.assigns.org_user)
+
+    %{user: user, org: org, product: product} = socket.assigns
+
+    params =
+      params
+      |> inject_conditions_map()
+      |> whitelist([:name, :conditions, :firmware_id])
+      |> Map.put(:org_id, org.id)
+      |> Map.put(:is_active, false)
+
+    org
+    |> Firmwares.get_firmware(params[:firmware_id])
+    |> case do
+      {:ok, firmware} ->
+        {firmware, Deployments.create_deployment(params)}
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+    |> case do
+      {:error, :not_found} ->
+        socket
+        |> send_toast(:error, "Invalid firmware selected")
+        |> noreply()
+
+      {_, {:ok, deployment}} ->
+        _ = DeploymentTemplates.audit_deployment_created(user, deployment)
+
+        socket
+        |> LiveToast.put_toast(:info, "Deployment created")
+        |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/deployments")
+        |> noreply()
+
+      {_firmware, {:error, changeset}} ->
+        socket
+        |> send_toast(:error, "There was an error creating the deployment")
+        |> assign(:form, to_form(changeset))
+        |> noreply()
+    end
+  end
+
+  defp firmware_dropdown_options(firmwares) do
+    firmwares
+    |> Enum.sort_by(
+      fn firmware ->
+        case Version.parse(firmware.version) do
+          {:ok, version} ->
+            version
+
+          :error ->
+            %Version{major: 0, minor: 0, patch: 0}
+        end
+      end,
+      {:desc, Version}
+    )
+    |> Enum.map(&[value: &1.id, key: firmware_display_name(&1)])
+  end
+
+  defp firmware_display_name(%Firmware{} = f) do
+    "#{f.version} - #{f.uuid}"
+  end
+
+  defp inject_conditions_map(%{"version" => version, "tags" => tags} = params) do
+    params
+    |> Map.put("conditions", %{
+      "version" => version,
+      "tags" =>
+        tags
+        |> tags_as_list()
+        |> MapSet.new()
+        |> MapSet.to_list()
+    })
+  end
+
+  defp inject_conditions_map(params), do: params
+
+  @doc """
+  Convert tags from a list to a comma-separated list (in a string)
+  """
+  def tags_to_string(%Phoenix.HTML.FormField{} = field) do
+    field.value ||
+      %{}
+      |> Map.get("tags", [])
+      |> Enum.join(", ")
+  end
+
+  defp tags_as_list(""), do: []
+
+  defp tags_as_list(tags) do
+    tags
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+  end
+end

--- a/lib/nerves_hub_web/live/deployments/newz.html.heex
+++ b/lib/nerves_hub_web/live/deployments/newz.html.heex
@@ -1,0 +1,119 @@
+<div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
+  <div class="flex gap-2.5">
+    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployments"} class="back-link flex gap-2.5 items-center">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+      <span class="text-base-400">All Deployments</span>
+    </.link>
+    <span class="text-base-400">/</span>
+    <span class="text-zinc-50 font-semibold">Add Deployment</span>
+  </div>
+
+  <div class="h-full border-l flex items-center justify-center border-base-700 bg-base-900">
+    <a :if={Application.get_env(:nerves_hub, :new_ui)} href={"/ui/switch?return_to=#{@current_path}"} class="">
+      <svg class="box-content px-5 h-5 w-5 stroke-zinc-500 hover:stroke-indigo-500" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M21 14V19C21 20.1046 20.1046 21 19 21H16M3 16V19C3 20.1046 3.89543 21 5 21H16M3 16V5C3 3.89543 3.89543 3 5 3H11M3 16C4.40293 15.7662 6.63687 15.7073 8.94504 16.2427M16 21C14.2965 18.2317 11.5726 16.8522 8.94504 16.2427M8.94504 16.2427C9.87157 15.1698 11.1851 14.1585 13 13.3925M8.5 7C8 7 7 7.3 7 8.5C7 9.7 8 10 8.5 10C9 10 10 9.7 10 8.5C10 7.3 9 7 8.5 7ZM17.5 9.46262L14.7188 11L15.25 7.74377L13 5.43769L16.1094 4.96262L17.5 2L18.8906 4.96262L22 5.43769L19.75 7.74377L20.2812 11L17.5 9.46262Z"
+          stroke-width="1.2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </a>
+  </div>
+</div>
+
+<div class="h-0 flex-1 overflow-y-auto">
+  <div class="flex items-center h-[90px] gap-4 px-6 py-7 border-b border-[#3F3F46] text-sm font-medium">
+    <h1 class="text-base font-semibold text-neutral-50">Add Deployment</h1>
+  </div>
+
+  <div :if={@firmware_required} class="h-full pb-16 flex flex-col items-center justify-center gap-4 p-6">
+    <span class="text-xl font-medium text-neutral-50">Please upload your first firmware before creating a deployment.</span>
+    <.link class="underline underline-offset-4 decoration-dotted hover:text-neutral-50" navigate={~p"/org/#{@org.name}/#{@product.name}/firmware"} aria-label="Add a new deployment">
+      Go to the firmware page
+    </.link>
+  </div>
+
+  <div :if={!@firmware_required} class="flex flex-col items-start justify-between gap-4 p-6">
+    <.form for={@form} class="w-full" phx-submit="create-deployment">
+      <div class="flex flex-col w-2/3 bg-zinc-900 border border-zinc-700 rounded">
+        <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
+          <div class="text-base text-neutral-50 font-medium">General settings</div>
+        </div>
+
+        <div class="flex p-6 gap-6 border-b border-zinc-700">
+          <div class="w-2/3 flex flex-col gap-6">
+            <.input field={@form[:name]} label="Name" placeholder="eg. Production" />
+          </div>
+        </div>
+
+        <div class="flex p-6 gap-6 border-b border-zinc-700">
+          <div class="w-2/3 flex flex-col gap-6">
+            <div class="flex gap-6">
+              <div class="w-1/2">
+                <.input field={@form[:platform]} type="select" options={@platforms} phx-change="platform-selected" label="Platform" prompt="Choose a platform" />
+              </div>
+
+              <div class="w-1/2">
+                <.input
+                  field={@form[:architecture]}
+                  type="select"
+                  options={@architectures}
+                  disabled={@architectures == []}
+                  phx-change="architecture-selected"
+                  label="Architecture"
+                  prompt={(@architectures != [] && "Choose an architecture") || ""}
+                />
+              </div>
+            </div>
+
+            <.input
+              field={@form[:firmware_id]}
+              type="select"
+              options={firmware_dropdown_options(@firmwares)}
+              disabled={@firmwares == []}
+              label="Firmware"
+              prompt={(@firmwares != [] && "Choose a firmware") || "Please select a platform and architecture first"}
+              hint="This firmware will be distributed to devices assigned to this deployment."
+            />
+
+            <%!-- <.input field={@form[:tags]} label="Description" placeholder="eg. sensor hub at customer X" />
+
+            <.input field={@form[:version]} value={tags_to_string(@form[:tags])} label="Tags" placeholder="eg. batch-123" /> --%>
+          </div>
+        </div>
+
+        <div class="flex p-6 gap-6">
+          <div class="w-2/3 flex flex-col gap-6">
+            <div class="text-base text-neutral-50 font-medium">Device matching conditions</div>
+            <div class="flex flex-col gap-3">
+              <p class="text-sm text-zinc-400">
+                These conditions are used for matching devices which don't have a configured deployment.
+              </p>
+              <p class="text-sm text-zinc-400">
+                The matching is undertaken when a device connects to the platform.
+              </p>
+            </div>
+            <div class="flex gap-6">
+              <div class="w-1/2">
+                <.input field={@form[:tags]} value={tags_to_string(@form[:conditions])} label="Tag(s) distributed to" placeholder="eg. batch-123" />
+              </div>
+
+              <div class="w-1/2">
+                <.input field={@form[:version]} value={@form[:conditions].value["version"]} label="Version requirement" placeholder="eg. 1.2.3" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex justify-between items-center h-14 px-4 border-t border-zinc-700">
+          <.button style="secondary" type="submit">
+            <.icon name="save" /> Save changes
+          </.button>
+        </div>
+      </div>
+    </.form>
+  </div>
+</div>

--- a/lib/nerves_hub_web/live/deployments/show-new.html.heex
+++ b/lib/nerves_hub_web/live/deployments/show-new.html.heex
@@ -50,7 +50,7 @@
         <span class="text-sm text-zinc-400 mr-1">Devices:</span>
 
         <div class="flex items-center">
-          <span class="text-sm text-base-300 mr-1">{@deployment.device_count}</span>
+          <span class="text-sm text-base-300 mr-1">{@deployment.device_count || 0}</span>
         </div>
       </div>
       <div class="flex h-7 py-1 px-2 items-center rounded bg-zinc-800">

--- a/lib/nerves_hub_web/live/deployments/show.ex
+++ b/lib/nerves_hub_web/live/deployments/show.ex
@@ -98,7 +98,7 @@ defmodule NervesHubWeb.Live.Deployments.Show do
   end
 
   @impl Phoenix.LiveView
-  def handle_info(:update_inflight_updates, socket) do
+  def handle_info(:update_inflight_updates, %{assigns: %{tab: :summary}} = socket) do
     Process.send_after(self(), :update_inflight_updates, 5000)
 
     %{assigns: %{deployment: deployment}} = socket
@@ -112,6 +112,12 @@ defmodule NervesHubWeb.Live.Deployments.Show do
     |> assign(:up_to_date_count, Devices.up_to_date_count(deployment))
     |> assign(:waiting_for_update_count, Devices.waiting_for_update_count(deployment))
     |> noreply()
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info(:update_inflight_updates, socket) do
+    Process.send_after(self(), :update_inflight_updates, 5000)
+    noreply(socket)
   end
 
   defp selected_tab(socket) do

--- a/lib/nerves_hub_web/live/deployments/show.ex
+++ b/lib/nerves_hub_web/live/deployments/show.ex
@@ -10,10 +10,10 @@ defmodule NervesHubWeb.Live.Deployments.Show do
 
   alias NervesHubWeb.Components.AuditLogFeed
 
-  alias NervesHubWeb.Components.DeploymentPage.Summary, as: SummaryTab
   alias NervesHubWeb.Components.DeploymentPage.Activity, as: ActivityTab
   alias NervesHubWeb.Components.DeploymentPage.ReleaseHistory, as: ReleaseHistoryTab
   alias NervesHubWeb.Components.DeploymentPage.Settings, as: SettingsTab
+  alias NervesHubWeb.Components.DeploymentPage.Summary, as: SummaryTab
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -322,6 +322,7 @@ defmodule NervesHubWeb.Router do
 
       live("/org/:org_name/:product_name/deployments", Live.Deployments.Index)
       live("/org/:org_name/:product_name/deployments/new", Live.Deployments.New)
+      live("/org/:org_name/:product_name/deployments/newz", Live.Deployments.Newz)
       live("/org/:org_name/:product_name/deployments/:name", Live.Deployments.Show, :summary)
 
       live(


### PR DESCRIPTION
I rejigged the UI a little.

I've had to use a `deployments/newz` for the route, for now, as the liveview and UI were different enough.

<img width="1512" alt="Screenshot 2025-01-25 at 3 38 41 PM" src="https://github.com/user-attachments/assets/189e8141-a137-437d-8f6e-beedd516bbce" />
