### PR TITLE
Fix an extensions bug related to channels not sharing assigns

### DIFF
--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -54,7 +54,7 @@ defmodule NervesHub.Extensions.Health do
           do: {to_string(key), to_string(val)}
 
     # Separate metrics from health report to store in metrics table
-    metrics = device_status["metrics"]
+    metrics = device_status["metrics"] || %{}
 
     health_report =
       device_status


### PR DESCRIPTION
We don't know of a devices firmware metadata until it connects for the first time. When it does connect, the `DeviceSocket` will fetch the device and the `firmware_metadata` field will be nil. This device is the one shared with other channels.

In `Extensions.Health` we are using `socket.assigns.device.firmware_metadata` which is going to be nil during its first connection to NervesHub, and will continue to exit sending reports and creating Sentry errors.

This test replicates the scenario of a device connecting for the first time,  then its firmware metadata being updated, and then connecting to the health extension, exposing the error.

Sadly, in tests, channels share assigns, so this was much harder to replicate.