### PR TITLE
Fix how device health is updated in the UI

### DIFF
--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -13,8 +13,6 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
   alias NervesHub.ManagedDeployments
   alias NervesHub.Scripts
 
-  alias NervesHub.Repo
-
   alias NervesHubWeb.Components.HealthStatus
   alias NervesHubWeb.Components.NewUI.DeviceLocation
 
@@ -22,6 +20,12 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
     socket
     |> assign(:latest_metrics, latest_metrics)
     |> assign_metadata()
+    |> ok()
+  end
+
+  def update(%{update_auto_refresh_health: auto_refresh_health}, socket) do
+    socket
+    |> assign(:auto_refresh_health, auto_refresh_health)
     |> ok()
   end
 
@@ -33,16 +37,20 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
   end
 
   def update(assigns, socket) do
+    device = Devices.get_complete_device(assigns.device_id)
+
     socket
-    |> assign(assigns)
-    |> assign(:device, Repo.preload(assigns.device, :deployment_group))
-    |> assign(:device, Repo.preload(assigns.device, :latest_health))
+    |> assign(:device, device)
+    |> assign(:product, device.product)
+    |> assign(:org, device.org)
+    |> assign(:device_connection, device.latest_connection)
     |> assign_support_scripts()
-    |> assign(:firmwares, Firmwares.get_firmware_for_device(assigns.device))
-    |> assign(:update_information, Devices.resolve_update(assigns.device))
-    |> assign(:latest_metrics, Metrics.get_latest_metric_set(assigns.device.id))
-    |> assign(:alarms, Alarms.get_current_alarms_for_device(assigns.device))
-    |> assign(:extension_overrides, extension_overrides(assigns.device, assigns.product))
+    |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
+    |> assign(:update_information, Devices.resolve_update(device))
+    |> assign(:latest_metrics, Metrics.get_latest_metric_set(device.id))
+    |> assign(:alarms, Alarms.get_current_alarms_for_device(device))
+    |> assign(:extension_overrides, extension_overrides(device, device.product))
+    |> assign(:auto_refresh_health, true)
     |> assign_metadata()
     |> assign_deployment_groups()
     |> ok()

--- a/lib/nerves_hub_web/live/devices/device_health.ex
+++ b/lib/nerves_hub_web/live/devices/device_health.ex
@@ -44,7 +44,7 @@ defmodule NervesHubWeb.Live.Devices.DeviceHealth do
 
     if connected?(socket) do
       socket.endpoint.subscribe("device:#{device.identifier}:internal")
-      socket.endpoint.subscribe("device:#{device.identifier}:extensions")
+      socket.endpoint.subscribe("device:#{device.id}:extensions")
     end
 
     socket

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -213,20 +213,18 @@
     </div>
   </div>
 
-  <.live_component
-    :if={@tab == :details}
-    module={DetailsPage}
-    id="device_details"
-    device={@device}
-    device_connection={@device_connection}
-    auto_refresh_health={!!@health_check_timer}
-    product={@product}
-    org={@org}
-    org_user={@org_user}
-    user={@user}
-  />
+  <.live_component :if={@tab == :details} module={DetailsPage} id="device_details" device_id={@device.id} org_user={@org_user} user={@user} />
 
-  <.live_component :if={@tab == :health} module={HealthPage} id="device_health" device={@device} org={@org} product={@product} />
+  <.live_component
+    :if={@tab == :health}
+    module={HealthPage}
+    id="device_health"
+    device_id={@device.id}
+    device_identifier={@device.identifier}
+    org_name={@org.name}
+    product_name={@product.name}
+    health_enabled?={@product.extensions.health && @device.extensions.health}
+  />
 
   <.live_component :if={@tab == :activity} module={ActivityPage} id="device_activity" device={@device} org={@org} product={@product} user={@user} />
 

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWeb.ChannelCase do
       end
 
       def subscribe_extensions(device) do
-        Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.identifier}:extensions")
+        Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.id}:extensions")
       end
 
       def assert_online_and_available(device) do


### PR DESCRIPTION
A bug was discovered where support script output was being cleared without the clear button being pressed.

A deep dive found two core issues:
1. the latest health report subscriptions were wrong and weren't being sent through to the details live component
2. anytime the device updated, which would happen with heartbeats or health updates, the details page `update/2` would be called, which would rerender the live component, clearing the support script.
 
I also found a follow-up issue: the health live component was, well, built incorrectly (by me). Instead of the parent liveview sending data through, it was trying to subscribe to broadcasts, and thus not getting any updates. The reason it would update is because the device was updated, which propagated to the health live component, and whenever that updated it would call `update/2` on the live component, refreshing all the data.

This PR addresses these issues, and implements some best practices in regards to assigns for live components.