### PR TITLE
[Paused] Remove some unused indexes and deprecated columns

### DIFF
--- a/priv/repo/migrations/20250213030301_remove_unused_indexes_and_columns.exs
+++ b/priv/repo/migrations/20250213030301_remove_unused_indexes_and_columns.exs
@@ -1,0 +1,22 @@
+defmodule NervesHub.Repo.Migrations.RemoveUnusedIndexesAndColumns do
+  use Ecto.Migration
+
+  def up do
+    drop(index(:devices, [:connection_status]))
+
+    alter table("device") do
+      remove(:connection_status)
+      remove(:connection_established_at)
+      remove(:connection_disconnected_at)
+      remove(:connection_last_seen_at)
+      remove(:connection_metadata)
+      remove(:connection_types)
+    end
+
+    drop(index(:device_connections, [:device_id, :established_at]))
+  end
+
+  def down do
+    raise "One way migration"
+  end
+end

--- a/priv/repo/migrations/20250213030301_remove_unused_indexes_and_columns.exs
+++ b/priv/repo/migrations/20250213030301_remove_unused_indexes_and_columns.exs
@@ -4,7 +4,7 @@ defmodule NervesHub.Repo.Migrations.RemoveUnusedIndexesAndColumns do
   def up do
     drop(index(:devices, [:connection_status]))
 
-    alter table("devics") do
+    alter table("devices") do
       remove(:connection_status)
       remove(:connection_established_at)
       remove(:connection_disconnected_at)

--- a/priv/repo/migrations/20250213030301_remove_unused_indexes_and_columns.exs
+++ b/priv/repo/migrations/20250213030301_remove_unused_indexes_and_columns.exs
@@ -4,7 +4,7 @@ defmodule NervesHub.Repo.Migrations.RemoveUnusedIndexesAndColumns do
   def up do
     drop(index(:devices, [:connection_status]))
 
-    alter table("device") do
+    alter table("devics") do
       remove(:connection_status)
       remove(:connection_established_at)
       remove(:connection_disconnected_at)


### PR DESCRIPTION
We have some old columns and indexes we no longer need.

This PR is used as a reminder for a March merge and deploy, shortly after the Orchestrator PR is merged and shipped.