### PR TITLE
Generate a dynamic livebook based on encoded params

### DIFF
--- a/lib/nerves_hub_web/controllers/livebook_template_controller.ex
+++ b/lib/nerves_hub_web/controllers/livebook_template_controller.ex
@@ -1,0 +1,70 @@
+defmodule NervesHubWeb.LivebookTemplateController do
+  use NervesHubWeb, :controller
+
+  def generate(conn, params) do
+    decoded =
+      params["encoded_params"]
+      |> Base.decode64!(padding: false)
+      |> JSON.decode!()
+
+    output = template(decoded["node"], decoded["cookie"])
+
+    conn
+    |> markdown_content_type()
+    |> send_resp(200, to_string(output))
+  end
+
+  defp markdown_content_type(%Plug.Conn{resp_headers: resp_headers} = conn) do
+    %{conn | resp_headers: [{"content-type", "text/markdown"} | resp_headers]}
+  end
+
+  defp template(node_hostname, cookie) do
+    attrs =
+      %{
+        "assign_to" => "",
+        "code" => "Toolshed.uname()\n\nToolshed.uptime()\n\nToolshed.hostname()",
+        "cookie_source" => "text",
+        "cookie_text" => cookie,
+        "node_source" => "text",
+        "node_text" => node_hostname
+      }
+      |> JSON.encode!()
+      |> Base.encode64(padding: false)
+
+    ~s"""
+    # Live Nerves Device
+
+    ```elixir
+    Mix.install([
+      {:kino, "~> 0.15.0"}
+    ])
+    ```
+
+    ## Section
+
+    <!-- livebook:{"attrs":"#{attrs}","chunks":null,"kind":"Elixir.Kino.RemoteExecutionCell","livebook_object":"smart_cell"} -->
+
+    ```elixir
+    require Kino.RPC
+    node = :"#{node_hostname}"
+    Node.set_cookie(node, :"#{cookie}")
+
+    Kino.RPC.eval_string(
+      node,
+      ~S\"\"\"
+      Toolshed.uname()
+
+      Toolshed.uptime()
+
+      Toolshed.hostname()
+      \"\"\",
+      file: __ENV__.file
+    )
+    ```
+
+    ```elixir
+
+    ```
+    """
+  end
+end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -200,6 +200,10 @@ defmodule NervesHubWeb.Router do
     post("/invite/:token", AccountController, :accept_invite)
   end
 
+  scope "/", NervesHubWeb, host: "livebook." do
+    get("/:encoded_params/nerves.livemd", LivebookTemplateController, :generate)
+  end
+
   scope "/org/:org_name/:product_name", NervesHubWeb do
     pipe_through([:browser, :logged_in, :org, :product])
 


### PR DESCRIPTION
This is an experiment towards making it easier to connect to a device using Livebook.

I could see this being its own app, but since its just one dynamic template I'd prefer to keep it here, at least to start with.

This uses a `livebook.` subdomain for the route, and the node and cookie for the script are base64 encoded in the url.

eg. https://livebook.nervescloud.com/eyJub2RlIjoibmVydmVzQDEwMC4xMDguMTA0Ljg4IiwiY29va2llIjoiOHQ2UU9JNjNiNk0yc1E3Tm5sdzdJSzBoZ294a2RubUFST21MWURuSGpSdyJ9/nerves.livemd