### PR TITLE
Support restricting device connections to the web endpoint

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -203,7 +203,9 @@ if config_env() == :prod do
   config :nerves_hub, NervesHubWeb.DeviceSocket,
     shared_secrets: [
       enabled: System.get_env("DEVICE_SHARED_SECRETS_ENABLED", "false") == "true"
-    ]
+    ],
+    web_endpoint_supported:
+      System.get_env("DEVICE_SOCKET_WEB_ENDPOINT_SUPPORTED", "true") == "true"
 end
 
 ##

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule NervesHubWeb.Endpoint do
     "/device-socket",
     NervesHubWeb.DeviceSocket,
     websocket: [
-      connect_info: [:peer_data, :x_headers],
+      connect_info: [:peer_data, :x_headers, source: __MODULE__],
       compress: true,
       timeout: 180_000,
       fullsweep_after: 0,

--- a/lib/nerves_hub_web/helpers/websocket_connection_error.ex
+++ b/lib/nerves_hub_web/helpers/websocket_connection_error.ex
@@ -1,12 +1,19 @@
 defmodule NervesHub.Helpers.WebsocketConnectionError do
   import Plug.Conn
 
-  @message "no certificate pair or shared secrets connection settings were provided"
+  @no_auth_message "no certificate pair or shared secrets connection settings were provided"
+  @check_uri_message "incorrect uri used, please contact support"
 
   def handle_error(conn, :no_auth) do
     conn
-    |> put_resp_header("nh-connection-error-reason", @message)
-    |> send_resp(401, @message)
+    |> put_resp_header("nh-connection-error-reason", @no_auth_message)
+    |> send_resp(401, @no_auth_message)
+  end
+
+  def handle_error(conn, :check_uri) do
+    conn
+    |> put_resp_header("nh-connection-error-reason", @check_uri_message)
+    |> send_resp(404, @check_uri_message)
   end
 
   def handle_error(conn, _reason), do: send_resp(conn, 401, "")

--- a/test/support/socket_client.ex
+++ b/test/support/socket_client.ex
@@ -291,7 +291,7 @@ defmodule SocketClient do
 
   @impl Slipstream
   def handle_disconnect(
-        {:error, {:upgrade_failure, %{reason: %{status_code: 401} = reason}}},
+        {:error, {:upgrade_failure, %{reason: reason}}},
         socket
       ) do
     socket =


### PR DESCRIPTION
This allows installations to disable shared secret device connections to web endpoints.

This is ideal for cases where you are running a devices endpoint and want to make sure all connections go there.