### PR TITLE
Correctly show device updates status

### DIFF
--- a/lib/nerves_hub_web/components/device_health/health_status.ex
+++ b/lib/nerves_hub_web/components/device_health/health_status.ex
@@ -7,10 +7,9 @@ defmodule NervesHubWeb.Components.HealthStatus do
 
   def render(assigns) do
     ~H"""
-    <div id={"health-tooltip-#{@device_id}"} phx-hook="ToolTip" data-placement={@tooltip_position}>
+    <div class="relative z-20" id={"health-tooltip-#{@device_id}"} phx-hook="ToolTip" data-placement={@tooltip_position}>
       <.icon name={icon_name(@health)} />
-
-      <div class="tooltip-content hidden w-max absolute top-0 left-0 z-40 text-xs px-2 py-1.5 rounded border border-[#3F3F46] bg-base-900 flex">
+      <div class="tooltip-content hidden w-max absolute top-0 left-0 z-20 text-xs px-2 py-1.5 rounded border border-[#3F3F46] bg-base-900 flex">
         <%= if @health && @health.status_reasons do %>
           <div :for={{status, reasons} <- @health.status_reasons}>
             {format_health_status_reason(status, reasons)}

--- a/lib/nerves_hub_web/components/device_update_status.ex
+++ b/lib/nerves_hub_web/components/device_update_status.ex
@@ -7,19 +7,25 @@ defmodule NervesHubWeb.Components.DeviceUpdateStatus do
     cond do
       Devices.device_in_penalty_box?(device) ->
         ~H"""
