### PR TITLE
Fix some metric and telemetry keys

### DIFF
--- a/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
+++ b/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
@@ -102,7 +102,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
 
   @decorate with_span("ManagedDeployments.Distributed.Orchestrator.trigger_update")
   def trigger_update(deployment_group) do
-    :telemetry.execute([:nerves_hub, :deployment_group, :trigger_update], %{count: 1})
+    :telemetry.execute([:nerves_hub, :deployments, :trigger_update], %{count: 1})
 
     slots = available_slots(deployment_group)
 
@@ -158,7 +158,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
 
   @spec tell_device_to_update(integer(), DeploymentGroup.t()) :: boolean()
   defp tell_device_to_update(device_id, deployment_group) do
-    :telemetry.execute([:nerves_hub, :deployment_group, :trigger_update, :device], %{count: 1})
+    :telemetry.execute([:nerves_hub, :deployments, :trigger_update, :device], %{count: 1})
 
     case Devices.told_to_update(device_id, deployment_group) do
       {:ok, _} -> true

--- a/lib/nerves_hub/managed_deployments/orchestrator.ex
+++ b/lib/nerves_hub/managed_deployments/orchestrator.ex
@@ -65,7 +65,7 @@ defmodule NervesHub.ManagedDeployments.Orchestrator do
 
   @decorate with_span("ManagedDeployments.Orchestrator.trigger_update")
   def trigger_update(deployment_group) do
-    :telemetry.execute([:nerves_hub, :deployment_group, :trigger_update], %{count: 1})
+    :telemetry.execute([:nerves_hub, :deployments, :trigger_update], %{count: 1})
 
     match_conditions = [
       {:and, {:==, {:map_get, :deployment_id, :"$1"}, deployment_group.id},
@@ -97,7 +97,7 @@ defmodule NervesHub.ManagedDeployments.Orchestrator do
     devices
     |> Enum.take(count)
     |> Enum.each(fn %{device_id: device_id, pid: pid} ->
-      :telemetry.execute([:nerves_hub, :deployment_group, :trigger_update, :device], %{count: 1})
+      :telemetry.execute([:nerves_hub, :deployments, :trigger_update, :device], %{count: 1})
 
       device = %Device{id: device_id}
 

--- a/lib/nerves_hub/statsd_metrics_reporter.ex
+++ b/lib/nerves_hub/statsd_metrics_reporter.ex
@@ -16,9 +16,8 @@ defmodule NervesHub.StatsdMetricsReporter do
            counter("nerves_hub.devices.disconnect.count", tags: [:env, :service]),
            counter("nerves_hub.devices.duplicate_connection", tags: [:env, :service]),
            counter("nerves_hub.devices.stale_connections", tags: [:env, :service]),
-           counter("nerves_hub.devices.deployment.changed.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.deployment.update.manual.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.deployment.update.automatic.count", tags: [:env, :service]),
+           counter("nerves_hub.devices.update.manual.count", tags: [:env, :service]),
+           counter("nerves_hub.devices.update.automatic.count", tags: [:env, :service]),
            counter("nerves_hub.devices.deployment.penalty_box.check.count",
              tags: [:env, :service]
            ),


### PR DESCRIPTION
- Change telemetry key names in the orchestrator to match proper terminology
- Remove `nerves_hub.devices.deployment.changed.count`, it's not used anywhere
- Rename device update count metric names so they match the telemetry keys they correspond to