### PR TITLE
Empty state UI tweaks (plus a button fix)

### DIFF
--- a/lib/nerves_hub_web/components/device_page/activity_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/activity_tab.ex
@@ -51,7 +51,12 @@ defmodule NervesHubWeb.Components.DevicePage.ActivityTab do
               </.link>
             </div>
           </div>
-          <div class="py-2 px-4 flex flex-col gap-1">
+          <div :if={Enum.empty?(@activity)} class="py-2 px-4 flex flex-col gap-1">
+            <div class="flex items-center justify-center p-14">
+              <span class="text-zinc-500 font-extralight">No audit logs found for the device.</span>
+            </div>
+          </div>
+          <div :if={Enum.any?(@activity)} class="py-2 px-4 flex flex-col gap-1">
             <div :for={entry <- @activity} class="flex items-center gap-6 h-16 p-2">
               <div class="flex items-center h-8 py-1 px-2 bg-zinc-800 border border-zinc-700 rounded-full">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -352,8 +352,8 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
             </.button>
           </div>
 
-          <div class="flex p-4 gap-4 items-center border-t border-zinc-700">
-            <form :if={Enum.any?(@firmwares)} id="push-update-form" phx-submit="push-update" class="flex gap-2 items-center w-full">
+          <div :if={Enum.any?(@firmwares)} class="flex p-4 gap-4 items-center border-t border-zinc-700">
+            <form id="push-update-form" phx-submit="push-update" class="flex gap-2 items-center w-full">
               <div class="grow grid grid-cols-1">
                 <label for="firmware" class="hidden">Firmware</label>
                 <select

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -374,9 +374,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   end
 
   defp custom_metrics(metrics) do
