### PR TITLE
Capture support script timeouts

### DIFF
--- a/lib/nerves_hub/scripts/runner.ex
+++ b/lib/nerves_hub/scripts/runner.ex
@@ -21,8 +21,12 @@ defmodule NervesHub.Scripts.Runner do
   end
 
   def send(device, command) do
-    {:ok, pid} = start_link(device)
-    GenServer.call(pid, {:send, command.text}, 10_000)
+    try do
+      {:ok, pid} = start_link(device)
+      {:ok, GenServer.call(pid, {:send, command.text}, 10_000)}
+    catch
+      :exit, _ -> {:error, "device not responding"}
+    end
   end
 
   def start_link(device) do

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -409,20 +409,12 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
             <span class="text-sm text-nerves-gray-500">No support scripts have been configured.</span>
           </div>
 
-          <div :if={Enum.any?(@support_scripts)} class="flex-col pt-2 px-4 pb-6 gap-4 items-center">
+          <div :if={Enum.any?(@support_scripts)} class="flex flex-col pt-2 px-4 pb-6 gap-2">
             <div :for={script <- @support_scripts} class="flex flex-col gap-2">
               <div class="flex gap-4">
                 <span class="text-base text-zinc-300">{script.name}</span>
 
-                <button
-                  :if={!disconnected?(@device_connection)}
-                  class="p-1 border border-green-500 rounded-full bg-zinc-800"
-                  type="button"
-                  disabled={script.running?}
-                  phx-target={@myself}
-                  phx-click="run-script"
-                  phx-value-id={script.id}
-                >
+                <button class="p-1 border border-green-500 rounded-full bg-zinc-800" type="button" disabled={script.running?} phx-target={@myself} phx-click="run-script" phx-value-id={script.id}>
                   <svg class="w-3 h-3 stroke-green-500" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M8 19V5L18 12L8 19Z" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
                   </svg>
@@ -618,8 +610,11 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
 
     output =
       case result do
-        {:ok, output} ->
+        {:ok, {:ok, output}} ->
           output
+
+        {:ok, {:error, reason}} ->
+          "Error: #{reason}"
 
         e ->
           inspect(e)

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -437,15 +437,14 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> noreply()
   end
 
-  def handle_async(
-        {:run_script, index},
-        result,
-        %{assigns: %{scripts: scripts}} = socket
-      ) do
+  def handle_async({:run_script, index}, result, %{assigns: %{scripts: scripts}} = socket) do
     output =
       case result do
-        {:ok, output} ->
+        {:ok, {:ok, output}} ->
           output
+
+        {:ok, {:error, reason}} ->
+          "Error: #{reason}"
 
         e ->
           inspect(e)


### PR DESCRIPTION
Timeouts are to be expected and shouldn't raise an error in Sentry.

This also adds a friendlier message to the UI

<img width="611" alt="Screenshot 2025-02-26 at 2 32 31 PM" src="https://github.com/user-attachments/assets/7ec47f79-e220-43f3-bfe1-0e308225ce7e" />

I also increased the gap between items.