### PR TITLE
Health Report: Only store metadata directly from the device

### DIFF
--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -48,18 +48,13 @@ defmodule NervesHub.Extensions.Health do
 
   @impl NervesHub.Extensions
   def handle_in("report", %{"value" => device_status}, socket) do
-    device_meta =
-      for {key, val} <- Map.from_struct(socket.assigns.device.firmware_metadata),
-          into: %{},
-          do: {to_string(key), to_string(val)}
-
     # Separate metrics from health report to store in metrics table
     metrics = device_status["metrics"] || %{}
 
     health_report =
       device_status
       |> Map.delete("metrics")
-      |> Map.put("metadata", Map.merge(device_status["metadata"], device_meta))
+      |> Map.put("metadata", device_status["metadata"])
 
     device_health = %{"device_id" => socket.assigns.device.id, "data" => health_report}
 


### PR DESCRIPTION
My suggestion is that the health report should be for data directly from the device, and thus, we shouldn't store `socket.device.firmware_metadata` in the report `metadata`

@lawik what are your thoughts?