### PR TITLE
Remove old orchestrator supervisor from application tree

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -83,7 +83,6 @@ defmodule NervesHub.Application do
 
       _ ->
         [
-          NervesHub.ManagedDeployments.Supervisor,
           ProcessHub.child_spec(%ProcessHub{hub_id: :deployment_orchestrators}),
           NervesHub.ManagedDeployments.Distributed.OrchestratorRegistration
         ]


### PR DESCRIPTION
The app can't start when trying to run the old orchestrator supervisor, which doesn't exist :) 

```
* (Mix) Could not start application nerves_hub: exited in: NervesHub.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (ArgumentError) The module NervesHub.ManagedDeployments.Supervisor was given as a child to a supervisor but it does not exist
            (elixir 1.18.3) lib/supervisor.ex:797: Supervisor.init_child/1
            (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
            (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
            (elixir 1.18.3) lib/supervisor.ex:783: Supervisor.init/2
            (elixir 1.18.3) lib/supervisor.ex:707: Supervisor.start_link/2
            (kernel 10.2.3) application_master.erl:295: :application_master.start_it_old/4
```