### PR TITLE
Default to sorting deployment groups by name while viewing DeploymentGroups.Index

### DIFF
--- a/lib/nerves_hub_web/live/deployment_groups/index.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.ex
@@ -115,7 +115,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
       page: pagination_opts["page_number"],
       page_size: pagination_opts["page_size"],
       sort: pagination_opts["sort"] || "name",
-      sort_direction: pagination_opts["sort_direction"],
+      sort_direction: pagination_opts["sort_direction"] || "asc",
       filters: filters
     }
 


### PR DESCRIPTION
@esvinson pointed this out: defaulting to deployment group name descending feels unnatural as a default sort order. `name asc` feels much better.