### PR TITLE
New UI: Display first connecting code properly

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -83,7 +83,6 @@ defmodule NervesHub.Application do
 
       _ ->
         [
-          NervesHub.ManagedDeployments.Supervisor,
           ProcessHub.child_spec(%ProcessHub{hub_id: :deployment_orchestrators}),
           NervesHub.ManagedDeployments.Distributed.OrchestratorRegistration
         ]

--- a/lib/nerves_hub_web/components/device_page/settings.ex
+++ b/lib/nerves_hub_web/components/device_page/settings.ex
@@ -76,7 +76,7 @@ defmodule NervesHubWeb.Components.DevicePage.Settings do
             </div>
 
             <div class="w-1/2 flex flex-col gap-2">
-              <.input field={@settings_form[:first_connect_code]} label="First connect code" type="textarea" rows="10" />
+              <.input field={@settings_form[:connecting_code]} label="First connect code" type="textarea" rows="10" />
               <div class="text-xs tracking-wide text-zinc-400">Make sure this is valid Elixir and will not crash the device</div>
             </div>
           </div>


### PR DESCRIPTION
The key `:first_connect_code` doesn't exist on the device-changeset-to-form map. The name of the device struct's column, `:connecting_code`, must be used.