### PR TITLE
Save the device location to `DeviceConnection.metadata`

### DIFF
--- a/lib/mix/tasks/gen.devices.ex
+++ b/lib/mix/tasks/gen.devices.ex
@@ -13,7 +13,9 @@ defmodule Mix.Tasks.NervesHub.Gen.Devices do
 
   alias NervesHub.Accounts
   alias NervesHub.Devices
+  alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Products
+  alias NervesHub.Repo
 
   @requirements ["app.start"]
   @preferred_cli_env :dev
@@ -36,18 +38,26 @@ defmodule Mix.Tasks.NervesHub.Gen.Devices do
       lng = -180..180 |> Enum.random()
       lat = -90..90 |> Enum.random()
 
-      Devices.create_device(%{
-        org_id: org.id,
-        product_id: product.id,
-        identifier: "generated-#{i}",
-        connection_metadata: %{
+      {:ok, device} =
+        Devices.create_device(%{
+          org_id: org.id,
+          product_id: product.id,
+          identifier: "generated-#{i}"
+        })
+
+      %DeviceConnection{
+        device_id: device.id,
+        established_at: DateTime.utc_now(:millisecond),
+        last_seen_at: DateTime.utc_now(:millisecond),
+        metadata: %{
           "location" => %{
             "longitude" => lng,
             "latitude" => lat,
             "source" => "generated"
           }
         }
-      })
+      }
+      |> Repo.insert!()
     end)
   end
 end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -143,8 +143,8 @@ defmodule NervesHub.Devices do
       id: d.id,
       identifier: d.identifier,
       connection_status: dc.status,
-      latitude: fragment("?->'location'->'latitude'", d.connection_metadata),
-      longitude: fragment("?->'location'->'longitude'", d.connection_metadata),
+      latitude: fragment("?->'location'->'latitude'", dc.metadata),
+      longitude: fragment("?->'location'->'longitude'", dc.metadata),
       firmware_uuid: fragment("?->'uuid'", d.firmware_metadata)
     })
     |> Repo.exclude_deleted()

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -90,20 +90,40 @@ defmodule NervesHub.Devices.Connections do
   Updates `status` and relevant timestamps for a device connection record,
   and stores the reason for disconnection if provided.
   """
-  @spec device_disconnected(UUIDv7.t(), String.t() | nil) ::
-          {:ok, DeviceConnection.t()} | {:error, Ecto.Changeset.t()}
+  @spec device_disconnected(UUIDv7.t(), String.t() | nil) :: :ok | :error
   def device_disconnected(ref_id, reason \\ nil) do
     now = DateTime.utc_now()
 
     DeviceConnection
-    |> Repo.get!(ref_id)
-    |> DeviceConnection.update_changeset(%{
-      last_seen_at: now,
-      disconnected_at: now,
-      disconnected_reason: reason,
-      status: :disconnected
-    })
-    |> Repo.update()
+    |> where(id: ^ref_id)
+    |> update([dc],
+      set: [
+        last_seen_at: ^now,
+        disconnected_at: ^now,
+        disconnected_reason: ^reason,
+        status: :disconnected
+      ]
+    )
+    |> Repo.update_all([])
+    |> case do
+      {1, _} -> :ok
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Updates the connection `metadata` by merging in new metadata.
+  """
+  @spec merge_update_metadata(UUIDv7.t(), map()) :: :ok | :error
+  def merge_update_metadata(ref_id, new_metadata) do
+    DeviceConnection
+    |> where(id: ^ref_id)
+    |> update([dc], set: [metadata: fragment("? || ?::jsonb", dc.metadata, ^new_metadata)])
+    |> Repo.update_all([])
+    |> case do
+      {1, _} -> :ok
+      _ -> :error
+    end
   end
 
   def clean_stale_connections() do

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -96,15 +96,14 @@ defmodule NervesHub.Devices.Connections do
 
     DeviceConnection
     |> where(id: ^ref_id)
