### PR TITLE
Improved function naming for toggling automatic updates

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1180,7 +1180,7 @@ defmodule NervesHub.Devices do
     update_device_with_audit(device, params, user, description)
   end
 
-  def toggle_health(device, user) do
+  def toggle_automatic_updates(device, user) do
     case device.updates_enabled do
       true ->
         disable_updates(device, user)

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -408,7 +408,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     authorized!(:"device:toggle-updates", org_user)
 
     {:ok, device} = Devices.get_device_by_identifier(org, device_identifier)
-    {:ok, device} = Devices.toggle_health(device, user)
+    {:ok, device} = Devices.toggle_automatic_updates(device, user)
 
     socket
     |> put_flash(:info, "Toggled device firmware updates")

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -148,7 +148,7 @@
 
             <button
               type="button"
-              phx-click="toggle_deployment_firmware_updates"
+              phx-click="toggle-automatic-updates"
               class={[
                 "relative inline-flex items-center h-3.5 w-6 shrink-0 cursor-pointer rounded-full border-1.5 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-0",
                 "bg-red-500"
@@ -178,7 +178,7 @@
 
             <button
               type="button"
-              phx-click="toggle_deployment_firmware_updates"
+              phx-click="toggle-automatic-updates"
               class={[
                 "relative inline-flex items-center h-3.5 w-6 shrink-0 cursor-pointer rounded-full border-1.5 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-0",
                 "bg-emerald-500"

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -332,13 +332,12 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> noreply()
   end
 
-  def handle_event(message, _params, socket)
-      when message in ["toggle_health_state", "toggle_deployment_firmware_updates"] do
+  def handle_event("toggle-automatic-updates", _params, socket) do
     %{org_user: org_user, user: user, device: device} = socket.assigns
 
     authorized!(:"device:toggle-updates", org_user)
 
-    {:ok, updated_device} = Devices.toggle_health(device, user)
+    {:ok, updated_device} = Devices.toggle_automatic_updates(device, user)
 
     message = [
       "Firmware updates ",

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -35,7 +35,7 @@
         <span class="button-icon console-icon"></span>
         <span class="action-text">Console</span>
       <% end %>
-      <button class="btn btn-outline-light btn-action" aria-label={if @device.updates_enabled, do: "Disable Updates", else: "Enable Updates"} type="button" phx-click="toggle_health_state">
+      <button class="btn btn-outline-light btn-action" aria-label={if @device.updates_enabled, do: "Disable Updates", else: "Enable Updates"} type="button" phx-click="toggle-automatic-updates">
         <span class="button-icon firmware-disabled"></span>
         <span class="action-text">{if @device.updates_enabled, do: "Disable Updates", else: "Enable Updates"}</span>
       </button>


### PR DESCRIPTION
This is a follow on from #2010 where the `phx-click` naming wasn't clear, as well as having duplicates.