### PR TITLE
Adjust device_connections worker frequency, increase timeout when deleting in batches

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -71,7 +71,7 @@ config :nerves_hub, Oban,
      crontab: [
        {"0 * * * *", NervesHub.Workers.ScheduleOrgAuditLogTruncation},
        {"*/1 * * * *", NervesHub.Workers.CleanStaleDeviceConnections},
-       {"0 */1 * * *", NervesHub.Workers.DeleteOldDeviceConnections},
+       {"1,16,31,46 * * * *", NervesHub.Workers.DeleteOldDeviceConnections},
        {"*/5 * * * *", NervesHub.Workers.ExpireInflightUpdates},
        {"*/15 * * * *", NervesHub.Workers.DeviceHealthTruncation}
      ]}

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -139,7 +139,7 @@ defmodule NervesHub.Devices.Connections do
     {delete_count, _} =
       DeviceConnection
       |> where([d], d.id in subquery(query))
-      |> Repo.delete_all()
+      |> Repo.delete_all(timeout: 30_000)
 
     if delete_count == 0 do
       :ok


### PR DESCRIPTION
- Increases the frequency of `DeleteOldDeviceConnections` and offsets it by a minute to ensure we're not stacking jobs on the hour
- Sets timeout for `delete_all` to 30s so DB has enough time to work