### PR TITLE
Make sure 'skip queue' firmware update message are sent to devices

### DIFF
--- a/lib/nerves_hub/managed_deployments/orchestrator.ex
+++ b/lib/nerves_hub/managed_deployments/orchestrator.ex
@@ -104,9 +104,9 @@ defmodule NervesHub.ManagedDeployments.Orchestrator do
       # Check again because other nodes are processing at the same time
       if Devices.count_inflight_updates_for(deployment_group) <
            deployment_group.concurrent_updates do
-        case Devices.told_to_update(device, deployment_group) do
-          {:ok, inflight_update} ->
-            send(pid, {"deployments/update", inflight_update})
+        case Devices.told_to_update(device, deployment_group, pid) do
+          {:ok, _inflight_update} ->
+            :ok
 
           :error ->
             Logger.error(

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -414,15 +414,8 @@ defmodule NervesHubWeb.Live.Devices.Show do
     deployment_group = NervesHub.Repo.preload(deployment_group, :firmware)
 
     case Devices.told_to_update(device, deployment_group) do
-      {:ok, inflight_update} ->
+      {:ok, _inflight_update} ->
         DeviceTemplates.audit_pushed_available_update(user, device, deployment_group)
-
-        _ =
-          NervesHubWeb.Endpoint.broadcast(
-            "device:#{device.id}",
-            "deployments/update",
-            inflight_update
-          )
 
         socket
         |> put_flash(:info, "Pushing available firmware update")

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -502,7 +502,12 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       assert Repo.aggregate(NervesHub.Devices.InflightUpdate, :count) == 1
 
-      assert_receive %Phoenix.Socket.Broadcast{event: "deployments/update"}
+      topic = "device:#{device.id}"
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "update-scheduled"
+      }
     end
 
     test "available update exists but deployment is not active", %{


### PR DESCRIPTION
I introduced some poor logic which impacted 'skip queue' calls.

The message was only sent to devices if they were using the new distributed orchestrator.

This fixes the issue by leaving the message sending to `told_to_update`, and making sure the pid of the device channel is passed through if the old message passing pattern is required.

Oh, also, the message that was being sent wasn't actually doing anything, so this cleans that up.