### PR TITLE
Use the new deployments orchestrator by default

### DIFF
--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -75,7 +75,10 @@ defmodule NervesHub.Deployments.Deployment do
     field(:device_count, :integer, virtual: true)
 
     # temporary addition while we feature test a new deployment management strategy
-    field(:orchestrator_strategy, Ecto.Enum, values: [:multi, :distributed], default: :multi)
+    field(:orchestrator_strategy, Ecto.Enum,
+      values: [:multi, :distributed],
+      default: :distributed
+    )
 
     timestamps()
   end

--- a/priv/repo/migrations/20250213215925_set_default_deployment_orchestrator_strategy.exs
+++ b/priv/repo/migrations/20250213215925_set_default_deployment_orchestrator_strategy.exs
@@ -5,6 +5,6 @@ defmodule NervesHub.Repo.Migrations.SetDefaultDeploymentOrchestratorStrategy do
   alias NervesHub.Repo
 
   def change do
-    Repo.update_all(Deployment, set: [orchestrator_strategy: "multi"])
+    Repo.update_all(Deployment, set: [orchestrator_strategy: "distributed"])
   end
 end


### PR DESCRIPTION
If you need the 'classic' orchestrator, then the UI can be enabled in `runtime.exs`, and the deployment can be switched over, but the new orchestrator should be the default.

At NervesCloud, we will be using the new orchestrator and not enabling the UI to switch to the old one.