### PR TITLE
Filter deployment groups by name

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -39,6 +39,7 @@ defmodule NervesHub.ManagedDeployments do
     sort_direction = Map.get(opts, :sort_direction, "desc")
 
     sort_opts = {String.to_existing_atom(sort_direction), String.to_atom(sort)}
+    filters = Map.get(opts, :filters, %{})
 
     flop = %Flop{
       page: String.to_integer(Map.get(opts, :page, "1")),
@@ -58,10 +59,29 @@ defmodule NervesHub.ManagedDeployments do
     |> join(:left, [d], dev in subquery(subquery), on: dev.deployment_id == d.id)
     |> join(:left, [d], f in assoc(d, :firmware))
     |> where([d], d.product_id == ^product.id)
+    |> build_filters(filters)
     |> sort_deployment_groups(sort_opts)
     |> preload([_d, _dev, f], firmware: f)
     |> select_merge([_f, dev], %{device_count: dev.device_count})
     |> Flop.run(flop)
+  end
+
+  # If filter amount increases the filtering functions can be moved to their own module,
+  # like device filtering.
+  defp build_filters(query, filters) do
+    Enum.reduce(filters, query, fn {key, value}, query ->
+      filter(query, filters, key, value)
+    end)
+  end
+
+  # Filter values are empty strings as default,
+  # they should be ignored.
+  defp filter(query, _filters, _key, "") do
+    query
+  end
+
+  defp filter(query, _filters, :name, value) do
+    where(query, [d], ilike(d.name, ^"%#{value}%"))
   end
 
   defp sort_deployment_groups(query, {direction, :platform}) do

--- a/lib/nerves_hub/managed_deployments/filtering.ex
+++ b/lib/nerves_hub/managed_deployments/filtering.ex
@@ -1,0 +1,27 @@
+defmodule NervesHub.ManagedDeployments.Filtering do
+  @moduledoc """
+  Encapsulates all deployment group filtering logic
+  """
+  import Ecto.Query
+
+  @spec build_filters(Ecto.Query.t(), %{optional(atom) => String.t()}) :: Ecto.Query.t()
+  def build_filters(query, filters) do
+    Enum.reduce(filters, query, fn {key, value}, query ->
+      filter(query, filters, key, value)
+    end)
+  end
+
+  @spec filter(Ecto.Query.t(), %{optional(atom) => String.t()}, atom, String.t()) ::
+          Ecto.Query.t()
+  def filter(query, filters, key, value)
+
+  # Filter values are empty strings as default,
+  # they should be ignored.
+  def filter(query, _filters, _key, "") do
+    query
+  end
+
+  def filter(query, _filters, :name, value) do
+    where(query, [d], ilike(d.name, ^"%#{value}%"))
+  end
+end

--- a/lib/nerves_hub_web/live/deployment_groups/index-new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index-new.html.heex
@@ -17,6 +17,30 @@
   <div class="flex items-center h-[90px] gap-4 px-6 py-7 border-b border-[#3F3F46] text-sm font-medium">
     <h1 class="text-xl leading-[30px] font-semibold text-neutral-50">All Deployment Groups</h1>
     <div class="rounded-sm bg-zinc-800 text-xs text-zinc-300 px-1.5 py-0.5 mr-auto">{@pager_meta.total_count}</div>
+    <form :if={Enum.any?(@entries) || @currently_filtering} class="flex items-center h-full" phx-change="update-filters">
+      <div class="grid grid-cols-1 h-full">
+        <input
+          type="text"
+          class="col-start-1 row-start-1 block h-full w-full bg-base-900 text-base-400 border border-base-600 rounded text-sm px-3 py-1 gap-2 font-normal h-5"
+          name="name"
+          id="deployment_group_search_top"
+          placeholder="Search..."
+          title="Search"
+          value={@current_filters[:name]}
+          phx-debounce="500"
+        />
+
+        <svg class="pointer-events-none col-start-1 row-start-1 mr-3 self-center justify-self-end" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path
+            d="M16.6668 16.6666L13.2916 13.2914M13.2916 13.2914C14.3472 12.2358 15.0002 10.7775 15.0002 9.16665C15.0002 5.94499 12.3885 3.33331 9.16683 3.33331C5.94517 3.33331 3.3335 5.94499 3.3335 9.16665C3.3335 12.3883 5.94517 15 9.16683 15C10.7777 15 12.236 14.3471 13.2916 13.2914Z"
+            stroke="#A1A1AA"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+    </form>
     <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/newz"} aria-label="Add a new deployment group">
       <.icon name="add" /> Create Deployment Group
     </.button>

--- a/lib/nerves_hub_web/live/deployment_groups/index.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.ex
@@ -51,12 +51,6 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
     |> noreply()
   end
 
-  defp filter_changes(params) do
-    Ecto.Changeset.cast({@default_filters, @filter_types}, params, Map.keys(@default_filters),
-      empty_values: []
-    ).changes
-  end
-
   @impl Phoenix.LiveView
   def handle_event("paginate", %{"page" => page_num}, socket) do
     params = %{"page_number" => page_num}
@@ -154,6 +148,12 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
         {key, value}
       end
     end
+  end
+
+  defp filter_changes(params) do
+    Ecto.Changeset.cast({@default_filters, @filter_types}, params, Map.keys(@default_filters),
+      empty_values: []
+    ).changes
   end
 
   defp firmware_simple_display_name(%Firmware{} = f) do

--- a/test/nerves_hub_web/live/deployment_groups/index_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/index_test.exs
@@ -56,8 +56,6 @@ defmodule NervesHubWeb.Live.DeploymentGroups.IndexTest do
     |> assert_has("td div", text: "0")
   end
 
-  # Disabled until new UI is the default template.
-  @tag :pending
   test "filter deployment groups on name", %{
     conn: conn,
     org: org,
@@ -65,6 +63,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.IndexTest do
     deployment_group: deployment_group
   } do
     conn
+    |> put_session("new_ui", true)
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups")
     |> assert_has("h1", text: "Deployment Groups")
     |> assert_has("a", text: deployment_group.name)

--- a/test/nerves_hub_web/live/deployment_groups/index_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/index_test.exs
@@ -55,4 +55,26 @@ defmodule NervesHubWeb.Live.DeploymentGroups.IndexTest do
     |> assert_has("a", text: deployment_group.name)
     |> assert_has("td div", text: "0")
   end
+
+  # Disabled until new UI is the default template.
+  @tag :pending
+  test "filter deployment groups on name", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group
+  } do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/deployment_groups")
+    |> assert_has("h1", text: "Deployment Groups")
+    |> assert_has("a", text: deployment_group.name)
+    |> unwrap(fn view ->
+      render_change(view, "update-filters", %{"name" => deployment_group.name})
+    end)
+    |> assert_has("a", text: deployment_group.name)
+    |> unwrap(fn view ->
+      render_change(view, "update-filters", %{"name" => "blah"})
+    end)
+    |> refute_has("a", text: deployment_group.name)
+  end
 end


### PR DESCRIPTION
Adds a search input that enables filtering on deployment group name (New UI only).
Added filtering mechanisms which makes it easy to add more filters in the future, much like on devices view.
