### PR TITLE
Reduce font size in console to prevent wrap

### DIFF
--- a/assets/ui-rework/hooks/console.js
+++ b/assets/ui-rework/hooks/console.js
@@ -10,7 +10,7 @@ const defaultTermOptions = {
   cursorStyle: "bar",
   macOptionIsMeta: true,
   fontFamily: "Ubuntu Mono, courier-new, courier, monospace",
-  fontSize: 16,
+  fontSize: 14,
   theme: {
     foreground: "#FFFAF4",
     background: "#0E1019",


### PR DESCRIPTION
The font is specified as Ubuntu Mono which didn't resolve on my machine. I believe the old UI resolved to Montserrat and the new on Inter. Not fully clear on why not the same monospace one instead.

The fonts have different font-sizes and will wrap differently. So I reduced the font size.

This restores RingLogger.viewer functionality preventing the console from wrapping so aggressively. Vertical real-estate is still a bit limited and I think we can address that separately. Those changes will be less straightforward.