-    Enum.reject(metrics, fn {key, _value} ->
-      key in @manual_metrics
-    end)
+    Enum.reject(metrics, &(elem(&1, 1) in @manual_metrics))
   end
 
   defp nice_round(val) when is_float(val), do: Float.round(val, 1)

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -91,7 +91,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   def render(assigns) do
     ~H"""
     <div class="w-full p-6">
-      <div :if={Enum.any?(@latest_metrics) && @health_enabled?} class="w-full flex flex-col bg-zinc-900 border border-zinc-700 rounded">
+      <div :if={Enum.any?(@latest_metrics) && @health_enabled?} class="mb-6 w-full flex flex-col bg-zinc-900 border border-zinc-700 rounded">
         <div class="flex flex-col shadow-device-details-content">
           <div class="flex pt-2 px-4 pb-4 gap-2 items-center justify-items-stretch flex-wrap">
             <div class="grow flex flex-col h-16 py-2 px-3 rounded border-b border-emerald-500 bg-health-good">
@@ -142,7 +142,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
         </div>
       </div>
 
-      <div class="my-6 w-full flex flex-col bg-zinc-900 border border-zinc-700 rounded">
+      <div class="w-full flex flex-col bg-zinc-900 border border-zinc-700 rounded">
         <div class="flex justify-between items-center h-14 px-4 border-b border-zinc-700">
           <div class="flex items-end gap-3">
             <div class="text-base text-neutral-50 font-medium">Health over time</div>
@@ -175,7 +175,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
 
         <div class="p-10 flex flex-col gap-10">
           <div :if={Enum.empty?(@charts)} class="flex items-center justify-center p-6">
-            <span class="text-indigo-500 font-extralight">No data for selected period.</span>
+            <span class="text-zinc-500 font-extralight">No metrics for the selected period.</span>
           </div>
 
           <div :for={chart <- @charts} :if={Enum.any?(@charts)} class="flex flex-col gap-3">

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -61,13 +61,11 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   def hooked_event("set-time-frame", %{"unit" => unit, "amount" => amount}, socket) do
     payload = %{unit: get_time_unit({unit, String.to_integer(amount)})}
 
-    socket =
-      socket
-      |> assign(:time_frame, {unit, String.to_integer(amount)})
-      |> push_event("update-time-unit", payload)
-      |> update_charts()
-
-    {:halt, socket}
+    socket
+    |> assign(:time_frame, {unit, String.to_integer(amount)})
+    |> push_event("update-time-unit", payload)
+    |> update_charts()
+    |> halt()
   end
 
   def hooked_event(_event, _params, socket), do: {:cont, socket}
@@ -78,12 +76,10 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
       ) do
     latest_metrics = Metrics.get_latest_metric_set(device.id)
 
-    socket =
-      socket
-      |> assign(:latest_metrics, latest_metrics)
-      |> assign_metadata()
-
-    {:halt, socket}
+    socket
+    |> assign(:latest_metrics, latest_metrics)
+    |> assign_metadata()
+    |> halt()
   end
 
   def hooked_info(_event, socket), do: {:cont, socket}
@@ -378,8 +374,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   end
 
   defp custom_metrics(metrics) do
-    metrics
-    |> Enum.reject(fn {key, _value} ->
+    Enum.reject(metrics, fn {key, _value} ->
       key in @manual_metrics
     end)
   end

--- a/lib/nerves_hub_web/live/support_scripts/index-new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/index-new.html.heex
@@ -24,39 +24,38 @@
       <.icon name="add" />Add Support Script
     </.button>
   </div>
-  <%= if Enum.any?(@scripts) do %>
-    <div class="listing">
-      <table>
-        <thead>
-          <tr>
-            <th phx-click="sort" phx-value-sort="name" class="cursor-pointer">
-              <Sorting.sort_icon text="Name" field="name" selected_field={@current_sort} selected_direction={@sort_direction} />
-            </th>
-            <th phx-click="sort" phx-value-sort="inserted_at" class="cursor-pointer">
-              <Sorting.sort_icon text="Added on" field="inserted_at" selected_field={@current_sort} selected_direction={@sort_direction} />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr :for={script <- @scripts} class="border-b border-zinc-800">
-            <td class="h-[52px]">
-              <.link class="size-full flex items-center" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/#{script.id}/edit"}>
-                {script.name}
-              </.link>
-            </td>
 
-            <td>
-              {Calendar.strftime(script.inserted_at, "%Y-%m-%d at %I:%M %p UTC")}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  <% else %>
-    <div class="h-full pb-16 flex items-center justify-center">
-      <span class="text-xl font-medium text-neutral-50">{@product.name} doesn’t have any Support Scripts.</span>
-    </div>
-  <% end %>
+  <div :if={Enum.any?(@scripts)} class="listing">
+    <table>
+      <thead>
+        <tr>
+          <th phx-click="sort" phx-value-sort="name" class="cursor-pointer">
+            <Sorting.sort_icon text="Name" field="name" selected_field={@current_sort} selected_direction={@sort_direction} />
+          </th>
+          <th phx-click="sort" phx-value-sort="inserted_at" class="cursor-pointer">
+            <Sorting.sort_icon text="Added on" field="inserted_at" selected_field={@current_sort} selected_direction={@sort_direction} />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr :for={script <- @scripts} class="border-b border-zinc-800">
+          <td class="h-[52px]">
+            <.link class="size-full flex items-center" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/#{script.id}/edit"}>
+              {script.name}
+            </.link>
+          </td>
+
+          <td>
+            {Calendar.strftime(script.inserted_at, "%Y-%m-%d at %I:%M %p UTC")}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div :if={Enum.empty?(@scripts)} class="h-full pb-16 flex items-center justify-center">
+    <span class="text-xl font-medium text-neutral-50">{@product.name} doesn’t have any Support Scripts.</span>
+  </div>
 </div>
 
 <Pager.render_with_page_sizes pager={@pager_meta} page_sizes={[25, 50, 100]} />

--- a/lib/nerves_hub_web/live/support_scripts/index-new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/index-new.html.heex
@@ -19,12 +19,10 @@
     <div class="rounded-sm bg-zinc-800 text-xs text-zinc-300 px-1.5 py-0.5 mr-auto">
       {@pager_meta.total_count}
     </div>
-    <.link class="action-button" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/new"} aria-label="Add Support Scripts">
-      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-        <path d="M4.1665 10.0001H9.99984M15.8332 10.0001H9.99984M9.99984 10.0001V4.16675M9.99984 10.0001V15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
-      <span class="action-text">Add Support Script</span>
-    </.link>
+
+    <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/new"} aria-label="Add a support script">
+      <.icon name="add" />Add Support Script
+    </.button>
   </div>
   <%= if Enum.any?(@scripts) do %>
     <div class="listing">

--- a/test/nerves_hub_web/live/new_ui/devices/activity_tab_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/activity_tab_test.exs
@@ -1,0 +1,35 @@
+defmodule NervesHubWeb.Live.NewUI.Devices.ActivityTabTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  alias NervesHub.AuditLogs.DeviceTemplates
+
+  setup %{conn: conn} do
+    [conn: init_test_session(conn, %{"new_ui" => true})]
+  end
+
+  test "no audit log history exists for the device", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device
+  } do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/activity")
+    |> assert_has("span", text: "No audit logs found for the device.")
+  end
+
+  test "audit log history exists for the device", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device,
+    user: user
+  } do
+    # Add audit log item for the device
+    DeviceTemplates.audit_reboot(user, device)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/activity")
+    |> assert_has("div", text: "User #{user.name} rebooted device #{device.identifier}")
+  end
+end

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Live.Devices.NewUI.IndexTest do
+defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
   alias NervesHub.Fixtures

--- a/test/nerves_hub_web/live/new_ui/devices/show_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/show_test.exs
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Live.Devices.NewUI.ShowTest do
+defmodule NervesHubWeb.Live.NewUI.Devices.ShowTest do
   use NervesHubWeb.ConnCase.Browser, async: false
   use Mimic
 

--- a/test/nerves_hub_web/live/new_ui/support_scripts_test.exs
+++ b/test/nerves_hub_web/live/new_ui/support_scripts_test.exs
@@ -1,0 +1,89 @@
+defmodule NervesHubWeb.Live.NewUI.SupportScriptsTest do
+  use NervesHubWeb.ConnCase.Browser, async: true
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Scripts
+
+  setup %{conn: conn, user: user, org: org} do
+    conn = init_test_session(conn, %{"new_ui" => true})
+
+    [conn: conn, product: Fixtures.product_fixture(user, org, %{name: "Amazing"})]
+  end
+
+  describe "list" do
+    test "show a message if there are no support scripts", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/scripts")
+      |> assert_has("span", text: "#{product.name} doesn’t have any Support Scripts")
+    end
+
+    test "shows all support scripts for a product", %{
+      conn: conn,
+      org: org,
+      product: product,
+      user: user
+    } do
+      {:ok, _script} = Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/scripts")
+      |> assert_has("td", text: "MOTD")
+    end
+  end
+
+  describe "delete" do
+    test "removes support script", %{conn: conn, org: org, product: product, user: user} do
+      {:ok, script} = Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/scripts/#{script.id}/edit")
+      |> assert_has("input", value: script.name)
+      |> click_button("Delete Script")
+      |> assert_path("/org/#{org.name}/#{product.name}/scripts")
+      |> assert_has("span", text: "#{product.name} doesn’t have any Support Scripts")
+    end
+  end
+
+  describe "new" do
+    test "requires a name and text", %{conn: conn, org: org, product: product} do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/scripts/new")
+      |> click_button("Save changes")
+      |> assert_path("/org/#{org.name}/#{product.name}/scripts/new")
+      |> assert_has("p", text: "can't be blank", count: 2)
+      |> fill_in("Name", with: "MOTD")
+      |> click_button("Save changes")
+      |> assert_path("/org/#{org.name}/#{product.name}/scripts/new")
+      |> assert_has("p", text: "can't be blank", count: 1)
+      |> fill_in("Script code", with: "NervesMOTD.print()")
+      |> click_button("Save changes")
+      |> assert_path("/org/#{org.name}/#{product.name}/scripts")
+      |> assert_has("td", text: "MOTD")
+    end
+  end
+
+  describe "edit" do
+    test "requires a name and text", %{conn: conn, org: org, product: product, user: user} do
+      {:ok, script} =
+        Scripts.create(product, user, %{name: "MOTD", text: "NervesMOTD.print()"})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/scripts/#{script.id}/edit")
+      |> fill_in("Name", with: "")
+      |> click_button("Save changes")
+      |> assert_path("/org/#{org.name}/#{product.name}/scripts/#{script.id}/edit")
+      |> assert_has("p", text: "can't be blank", count: 1)
+      |> fill_in("Name", with: "MOTDDDDD")
+      |> fill_in("Script code", with: "dbg(NervesMOTD.print())")
+      |> click_button("Save changes")
+      |> assert_path("/org/#{org.name}/#{product.name}/scripts")
+      |> assert_has("td", text: "MOTDDDDD")
+
+      assert %{text: "dbg(NervesMOTD.print())"} = Scripts.get!(script.id)
+    end
+  end
+end


### PR DESCRIPTION
- Improve the Device Health tab empty state
- Hide the entire update section on the Details tab if there are no firmware
- Add an empty state for the Device activity tab
- Prefer `:if` over `<%= if ... %>`
- Fix the "Add Support Script" button
- Some minor piping improvements
