### PR TITLE
Remove unused heartbeat `handle_info`

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -283,11 +283,6 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  def handle_info(%Broadcast{event: "connection:heartbeat"}, socket) do
-    # Expected message that is not used here :)
-    {:noreply, socket}
-  end
-
   def handle_info(msg, socket) do
     # Ignore unhandled messages so that it doesn't crash the link process
     # preventing cascading problems.


### PR DESCRIPTION
`"connection:heartbeat"` is sent to the `"device:#{result.identifier}:internal"` topic, but the `DeviceChannel` doesn't subscribe to this topic.