### PR TITLE
Cache the `product_id` in the `DeviceConnection`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -56,6 +56,7 @@ config :nerves_hub, Oban,
   notifier: Oban.Notifiers.PG,
   log: false,
   queues: [
+    analytics: 3,
     delete_archive: 1,
     delete_firmware: 1,
     device: 1,
@@ -73,7 +74,8 @@ config :nerves_hub, Oban,
        {"*/1 * * * *", NervesHub.Workers.CleanStaleDeviceConnections},
        {"1,16,31,46 * * * *", NervesHub.Workers.DeleteOldDeviceConnections},
        {"*/5 * * * *", NervesHub.Workers.ExpireInflightUpdates},
-       {"*/15 * * * *", NervesHub.Workers.DeviceHealthTruncation}
+       {"*/15 * * * *", NervesHub.Workers.DeviceHealthTruncation},
+       {"*/1 * * * *", NervesHub.Workers.ConnectedDeviceCount}
      ]}
   ]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -56,7 +56,6 @@ config :nerves_hub, Oban,
   notifier: Oban.Notifiers.PG,
   log: false,
   queues: [
-    analytics: 3,
     delete_archive: 1,
     delete_firmware: 1,
     device: 1,
@@ -74,8 +73,7 @@ config :nerves_hub, Oban,
        {"*/1 * * * *", NervesHub.Workers.CleanStaleDeviceConnections},
        {"1,16,31,46 * * * *", NervesHub.Workers.DeleteOldDeviceConnections},
        {"*/5 * * * *", NervesHub.Workers.ExpireInflightUpdates},
-       {"*/15 * * * *", NervesHub.Workers.DeviceHealthTruncation},
-       {"*/1 * * * *", NervesHub.Workers.ConnectedDeviceCount}
+       {"*/15 * * * *", NervesHub.Workers.DeviceHealthTruncation}
      ]}
   ]
 

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -34,13 +34,14 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connecting(non_neg_integer()) ::
+  @spec device_connecting(non_neg_integer(), non_neg_integer()) ::
           {:ok, DeviceConnection.t()} | {:error, Ecto.Changeset.t()}
-  def device_connecting(device_id) do
+  def device_connecting(device_id, product_id) do
     now = DateTime.utc_now()
 
     changeset =
       DeviceConnection.create_changeset(%{
+        product_id: product_id,
         device_id: device_id,
         established_at: now,
         last_seen_at: now,

--- a/lib/nerves_hub/devices/device_connection.ex
+++ b/lib/nerves_hub/devices/device_connection.ex
@@ -4,15 +4,18 @@ defmodule NervesHub.Devices.DeviceConnection do
   import Ecto.Changeset
 
   alias NervesHub.Devices.Device
+  alias NervesHub.Products.Product
 
   @type t :: %__MODULE__{}
   @primary_key {:id, UUIDv7, autogenerate: true}
-  @required_params [:device_id, :status, :last_seen_at, :established_at]
+  @required_params [:product_id, :device_id, :status, :last_seen_at, :established_at]
   @wanted_on_create @required_params ++ [:metadata]
   @wanted_on_update @required_params ++ [:disconnected_at, :disconnected_reason, :metadata]
 
   schema "device_connections" do
+    belongs_to(:product, Product)
     belongs_to(:device, Device)
+
     field(:established_at, :utc_datetime_usec)
     field(:last_seen_at, :utc_datetime_usec)
     field(:disconnected_at, :utc_datetime_usec)

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -209,7 +209,8 @@ defmodule NervesHubWeb.DeviceSocket do
   @decorate with_span("Channels.DeviceSocket.on_connect#provisioned")
   defp on_connect(%{assigns: %{device: device}} = socket) do
     # Report connection and use connection id as reference
-    {:ok, %DeviceConnection{id: connection_id}} = Connections.device_connecting(device.id)
+    {:ok, %DeviceConnection{id: connection_id}} =
+      Connections.device_connecting(device.id, device.product_id)
 
     :telemetry.execute([:nerves_hub, :devices, :connect], %{count: 1}, %{
       ref_id: connection_id,

--- a/priv/repo/migrations/20250322003835_add_product_id_to_device_connections_table.exs
+++ b/priv/repo/migrations/20250322003835_add_product_id_to_device_connections_table.exs
@@ -3,9 +3,7 @@ defmodule NervesHub.Repo.Migrations.AddProductIdToDeviceConnectionsTable do
 
   def change do
     alter table(:device_connections) do
-      add(:product_id, :integer)
+      add(:product_id, :bigint)
     end
-
-    create(index(:device_connections, [:product_id]))
   end
 end

--- a/priv/repo/migrations/20250322003835_add_product_id_to_device_connections_table.exs
+++ b/priv/repo/migrations/20250322003835_add_product_id_to_device_connections_table.exs
@@ -1,0 +1,11 @@
+defmodule NervesHub.Repo.Migrations.AddProductIdToDeviceConnectionsTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:device_connections) do
+      add(:product_id, :integer)
+    end
+
+    create(index(:device_connections, [:product_id]))
+  end
+end

--- a/priv/repo/migrations/20250324172254_index_device_connections_product_id.exs
+++ b/priv/repo/migrations/20250324172254_index_device_connections_product_id.exs
@@ -1,0 +1,10 @@
+defmodule NervesHub.Repo.Migrations.IndexDeviceConnectionsProductId do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create(index(:device_connections, [:product_id], concurrently: true))
+  end
+end

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -22,7 +22,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
 
   test "device connecting -> connected -> disconnected", %{device: device} do
     assert {:ok, %DeviceConnection{id: ref, status: :connecting}} =
-             Connections.device_connecting(device.id)
+             Connections.device_connecting(device.id, device.product_id)
 
     assert %DeviceConnection{status: :connecting} = Connections.get_latest_for_device(device.id)
 
@@ -39,7 +39,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
 
   test "device heartbeat", %{device: device} do
     assert {:ok, %DeviceConnection{id: connection_id, last_seen_at: first_seen_at} = connection} =
-             Connections.device_connecting(device.id)
+             Connections.device_connecting(device.id, device.product_id)
 
     assert :ok = Connections.device_connected(connection_id)
 
@@ -53,7 +53,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
   end
 
   test "deleting old device_connections", %{device: device} do
-    {:ok, _} = Connections.device_connecting(device.id)
+    {:ok, _} = Connections.device_connecting(device.id, device.product_id)
     two_weeks_ago = DateTime.utc_now() |> DateTime.add(-14, :day)
 
     deleted_device_connection =
@@ -75,7 +75,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
   test "deleting old device_connections never deletes a devices's last device_connection", %{
     device: device
   } do
-    {:ok, _} = Connections.device_connecting(device.id)
+    {:ok, _} = Connections.device_connecting(device.id, device.product_id)
 
     %{latest_connection: latest_connection} =
       device |> Repo.reload() |> Repo.preload(:latest_connection)

--- a/test/nerves_hub/devices/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/devices/distributed/orchestrator_test.exs
@@ -77,7 +77,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device1.id)
+    {:ok, connection} = Connections.device_connecting(device1.id, device1.product_id)
     :ok = Connections.device_connected(connection.id)
     Devices.deployment_device_online(device1)
 
@@ -92,7 +92,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic2)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
     :ok = Connections.device_connected(connection.id)
     Devices.deployment_device_online(device2)
 
@@ -104,7 +104,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic3)
 
     device3 = Devices.update_deployment_group(device3, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device3.id)
