### PR TITLE
New UI: Speed up the loading of the device and deployment page tabs

### DIFF
--- a/lib/nerves_hub_web/live/deployments/show-new.html.heex
+++ b/lib/nerves_hub_web/live/deployments/show-new.html.heex
@@ -73,16 +73,16 @@
 
   <div class="flex w-full justify-between px-6 border-b border-zinc-700">
     <div class="flex">
-      <.link class={tab_classes(@tab, :summary)} navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}"}>
+      <.link class={tab_classes(@tab, :summary)} patch={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}"}>
         Summary
       </.link>
-      <.link class={tab_classes(@tab, :release_history)} navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}/releases"}>
+      <.link class={tab_classes(@tab, :release_history)} patch={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}/releases"}>
         Release History
       </.link>
-      <.link class={tab_classes(@tab, :activity)} navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}/activity"}>
+      <.link class={tab_classes(@tab, :activity)} patch={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}/activity"}>
         Activity
       </.link>
-      <.link class={tab_classes(@tab, :settings)} navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}/settings"}>
+      <.link class={tab_classes(@tab, :settings)} patch={~p"/org/#{@org.name}/#{@product.name}/deployments/#{@deployment.name}/settings"}>
         Settings
       </.link>
     </div>

--- a/lib/nerves_hub_web/live/deployments/show.ex
+++ b/lib/nerves_hub_web/live/deployments/show.ex
@@ -54,6 +54,13 @@ defmodule NervesHubWeb.Live.Deployments.Show do
     |> ok()
   end
 
+  @impl Phoenix.LiveView
+  def handle_params(_params, _uri, socket) do
+    socket
+    |> selected_tab()
+    |> noreply()
+  end
+
   defp schedule_inflight_updates_updater(socket) do
     if connected?(socket) do
       Process.send_after(self(), :update_inflight_updates, 5000)

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -163,19 +163,19 @@
 
   <div class="flex w-full justify-between px-6 border-b border-zinc-700">
     <div class="flex">
-      <.link class={tab_classes(@tab, :details)} navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}"}>
+      <.link class={tab_classes(@tab, :details)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}"}>
         Details
       </.link>
-      <.link class={tab_classes(@tab, :health)} navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/healthz"}>
+      <.link class={tab_classes(@tab, :health)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/healthz"}>
         Health
       </.link>
-      <.link class={tab_classes(@tab, :activity)} navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/activity"}>
+      <.link class={tab_classes(@tab, :activity)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/activity"}>
         Activity
       </.link>
-      <.link class={tab_classes(@tab, :console)} navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/conzole"}>
+      <.link class={tab_classes(@tab, :console)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/conzole"}>
         Console
       </.link>
-      <.link class={tab_classes(@tab, :settings)} navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/settingz"}>
+      <.link class={tab_classes(@tab, :settings)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/settingz"}>
         Settings
       </.link>
     </div>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -63,7 +63,9 @@ defmodule NervesHubWeb.Live.Devices.Show do
   end
 
   def handle_params(_params, _uri, socket) do
-    {:noreply, socket}
+    socket
+    |> selected_tab()
+    |> noreply()
   end
 
   def handle_info(:reload_device, socket) do


### PR DESCRIPTION
Using `patch` means the same process liveview can be used, saving on the need to destroy a liveview and start one back up.