### PR TITLE
Remove padding and box around the console

### DIFF
--- a/lib/nerves_hub_web/components/device_page/console.ex
+++ b/lib/nerves_hub_web/components/device_page/console.ex
@@ -31,41 +31,16 @@ defmodule NervesHubWeb.Components.DevicePage.Console do
   def render(assigns) do
     ~H"""
     <div class="size-full">
-      <div :if={authorized?(:"device:console", @org_user) && @console_active?} class="flex flex-col size-full items-start justify-between">
-        <div id="console-and-chat" class="size-full flex gap-4 p-6" phx-update="ignore">
-          <div class="flex flex-col w-full bg-zinc-900 border border-zinc-700 rounded">
-            <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
-              <div id="console-title" class="text-base text-neutral-50 font-medium">Console</div>
-            </div>
-            <div id="dropzone" class="grow flex p-6 gap-6">
-              <div id="console" phx-hook="Console" data-user-token={@user_token} data-device-id={@device.id} class="w-full h-full"></div>
-            </div>
+      <div class="flex flex-col size-full items-start justify-between">
+        <div id="console-and-chat" class="size-full flex bg-black p-12" phx-update="ignore" style="background-color: rgb(14, 16, 25);">
+          <div :if={authorized?(:"device:console", @org_user) && @console_active?} id="dropzone" class="grow">
+            <div id="console" phx-hook="Console" data-user-token={@user_token} data-device-id={@device.id} class="w-full h-full"></div>
           </div>
-        </div>
-      </div>
-
-      <div :if={authorized?(:"device:console", @org_user) && !@console_active?} class="flex flex-col size-full items-start justify-between">
-        <div id="console-and-chat" class="size-full flex gap-4 p-6" phx-update="ignore">
-          <div class="flex flex-col w-full bg-zinc-900 border border-zinc-700 rounded">
-            <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
-              <div class="text-base text-neutral-50 font-medium">Console</div>
-            </div>
-            <div class="grow flex justify-center items-center p-6 gap-6 text-medium">
-              The device console isn't currently available.
-            </div>
+          <div :if={authorized?(:"device:console", @org_user) && !@console_active?} class="grow flex justify-center items-center p-6 gap-6 text-medium font-mono">
+            The device console isn't currently available.
           </div>
-        </div>
-      </div>
-
-      <div :if={!authorized?(:"device:console", @org_user)} class="flex flex-col size-full items-start justify-between">
-        <div id="console-and-chat" class="size-full flex gap-4 p-6" phx-update="ignore">
-          <div class="flex flex-col w-full bg-zinc-900 border border-zinc-700 rounded">
-            <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
-              <div class="text-base text-neutral-50 font-medium">Console</div>
-            </div>
-            <div class="grow flex justify-center items-center p-6 gap-6 text-medium text-red-500">
-              You don't have the required permissions to access a Device console.
-            </div>
+          <div :if={!authorized?(:"device:console", @org_user)} class="grow flex justify-center items-center p-6 gap-6 text-medium text-red-500 font-mono">
+            You don't have the required permissions to access a Device console.
           </div>
         </div>
       </div>


### PR DESCRIPTION
I think this is a better immersive console.

Next step in my book is a theatre-mode, faux-fullscreen. But this is a good start on using the space.

From this:
<img width="1457" alt="Screenshot 2025-03-23 at 09 49 44" src="https://github.com/user-attachments/assets/c583e871-ff80-4640-bae6-a104587ab892" />

To this:
<img width="1453" alt="Screenshot 2025-03-23 at 09 49 28" src="https://github.com/user-attachments/assets/8c6ee80e-b37e-402b-8f11-ce1dae9b1def" />
