### PR TITLE
Broadcast that a device has been updated when setting and clearing deployment

### DIFF
--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -785,4 +785,34 @@ defmodule NervesHub.DevicesTest do
       assert 7 = Enum.count(healths)
     end
   end
+
+  describe "update_deployment/2" do
+    test "updates deployment and broadcasts 'devices/updated'", %{
+      device: device,
+      deployment: deployment
+    } do
+      refute device.deployment_id
+
+      NervesHubWeb.Endpoint.subscribe("device:#{device.id}")
+      _ = Devices.update_deployment(device, deployment)
+
+      assert device.deployment_id == deployment.id
+      assert_receive %{event: "devices/updated"}
+    end
+  end
+
+  describe "clear_deployment1/2" do
+    test "clears deployment and broadcasts 'devices/updated'", %{
+      device: device,
+      deployment: deployment
+    } do
+      device = Devices.update_deployment(device, deployment)
+
+      NervesHubWeb.Endpoint.subscribe("device:#{device.id}")
+      device = Devices.clear_deployment(device)
+
+      refute device.deployment_id
+      assert_receive %{event: "devices/updated"}
+    end
+  end
 end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -794,7 +794,7 @@ defmodule NervesHub.DevicesTest do
       refute device.deployment_id
 
       NervesHubWeb.Endpoint.subscribe("device:#{device.id}")
-      _ = Devices.update_deployment(device, deployment)
+      device = Devices.update_deployment(device, deployment)
 
       assert device.deployment_id == deployment.id
       assert_receive %{event: "devices/updated"}

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -294,6 +294,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       } = fixture
 
       device2 = Fixtures.device_fixture(org, product, firmware)
+      Endpoint.subscribe("device:#{device2.id}")
 
       refute device.deployment_id
       refute device2.deployment_id
@@ -309,6 +310,9 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       end)
       |> click_button("#move-deployment-submit", "Move")
       |> assert_has("div", text: "2 devices added to deployment")
+
+      assert_receive %{event: "devices/updated"}
+      assert_receive %{event: "devices/updated"}
 
       assert Repo.reload(device) |> Map.get(:deployment_id)
       assert Repo.reload(device2) |> Map.get(:deployment_id)

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -648,6 +648,23 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("div", text: "No Eligible Deployments")
     end
+
+    test "broadcasts to devices channel", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device,
+      deployment: deployment
+    } do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("div", text: "Product Deployments")
+      |> unwrap(fn view ->
+        render_change(view, "set-deployment", %{"deployment_id" => deployment.id})
+      end)
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "devices/updated"}
+    end
   end
 
   def device_show_path(%{device: device, org: org, product: product}) do


### PR DESCRIPTION
The device channel needs to be notified when a device's deployment changes so it can resubscribe to the proper deployment channel and send an update if available.