### PR TITLE
Fix a bug with how we were filtering on connection type

### DIFF
--- a/lib/nerves_hub/devices/filtering.ex
+++ b/lib/nerves_hub/devices/filtering.ex
@@ -51,7 +51,11 @@ defmodule NervesHub.Devices.Filtering do
   end
 
   def filter(query, _filters, :connection_type, value) do
-    where(query, [latest_connection: lc], ^value in lc.metadata["connection_types"])
+    where(
+      query,
+      [latest_connection: lc],
+      fragment("?::jsonb <@ ?", ^[value], lc.metadata["connection_types"])
+    )
   end
 
   def filter(query, _filters, :firmware_version, value) do


### PR DESCRIPTION
Fixes and closes a Sentry error

```
Postgrex.Error: ERROR 42809 (wrong_object_type) op ANY/ALL (array) requires array on right side

    query: SELECT d0."id", d0."org_id", d0."product_id", d0."deployment_id", d0."latest_connection_id", 
d0."latest_health_id", d0."identifier", d0."description", d0."tags", d0."connecting_code", 
d0."custom_location_coordinates", d0."extensions", d0."first_seen_at", d0."status", d0."firmware_metadata", 
d0."updates_enabled", d0."update_attempts", d0."updates_blocked_until", d0."deleted_at", d0."inserted_at", 
d0."updated_at", d1."id", d1."device_id", d1."established_at", d1."last_seen_at", d1."disconnected_at", 
d1."disconnected_reason", d1."metadata", d1."status", d2."id", d2."device_id", d2."data", d2."status", d2."status_reasons", 
d2."inserted_at" FROM "devices" AS d0 LEFT OUTER JOIN "device_connections" AS d1 ON d1."id" = 
d0."latest_connection_id" LEFT OUTER JOIN "device_health" AS d2 ON d2."id" = d0."latest_health_id" WHERE 
(d0."product_id" = $1) AND (d0."deleted_at" IS NULL) AND ($2 = ANY((d1."metadata"#>'{"connection_types"}'))) 
ORDER BY d0."identifier" LIMIT $3 OFFSET $4
```