### PR TITLE
Incorporate a random jitter into the device heartbeat

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,7 +28,9 @@ config :nerves_hub,
   device_deployment_change_jitter_seconds:
     String.to_integer(System.get_env("DEVICE_DEPLOYMENT_CHANGE_JITTER_SECONDS", "10")),
   device_last_seen_update_interval_minutes:
-    String.to_integer(System.get_env("DEVICE_LAST_SEEN_UPDATE_INTERVAL_MINUTES", "5")),
+    String.to_integer(System.get_env("DEVICE_LAST_SEEN_UPDATE_INTERVAL_MINUTES", "15")),
+  device_last_seen_update_interval_jitter:
+    String.to_integer(System.get_env("DEVICE_LAST_SEEN_UPDATE_INTERVAL_JITTER", "5")),
   device_connection_max_age_days:
     String.to_integer(System.get_env("DEVICE_CONNECTION_MAX_AGE_DAYS", "14")),
   device_connection_delete_limit:

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -255,7 +255,10 @@ defmodule NervesHubWeb.DeviceSocket do
   end
 
   defp last_seen_update_interval() do
-    Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
+    jitter = Application.get_env(:nerves_hub, :device_last_seen_update_interval_jitter)
+
+    Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes) +
+      Enum.random(-jitter..jitter)
   end
 
   def shared_secrets_enabled?() do


### PR DESCRIPTION
If a horde of devices connects at the same time, this will help distribute the heartbeat updates, and the jitter will be incorporated on every check, further randomizing the spread.