### PR TITLE
Support device index table row links in webkit

### DIFF
--- a/assets/ui-rework/app.css
+++ b/assets/ui-rework/app.css
@@ -253,6 +253,19 @@
     font-weight: 500;
     line-height: 20px;
   }
+
+  .clickable-table-row {
+    position: relative;
+    transform: translate(0);
+    clip-path: inset(0);
+  }
+
+  .clickable-table-row-mask {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    max-height: 52px;
+  }
 }
 
 html {

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -100,7 +100,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr :for={device <- @devices} class={["border-b border-zinc-800 relative isolate", device.id in @selected_devices && "selected-row"]} style={progress_style(@progress[device.id])}>
+          <tr :for={device <- @devices} class={["border-b border-zinc-800 isolate clickable-table-row", device.id in @selected_devices && "selected-row"]} style={progress_style(@progress[device.id])}>
             <td class="checkbox">
               <input
                 id={"checkbox-device-#{device.id}"}
@@ -152,7 +152,7 @@
                 </span>
                 <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m font-mono">
                   {device.identifier}
-                  <span class="absolute inset-0 z-10"></span>
+                  <span class="clickable-table-row-mask" />
                 </.link>
                 <span class={["flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800", !@progress[device.id] && "invisible"]}>
                   <span class="text-xs text-zinc-300 tracking-tight">updating</span>


### PR DESCRIPTION
Webkit doesn't support `display: relative` on `<tr />`'s. That means that our absolute-positioned table row mask, which allows the entire table row to be clickable, takes up the entire page 😖 Using a mix of `clip-path` and `transform: translate()` is enough to tell Webkit to keep the bounds in the table row.

#### Webkit pre-fix
![CleanShot 2025-04-05 at 07 35 56](https://github.com/user-attachments/assets/525e41bb-79c0-4714-be64-020ceca61c1f)

#### Webkit post-fix
![CleanShot 2025-04-05 at 07 33 06](https://github.com/user-attachments/assets/3d631de5-30d3-4522-b3ba-26f86537e144)

#### Chromium post-fix
![CleanShot 2025-04-05 at 07 31 26](https://github.com/user-attachments/assets/1942e538-315b-4aa0-ae17-1da4661e5647)
