### PR TITLE
Cleanly close the device connection during channel tests

### DIFF
--- a/lib/nerves_hub/audit_logs.ex
+++ b/lib/nerves_hub/audit_logs.ex
@@ -104,4 +104,9 @@ defmodule NervesHub.AuditLogs do
 
     {:ok, count}
   end
+
+  # used in some tests
+  def with_description(desc) do
+    where(AuditLog, [a], like(a.description, ^desc))
+  end
 end

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -19,10 +19,13 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
-    {:ok, _, _} =
+    {:ok, _, device_channel} =
       subscribe_and_join_with_default_device_api_version(socket, DeviceChannel, "device")
 
     assert_push("extensions:get", _extensions)
+
+    assert_online_and_available(device)
+    close_cleanly(device_channel)
   end
 
   test "joining extensions channel works when the device has connected for the first time" do
@@ -84,12 +87,12 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
-    {:ok, _, socket} =
+    {:ok, _, _device_channel} =
       subscribe_and_join_with_default_device_api_version(socket, DeviceChannel, "device")
 
     assert_push("extensions:get", _extensions)
 
-    assert {:ok, attach_list, _} =
+    assert {:ok, attach_list, _extensions_channel} =
              subscribe_and_join_with_default_device_api_version(
                socket,
                ExtensionsChannel,
@@ -112,12 +115,12 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
-    {:ok, _, socket} =
+    {:ok, _, _device_channel} =
       subscribe_and_join_with_default_device_api_version(socket, DeviceChannel, "device")
 
     assert_push("extensions:get", _extensions)
 
-    assert {:ok, ["health"], _} =
+    assert {:ok, ["health"], _extensions_channel} =
              subscribe_and_join_with_default_device_api_version(
                socket,
                ExtensionsChannel,
@@ -157,12 +160,12 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
       "nerves_fw_platform" => "test_host"
     }
 
-    {:ok, _, socket} =
+    {:ok, _, _device_channel} =
       subscribe_and_join_with_default_device_api_version(socket, DeviceChannel, "device", params)
 
     assert_push("extensions:get", _extensions)
 
-    assert {:ok, attach_list, _} =
+    assert {:ok, attach_list, _extensions_channel} =
              subscribe_and_join_with_default_device_api_version(
                socket,
                ExtensionsChannel,

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -1,8 +1,6 @@
 defmodule NervesHubWeb.WebsocketTest do
   use NervesHubWeb.ChannelCase
 
-  use AssertEventually, timeout: 500, interval: 50
-
   import TrackerHelper
 
   alias NervesHub.AuditLogs
@@ -1184,10 +1182,5 @@ defmodule NervesHubWeb.WebsocketTest do
     SocketClient.clean_close(socket)
     eventually assert_connection_change()
     eventually(assert(Repo.all(where(DeviceConnection, status: :connected)) == []))
-  end
-
-  def assert_online_and_available(device) do
-    eventually assert [{_, %{}}] =
-                        Registry.match(NervesHub.Devices.Registry, device.id, :_)
   end
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -21,6 +21,7 @@ defmodule NervesHubWeb.ChannelCase do
       import Phoenix.ChannelTest
       use DefaultMocks
       use Oban.Testing, repo: NervesHub.ObanRepo
+      use AssertEventually, timeout: 500, interval: 50
 
       # The default endpoint for testing
       @endpoint NervesHubWeb.DeviceEndpoint
@@ -31,6 +32,16 @@ defmodule NervesHubWeb.ChannelCase do
 
       def subscribe_extensions(device) do
         Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.identifier}:extensions")
+      end
+
+      def assert_online_and_available(device) do
+        eventually assert [{_, %{}}] =
+                            Registry.match(NervesHub.Devices.Registry, device.id, :_)
+      end
+
+      def close_cleanly(channel) do
+        Process.unlink(channel.channel_pid)
+        :ok = close(channel)
       end
     end
   end


### PR DESCRIPTION
Postgres was complaining. This makes sure it doesn't happen anymore.