### PR TITLE
Make sure firmware is selected when processing `push-update`

### DIFF
--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -546,6 +546,12 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
     end
   end
 
+  def handle_event("push-update", %{"uuid" => uuid}, socket) when uuid == "" do
+    socket
+    |> send_toast(:error, "Please select a firmware version to send to the device.")
+    |> noreply()
+  end
+
   def handle_event("push-update", %{"uuid" => uuid}, socket) do
     authorized!(:"device:push-update", socket.assigns.org_user)
 


### PR DESCRIPTION
Fixes a UI/UX use case where the 'send update' button can be pressed even though no firmware has been selected.