### PR TITLE
Fix starting scripts from API endpoint

### DIFF
--- a/lib/nerves_hub_web/controllers/api/script_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/script_controller.ex
@@ -31,30 +31,27 @@ defmodule NervesHubWeb.API.ScriptController do
   def send(conn, %{"identifier" => identifier, "id" => id}) do
     %{user: user} = conn.assigns
 
-    case Devices.get_by_identifier(identifier) do
-      {:ok, device} ->
-        if Accounts.has_org_role?(device.org, user, :view) do
-          case Scripts.get(device.product, id) do
-            {:ok, command} ->
-              text(conn, Scripts.Runner.send(device, command))
-
-            {:error, :not_found} ->
-              conn
-              |> put_status(404)
-              |> put_view(NervesHubWeb.API.ErrorView)
-              |> render(:"404")
-          end
-        else
-          conn
-          |> put_resp_header("content-type", "application/json")
-          |> send_resp(403, Jason.encode!(%{status: "missing required role: read"}))
-        end
-
+    with {:ok, device} <- Devices.get_by_identifier(identifier),
+         true <- Accounts.has_org_role?(device.org, user, :view) || :not_allowed,
+         {:ok, command} <- Scripts.get(device.product, id),
+         {:ok, io} <- Scripts.Runner.send(device, command) do
+      text(conn, io)
+    else
       {:error, :not_found} ->
         conn
         |> put_status(404)
         |> put_view(NervesHubWeb.API.ErrorView)
         |> render(:"404")
+
+      :not_allowed ->
+        conn
+        |> put_resp_header("content-type", "application/json")
+        |> send_resp(403, Jason.encode!(%{status: "missing required role: read"}))
+
+      {:error, err} ->
+        conn
+        |> put_resp_header("content-type", "application/json")
+        |> send_resp(504, Jason.encode!(%{errors: %{detail: err}}))
     end
   end
 end


### PR DESCRIPTION
https://github.com/nerves-hub/nerves_hub_web/pull/1923 introduced a change to handle when scripts timeout waiting for data back. However, it missed adjusting for the change in `NervesHubWeb.API.ScriptController` so using the API is broken.

This fixes to match that new return value and adds a `504` response if it times out waiting for the script reply.