### PR TITLE
Show users currently watching device page

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -40,7 +40,8 @@ defmodule NervesHub.Application do
           {Phoenix.PubSub, name: NervesHub.PubSub},
           {Cluster.Supervisor, [topologies]},
           {Task.Supervisor, name: NervesHub.TaskSupervisor},
-          {Oban, Application.fetch_env!(:nerves_hub, Oban)}
+          {Oban, Application.fetch_env!(:nerves_hub, Oban)},
+          NervesHubWeb.Presence
         ] ++
         deployments_orchestrator(deploy_env()) ++
         endpoints(deploy_env())

--- a/lib/nerves_hub_web/channels/presence.ex
+++ b/lib/nerves_hub_web/channels/presence.ex
@@ -8,4 +8,43 @@ defmodule NervesHubWeb.Presence do
   use Phoenix.Presence,
     otp_app: :nerves_hub,
     pubsub_server: NervesHub.PubSub
+
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  def fetch(_topic, presences) do
+    for {key, %{metas: [meta | metas]}} <- presences, into: %{} do
+      {key, %{metas: [meta | metas], id: key, user: %{name: meta.name}}}
+    end
+  end
+
+  def handle_metas(topic, %{joins: joins, leaves: leaves}, presences, state) do
+    for {user_id, presence} <- joins do
+      user_data = %{id: user_id, user: presence.user, metas: Map.fetch!(presences, user_id)}
+      msg = {__MODULE__, {:join, user_data}}
+      Phoenix.PubSub.local_broadcast(NervesHub.PubSub, "proxy:#{topic}", msg)
+    end
+
+    for {user_id, presence} <- leaves do
+      metas =
+        case Map.fetch(presences, user_id) do
+          {:ok, presence_metas} -> presence_metas
+          :error -> []
+        end
+
+      user_data = %{id: user_id, user: presence.user, metas: metas}
+      msg = {__MODULE__, {:leave, user_data}}
+      Phoenix.PubSub.local_broadcast(NervesHub.PubSub, "proxy:#{topic}", msg)
+    end
+
+    {:ok, state}
+  end
+
+  def list_online_users(),
+    do: list("online_users") |> Enum.map(fn {_id, presence} -> presence end)
+
+  def track_user(id, params), do: track(self(), "online_users", id, params)
+
+  def subscribe(), do: Phoenix.PubSub.subscribe(NervesHub.PubSub, "proxy:online_users")
 end

--- a/lib/nerves_hub_web/channels/presence.ex
+++ b/lib/nerves_hub_web/channels/presence.ex
@@ -1,0 +1,11 @@
+defmodule NervesHubWeb.Presence do
+  @moduledoc """
+  Provides presence tracking to channels and processes.
+
+  See the [`Phoenix.Presence`](https://hexdocs.pm/phoenix/Phoenix.Presence.html)
+  docs for more details.
+  """
+  use Phoenix.Presence,
+    otp_app: :nerves_hub,
+    pubsub_server: NervesHub.PubSub
+end

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -11,13 +11,12 @@
   </div>
 
   <div class="flex items-center gap-2 ml-auto mr-6">
-    <div class="my-4 pr-2 border-r border-base-700 flex space-x-[-10px]">
+    <div id="online-users" phx-update="stream" class="my-4 pr-2 border-r border-base-700 flex space-x-[2px]">
       <div
-        :for={{%{name: name}, idx} <- Enum.with_index(@active_users)}
-        class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700 "
-        style={"z-index:#{length(@active_users) - idx}"}
+        :for={{id, %{user: user}} <- @streams.presences}
+        class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700 " id={id}
       >
