### PR TITLE
Ensure available deployments match selected devices architecture and platform when batch-updating

### DIFF
--- a/lib/nerves_hub/deployments.ex
+++ b/lib/nerves_hub/deployments.ex
@@ -182,6 +182,16 @@ defmodule NervesHub.Deployments do
     |> Repo.one!()
   end
 
+  @spec get_by_product_and_platform(Product.t(), binary()) :: [Deployment.t()]
+  def get_by_product_and_platform(product, platform) do
+    Deployment
+    |> where(product_id: ^product.id)
+    |> join(:left, [d], f in assoc(d, :firmware))
+    |> where([_d, f], f.platform == ^platform)
+    |> preload([_d, f], firmware: f)
+    |> Repo.all()
+  end
+
   @spec get_deployment_by_name(Product.t(), String.t()) ::
           {:ok, Deployment.t()} | {:error, :not_found}
   def get_deployment_by_name(product, name) do

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -446,9 +446,9 @@
           <label for="move_to" class="sidebar-label">Move device(s) to deployment:</label>
 
           <div class="flex gap-2">
-            <select name="deployment" id="move_to_deployment" class="sidebar-select">
+            <select name="deployment" id="move_to_deployment" class="sidebar-select" disabled={Enum.empty?(@available_deployments_for_selected_devices)}>
               <option value="">Select deployment</option>
-              <%= for deployment <- @deployments do %>
+              <%= for deployment <- @available_deployments_for_selected_devices do %>
                 <option value={deployment.id} {if @target_deployment && @target_deployment.id == deployment.id, do: [selected: true], else: []}>
                   {deployment.name} - {deployment.firmware.architecture} - {deployment.firmware.platform}
                 </option>

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -442,13 +442,13 @@
           </div>
         </form>
 
-        <form id="deployment-move" class="flex flex-col gap-2" phx-change="target-deployment" phx-submit="move-devices-deployment">
-          <label for="move_to" class="sidebar-label">Move device(s) to deployment:</label>
+        <form :if={Enum.any?(@available_deployments_for_filtered_platform)} id="deployment-move" class="flex flex-col gap-2" phx-change="target-deployment" phx-submit="move-devices-deployment">
+          <label for="move_to" class="sidebar-label">Move device(s) to deployment filtered by platform:</label>
 
           <div class="flex gap-2">
-            <select name="deployment" id="move_to_deployment" class="sidebar-select" disabled={Enum.empty?(@available_deployments_for_selected_devices)}>
+            <select name="deployment" id="move_to_deployment" class="sidebar-select">
               <option value="">Select deployment</option>
-              <%= for deployment <- @available_deployments_for_selected_devices do %>
+              <%= for deployment <- @available_deployments_for_filtered_platform do %>
                 <option value={deployment.id} {if @target_deployment && @target_deployment.id == deployment.id, do: [selected: true], else: []}>
                   {deployment.name} - {deployment.firmware.architecture} - {deployment.firmware.platform}
                 </option>

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -4,17 +4,13 @@ defmodule NervesHubWeb.Live.Devices.Index do
   require Logger
   require OpenTelemetry.Tracer, as: Tracer
 
-  import Ecto.Query
-
   alias NervesHub.AuditLogs.DeviceTemplates
-  alias NervesHub.Deployments.Deployment
+  alias NervesHub.Deployments
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
-  alias NervesHub.Devices.Device
   alias NervesHub.Devices.Metrics
   alias NervesHub.Firmwares
   alias NervesHub.Products.Product
-  alias NervesHub.Repo
   alias NervesHub.Tracker
 
   alias Phoenix.LiveView.JS
@@ -101,7 +97,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:total_entries, 0)
     |> assign(:current_alarms, Alarms.get_current_alarm_types(product.id))
     |> assign(:metrics_keys, Metrics.default_metrics())
-    |> assign(:available_deployments_for_selected_devices, [])
+    |> assign(:available_deployments_for_filtered_platform, [])
     |> assign(:target_deployment, nil)
     |> subscribe_and_refresh_device_list_timer()
     |> ok()
@@ -121,6 +117,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:currently_filtering, filters != @default_filters)
     |> assign(:params, unsigned_params)
     |> assign_display_devices()
+    |> maybe_assign_available_deployments_for_filtered_platform()
     |> noreply()
   end
 
@@ -228,7 +225,6 @@ defmodule NervesHubWeb.Live.Devices.Index do
     socket =
       socket
       |> assign(:selected_devices, selected_devices)
-      |> maybe_update_available_deployments_for_selected_devices()
 
     {:noreply, socket}
   end
@@ -246,14 +242,13 @@ defmodule NervesHubWeb.Live.Devices.Index do
     socket =
       socket
       |> assign(:selected_devices, selected_devices)
-      |> maybe_update_available_deployments_for_selected_devices()
 
     {:noreply, socket}
   end
 
   def handle_event("deselect-all", _, socket) do
     {:noreply,
-     assign(socket, %{selected_devices: [], available_deployments_for_selected_devices: []})}
+     assign(socket, %{selected_devices: [], available_deployments_for_filtered_platform: []})}
   end
 
   def handle_event("validate-tags", %{"tags" => tags}, socket) do
