### PR TITLE
Switch to showing (and sorting) on a devices last connection `established_at` datetime

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -156,6 +156,18 @@ defmodule NervesHub.Devices do
     |> Repo.all()
   end
 
+  defp sort_devices(query, {:asc, :connection_established_at}) do
+    order_by(query, [latest_connection: latest_connection],
+      desc_nulls_last: latest_connection.established_at
+    )
+  end
+
+  defp sort_devices(query, {:desc, :connection_established_at}) do
+    order_by(query, [latest_connection: latest_connection],
+      asc_nulls_first: latest_connection.established_at
+    )
+  end
+
   defp sort_devices(query, {:asc, :connection_last_seen_at}) do
     order_by(query, [latest_connection: latest_connection],
       desc_nulls_last: latest_connection.last_seen_at

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -90,8 +90,8 @@
             </th>
             <th>Firmware</th>
             <th>Platform</th>
-            <th phx-click="sort" phx-value-sort="connection_last_seen_at" class="cursor-pointer">
-              <Sorting.sort_icon text="Seen" field="connection_last_seen_at" selected_field={@current_sort} selected_direction={@sort_direction} />
+            <th phx-click="sort" phx-value-sort="connection_established_at" class="cursor-pointer">
+              <Sorting.sort_icon text="Uptime" field="connection_established_at" selected_field={@current_sort} selected_direction={@sort_direction} />
             </th>
             <th phx-click="sort" phx-value-sort="tags" class="cursor-pointer">
               <Sorting.sort_icon text="Tags" field="tags" selected_field={@current_sort} selected_direction={@sort_direction} />
@@ -119,7 +119,7 @@
             </td>
             <td>
               <div class="flex gap-[8px] items-center">
-                <span title={last_seen_at_status(device.latest_connection)}>
+                <span title={connection_established_at_status(device.latest_connection)}>
                   <%= if @device_statuses[device.identifier] == "online" do %>
                     <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
                       <circle cx="3" cy="3" r="3" fill="#10B981" />
@@ -206,8 +206,8 @@
             </td>
 
             <td>
-              <div :if={device.latest_connection} title={last_seen_at(device.latest_connection)}>
-                {last_seen_at(device.latest_connection)}
+              <div :if={device.latest_connection} title={connection_established_at(device.latest_connection)}>
+                {connection_established_at(device.latest_connection)}
               </div>
             </td>
 

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -550,6 +550,22 @@ defmodule NervesHubWeb.Live.Devices.Index do
     """
   end
 
+  defp connection_established_at_status(nil), do: "Not seen yet"
+
+  defp connection_established_at_status(latest_connection),
+    do: "Last connected at #{connection_established_at_formatted(latest_connection)}"
+
+  defp connection_established_at(nil), do: ""
+
+  defp connection_established_at(latest_connection),
+    do: connection_established_at_formatted(latest_connection)
+
+  defp connection_established_at_formatted(latest_connection) do
+    latest_connection
+    |> Map.get(:established_at)
+    |> DateTimeFormat.from_now()
+  end
+
   defp last_seen_at_status(nil), do: "Not seen yet"
 
   defp last_seen_at_status(latest_connection),


### PR DESCRIPTION
This was some feedback from a NervesCloud user, and makes a lot of sense to me.

There is some code duplication which will be resolved when we start removing the old UI code.