### PR TITLE
Remove the need to store the devices deployment in the `DeviceChannel`

### DIFF
--- a/lib/nerves_hub/archives.ex
+++ b/lib/nerves_hub/archives.ex
@@ -71,18 +71,10 @@ defmodule NervesHub.Archives do
   def archive_for_deployment(nil), do: nil
 
   def archive_for_deployment(deployment_id) do
-    deployment =
-      Deployment
-      |> where(id: ^deployment_id)
-      |> join(:inner, [d], a in assoc(d, :archive))
-      |> preload([_, a], archive: a)
-      |> Repo.one()
-
-    if deployment do
-      deployment.archive
-    else
-      nil
-    end
+    Archive
+    |> join(:inner, [a], d in Deployment, on: d.archive_id == a.id)
+    |> where([a, d], d.id == ^deployment_id)
+    |> Repo.one()
   end
 
   # TODO: check on other return signatures

--- a/lib/nerves_hub/archives.ex
+++ b/lib/nerves_hub/archives.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Archives do
 
   require Logger
 
+  alias NervesHub.Deployments.Deployment
   alias NervesHub.Archives.Archive
   alias NervesHub.Fwup
   alias NervesHub.Products.Product
@@ -64,6 +65,24 @@ defmodule NervesHub.Archives do
     |> join(:inner, [a, p], o in assoc(p, :org))
     |> preload([a, p, o], product: {p, org: o})
     |> Repo.one!()
+  end
+
+  @spec archive_for_deployment(integer()) :: Archive.t() | nil
+  def archive_for_deployment(nil), do: nil
+
+  def archive_for_deployment(deployment_id) do
+    deployment =
+      Deployment
+      |> where(id: ^deployment_id)
+      |> join(:inner, [d], a in assoc(d, :archive))
+      |> preload([_, a], archive: a)
+      |> Repo.one()
+
+    if deployment do
+      deployment.archive
+    else
+      nil
+    end
   end
 
   # TODO: check on other return signatures

--- a/lib/nerves_hub/audit_logs/templates/device_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/device_templates.ex
@@ -72,9 +72,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     AuditLogs.audit!(device, device, description)
   end
 
-  @spec audit_device_deployment_update_triggered(Device.t(), UUIDv7.t()) :: :ok
-  def audit_device_deployment_update_triggered(device, reference_id) do
-    deployment = device.deployment
+  @spec audit_device_deployment_update_triggered(Device.t(), Deployment.t(), UUIDv7.t()) :: :ok
+  def audit_device_deployment_update_triggered(device, deployment, reference_id) do
     firmware = deployment.firmware
 
     description =

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -10,6 +10,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.AuditLogs
   alias NervesHub.AuditLogs.DeviceTemplates
   alias NervesHub.Certificate
+  alias NervesHub.Deployments
   alias NervesHub.Deployments.Deployment
   alias NervesHub.Deployments.Orchestrator
   alias NervesHub.Devices.CACertificate
@@ -673,7 +674,7 @@ defmodule NervesHub.Devices do
   def resolve_update(%{deployment_id: nil}), do: %UpdatePayload{update_available: false}
 
   def resolve_update(device) do
-    deployment = Repo.preload(device.deployment, [:firmware])
+    {:ok, deployment} = Deployments.get_deployment_for_device(device)
 
     case verify_update_eligibility(device, deployment) do
       {:ok, _device} ->

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -41,6 +41,7 @@ defmodule NervesHubWeb.DeviceChannel do
       device
       |> Deployments.verify_deployment_membership()
       |> Deployments.set_deployment()
+      |> Map.put(:deployment, nil)
 
     maybe_send_public_keys(device, socket, params)
 
@@ -124,8 +125,6 @@ defmodule NervesHubWeb.DeviceChannel do
 
   @decorate with_span("Channels.DeviceChannel.handle_info:deployments/update")
   def handle_info({"deployments/update", inflight_update}, %{assigns: %{device: device}} = socket) do
-    device = deployment_preload(device)
-
     payload = Devices.resolve_update(device)
 
     case payload.update_available do
@@ -140,6 +139,7 @@ defmodule NervesHubWeb.DeviceChannel do
         # as a loosely valid attempt to update
         DeviceTemplates.audit_device_deployment_update_triggered(
           device,
+          payload.deployment,
           socket.assigns.reference_id
         )
 
@@ -154,14 +154,7 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   def handle_info(%Broadcast{event: "archives/updated"}, socket) do
-    device = deployment_preload(socket.assigns.device)
-
-    socket =
-      socket
-      |> assign(:device, device)
-      |> maybe_send_archive()
-
-    {:noreply, socket}
+    {:noreply, maybe_send_archive(socket)}
   end
 
   def handle_info(%Broadcast{event: "moved"}, %{assigns: %{device: device}} = socket) do
@@ -307,7 +300,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
       socket =
         socket
-        |> assign(:device, deployment_preload(device))
+        |> assign(:device, device)
         |> assign(:update_started?, true)
 
       {:noreply, socket}
@@ -439,7 +432,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
   defp update_device(socket, device) do
     socket
-    |> assign(:device, deployment_preload(device))
+    |> assign(:device, device)
     |> update_deployment_subscription(device)
   end
 
@@ -466,20 +459,12 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  defp deployment_preload(device) do
-    Repo.preload(device, [deployment: [:archive, :firmware]], force: true)
-  end
-
-  defp maybe_send_archive(socket) do
-    device = deployment_preload(socket.assigns.device)
-
+  defp maybe_send_archive(%{assigns: %{device: device}} = socket) do
     updates_enabled = device.updates_enabled && !Devices.device_in_penalty_box?(device)
     version_match = Version.match?(socket.assigns.device_api_version, ">= 2.0.0")
 
     if updates_enabled && version_match do
-      if device.deployment && device.deployment.archive do
-        archive = device.deployment.archive
-
+      if archive = Archives.archive_for_deployment(device.deployment_id) do
         push(socket, "archive", %{
           size: archive.size,
           uuid: archive.uuid,


### PR DESCRIPTION
This is all about reducing the information stored in the assigns for the `DeviceChannel`. 

It's also allowed us to remove a bunch of preloads which were being done often and fairly aggressively.