-    |> update([dc],
+    |> Repo.update_all(
       set: [
-        last_seen_at: ^now,
-        disconnected_at: ^now,
-        disconnected_reason: ^reason,
+        last_seen_at: now,
+        disconnected_at: now,
+        disconnected_reason: reason,
         status: :disconnected
       ]
     )
-    |> Repo.update_all([])
     |> case do
       {1, _} -> :ok
       _ -> :error

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -68,7 +68,7 @@ defmodule NervesHub.Devices.Device do
 
     timestamps()
 
-    # Deprecated fields, remove these any time after 29/1/2025.
+    # Deprecated fields, remove these on or after the 5th of Jan 2025.
     # Also remove index from NervesHub.Repo.Migrations.AddConnectionStatusIndexToDevices.
     # field(:connection_status, Ecto.Enum,
     #   values: [:connected, :disconnected, :not_seen],
@@ -77,8 +77,6 @@ defmodule NervesHub.Devices.Device do
     # field(:connection_established_at, :utc_datetime)
     # field(:connection_disconnected_at, :utc_datetime)
     # field(:connection_last_seen_at, :utc_datetime)
-
-    # Deprecated fields, remove these any time after 28/2/2025.
     # field(:connection_metadata, :map, default: %{})
     # field(:connection_types, {:array, Ecto.Enum}, values: [:cellular, :ethernet, :wifi])
   end

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -26,7 +26,6 @@ defmodule NervesHub.Devices.Device do
     :updates_blocked_until,
     :connecting_code,
     :deployment_id,
-    :connection_types,
     :status,
     :first_seen_at
   ]
@@ -67,8 +66,6 @@ defmodule NervesHub.Devices.Device do
 
     field(:deleted_at, :utc_datetime)
 
-    field(:connection_types, {:array, Ecto.Enum}, values: [:cellular, :ethernet, :wifi])
-
     timestamps()
 
     # Deprecated fields, remove these any time after 29/1/2025.
@@ -83,6 +80,7 @@ defmodule NervesHub.Devices.Device do
 
     # Deprecated fields, remove these any time after 28/2/2025.
     # field(:connection_metadata, :map, default: %{})
+    # field(:connection_types, {:array, Ecto.Enum}, values: [:cellular, :ethernet, :wifi])
   end
 
   def changeset(%Device{} = device, params) do

--- a/lib/nerves_hub/devices/filtering.ex
+++ b/lib/nerves_hub/devices/filtering.ex
@@ -47,7 +47,7 @@ defmodule NervesHub.Devices.Filtering do
   end
 
   def filter(query, _filters, :connection_type, value) do
-    where(query, [d], ^value in d.connection_types)
+    where(query, [latest_connection: lc], ^value in lc.metadata["connection_types"])
   end
 
   def filter(query, _filters, :firmware_version, value) do

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -175,6 +175,7 @@ defmodule NervesHubWeb.DeviceChannel do
     device = Repo.reload(device)
 
     maybe_update_registry(socket, device, %{
+      deployment_id: device.deployment_id,
       updates_enabled: device.updates_enabled && !Devices.device_in_penalty_box?(device)
     })
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -14,6 +14,7 @@ defmodule NervesHubWeb.DeviceChannel do
   alias NervesHub.AuditLogs.DeviceTemplates
   alias NervesHub.Deployments
   alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
   alias NervesHub.Firmwares
   alias NervesHub.Helpers.Logging
@@ -313,9 +314,13 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  def handle_in("connection_types", %{"values" => types}, %{assigns: %{device: device}} = socket) do
-    {:ok, device} = Devices.update_device(device, %{"connection_types" => types})
-    {:noreply, assign(socket, :device, device)}
+  def handle_in(
+        "connection_types",
+        %{"values" => types},
+        %{assigns: %{reference_id: ref_id}} = socket
+      ) do
+    :ok = Connections.merge_update_metadata(ref_id, %{"connection_types" => types})
+    {:noreply, socket}
   end
 
   def handle_in("status_update", %{"status" => _status}, socket) do

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -263,7 +263,7 @@ defmodule NervesHubWeb.DeviceSocket do
       identifier: device.identifier
     })
 
