### PR TITLE
Remove the need to get a connection before updating it

### DIFF
--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -77,15 +77,13 @@ defmodule NervesHub.Devices.Connections do
         ]
       )
 
-    Phoenix.Channel.Server.broadcast_from!(
+    Phoenix.Channel.broadcast_from!(
       NervesHub.PubSub,
       self(),
       "device:#{result.identifier}:internal",
       "connection:heartbeat",
       %{}
     )
-
-    :ok
   end
 
   @doc """

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -77,7 +77,7 @@ defmodule NervesHub.Devices.Connections do
         ]
       )
 
-    Phoenix.Channel.broadcast_from!(
+    Phoenix.Channel.Server.broadcast_from!(
       NervesHub.PubSub,
       self(),
       "device:#{result.identifier}:internal",

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -63,12 +63,29 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Updates the `last_seen_at`field for a device connection with current timestamp
   """
-  @spec device_heartbeat(UUIDv7.t()) :: {:ok, DeviceConnection.t()} | {:error, Ecto.Changeset.t()}
-  def device_heartbeat(ref_id) do
-    DeviceConnection
-    |> Repo.get!(ref_id)
-    |> DeviceConnection.update_changeset(%{last_seen_at: DateTime.utc_now()})
-    |> Repo.update()
+  @spec device_heartbeat(UUIDv7.t()) :: :ok
+  def device_heartbeat(id) do
+    {1, [result]} =
+      DeviceConnection
+      |> join(:inner, [dc], d in assoc(dc, :device), as: :device)
+      |> select([device: device], %{identifier: device.identifier})
+      |> where([dc], dc.id == ^id)
+      |> Repo.update_all(
+        set: [
+          status: "connected",
+          last_seen_at: DateTime.utc_now()
+        ]
+      )
+
+    Phoenix.Channel.Server.broadcast_from!(
+      NervesHub.PubSub,
+      self(),
+      "device:#{result.identifier}:internal",
+      "connection:heartbeat",
+      %{}
+    )
+
+    :ok
   end
 
   @doc """

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -46,25 +46,9 @@ defmodule NervesHubWeb.DeviceSocket do
   end
 
   @decorate with_span("Channels.DeviceSocket.heartbeat")
-  defp heartbeat(
-         %Phoenix.Socket.Message{topic: "phoenix", event: "heartbeat"},
-         %{
-           assigns: %{
-             reference_id: ref_id,
-             device: device
-           }
-         } = socket
-       ) do
+  defp heartbeat(%Phoenix.Socket.Message{topic: "phoenix", event: "heartbeat"}, socket) do
     if heartbeat?(socket) do
-      {:ok, _device_connection} = Connections.device_heartbeat(ref_id)
-
-      _ =
-        socket.endpoint.broadcast_from(
-          self(),
-          "device:#{device.identifier}:internal",
-          "connection:heartbeat",
-          %{}
-        )
+      Connections.device_heartbeat(socket.assigns.reference_id)
 
       last_heartbeat =
         DateTime.utc_now()

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -26,12 +26,13 @@ defmodule NervesHub.Devices.ConnectionsTest do
   end
 
   test "device heartbeat", %{device: device} do
-    assert {:ok, %DeviceConnection{id: connection_id, last_seen_at: first_seen_at}} =
+    assert {:ok, %DeviceConnection{id: connection_id, last_seen_at: first_seen_at} = connection} =
              Connections.device_connected(device.id)
 
-    assert {:ok,
-            %DeviceConnection{id: ^connection_id, last_seen_at: last_seen_at, status: :connected}} =
-             Connections.device_heartbeat(connection_id)
+    Connections.device_heartbeat(connection_id)
+
+    %DeviceConnection{id: ^connection_id, last_seen_at: last_seen_at, status: :connected} =
+      Repo.reload(connection)
 
     assert last_seen_at > first_seen_at
     assert %DeviceConnection{status: :connected} = Connections.get_latest_for_device(device.id)


### PR DESCRIPTION
This rejigs the `device_heartbeat` function a little, moving the broadcast into the function and out of the socket.

This also removes the `Repo.get!`, instead using `Repo.update_all`

A `join` has been added so we can fetch the device identifier to use for the broadcast.