### PR TITLE
Allow the old UI to continue to enable and disable firmware updates when viewing a device

### DIFF
--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -318,7 +318,8 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> noreply()
   end
 
-  def handle_event("toggle_deployment_firmware_updates", _params, socket) do
+  def handle_event(message, _params, socket)
+      when message in ["toggle_health_state", "toggle_deployment_firmware_updates"] do
     %{org_user: org_user, user: user, device: device} = socket.assigns
 
     authorized!(:"device:toggle-updates", org_user)


### PR DESCRIPTION
Even though we aren't implementing new features for the old UI it should still be functional.