### PR TITLE
Add support for clear and update deployment broadcasts

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -739,7 +739,7 @@ defmodule NervesHub.Devices do
       |> Ecto.Changeset.put_change(:deployment_id, deployment.id)
       |> Repo.update!()
 
-    _ = broadcast(device, "devices/updated")
+    _ = broadcast(device, "devices/deployment-updated", %{deployment_id: deployment.id})
 
     Map.put(device, :deployment, deployment)
   end
@@ -752,7 +752,7 @@ defmodule NervesHub.Devices do
       |> Ecto.Changeset.put_change(:deployment_id, nil)
       |> Repo.update!()
 
-    _ = broadcast(device, "devices/updated")
+    _ = broadcast(device, "devices/deployment-cleared")
 
     Map.put(device, :deployment, nil)
   end
@@ -1126,11 +1126,13 @@ defmodule NervesHub.Devices do
     end
   end
 
-  defp broadcast(%Device{id: id}, event) do
+  defp broadcast(device, event), do: broadcast(device, event, %{})
+
+  defp broadcast(%Device{id: id}, event, payload) do
     Phoenix.PubSub.broadcast(
       NervesHub.PubSub,
       "device:#{id}",
-      %Phoenix.Socket.Broadcast{event: event}
+      %Phoenix.Socket.Broadcast{event: event, payload: payload}
     )
   end
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -787,7 +787,7 @@ defmodule NervesHub.DevicesTest do
   end
 
   describe "update_deployment/2" do
-    test "updates deployment and broadcasts 'devices/updated'", %{
+    test "updates deployment and broadcasts 'devices/deployment-updated'", %{
       device: device,
       deployment: deployment
     } do
@@ -797,12 +797,12 @@ defmodule NervesHub.DevicesTest do
       device = Devices.update_deployment(device, deployment)
 
       assert device.deployment_id == deployment.id
-      assert_receive %{event: "devices/updated"}
+      assert_receive %{event: "devices/deployment-updated"}
     end
   end
 
   describe "clear_deployment1/2" do
-    test "clears deployment and broadcasts 'devices/updated'", %{
+    test "clears deployment and broadcasts 'devices/deployment-cleared'", %{
       device: device,
       deployment: deployment
     } do
@@ -812,7 +812,7 @@ defmodule NervesHub.DevicesTest do
       device = Devices.clear_deployment(device)
 
       refute device.deployment_id
-      assert_receive %{event: "devices/updated"}
+      assert_receive %{event: "devices/deployment-cleared"}
     end
   end
 end

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -578,6 +578,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       end)
       |> assert_has("div", text: "Eligible Deployments")
 
+      assert_receive %Phoenix.Socket.Broadcast{event: "devices/deployment-cleared"}
+
       refute Repo.reload(device) |> Map.get(:deployment_id)
     end
 
@@ -667,7 +669,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         render_change(view, "set-deployment", %{"deployment_id" => deployment.id})
       end)
 
-      assert_receive %Phoenix.Socket.Broadcast{event: "devices/updated"}
+      assert_receive %Phoenix.Socket.Broadcast{event: "devices/deployment-updated"}
     end
   end
 


### PR DESCRIPTION
More focused events, and use the information from the event instead of reloading data.