### PR TITLE
Allow for the main DB pool to have a customized pool count

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -243,6 +243,7 @@ if config_env() == :prod do
     url: System.fetch_env!("DATABASE_URL"),
     ssl: database_ssl_opts,
     pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE", "20")),
+    pool_count: String.to_integer(System.get_env("DATABASE_POOL_COUNT", "1")),
     socket_options: database_socket_options,
     queue_target: 5000
 


### PR DESCRIPTION
From the Ecto docs:

> the number of pools to run concurrently, increase this option when the pool itself may be under contention. When running multiple pools, queries are randomly routed to different pools, without taking into account how many connections are available in each. So in some circumstances, you may be routed to a fully busy pool while others have connections available. The overall number of connections used will be pool_size * pool_count. Defaults to 1