@@ -304,7 +299,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   def handle_event("target-deployment", %{"deployment" => deployment_id}, socket) do
     deployment =
       Enum.find(
-        socket.assigns.available_deployments_for_selected_devices,
+        socket.assigns.available_deployments_for_filtered_platform,
         &(&1.id == String.to_integer(deployment_id))
       )
 
@@ -720,68 +715,17 @@ defmodule NervesHubWeb.Live.Devices.Index do
     """
   end
 
-  # if selected devices have matching architecture and platform, find available deployments
-  defp maybe_update_available_deployments_for_selected_devices(
-         %{
-           assigns: %{
-             product: %{id: product_id},
-             selected_devices: selected_devices
-           }
-         } = socket
-       ) do
-    selected_devices_arch_and_platform_match? =
-      selected_devices_arch_and_platform_match?(selected_devices)
-
-    if selected_devices_arch_and_platform_match? do
-      deployments =
-        get_deployments_by_product_architecture_platform(product_id, selected_devices)
-
-      socket
-      |> assign(:available_deployments_for_selected_devices, deployments)
-      |> assign(:debounce_active, true)
-    else
-      assign(socket, :available_deployments_for_selected_devices, [])
-    end
-  end
-
-  defp selected_devices_arch_and_platform_match?(device_ids) do
-    from(d in Device,
-      where: d.id in ^device_ids,
-      select: [
-        fragment("firmware_metadata ->> 'architecture'"),
-        fragment("firmware_metadata ->> 'platform'")
-      ],
-      distinct: true
+  defp maybe_assign_available_deployments_for_filtered_platform(
+         %{assigns: %{product: product, current_filters: %{platform: platform}}} = socket
+       )
+       when platform != "" do
+    assign(
+      socket,
+      :available_deployments_for_filtered_platform,
+      Deployments.get_by_product_and_platform(product, platform)
     )
-    |> Repo.all()
-    |> then(&(length(&1) == 1))
   end
 
-  # defp get_deployments_by_product_architecture_platform(_product_id, []), do: []
-
-  defp get_deployments_by_product_architecture_platform(product_id, device_ids) do
-    unique_architectures_from_selected_devices_query =
-      from(d in Device,
-        where: d.id in ^device_ids,
-        distinct: fragment("firmware_metadata ->> 'architecture'"),
-        select: fragment("firmware_metadata ->> 'architecture'")
-      )
-
-    unique_platforms_from_selected_devices_query =
-      from(d in Device,
-        where: d.id in ^device_ids,
-        distinct: fragment("firmware_metadata ->> 'platform'"),
-        select: fragment("firmware_metadata ->> 'platform'")
-      )
-
-    from(d in Deployment,
-      join: f in assoc(d, :firmware),
-      where: d.product_id == ^product_id,
-      where: f.architecture in subquery(unique_architectures_from_selected_devices_query),
-      where: f.platform in subquery(unique_platforms_from_selected_devices_query),
-      distinct: true,
-      preload: [firmware: f]
-    )
-    |> Repo.all()
-  end
+  defp maybe_assign_available_deployments_for_filtered_platform(socket),
+    do: assign(socket, :available_deployments_for_filtered_platform, [])
 end

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -234,13 +234,13 @@
           <div class={if @valid_tags, do: "hidden"}><span class="has-error"> Tags Cannot Contain Spaces </span></div>
         </form>
 
-        <form id="move-deployment" class="col-lg-4" phx-change="target-deployment" phx-submit="move-devices-deployment">
+        <form :if={Enum.any?(@available_deployments_for_filtered_platform)} id="move-deployment" class="col-lg-4" phx-change="target-deployment" phx-submit="move-devices-deployment">
           <label for="move_to_deployment">Move device(s) to deployment:</label>
           <div class="flex-row align-items-center">
             <div class="flex-grow pos-rel">
-              <select name="deployment" id="move_to_deployment" class="form-control" disabled={Enum.empty?(@available_deployments_for_selected_devices)}>
+              <select name="deployment" id="move_to_deployment" class="form-control">
                 <option value=""></option>
-                <%= for deployment <- @available_deployments_for_selected_devices do %>
+                <%= for deployment <- @available_deployments_for_filtered_platform do %>
                   <option value={deployment.id} {if @target_deployment && @target_deployment.id == deployment.id, do: [selected: true], else: []}>{deployment.name}</option>
                 <% end %>
               </select>

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -238,9 +238,9 @@
           <label for="move_to_deployment">Move device(s) to deployment:</label>
           <div class="flex-row align-items-center">
             <div class="flex-grow pos-rel">
-              <select name="deployment" id="move_to_deployment" class="form-control">
+              <select name="deployment" id="move_to_deployment" class="form-control" disabled={Enum.empty?(@available_deployments_for_selected_devices)}>
                 <option value=""></option>
-                <%= for deployment <- @deployments do %>
+                <%= for deployment <- @available_deployments_for_selected_devices do %>
                   <option value={deployment.id} {if @target_deployment && @target_deployment.id == deployment.id, do: [selected: true], else: []}>{deployment.name}</option>
                 <% end %>
               </select>

--- a/priv/repo/migrations/20250220222631_create_devices_firmware_metadata_architecture_index.exs
+++ b/priv/repo/migrations/20250220222631_create_devices_firmware_metadata_architecture_index.exs
@@ -1,9 +1,0 @@
-defmodule NervesHub.Repo.Migrations.CreateDevicesFirmwareMetadataArchitectureIndex do
-  use Ecto.Migration
-  @disable_ddl_transaction true
-
-
-  def change do
-    create_if_not_exists index("devices", ["(firmware_metadata->'architecture')"], name: :devices_architecture_index, using: "GIN", concurrently: true)
-  end
-end

--- a/priv/repo/migrations/20250220222631_create_devices_firmware_metadata_architecture_index.exs
+++ b/priv/repo/migrations/20250220222631_create_devices_firmware_metadata_architecture_index.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.CreateDevicesFirmwareMetadataArchitectureIndex do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+
+  def change do
+    create_if_not_exists index("devices", ["(firmware_metadata->'architecture')"], name: :devices_architecture_index, using: "GIN", concurrently: true)
+  end
+end

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -2,7 +2,6 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
   alias NervesHub.Devices
-  alias NervesHub.Firmwares.FirmwareMetadata
   alias NervesHub.Fixtures
 
   alias NervesHub.Repo
@@ -316,80 +315,6 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       assert Repo.reload(device) |> Map.get(:deployment_id)
       assert Repo.reload(device2) |> Map.get(:deployment_id)
-    end
-
-    test "selecting multiple devices to add to deployment but some don't match firmware requirements",
-         %{conn: conn, fixture: fixture} do
-      %{
-        device: device,
-        org: org,
-        product: product,
-        firmware: firmware,
-        deployment: deployment
-      } = fixture
-
-      device2 = Fixtures.device_fixture(org, product, firmware)
-
-      different_firmware_params =
-        %FirmwareMetadata{device2.firmware_metadata | platform: "foo"} |> Map.from_struct()
-
-      {:ok, device2} = Devices.update_firmware_metadata(device2, different_firmware_params)
-
-      refute device.deployment_id
-      refute device2.deployment_id
-
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/devices")
-      |> unwrap(fn view ->
-        render_change(view, "select-all", %{"id" => device.id})
-      end)
-      |> assert_has("span", text: "2 selected")
-      |> unwrap(fn view ->
-        render_change(view, "target-deployment", %{"deployment" => to_string(deployment.id)})
-      end)
-      |> click_button("#move-deployment-submit", "Move")
-      |> assert_has("div", text: "1 device added to deployment")
-      |> assert_has("div", text: "1 device could not be added")
-
-      assert Repo.reload(device) |> Map.get(:deployment_id)
-      refute Repo.reload(device2) |> Map.get(:deployment_id)
-    end
-
-    test "selecting multiple devices to add to deployment but none match firmware requirements",
-         %{conn: conn, fixture: fixture} do
-      %{
-        device: device,
-        org: org,
-        product: product,
-        firmware: firmware,
-        deployment: deployment
-      } = fixture
-
-      device2 = Fixtures.device_fixture(org, product, firmware)
-
-      different_firmware_params =
-        %FirmwareMetadata{device2.firmware_metadata | platform: "foo"} |> Map.from_struct()
-
-      {:ok, device} = Devices.update_firmware_metadata(device, different_firmware_params)
-      {:ok, device2} = Devices.update_firmware_metadata(device2, different_firmware_params)
-
-      refute device.deployment_id
-      refute device2.deployment_id
-
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/devices")
-      |> unwrap(fn view ->
-        render_change(view, "select-all", %{"id" => device.id})
-      end)
-      |> assert_has("span", text: "2 selected")
-      |> unwrap(fn view ->
-        render_change(view, "target-deployment", %{"deployment" => to_string(deployment.id)})
-      end)
-      |> click_button("#move-deployment-submit", "Move")
-      |> assert_has("div", text: "No devices selected could be added to deployment")
-
-      refute Repo.reload(device) |> Map.get(:deployment_id)
-      refute Repo.reload(device2) |> Map.get(:deployment_id)
     end
   end
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -299,7 +299,9 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       refute device2.deployment_id
 
       conn
-      |> visit("/org/#{org.name}/#{product.name}/devices")
+      |> visit(
+        "/org/#{org.name}/#{product.name}/devices?platform=#{deployment.firmware.platform}"
+      )
       |> unwrap(fn view ->
         render_change(view, "select-all", %{"id" => device.id})
       end)


### PR DESCRIPTION
Previously, we displayed all deployments as options when batch-updating devices. This is confusing because you could see deployments that shouldn't be options. This PR now requires you to filter by platform first before having the ability to bulk move devices into a deployment. 

This change does create an extra step when moving devices to a deployment but it's important to note this is an interim feature before #1653 is finished.