### PR TITLE
Fix date comparison when checking certificate status.

### DIFF
--- a/lib/nerves_hub_web/components/ca_helpers.ex
+++ b/lib/nerves_hub_web/components/ca_helpers.ex
@@ -15,10 +15,10 @@ defmodule NervesHubWeb.Components.CAHelpers do
   def certificate_status(assigns) do
     status =
       cond do
-        DateTime.compare(assigns.not_after, DateTime.utc_now()) == :gt ->
+        DateTime.compare(DateTime.utc_now(), assigns.not_after) == :gt ->
           "Expired"
 
-        DateTime.compare(assigns.not_after, DateTime.shift(DateTime.utc_now(), month: -3)) == :gt ->
+        DateTime.compare(DateTime.shift(DateTime.utc_now(), month: -3), assigns.not_after) == :gt ->
           "Expiring Soon"
 
         true ->


### PR DESCRIPTION
Currently certificate_status displays as expired on valid certificates.