-        <svg title="Device in the penalty box" class="size-4 stroke-amber-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-          <path
-            d="M19 14V5C17.5 5.16667 14 5 12 3C11.4286 3.57143 10.7347 3.9932 10 4.30029M5 5V14C5 18 12 21 12 21C12 21 15.2039 19.6269 17.2766 17.5M3 3L21 21"
-            stroke-width="1.2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
+        <div class="relative z-20" id={"update-status-#{@device.id}"} phx-hook="ToolTip" data-placement="top">
+          <svg class="size-4 stroke-amber-500 z-10" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M19 14V5C17.5 5.16667 14 5 12 3C11.4286 3.57143 10.7347 3.9932 10 4.30029M5 5V14C5 18 12 21 12 21C12 21 15.2039 19.6269 17.2766 17.5M3 3L21 21"
+              stroke-width="1.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <div class="tooltip-content hidden w-max absolute top-0 left-0 z-20 text-xs px-2 py-1.5 rounded border border-[#3F3F46] bg-base-900 flex">
+            Updates blocked {friendly_blocked_until(@device.updates_blocked_until)}
+            <div class="tooltip-arrow absolute w-2 h-2 border-[#3F3F46] bg-base-900 origin-center rotate-45"></div>
+          </div>
+        </div>
         """
 
       device.updates_enabled ->
         ~H"""
-        <svg title="Updates enabled" xmlns="http://www.w3.org/2000/svg" class="size-4 stroke-emerald-500" viewBox="0 0 16 16" fill="none">
+        <svg title="Updates enabled" xmlns="http://www.w3.org/2000/svg" class="size-4 stroke-emerald-500 z-10" viewBox="0 0 16 16" fill="none">
           <path
             d="M6.00016 8L7.3335 9.33333L10.0002 6M8.00016 14C8.00016 14 12.6668 12 12.6668 9.33333V3.33333C11.6668 3.44444 9.3335 3.33333 8.00016 2C6.66683 3.33333 4.3335 3.44444 3.3335 3.33333V9.33333C3.3335 12 8.00016 14 8.00016 14Z"
             stroke-width="1.2"
@@ -31,15 +37,46 @@ defmodule NervesHubWeb.Components.DeviceUpdateStatus do
 
       true ->
         ~H"""
-        <svg title="Updates disabled" xmlns="http://www.w3.org/2000/svg" class="size-4 stroke-zinc-400" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M12.6667 9.33333V3.33333C11.6667 3.44444 9.33333 3.33333 8 2C7.61905 2.38095 7.15646 2.66213 6.66667 2.86686M3.33333 3.33333V9.33333C3.33333 12 8 14 8 14C8 14 10.1359 13.0846 11.5177 11.6667M2 2L14 14"
-            stroke-width="1.2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
+        <div class="relative z-20" id={"update-status-#{@device.id}"} phx-hook="ToolTip" data-placement="top">
+          <svg title="Updates disabled" xmlns="http://www.w3.org/2000/svg" class="size-4 stroke-red-500 z-10" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M12.6667 9.33333V3.33333C11.6667 3.44444 9.33333 3.33333 8 2C7.61905 2.38095 7.15646 2.66213 6.66667 2.86686M3.33333 3.33333V9.33333C3.33333 12 8 14 8 14C8 14 10.1359 13.0846 11.5177 11.6667M2 2L14 14"
+              stroke-width="1.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <div class="tooltip-content hidden w-max absolute top-0 left-0 z-20 text-xs px-2 py-1.5 rounded border border-[#3F3F46] bg-base-900 flex">
+            Updates disabled
+            <div class="tooltip-arrow absolute w-2 h-2 border-[#3F3F46] bg-base-900 origin-center rotate-45"></div>
+          </div>
+        </div>
         """
+    end
+  end
+
+  defp friendly_blocked_until(blocked_until) do
+    cond do
+      DateTime.diff(blocked_until, DateTime.utc_now(), :second) < 60 ->
+        "for less than a minute"
+
+      DateTime.diff(blocked_until, DateTime.utc_now(), :minute) < 2 ->
+        "for around a minute"
+
+      DateTime.diff(blocked_until, DateTime.utc_now(), :minute) < 55 ->
+        "for #{DateTime.diff(blocked_until, DateTime.utc_now(), :minute)} minutes"
+
+      DateTime.diff(blocked_until, DateTime.utc_now(), :minute) < 60 ->
+        "for less than an hour"
+
+      DateTime.diff(blocked_until, DateTime.utc_now(), :minute) < 63 ->
+        "for an hour"
+
+      DateTime.diff(blocked_until, DateTime.utc_now(), :hour) < 24 ->
+        "for #{DateTime.diff(blocked_until, DateTime.utc_now(), :hour)} hours"
+
+      true ->
+        "until #{Calendar.strftime(blocked_until, "%B %-d, %Y %-I:%M %p %Z")}"
     end
   end
 end

--- a/lib/nerves_hub_web/components/device_update_status.ex
+++ b/lib/nerves_hub_web/components/device_update_status.ex
@@ -1,0 +1,45 @@
+defmodule NervesHubWeb.Components.DeviceUpdateStatus do
+  use NervesHubWeb, :component
+
+  alias NervesHub.Devices
+
+  def render(%{device: device} = assigns) do
+    cond do
+      Devices.device_in_penalty_box?(device) ->
+        ~H"""
+        <svg title="Device in the penalty box" class="size-4 stroke-amber-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M19 14V5C17.5 5.16667 14 5 12 3C11.4286 3.57143 10.7347 3.9932 10 4.30029M5 5V14C5 18 12 21 12 21C12 21 15.2039 19.6269 17.2766 17.5M3 3L21 21"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        """
+
+      device.updates_enabled ->
+        ~H"""
+        <svg title="Updates enabled" xmlns="http://www.w3.org/2000/svg" class="size-4 stroke-emerald-500" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M6.00016 8L7.3335 9.33333L10.0002 6M8.00016 14C8.00016 14 12.6668 12 12.6668 9.33333V3.33333C11.6668 3.44444 9.3335 3.33333 8.00016 2C6.66683 3.33333 4.3335 3.44444 3.3335 3.33333V9.33333C3.3335 12 8.00016 14 8.00016 14Z"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        """
+
+      true ->
+        ~H"""
+        <svg title="Updates disabled" xmlns="http://www.w3.org/2000/svg" class="size-4 stroke-zinc-400" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M12.6667 9.33333V3.33333C11.6667 3.44444 9.33333 3.33333 8 2C7.61905 2.38095 7.15646 2.66213 6.66667 2.86686M3.33333 3.33333V9.33333C3.33333 12 8 14 8 14C8 14 10.1359 13.0846 11.5177 11.6667M2 2L14 14"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        """
+    end
+  end
+end

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -150,7 +150,7 @@
                       </svg> --%>
                   <% end %>
                 </span>
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m">
+                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m font-mono">
                   {device.identifier}
                   <span class="absolute inset-0 z-10"></span>
                 </.link>
@@ -168,7 +168,7 @@
 
             <td>
               <div class="flex gap-[8px] items-center">
-                <span>
+                <span class="font-mono">
                   <%= if is_nil(device.firmware_metadata) do %>
                     Unknown
                   <% else %>

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -174,24 +174,7 @@
                     {device.firmware_metadata.version}
                   <% end %>
                 </span>
-                <svg :if={device.firmware_metadata && device.updates_enabled} title="Updates enabled" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M6.00016 8L7.3335 9.33333L10.0002 6M8.00016 14C8.00016 14 12.6668 12 12.6668 9.33333V3.33333C11.6668 3.44444 9.3335 3.33333 8.00016 2C6.66683 3.33333 4.3335 3.44444 3.3335 3.33333V9.33333C3.3335 12 8.00016 14 8.00016 14Z"
-                    stroke="#10B981"
-                    stroke-width="1.2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-                <svg :if={device.firmware_metadata && not device.updates_enabled} title="Updates disabled" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M12.6667 9.33333V3.33333C11.6667 3.44444 9.33333 3.33333 8 2C7.61905 2.38095 7.15646 2.66213 6.66667 2.86686M3.33333 3.33333V9.33333C3.33333 12 8 14 8 14C8 14 10.1359 13.0846 11.5177 11.6667M2 2L14 14"
-                    stroke="#A1A1AA"
-                    stroke-width="1.2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
+                <DeviceUpdateStatus.render :if={not is_nil(device.deployment_id)} device={device} />
               </div>
             </td>
 

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -100,7 +100,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr :for={device <- @devices} class={["border-b border-zinc-800 relative", device.id in @selected_devices && "selected-row"]} style={progress_style(@progress[device.id])}>
+          <tr :for={device <- @devices} class={["border-b border-zinc-800 relative isolate", device.id in @selected_devices && "selected-row"]} style={progress_style(@progress[device.id])}>
             <td class="checkbox">
               <input
                 id={"checkbox-device-#{device.id}"}
@@ -111,7 +111,7 @@
                 phx-value-id={device.id}
                 phx-click="select"
               />
-              <label for={"checkbox-device-#{device.id}"}>
+              <label for={"checkbox-device-#{device.id}"} class="relative z-20">
                 <svg :if={device.id in @selected_devices} xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
                   <path d="M2.5 6.5L4.5 8.5L10 3" stroke="#F4F4F5" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
@@ -152,6 +152,7 @@
                 </span>
                 <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
                   {device.identifier}
+                  <span class="absolute inset-0 z-10"></span>
                 </.link>
                 <span class={["flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800", !@progress[device.id] && "invisible"]}>
                   <span class="text-xs text-zinc-300 tracking-tight">updating</span>
@@ -161,7 +162,7 @@
 
             <td>
               <div class="flex gap-[8px] items-center justify-center">
-                <HealthStatus.render device_id={device.id} health={device.latest_health} />
+                <HealthStatus.render device_id={device.id} health={device.latest_health} tooltip_position="top" />
               </div>
             </td>
 

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -150,7 +150,7 @@
                       </svg> --%>
                   <% end %>
                 </span>
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
+                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m">
                   {device.identifier}
                   <span class="absolute inset-0 z-10"></span>
                 </.link>

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -16,6 +16,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias Phoenix.LiveView.JS
   alias Phoenix.Socket.Broadcast
 
+  alias NervesHubWeb.Components.DeviceUpdateStatus
   alias NervesHubWeb.Components.HealthStatus
   alias NervesHubWeb.Components.Sorting
   alias NervesHubWeb.LayoutView.DateTimeFormat

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -62,7 +62,7 @@
           <circle cx="3" cy="3" r="3" fill="#71717A" />
         </svg>
       <% end %>
-      <h1 class="text-xl font-semibold leading-[30px] text-zinc-50">
+      <h1 class="text-xl font-semibold leading-[30px] text-zinc-50 font-mono">
         {@device.identifier}
       </h1>
     </div>
@@ -71,10 +71,10 @@
       <div class="flex h-7 py-1 px-2 items-center rounded bg-zinc-800">
         <span class="text-sm text-zinc-400 mr-1">Version:</span>
 
-        <span :if={is_nil(@device.firmware_metadata)} class="text-sm text-base-300">Unknown</span>
+        <span :if={is_nil(@device.firmware_metadata)} class="text-sm text-base-300 font-mono">Unknown</span>
 
         <.link :if={@device.firmware_metadata} navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@device.firmware_metadata.uuid}"} class="flex items-center">
-          <span class="text-sm text-base-300 mr-1">{@device.firmware_metadata.version} ({String.slice(@device.firmware_metadata.uuid, 0..7)})</span>
+          <span class="text-sm text-base-300 mr-1 font-mono">{@device.firmware_metadata.version} ({String.slice(@device.firmware_metadata.uuid, 0..7)})</span>
           <svg class="w-4 h-4" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path
               d="M8 10V8M8 6V5.99333M14 8C14 11.3137 11.3137 14 8 14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8Z"


### PR DESCRIPTION
Fixes an issue reported via Slack where the penalty box status was incorrect on the device list page.

I also added a tooltip to show how long the device is in the penalty box, aaaaaand I've also made the entire row clickable.

Oh, and I also made the device identifier and firmware version use `font-mono`

<img width="1247" alt="Screenshot 2025-03-11 at 7 17 40 PM" src="https://github.com/user-attachments/assets/be59ae17-990b-4c4c-a7bb-966fec4539e1" />
<img width="1245" alt="Screenshot 2025-03-11 at 7 17 00 PM" src="https://github.com/user-attachments/assets/e58bff83-7b3c-4a2f-aeac-69f0c6f3e549" />
