### PR TITLE
UI fixups

### DIFF
--- a/assets/ui-rework/app.css
+++ b/assets/ui-rework/app.css
@@ -257,7 +257,6 @@
   .clickable-table-row {
     position: relative;
     transform: translate(0);
-    clip-path: inset(0);
   }
 
   .clickable-table-row-mask {

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -184,7 +184,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
                   phx-click="remove-unmatched-devices-from-deployment-group"
                   data-confirm={"This will remove #{@unmatched_device_count} #{if @unmatched_device_count == 1, do: "device", else: "devices"} from #{@deployment_group.name}. Continue?"}
                 >
-                  <.icon name="trash" class="mr-1" /> Remove {if @unmatched_device_count == 1, do: "device", else: "devices"}
+                  <.icon name="trash" class="mr-1 stroke-zinc-400" /> Remove {if @unmatched_device_count == 1, do: "device", else: "devices"}
                 </button>
                 <div id="remove-devices-from-deployment-group" class="relative z-20" phx-hook="ToolTip" data-placement="top">
                   <.icon name="info" class="stroke-zinc-400" />


### PR DESCRIPTION
Allow tooltips to work with inset and absolutely positioned row mask (tested w/Webkit and Chromium):

### Before
![CleanShot 2025-04-10 at 13 58 03](https://github.com/user-attachments/assets/ef1593a8-53ad-4de2-ba26-140a82780bd4)


### After
![CleanShot 2025-04-10 at 13 55 03](https://github.com/user-attachments/assets/13d09b61-502f-4b28-854b-95e2ff05b34a)


Fix the "Remove devices" from deployment group icon stroke:

### Before
<img width="204" alt="CleanShot 2025-04-10 at 13 57 43@2x" src="https://github.com/user-attachments/assets/e4c687ab-f2c6-455d-9f41-8dc12d2cfe67" />


### After
<img width="194" alt="CleanShot 2025-04-10 at 13 55 51@2x" src="https://github.com/user-attachments/assets/f8cec1a5-7801-4444-944f-966bbc4645fc" />
