### PR TITLE
Track the link api version in the connection metadata

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -372,8 +372,12 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  defp assign_api_version(socket, params) do
-    assign(socket, :device_api_version, Map.get(params, "device_api_version", "1.0.0"))
+  defp assign_api_version(%{assigns: %{reference_id: ref_id}} = socket, params) do
+    version = Map.get(params, "device_api_version", "1.0.0")
+
+    :ok = Connections.merge_update_metadata(ref_id, %{"device_api_version" => version})
+
+    assign(socket, :device_api_version, version)
   end
 
   defp retry_device_registration(socket, attempt) do


### PR DESCRIPTION
This is useful for knowing if there are devices we, as a platform, might want to recommend users/customers upgrade.

Eg. security, performance, feature set, compatibility