### PR TITLE
Fix: New devices connecting shouldn't cause extension errors

### DIFF
--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -73,7 +73,10 @@ defmodule NervesHub.Devices.Device do
     # field(:connection_established_at, :utc_datetime)
     # field(:connection_disconnected_at, :utc_datetime)
     # field(:connection_last_seen_at, :utc_datetime)
-    embeds_one(:extensions, DeviceExtensionsSetting, on_replace: :update)
+    embeds_one(:extensions, DeviceExtensionsSetting,
+      defaults_to_struct: true,
+      on_replace: :update
+    )
   end
 
   def changeset(%Device{} = device, params) do

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -77,6 +77,14 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
   end
 
   test "a new device connecting via Shared Secrets (JITP) and joining extensions channel is fine" do
+    Application.put_env(:nerves_hub, NervesHubWeb.DeviceSocket, shared_secrets: [enabled: true])
+
+    on_exit(fn ->
+      Application.put_env(:nerves_hub, NervesHubWeb.DeviceSocket,
+        shared_secrets: [enabled: false]
+      )
+    end)
+
     user = Fixtures.user_fixture()
     org = Fixtures.org_fixture(user)
     product = Fixtures.product_fixture(user, org)

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -16,6 +16,7 @@ defmodule NervesHubWeb.WebsocketTest do
   alias NervesHub.Fixtures
   alias NervesHub.Products
   alias NervesHub.Repo
+  alias NervesHub.Support.Utils
   alias NervesHubWeb.DeviceEndpoint
   alias NervesHubWeb.Endpoint
 
@@ -326,7 +327,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, identifier)
+        headers: Utils.nh1_key_secret_headers(auth, identifier)
       ]
 
       params = %{
@@ -360,7 +361,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, identifier) |> Enum.reverse()
+        headers: Utils.nh1_key_secret_headers(auth, identifier) |> Enum.reverse()
       ]
 
       params = %{
@@ -395,7 +396,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, identifier, signed_at: expired)
+        headers: Utils.nh1_key_secret_headers(auth, identifier, signed_at: expired)
       ]
 
       {:ok, socket} = SocketClient.start_link(opts)
@@ -409,7 +410,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, device.identifier)
+        headers: Utils.nh1_key_secret_headers(auth, device.identifier)
       ]
 
       params = %{
@@ -437,7 +438,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, "this-is-not-the-device-identifier")
+        headers: Utils.nh1_key_secret_headers(auth, "this-is-not-the-device-identifier")
       ]
 
       {:ok, socket} = SocketClient.start_link(opts)
@@ -459,7 +460,7 @@ defmodule NervesHubWeb.WebsocketTest do
         opts = [
           mint_opts: [protocols: [:http1]],
           uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-          headers: nh1_key_secret_headers(auth, device.identifier)
+          headers: Utils.nh1_key_secret_headers(auth, device.identifier)
         ]
 
         {:ok, socket} = SocketClient.start_link(opts)
@@ -493,7 +494,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, identifier)
+        headers: Utils.nh1_key_secret_headers(auth, identifier)
       ]
 
       params = %{
@@ -547,7 +548,7 @@ defmodule NervesHubWeb.WebsocketTest do
       opts = [
         mint_opts: [protocols: [:http1]],
         uri: "ws://127.0.0.1:#{@web_port}/device-socket/websocket",
-        headers: nh1_key_secret_headers(auth, identifier)
+        headers: Utils.nh1_key_secret_headers(auth, identifier)
       ]
 
       params = %{
@@ -608,32 +609,6 @@ defmodule NervesHubWeb.WebsocketTest do
 
     assert assigns.error_reason ==
              "no certificate pair or shared secrets connection settings were provided"
-  end
-
-  defp nh1_key_secret_headers(auth, identifier, opts \\ []) do
-    opts =
-      opts
-      |> Keyword.put_new(:key_digest, :sha256)
-      |> Keyword.put_new(:key_iterations, 1000)
-      |> Keyword.put_new(:key_length, 32)
-      |> Keyword.put_new(:signed_at, System.system_time(:second))
-
-    alg = "NH1-HMAC-#{opts[:key_digest]}-#{opts[:key_iterations]}-#{opts[:key_length]}"
-
-    salt = """
-    NH1:device-socket:shared-secret:connect
-
-    x-nh-alg=#{alg}
-    x-nh-key=#{auth.key}
-    x-nh-time=#{opts[:signed_at]}
-    """
-
-    [
-      {"x-nh-alg", alg},
-      {"x-nh-key", auth.key},
-      {"x-nh-time", to_string(opts[:signed_at])},
-      {"x-nh-signature", Plug.Crypto.sign(auth.secret, salt, identifier, opts)}
-    ]
   end
 
   describe "firmware update" do

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,0 +1,29 @@
+defmodule NervesHub.Support.Utils do
+  @moduledoc false
+
+  def nh1_key_secret_headers(auth, identifier, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put_new(:key_digest, :sha256)
+      |> Keyword.put_new(:key_iterations, 1000)
+      |> Keyword.put_new(:key_length, 32)
+      |> Keyword.put_new(:signed_at, System.system_time(:second))
+
+    alg = "NH1-HMAC-#{opts[:key_digest]}-#{opts[:key_iterations]}-#{opts[:key_length]}"
+
+    salt = """
+    NH1:device-socket:shared-secret:connect
+
+    x-nh-alg=#{alg}
+    x-nh-key=#{auth.key}
+    x-nh-time=#{opts[:signed_at]}
+    """
+
+    [
+      {"x-nh-alg", alg},
+      {"x-nh-key", auth.key},
+      {"x-nh-time", to_string(opts[:signed_at])},
+      {"x-nh-signature", Plug.Crypto.sign(auth.secret, salt, identifier, opts)}
+    ]
+  end
+end


### PR DESCRIPTION
This relates to an issue found via Sentry.

```
UndefinedFunctionError nil.__struct__/0
lib/nerves_hub_web/channels/extensions_channel.ex in anonymous fn/3 in NervesHubWeb.ExtensionsChannel.parse_extensions/2 at line 34
```

This only occurred when the device was created during connection, eg. shared secrets jitp. The `:extensions` `embeds_one` in Device was nil on creation. The fix was just asking Ecto to set a default.