### PR TITLE
Backport device_connection indexes, sort when deleting them so index is used

### DIFF
--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -175,6 +175,7 @@ defmodule NervesHub.Devices.Connections do
       |> where([dc, d], dc.id != d.latest_connection_id)
       |> select([dc], dc.id)
       |> limit(^delete_limit)
+      |> order_by(:last_seen_at)
 
     {delete_count, _} =
       DeviceConnection

--- a/priv/repo/migrations/20250312132817_add_device_connection_last_seen_at_indexes.exs
+++ b/priv/repo/migrations/20250312132817_add_device_connection_last_seen_at_indexes.exs
@@ -1,0 +1,10 @@
+defmodule NervesHub.Repo.Migrations.AddDeviceConnectionLastSeenAtIndexes do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute("CREATE INDEX CONCURRENTLY device_connections_not_connected_last_seen_idx ON device_connections(last_seen_at) WHERE status <> 'connected';")
+    execute("CREATE INDEX CONCURRENTLY device_connections_connected_last_seen_at_idx ON device_connections(last_seen_at) WHERE status = 'connected';")
+  end
+end

--- a/priv/repo/migrations/20250312132817_add_device_connection_last_seen_at_indexes.exs
+++ b/priv/repo/migrations/20250312132817_add_device_connection_last_seen_at_indexes.exs
@@ -4,7 +4,7 @@ defmodule NervesHub.Repo.Migrations.AddDeviceConnectionLastSeenAtIndexes do
   @disable_migration_lock true
 
   def change do
-    execute("CREATE INDEX CONCURRENTLY device_connections_not_connected_last_seen_idx ON device_connections(last_seen_at) WHERE status <> 'connected';")
-    execute("CREATE INDEX CONCURRENTLY device_connections_connected_last_seen_at_idx ON device_connections(last_seen_at) WHERE status = 'connected';")
+    execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS device_connections_not_connected_last_seen_idx ON device_connections(last_seen_at) WHERE status <> 'connected';")
+    execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS device_connections_connected_last_seen_at_idx ON device_connections(last_seen_at) WHERE status = 'connected';")
   end
 end


### PR DESCRIPTION
This PR backports two indexes on `device_connections` we've been using in production. I'm also adding an `order_by` when deleting `device_connections` so an index is used.