-    {:ok, _device_connection} = Connections.device_disconnected(reference_id)
+    :ok = Connections.device_disconnected(reference_id)
 
     Tracker.offline(device)
 

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -380,7 +380,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
 
       <div class="w-1/2 flex flex-col gap-4">
         <div class="flex flex-col items-start rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
-          <DeviceLocation.render enabled_product={@product.extensions.geo} enabled_device={@device.extensions.geo} location={@device.connection_metadata["location"]} />
+          <DeviceLocation.render enabled_product={@product.extensions.geo} enabled_device={@device.extensions.geo} location={fetch_location(@device.latest_connection)} />
         </div>
 
         <div class="flex flex-col rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
@@ -606,4 +606,7 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
   defp has_description?(description) do
     is_binary(description) and byte_size(description) > 0
   end
+
+  defp fetch_location(nil), do: %{}
+  defp fetch_location(connection), do: connection.metadata["location"]
 end

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -569,6 +569,9 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> assign(:device, device)
   end
 
+  defp fetch_location(nil), do: %{}
+  defp fetch_location(connection), do: connection.metadata["location"]
+
   def show_menu(id, js \\ %JS{}) do
     JS.show(js, transition: "fade-in", to: "##{id}")
   end

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -73,7 +73,7 @@
         <span :for={tag <- @device.tags || []} class="badge">{tag}</span>
       </div>
 
-      <DeviceLocation.render :if={@product.extensions.geo and @device.extensions.geo} location={@device.connection_metadata["location"]} />
+      <DeviceLocation.render :if={@product.extensions.geo and @device.extensions.geo} location={fetch_location(@device.latest_connection)} />
 
       <%= if !Enum.empty?(@metadata) do %>
         <h3 class="mb-2">Metadata</h3>

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -39,18 +39,13 @@ defmodule NervesHub.Devices.ConnectionsTest do
   end
 
   test "device disconnect", %{device: device} do
-    assert {:ok, %DeviceConnection{id: connection_id, status: :connected}} =
-             Connections.device_connected(device.id)
+    assert {:ok, connection} = Connections.device_connected(device.id)
+    assert :connected = connection.status
+    assert :ok = Connections.device_disconnected(connection.id)
 
-    assert {:ok,
-            %DeviceConnection{
-              id: ^connection_id,
-              status: :disconnected,
-              disconnected_at: disconnected_at
-            }} =
-             Connections.device_disconnected(connection_id)
+    connection = NervesHub.Repo.reload(connection)
 
-    refute is_nil(disconnected_at)
+    refute is_nil(connection.disconnected_at)
 
     assert %DeviceConnection{status: :disconnected} = Connections.get_latest_for_device(device.id)
   end

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -126,8 +126,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
     # check the state of the device's connection types
     _socket = :sys.get_state(socket.channel_pid)
 
-    device = NervesHub.Repo.reload(device)
-    assert device.connection_types == [:ethernet, :wifi]
+    device = NervesHub.Repo.reload(device) |> NervesHub.Repo.preload(:latest_connection)
+    assert device.latest_connection.metadata["connection_types"] == ["ethernet", "wifi"]
   end
 
   describe "unhandled messages are caught" do

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -7,6 +7,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   alias NervesHub.AuditLogs
   alias NervesHub.Deployments
   alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Metrics
   alias NervesHub.Fixtures
   alias NervesHub.Repo
@@ -256,7 +257,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      Devices.update_device(device, %{connection_metadata: %{"location" => %{}}})
+      {:ok, connection} = Connections.device_connected(device.id)
+      :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{}})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -270,7 +272,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "location" => %{"error_code" => "BOOP", "error_description" => "BEEP"}
       }
 
-      Devices.update_device(device, %{connection_metadata: metadata})
+      {:ok, connection} = Connections.device_connected(device.id)
+      :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -290,7 +293,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         }
       }
 
-      Devices.update_device(device, %{connection_metadata: metadata})
+      {:ok, connection} = Connections.device_connected(device.id)
+      :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")


### PR DESCRIPTION
This moves `connection_metadata` and `connection_types` to both use `DeviceConnection.metadata`.

Next week we can create a PR to remove unused fields from the `devices` table.