+    {:ok, connection} = Connections.device_connecting(device3.id, device3.product_id)
     :ok = Connections.device_connected(connection.id)
     Devices.deployment_device_online(device3)
 
@@ -124,11 +124,11 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
       ManagedDeployments.update_deployment_group(deployment_group, %{concurrent_updates: 1})
 
     device = Devices.update_deployment_group(device, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device.id)
+    {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
     :ok = Connections.device_connected(connection.id)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
     :ok = Connections.device_connected(connection.id)
 
     topic1 = "device:#{device.id}"
@@ -158,7 +158,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
 
     # bring the second device 'online'
     Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
     :ok = Connections.device_connected(connection.id)
 
     # sent by the device after its updated
@@ -229,7 +229,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
 
-    {:ok, connection} = Connections.device_connecting(device1.id)
+    {:ok, connection} = Connections.device_connecting(device1.id, device1.product_id)
     :ok = Connections.device_connected(connection.id)
 
     Devices.deployment_device_online(device1)
@@ -256,7 +256,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
       Devices.update_device(device2, %{firmware_metadata: %{"uuid" => firmware.uuid}})
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
     :ok = Connections.device_connected(connection.id)
     Devices.deployment_device_online(device2)
 
@@ -300,7 +300,7 @@ defmodule NervesHub.Devices.Distributed.OrchestratorTest do
     device1 = Devices.update_deployment_group(device1, deployment_group)
     {:ok, device1} = Devices.update_device(device1, %{updates_enabled: false})
 
-    {:ok, connection} = Connections.device_connecting(device1.id)
+    {:ok, connection} = Connections.device_connecting(device1.id, device1.product_id)
     :ok = Connections.device_connected(connection.id)
 
     Devices.deployment_device_online(device1)

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -95,7 +95,9 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       assert html =~ "offline"
 
-      {:ok, connection} = Connections.device_connecting(fixture.device.id)
+      {:ok, connection} =
+        Connections.device_connecting(fixture.device.id, fixture.device.product_id)
+
       :ok = Connections.device_connected(connection.id)
 
       send(view.pid, %Broadcast{event: "connection:change", payload: %{status: "online"}})
@@ -260,7 +262,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{}})
 
@@ -276,7 +278,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "location" => %{"error_code" => "BOOP", "error_description" => "BEEP"}
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
@@ -298,7 +300,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         }
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -448,6 +448,7 @@ defmodule NervesHub.Fixtures do
     DeviceConnection.create_changeset(
       Map.merge(
         %{
+          product_id: device.product_id,
           device_id: device.id,
           established_at: now,
           last_seen_at: now,


### PR DESCRIPTION
This is required for improved query perf when polling for the count of connected devices grouped by `product_id`.

The way to do such a query, before these changes, required a join, and that itself just added more for the query planner to take care of.

This work is a required part of an Insights dashboard I'm working on.