### PR TITLE
Only include specified device in presence stream

### DIFF
--- a/lib/nerves_hub_web/channels/presence.ex
+++ b/lib/nerves_hub_web/channels/presence.ex
@@ -41,10 +41,10 @@ defmodule NervesHubWeb.Presence do
     {:ok, state}
   end
 
-  def list_online_users(),
-    do: list("online_users") |> Enum.map(fn {_id, presence} -> presence end)
+  def list_online_users(topic),
+    do: list(topic) |> Enum.map(fn {_id, presence} -> presence end)
 
-  def track_user(id, params), do: track(self(), "online_users", id, params)
+  def track_user(topic, id, params), do: track(self(), topic, id, params)
 
-  def subscribe(), do: Phoenix.PubSub.subscribe(NervesHub.PubSub, "proxy:online_users")
+  def subscribe(topic), do: Phoenix.PubSub.subscribe(NervesHub.PubSub, "proxy:#{topic}")
 end

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -11,8 +11,8 @@
   </div>
 
   <div class="flex items-center gap-2 ml-auto mr-6">
-    <div id="online-users" phx-update="stream" class="border-r border-base-700 px-5 mr-3 h-8 flex flex-row-reverse -space-x-1 space-x-reverse overflow-hidden">
-      <div :for={{id, %{user: user}} <- @streams.presences} class="inline-flex items-center justify-center" id={id}>
+    <div id="present-users" phx-update="stream" class="border-r border-base-700 px-5 mr-3 h-8 flex flex-row-reverse -space-x-1 space-x-reverse overflow-hidden">
+      <div :for={{id, %{user: user}} <- @streams.presences} class="inline-flex items-center justify-center z-10" id={id}>
         <span class="inline-flex items-center justify-center px-1 size-7 ring-2 ring-zinc-600 rounded-full bg-zinc-800 font-medium text-zinc-400 text-sm">
           {String.split(user.name) |> Enum.map(fn w -> String.at(w, 0) |> String.upcase() end)}
         </span>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -529,13 +529,14 @@ defmodule NervesHubWeb.Live.Devices.Show do
     Devices.get_device_by_identifier!(org, identifier, [:latest_connection, :latest_health])
   end
 
-  defp setup_presence_tracking(%{assigns: %{user: user}} = socket) do
+  defp setup_presence_tracking(%{assigns: %{device: device, user: user}} = socket) do
+    topic = "device-#{device.identifier}"
     socket = stream(socket, :presences, [])
 
     if connected?(socket) do
-      Presence.track_user(user.id, %{name: user.name})
-      Presence.subscribe()
-      stream(socket, :presences, Presence.list_online_users())
+      Presence.track_user(topic, user.id, %{name: user.name})
+      Presence.subscribe(topic)
+      stream(socket, :presences, Presence.list_online_users(topic))
     else
       socket
     end


### PR DESCRIPTION
Changes topic for presence stream, from general "online-users" to "device-IDENTIFIER".

Also includes a fix for z-index on stacked user avatars.