### PR TITLE
Reduce queries made during device socket connection

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -350,7 +350,7 @@ defmodule NervesHub.Devices do
     %Device{}
     |> Device.changeset(params)
     |> Repo.insert()
-    |> Repo.preload(:product)
+    |> Repo.maybe_preload(:product)
   end
 
   def set_as_provisioned!(device) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -254,6 +254,21 @@ defmodule NervesHub.Devices do
     |> preload([latest_connection: lc], latest_connection: lc)
   end
 
+  def get_device_by_x509(cert) do
+    fingerprint = NervesHub.Certificate.fingerprint(cert)
+
+    Device
+    |> join(:inner, [d], p in assoc(d, :product))
+    |> join(:inner, [d], dc in assoc(d, :device_certificates))
+    |> where([_, _, dc], dc.fingerprint: ^fingerprint)
+    |> preload([_d, p], product: p)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      certificate -> {:ok, certificate}
+    end
+  end
+
   @spec get_shared_secret_auth(String.t()) ::
           {:ok, SharedSecretAuth.t()} | {:error, :not_found}
   def get_shared_secret_auth(key) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -262,7 +262,7 @@ defmodule NervesHub.Devices do
     Device
     |> join(:inner, [d], p in assoc(d, :product))
     |> join(:inner, [d], dc in assoc(d, :device_certificates))
-    |> where([_, _, dc], dc.fingerprint: ^fingerprint)
+    |> where([_, _, dc], dc.fingerprint == ^fingerprint)
     |> preload([_d, p], product: p)
     |> Repo.one()
     |> case do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -437,7 +437,10 @@ defmodule NervesHub.Devices do
   def get_device_certificate_by_x509(cert) do
     fingerprint = NervesHub.Certificate.fingerprint(cert)
 
-    from(DeviceCertificate, where: [fingerprint: ^fingerprint], preload: :device)
+    DeviceCertificate
+    |> where(fingerprint: ^fingerprint)
+    |> join(:inner, [dc], d in assoc(dc, :device))
+    |> preload([_dc, d], device: d)
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}
@@ -448,10 +451,10 @@ defmodule NervesHub.Devices do
   def get_device_certificates_by_public_key(otp_cert) do
     pk_fingerprint = NervesHub.Certificate.public_key_fingerprint(otp_cert)
 
-    from(c in DeviceCertificate,
-      where: [public_key_fingerprint: ^pk_fingerprint],
-      preload: [:device]
-    )
+    DeviceCertificate
+    |> where(public_key_fingerprint: ^pk_fingerprint)
+    |> join(:inner, [dc], d in assoc(dc, :device))
+    |> preload([_dc, d], device: d)
     |> Repo.all()
   end
 

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -39,6 +39,8 @@ defmodule NervesHub.Devices do
   def get_active_device(filters) do
     Device
     |> Repo.exclude_deleted()
+    |> join(:inner, [d], p in assoc(d, :product))
+    |> preload([_d, p], product: p)
     |> Repo.get_by(filters)
     |> case do
       nil -> {:error, :not_found}
@@ -348,6 +350,7 @@ defmodule NervesHub.Devices do
     %Device{}
     |> Device.changeset(params)
     |> Repo.insert()
+    |> Repo.preload(:product)
   end
 
   def set_as_provisioned!(device) do

--- a/lib/nerves_hub/repo.ex
+++ b/lib/nerves_hub/repo.ex
@@ -25,6 +25,14 @@ defmodule NervesHub.Repo do
 
   def reload_assoc({:error, changeset}, _), do: {:error, changeset}
 
+  def maybe_preload({:ok, entity}, assocs) do
+    {:ok, preload(entity, assocs)}
+  end
+
+  def maybe_preload({:error, _} = result, _assocs) do
+    result
+  end
+
   def soft_delete(struct_or_changeset) do
     struct_or_changeset
     |> soft_delete_changeset()

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -6,7 +6,6 @@ defmodule NervesHubWeb.DeviceSocket do
 
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
-  alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Products
   alias NervesHub.Tracker
@@ -78,7 +77,7 @@ defmodule NervesHubWeb.DeviceSocket do
     X509.Certificate.from_der!(ssl_cert)
     |> Devices.get_device_by_x509()
     |> case do
-      {:ok, %{device: %Device{} = device}} ->
+      {:ok, device} ->
         socket_and_assigns(socket, device)
 
       error ->

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -79,7 +79,7 @@ defmodule NervesHubWeb.DeviceSocket do
     |> Devices.get_device_by_x509()
     |> case do
       {:ok, %{device: %Device{} = device}} ->
-        socket_and_assigns(socket, Devices.preload_product(device))
+        socket_and_assigns(socket, device)
 
       error ->
         :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
@@ -103,7 +103,7 @@ defmodule NervesHubWeb.DeviceSocket do
          {:ok, signature} <- Map.fetch(headers, "x-nh-signature"),
          {:ok, identifier} <- Crypto.verify(auth.secret, salt, signature, verification_opts),
          {:ok, device} <- get_or_maybe_create_device(auth, identifier) do
-      socket_and_assigns(socket, Devices.preload_product(device))
+      socket_and_assigns(socket, device)
     else
       error ->
         :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -76,7 +76,7 @@ defmodule NervesHubWeb.DeviceSocket do
   def connect(_params, socket, %{peer_data: %{ssl_cert: ssl_cert}})
       when not is_nil(ssl_cert) do
     X509.Certificate.from_der!(ssl_cert)
-    |> Devices.get_device_certificate_by_x509()
+    |> Devices.get_device_by_x509()
     |> case do
       {:ok, %{device: %Device{} = device}} ->
         socket_and_assigns(socket, Devices.preload_product(device))


### PR DESCRIPTION
Optimize some queries used during device connection, with a focus on making sure the product assoc is returned with the device.