### PR TITLE
New UI: Remove the chat from the console

### DIFF
--- a/assets/ui-rework/hooks/console.js
+++ b/assets/ui-rework/hooks/console.js
@@ -84,17 +84,12 @@ export default {
       }, 300)
     )
 
-    const chatBody = document.getElementById("chat-body")
-    const chatMessage = document.getElementById("chat-message")
-
     channel
       .join()
       .receive("ok", () => {
-        console.log("JOINED")
         // This will be the same for everyone, the first time it should be used
         // and there after it will be ignored as a noop by erlang
         channel.push("window_size", { height: term.rows, width: term.cols })
-        channel.push("message", { event: "loaded the console" })
       })
       .receive("error", () => {
         console.log("ERROR")
@@ -107,25 +102,6 @@ export default {
     // Write data from device to console
     channel.on("up", payload => {
       term.write(payload.data)
-    })
-
-    channel.on("message", payload => {
-      if (payload.text) {
-        chatBody.append(`${payload.name}: ${payload.text}\n`)
-      } else if (payload.event) {
-        chatBody.append(`${payload.name} ${payload.event}\n`)
-      }
-      chatBody.scrollTop = chatBody.scrollHeight
-    })
-
-    chatBody.addEventListener("click", () => {
-      chatMessage.focus()
-    })
-    chatMessage.addEventListener("keypress", e => {
-      if (e.key == "Enter") {
-        channel.push("message", { text: chatMessage.value })
-        chatMessage.value = ""
-      }
     })
 
     // store version outside of callback closure to set
@@ -195,7 +171,6 @@ export default {
     })
 
     channel.onClose(() => {
-      console.log("CLOSED")
       term.blur()
       term.setOption("cursorBlink", false)
       term.write("DISCONNECTED")
@@ -224,12 +199,10 @@ export default {
           const reader = file.stream().getReader()
 
           channel.push("file-data/start", { filename: file.name })
-          channel.push("message", { event: `starting to upload ${file.name}` })
 
           reader.read().then(function process({ done, value }) {
             if (done) {
               channel.push("file-data/stop", { filename: file.name })
-              channel.push("message", { event: `uploaded ${file.name}` })
               return
             }
 

--- a/lib/nerves_hub_web/components/device_page/console.ex
+++ b/lib/nerves_hub_web/components/device_page/console.ex
@@ -16,7 +16,7 @@ defmodule NervesHubWeb.Components.DevicePage.Console do
     <div class="size-full">
       <div :if={authorized?(:"device:console", @org_user) && @console_active?} class="flex flex-col size-full items-start justify-between">
         <div id="console-and-chat" class="size-full flex gap-4 p-6" phx-update="ignore">
-          <div class="flex flex-col w-9/12 bg-zinc-900 border border-zinc-700 rounded">
+          <div class="flex flex-col w-full bg-zinc-900 border border-zinc-700 rounded">
             <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
               <div id="console-title" class="text-base text-neutral-50 font-medium">Console</div>
             </div>
@@ -24,24 +24,12 @@ defmodule NervesHubWeb.Components.DevicePage.Console do
               <div id="console" phx-hook="Console" data-user-token={@user_token} data-device-id={@device.id} class="w-full h-full"></div>
             </div>
           </div>
-
-          <div class="flex flex-col w-3/12 bg-zinc-900 border border-zinc-700 rounded">
-            <div class="flex-none flex justify-between items-center h-14 px-4 border-b border-zinc-700">
-              <div class="text-base text-neutral-50 font-medium">Chat</div>
-            </div>
-            <div class="flex-1 flex justify-between items-center h-14 p-4 border-b border-zinc-700">
-              <pre id="chat-body" class="h-full leading-loose text-xs"></pre>
-            </div>
-            <div class="flex-none flex justify-between items-center h-14 px-4 border-b border-zinc-900 bg-zinc-900">
-              <input id="chat-message" type="text" class="py-1.5 px-2 block w-full border-0 text-zinc-400 bg-zinc-900 ring-0 focus:ring-0 sm:text-sm" />
-            </div>
-          </div>
         </div>
       </div>
 
       <div :if={authorized?(:"device:console", @org_user) && !@console_active?} class="flex flex-col size-full items-start justify-between">
         <div id="console-and-chat" class="size-full flex gap-4 p-6" phx-update="ignore">
-          <div class="flex flex-col w-9/12 bg-zinc-900 border border-zinc-700 rounded">
+          <div class="flex flex-col w-full bg-zinc-900 border border-zinc-700 rounded">
             <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
               <div class="text-base text-neutral-50 font-medium">Console</div>
             </div>
@@ -49,41 +37,17 @@ defmodule NervesHubWeb.Components.DevicePage.Console do
               The device console isn't currently available.
             </div>
           </div>
-
-          <div class="flex flex-col w-3/12 bg-zinc-900 border border-zinc-700 rounded">
-            <div class="flex-none flex justify-between items-center h-14 px-4 border-b border-zinc-700">
-              <div class="text-base text-neutral-50 font-medium">Chat</div>
-            </div>
-            <div class="flex-1 flex justify-between items-center h-14 p-4 border-b border-zinc-700">
-              <pre id="chat-body" class="h-full leading-loose text-xs"></pre>
-            </div>
-            <div class="flex-none flex justify-between items-center h-14 px-4 border-b border-zinc-900 bg-zinc-900">
-              <input id="chat-message" type="text" class="py-1.5 px-2 block w-full border-0 text-zinc-400 bg-zinc-900 ring-0 focus:ring-0 sm:text-sm" />
-            </div>
-          </div>
         </div>
       </div>
 
       <div :if={!authorized?(:"device:console", @org_user)} class="flex flex-col size-full items-start justify-between">
         <div id="console-and-chat" class="size-full flex gap-4 p-6" phx-update="ignore">
-          <div class="flex flex-col w-9/12 bg-zinc-900 border border-zinc-700 rounded">
+          <div class="flex flex-col w-full bg-zinc-900 border border-zinc-700 rounded">
             <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
               <div class="text-base text-neutral-50 font-medium">Console</div>
             </div>
             <div class="grow flex justify-center items-center p-6 gap-6 text-medium text-red-500">
               You don't have the required permissions to access a Device console.
-            </div>
-          </div>
-
-          <div class="flex flex-col w-3/12 bg-zinc-900 border border-zinc-700 rounded">
-            <div class="flex-none flex justify-between items-center h-14 px-4 border-b border-zinc-700">
-              <div class="text-base text-neutral-50 font-medium">Chat</div>
-            </div>
-            <div class="flex-1 flex justify-between items-center h-14 p-4 border-b border-zinc-700">
-              <pre id="chat-body" class="h-full leading-loose text-xs"></pre>
-            </div>
-            <div class="flex-none flex justify-between items-center h-14 px-4 border-b border-zinc-900 bg-zinc-900">
-              <input id="chat-message" type="text" class="py-1.5 px-2 block w-full border-0 text-zinc-400 bg-zinc-900 ring-0 focus:ring-0 sm:text-sm" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This frees up some space on smaller screens.

In the future I would like to use toast or flash notifications for console events, like when the file upload has started or finished, or someone else has joined the console.