### PR TITLE
Add proper assigns to DeviceDetailsPage, ensure firmware is loaded on deployment group

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1453,6 +1453,8 @@ defmodule NervesHub.Devices do
   end
 
   def told_to_update(device_id, deployment_group, device_channel_pid) do
+    deployment_group = Repo.preload(deployment_group, :firmware)
+
     expires_at =
       DateTime.utc_now()
       |> DateTime.add(60 * deployment_group.inflight_update_expiration_minutes, :second)

--- a/lib/nerves_hub_web/components/device_page/details.ex
+++ b/lib/nerves_hub_web/components/device_page/details.ex
@@ -43,6 +43,8 @@ defmodule NervesHubWeb.Components.DevicePage.Details do
     |> assign(:device, device)
     |> assign(:product, device.product)
     |> assign(:org, device.org)
+    |> assign(:org_user, assigns.org_user)
+    |> assign(:user, assigns.user)
     |> assign(:device_connection, device.latest_connection)
     |> assign_support_scripts()
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))


### PR DESCRIPTION
This is a fix for two issues we're seeing in our most recent release.

1.) The `firmware` association needs to be loaded before work in `Device.told_to_update/3`. I'm not sure the root cause but I'm not pressed to find it.
2.) `user` and `org_user` assigns were missing from the DeviceDetailsPage socket. The cause was https://github.com/nerves-hub/nerves_hub_web/commit/6b423f59be1b2a6e56c66246e23e210a6bed519f#diff-fe77162690c4853d5e459262184c9ada52018dac27c388bde3e97f2bc6dad980L37, where the blanket `assign(assigns)` was removed.