-        <span class="font-medium text-gray-600 dark:text-gray-300">{String.split(name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}</span>
+        <span class="font-medium text-gray-600 dark:text-gray-300">{String.split(user.name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}</span>
       </div>
     </div>
     <.button :if={@pinned?} aria-label="Unpin device" style="primary" phx-click="unpin">

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -9,7 +9,13 @@
     <span class="text-base-400">/</span>
     <span class="text-zinc-50 font-semibold">{@device.identifier}</span>
   </div>
+
   <div class="flex items-center gap-2 ml-auto mr-6">
+    <div class="my-4 pr-2 border-r border-base-700 flex space-x-[-10px]">
+      <div :for={%{name: name} <- @active_users} class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700">
+        <span class="font-medium text-gray-600 dark:text-gray-300">{String.split(name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}</span>
+      </div>
+    </div>
     <.button :if={@pinned?} aria-label="Unpin device" style="primary" phx-click="unpin">
       <.icon name="pinned" />
     </.button>

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -13,7 +13,7 @@
   <div class="flex items-center gap-2 ml-auto mr-6">
     <div class="my-4 pr-2 border-r border-base-700 flex space-x-[-10px]">
       <div
-        :for={{%{name: name, id: id}, idx} <- Enum.with_index(@active_users)}
+        :for={{%{name: name}, idx} <- Enum.with_index(@active_users)}
         class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700 "
         style={"z-index:#{length(@active_users) - idx}"}
       >

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -11,12 +11,11 @@
   </div>
 
   <div class="flex items-center gap-2 ml-auto mr-6">
-    <div id="online-users" phx-update="stream" class="my-4 pr-2 border-r border-base-700 flex space-x-[2px]">
-      <div
-        :for={{id, %{user: user}} <- @streams.presences}
-        class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700 " id={id}
-      >
-        <span class="font-medium text-gray-600 dark:text-gray-300">{String.split(user.name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}</span>
+    <div id="online-users" phx-update="stream" class="border-r border-base-700 px-5 mr-3 h-8 flex flex-row-reverse -space-x-1 space-x-reverse overflow-hidden">
+      <div :for={{id, %{user: user}} <- @streams.presences} class="inline-flex items-center justify-center" id={id}>
+        <span class="inline-flex items-center justify-center px-1 size-7 ring-2 ring-zinc-600 rounded-full bg-zinc-800 font-medium text-zinc-400 text-sm">
+          {String.split(user.name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}
+        </span>
       </div>
     </div>
     <.button :if={@pinned?} aria-label="Unpin device" style="primary" phx-click="unpin">

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -12,7 +12,11 @@
 
   <div class="flex items-center gap-2 ml-auto mr-6">
     <div class="my-4 pr-2 border-r border-base-700 flex space-x-[-10px]">
-      <div :for={%{name: name} <- @active_users} class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700">
+      <div
+        :for={{%{name: name, id: id}, idx} <- Enum.with_index(@active_users)}
+        class="relative inline-flex items-center justify-center w-8 h-8 pt-0.5 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600 border-base-700 "
+        style={"z-index:#{length(@active_users) - idx}"}
+      >
         <span class="font-medium text-gray-600 dark:text-gray-300">{String.split(name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}</span>
       </div>
     </div>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -30,9 +30,8 @@ defmodule NervesHubWeb.Live.Devices.Show do
   alias NervesHubWeb.Components.DevicePage.Health, as: HealthPage
   alias NervesHubWeb.Components.DevicePage.Settings, as: SettingsPage
 
-  alias Phoenix.Socket.Broadcast
-
   alias NervesHubWeb.Presence
+  alias Phoenix.Socket.Broadcast
 
   @running_script_placeholder "Running Script.."
   @presence_topic "device_presence:"

--- a/test/nerves_hub_web/live/devices/new_ui/show_test.exs
+++ b/test/nerves_hub_web/live/devices/new_ui/show_test.exs
@@ -1,0 +1,84 @@
+defmodule NervesHubWeb.Live.Devices.NewUI.ShowTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+  use Mimic
+
+  alias NervesHub.Accounts
+  alias NervesHub.Fixtures
+
+  alias NervesHubWeb.Endpoint
+
+  setup %{conn: conn, fixture: %{device: device}} = context do
+    Endpoint.subscribe("device:#{device.id}")
+
+    conn = init_test_session(conn, %{"new_ui" => true})
+
+    Map.put(context, :conn, conn)
+  end
+
+  describe "who is currently viewing the device page" do
+    setup do
+      # https://hexdocs.pm/phoenix/Phoenix.Presence.html#module-testing-with-presence
+      on_exit(fn ->
+        for pid <- NervesHubWeb.Presence.fetchers_pids() do
+          ref = Process.monitor(pid)
+          assert_receive {:DOWN, ^ref, _, _, _}, 1000
+        end
+      end)
+    end
+
+    test "only the current user", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device,
+      user: user
+    } do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("#online-users > #presences-#{user.id} > span", text: user_initials(user))
+    end
+
+    test "two users", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device,
+      user: user
+    } do
+      user_two = Fixtures.user_fixture()
+      {:ok, _} = Accounts.add_org_user(org, user_two, %{role: :view})
+
+      conn_two =
+        build_conn()
+        |> init_test_session(%{"auth_user_id" => user_two.id})
+        |> init_test_session(%{"new_ui" => true})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("#online-users > #presences-#{user.id} > span", text: user_initials(user))
+
+      conn_two
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("#online-users > #presences-#{user.id} > span", text: user_initials(user))
+      |> assert_has("#online-users > #presences-#{user_two.id} > span",
+        text: user_initials(user_two)
+      )
+    end
+
+    defp user_initials(user) do
+      String.split(user.name)
+      |> Enum.map(fn w ->
+        String.at(w, 0)
+        |> String.upcase()
+      end)
+      |> Enum.join("")
+    end
+  end
+
+  def device_show_path(%{device: device, org: org, product: product}) do
+    ~p"/org/#{org.name}/#{product.name}/devices/#{device.identifier}"
+  end
+end


### PR DESCRIPTION
Adds Phoenix Presence, to application in general and device page specifically.

Tracks user on mount, subscribes to events for device's presence and populates user list on presence diff.


Todo:
- Better styling on user circles