### PR TITLE
Load the device list async, for a better and faster UX

### DIFF
--- a/lib/nerves_hub_web/helpers/role_validate_helpers.ex
+++ b/lib/nerves_hub_web/helpers/role_validate_helpers.ex
@@ -14,18 +14,14 @@ defmodule NervesHubWeb.Helpers.RoleValidateHelpers do
   end
 
   def validate_role(_conn, [{_key, value}]) do
-    halt_role(value)
+    raise NervesHubWeb.UnauthorizedError, required_role: to_string(value)
   end
 
   def validate_org_user_role(conn, org, user, role) do
     if NervesHub.Accounts.has_org_role?(org, user, role) do
       conn
     else
-      halt_role(to_string(role))
+      raise NervesHubWeb.UnauthorizedError, required_role: to_string(role)
     end
-  end
-
-  def halt_role(required_role) do
-    raise NervesHubWeb.UnauthorizedError, required_role: required_role
   end
 end

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -79,7 +79,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr :for={_ <- 1..10} class="border-b border-zinc-800 isolate clickable-table-row animate-pulse">
+            <tr :for={_ <- 1..25} class="border-b border-zinc-800 isolate clickable-table-row animate-pulse">
               <td class="checkbox"><input class="checkbox opacity-50" type="checkbox" /></td>
               <td>
                 <div class="flex gap-[8px] items-center">

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -15,8 +15,15 @@
 
 <div class="h-0 flex-1 overflow-y-auto">
   <div class="flex items-center h-[90px] gap-4 px-6 py-7 border-b border-[#3F3F46] text-sm font-medium">
-    <h1 class="text-xl leading-[30px] font-semibold text-neutral-50">All Devices</h1>
-    <div class="rounded-sm bg-zinc-800 text-xs text-zinc-300 px-1.5 py-0.5 mr-auto">{@total_entries}</div>
+    <h1 :if={!@devices.ok?} class="text-xl leading-[30px] font-semibold text-neutral-50">Loading...</h1>
+    <h1 :if={@devices.ok?} id="devices-header" class="text-xl leading-[30px] font-semibold text-neutral-50 hidden" phx-mounted={fade_in("#devices-header")}>
+      All Devices
+    </h1>
+    <div class="mr-auto">
+      <div :if={@devices.ok?} id="device-count" class="rounded-sm bg-zinc-800 text-xs text-zinc-300 px-1.5 py-0.5 mr-auto hidden" phx-mounted={fade_in("#device-count")}>
+        {@total_entries}
+      </div>
+    </div>
     <form :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} class="flex items-center h-full" phx-change="update-filters">
       <div class="grid grid-cols-1 h-full">
         <input
@@ -54,8 +61,61 @@
 
   <.async_result :let={devices} assign={@devices}>
     <:loading>
-      <div class="h-full pb-16 flex items-center justify-center">
-        <span class="text-xl font-medium text-neutral-50 animate-pulse">Loading devices ...</span>
+      <div class="listing">
+        <table>
+          <thead>
+            <tr>
+              <th class="checkbox">
+                <input class="checkbox" disabled type="checkbox" />
+              </th>
+              <th>Identifier</th>
+              <th class="w-24">
+                <div class="flex justify-center">Health</div>
+              </th>
+              <th>Firmware</th>
+              <th>Platform</th>
+              <th>Uptime</th>
+              <th>Tags</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={_ <- 1..10} class="border-b border-zinc-800 isolate clickable-table-row animate-pulse">
+              <td class="checkbox"><input class="checkbox opacity-50" type="checkbox" /></td>
+              <td>
+                <div class="flex gap-[8px] items-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
+                    <circle cx="3" cy="3" r="3" fill="#71717A" />
+                  </svg>
+                  <div class="h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-[200px]"></div>
+                </div>
+              </td>
+
+              <td>
+                <div class="flex gap-[8px] items-center justify-center">
+                  <div class="size-4 bg-gray-200 rounded-full dark:bg-gray-700"></div>
+                </div>
+              </td>
+
+              <td>
+                <div class="h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-[80px]"></div>
+              </td>
+
+              <td>
+                <div class="h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 max-w-[80px]"></div>
+              </td>
+
+              <td>
+                <div class="h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 max-w-[80px]"></div>
+              </td>
+
+              <td>
+                <div class="flex items-center gap-[4px]">
+                  <div class="tag h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-[30px]"></div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </:loading>
     <:failed :let={_failure}>
@@ -70,8 +130,8 @@
         <span class="text-xl font-medium text-neutral-50">{@product.name} doesn’t have any devices yet.</span>
       </div>
     <% else %>
-      <div class="listing">
-        <table class="">
+      <div id="device-list" class="listing hidden" phx-mounted={fade_in("#device-list")}>
+        <table>
           <thead>
             <tr>
               <th class="checkbox">

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -17,7 +17,7 @@
   <div class="flex items-center h-[90px] gap-4 px-6 py-7 border-b border-[#3F3F46] text-sm font-medium">
     <h1 class="text-xl leading-[30px] font-semibold text-neutral-50">All Devices</h1>
     <div class="rounded-sm bg-zinc-800 text-xs text-zinc-300 px-1.5 py-0.5 mr-auto">{@total_entries}</div>
-    <form :if={Enum.any?(@devices) || @currently_filtering} class="flex items-center h-full" phx-change="update-filters">
+    <form :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} class="flex items-center h-full" phx-change="update-filters">
       <div class="grid grid-cols-1 h-full">
         <input
           type="text"
@@ -41,213 +41,226 @@
         </svg>
       </div>
     </form>
-    <.button :if={Enum.any?(@devices) || @currently_filtering} type="link" aria-label="Export devices" href={~p"/org/#{@org.name}/#{@product.name}/devices/export"} download>
+    <.button :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org.name}/#{@product.name}/devices/export"} download>
       <.icon name="export" /> Export
     </.button>
     <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"} aria-label="Add new device">
       <.icon name="add" /> Add Device
     </.button>
-    <.button :if={Enum.any?(@devices) || @currently_filtering} type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
+    <.button :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
       <.icon name="filter" /> Filters
     </.button>
   </div>
 
-  <%= if Enum.empty?(@devices) && !@currently_filtering do %>
-    <!-- TODO: Go over empty-state with new design -->
-    <div class="h-full pb-16 flex items-center justify-center">
-      <span class="text-xl font-medium text-neutral-50">{@product.name} doesn’t have any devices yet.</span>
-    </div>
-  <% else %>
-    <div class="listing">
-      <table class="">
-        <thead>
-          <tr>
-            <th class="checkbox">
-              <input
-                class="checkbox"
-                checked={Enum.any?(@selected_devices)}
-                id="check-uncheck"
-                title="Check/uncheck all"
-                {[checked: Enum.count(@selected_devices) == Enum.count(@devices)]}
-                id="toggle-all"
-                name="toggle-all"
-                type="checkbox"
-                phx-click="select-all"
-              />
-              <label for="check-uncheck">
-                <span class="hidden">Select all devices</span>
-                <svg :if={Enum.any?(@selected_devices)} xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path d="M2 6H6H10" stroke="#F4F4F5" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </label>
-            </th>
-            <th phx-click="sort" phx-value-sort="identifier" class="cursor-pointer">
-              <Sorting.sort_icon text="Identifier" field="identifier" selected_field={@current_sort} selected_direction={@sort_direction} />
-            </th>
-            <th class="w-24">
-              <div class="flex justify-center">
-                <span>Health</span>
-              </div>
-            </th>
-            <th>Firmware</th>
-            <th>Platform</th>
-            <th phx-click="sort" phx-value-sort="connection_established_at" class="cursor-pointer">
-              <Sorting.sort_icon text="Uptime" field="connection_established_at" selected_field={@current_sort} selected_direction={@sort_direction} />
-            </th>
-            <th phx-click="sort" phx-value-sort="tags" class="cursor-pointer">
-              <Sorting.sort_icon text="Tags" field="tags" selected_field={@current_sort} selected_direction={@sort_direction} />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr :for={device <- @devices} class={["border-b border-zinc-800 isolate clickable-table-row", device.id in @selected_devices && "selected-row"]} style={progress_style(@progress[device.id])}>
-            <td class="checkbox">
-              <input
-                id={"checkbox-device-#{device.id}"}
-                class="checkbox"
-                {if device.id in @selected_devices, do: [checked: true], else: []}
-                type="checkbox"
-                id={"#{device.id}-select"}
-                phx-value-id={device.id}
-                phx-click="select"
-              />
-              <label for={"checkbox-device-#{device.id}"} class="relative z-20">
-                <svg :if={device.id in @selected_devices} xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path d="M2.5 6.5L4.5 8.5L10 3" stroke="#F4F4F5" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </label>
-            </td>
-            <td>
-              <div class="flex gap-[8px] items-center">
-                <span title={connection_established_at_status(device.latest_connection)}>
-                  <%= if @device_statuses[device.identifier] == "online" do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
-                      <circle cx="3" cy="3" r="3" fill="#10B981" />
-                    </svg>
-                    <!-- use this when we have connection type information -->
-                    <%!-- <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <path
-                          d="M10.8573 9.17153C10.1261 8.44767 9.11595 7.99996 8.00016 7.99996C6.88438 7.99996 5.87423 8.44767 5.14302 9.17153M12.7621 7.28591C11.5434 6.07948 9.8598 5.33329 8.00016 5.33329C6.14052 5.33329 4.45694 6.07948 3.23826 7.28591M14.6668 5.4003C12.9607 3.71129 10.6037 2.66663 8.00016 2.66663C5.39667 2.66663 3.03964 3.71129 1.3335 5.4003M9.34703 12C9.34703 12.7363 8.74402 13.3333 8.00016 13.3333C7.25631 13.3333 6.65329 12.7363 6.65329 12C6.65329 11.6318 6.80405 11.2984 7.04778 11.0572C7.29152 10.8159 7.62823 10.6666 8.00016 10.6666C8.37209 10.6666 8.70881 10.8159 8.95254 11.0572C9.19628 11.2984 9.34703 11.6318 9.34703 12Z"
-                          stroke="#10B981"
-                          stroke-width="1.2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                        />
-                      </svg> --%>
-                  <% else %>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
-                      <circle cx="3" cy="3" r="3" fill="#71717A" />
-                    </svg>
-                    <!-- use this when we have connection type information -->
-                    <%!-- <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <path
-                          d="M8.00016 5.33333C9.8598 5.33333 11.5434 6.07953 12.7621 7.28596M14.6668 5.40034C12.9607 3.71134 10.6037 2.66667 8.00016 2.66667C7.3139 2.66667 6.64477 2.73925 6.00016 2.87709M5.14302 9.17157C5.87423 8.44772 6.88438 8 8.00016 8M3.23826 7.28595C3.91937 6.61169 4.7457 6.08118 5.66683 5.74436M1.3335 5.40034C2.0158 4.72489 2.8022 4.15249 3.66683 3.70874M2.00016 2L14.0002 14M9.34703 12C9.34703 12.7364 8.74402 13.3333 8.00016 13.3333C7.25631 13.3333 6.65329 12.7364 6.65329 12C6.65329 11.6318 6.80405 11.2985 7.04778 11.0572C7.29152 10.8159 7.62823 10.6667 8.00016 10.6667C8.37209 10.6667 8.70881 10.8159 8.95254 11.0572C9.19628 11.2985 9.34703 11.6318 9.34703 12Z"
-                          stroke="#EF4444"
-                          stroke-width="1.2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                        />
-                      </svg> --%>
-                  <% end %>
-                </span>
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m font-mono">
-                  {device.identifier}
-                  <span class="clickable-table-row-mask" />
-                </.link>
-                <span class={["flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800", !@progress[device.id] && "invisible"]}>
-                  <span class="text-xs text-zinc-300 tracking-tight">updating</span>
-                </span>
-              </div>
-            </td>
+  <.async_result :let={devices} assign={@devices}>
+    <:loading>
+      <div class="h-full pb-16 flex items-center justify-center">
+        <span class="text-xl font-medium text-neutral-50 animate-pulse">Loading devices ...</span>
+      </div>
+    </:loading>
+    <:failed :let={_failure}>
+      <div class="h-full pb-16 flex items-center justify-center">
+        <span class="text-xl font-medium text-neutral-50">There was an error loading the device list, please contact support.</span>
+      </div>
+    </:failed>
 
-            <td>
-              <div class="flex gap-[8px] items-center justify-center">
-                <HealthStatus.render device_id={device.id} health={device.latest_health} tooltip_position="top" />
-              </div>
-            </td>
+    <%= if Enum.empty?(devices) && !@currently_filtering do %>
+      <!-- TODO: Go over empty-state with new design -->
+      <div class="h-full pb-16 flex items-center justify-center">
+        <span class="text-xl font-medium text-neutral-50">{@product.name} doesn’t have any devices yet.</span>
+      </div>
+    <% else %>
+      <div class="listing">
+        <table class="">
+          <thead>
+            <tr>
+              <th class="checkbox">
+                <input
+                  class="checkbox"
+                  checked={Enum.any?(@selected_devices)}
+                  id="check-uncheck"
+                  title="Check/uncheck all"
+                  {[checked: Enum.count(@selected_devices) == Enum.count(devices)]}
+                  id="toggle-all"
+                  name="toggle-all"
+                  type="checkbox"
+                  phx-click="select-all"
+                />
+                <label for="check-uncheck">
+                  <span class="hidden">Select all devices</span>
+                  <svg :if={Enum.any?(@selected_devices)} xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path d="M2 6H6H10" stroke="#F4F4F5" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </label>
+              </th>
+              <th phx-click="sort" phx-value-sort="identifier" class="cursor-pointer">
+                <Sorting.sort_icon text="Identifier" field="identifier" selected_field={@current_sort} selected_direction={@sort_direction} />
+              </th>
+              <th class="w-24">
+                <div class="flex justify-center">
+                  <span>Health</span>
+                </div>
+              </th>
+              <th>Firmware</th>
+              <th>Platform</th>
+              <th phx-click="sort" phx-value-sort="connection_established_at" class="cursor-pointer">
+                <Sorting.sort_icon text="Uptime" field="connection_established_at" selected_field={@current_sort} selected_direction={@sort_direction} />
+              </th>
+              <th phx-click="sort" phx-value-sort="tags" class="cursor-pointer">
+                <Sorting.sort_icon text="Tags" field="tags" selected_field={@current_sort} selected_direction={@sort_direction} />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={device <- devices} class={["border-b border-zinc-800 isolate clickable-table-row", device.id in @selected_devices && "selected-row"]} style={progress_style(@progress[device.id])}>
+              <td class="checkbox">
+                <input
+                  id={"checkbox-device-#{device.id}"}
+                  class="checkbox"
+                  {if device.id in @selected_devices, do: [checked: true], else: []}
+                  type="checkbox"
+                  id={"#{device.id}-select"}
+                  phx-value-id={device.id}
+                  phx-click="select"
+                />
+                <label for={"checkbox-device-#{device.id}"} class="relative z-20">
+                  <svg :if={device.id in @selected_devices} xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path d="M2.5 6.5L4.5 8.5L10 3" stroke="#F4F4F5" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </label>
+              </td>
+              <td>
+                <div class="flex gap-[8px] items-center">
+                  <span title={connection_established_at_status(device.latest_connection)}>
+                    <%= if @device_statuses.result[device.identifier] == "online" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
+                        <circle cx="3" cy="3" r="3" fill="#10B981" />
+                      </svg>
+                      <!-- use this when we have connection type information -->
+                      <%!-- <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+                          <path
+                            d="M10.8573 9.17153C10.1261 8.44767 9.11595 7.99996 8.00016 7.99996C6.88438 7.99996 5.87423 8.44767 5.14302 9.17153M12.7621 7.28591C11.5434 6.07948 9.8598 5.33329 8.00016 5.33329C6.14052 5.33329 4.45694 6.07948 3.23826 7.28591M14.6668 5.4003C12.9607 3.71129 10.6037 2.66663 8.00016 2.66663C5.39667 2.66663 3.03964 3.71129 1.3335 5.4003M9.34703 12C9.34703 12.7363 8.74402 13.3333 8.00016 13.3333C7.25631 13.3333 6.65329 12.7363 6.65329 12C6.65329 11.6318 6.80405 11.2984 7.04778 11.0572C7.29152 10.8159 7.62823 10.6666 8.00016 10.6666C8.37209 10.6666 8.70881 10.8159 8.95254 11.0572C9.19628 11.2984 9.34703 11.6318 9.34703 12Z"
+                            stroke="#10B981"
+                            stroke-width="1.2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          />
+                        </svg> --%>
+                    <% else %>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
+                        <circle cx="3" cy="3" r="3" fill="#71717A" />
+                      </svg>
+                      <!-- use this when we have connection type information -->
+                      <%!-- <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+                          <path
+                            d="M8.00016 5.33333C9.8598 5.33333 11.5434 6.07953 12.7621 7.28596M14.6668 5.40034C12.9607 3.71134 10.6037 2.66667 8.00016 2.66667C7.3139 2.66667 6.64477 2.73925 6.00016 2.87709M5.14302 9.17157C5.87423 8.44772 6.88438 8 8.00016 8M3.23826 7.28595C3.91937 6.61169 4.7457 6.08118 5.66683 5.74436M1.3335 5.40034C2.0158 4.72489 2.8022 4.15249 3.66683 3.70874M2.00016 2L14.0002 14M9.34703 12C9.34703 12.7364 8.74402 13.3333 8.00016 13.3333C7.25631 13.3333 6.65329 12.7364 6.65329 12C6.65329 11.6318 6.80405 11.2985 7.04778 11.0572C7.29152 10.8159 7.62823 10.6667 8.00016 10.6667C8.37209 10.6667 8.70881 10.8159 8.95254 11.0572C9.19628 11.2985 9.34703 11.6318 9.34703 12Z"
+                            stroke="#EF4444"
+                            stroke-width="1.2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          />
+                        </svg> --%>
+                    <% end %>
+                  </span>
+                  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m font-mono">
+                    {device.identifier}
+                    <span class="clickable-table-row-mask" />
+                  </.link>
+                  <span class={["flex items-center gap-1 ml-2 pl-2.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800", !@progress[device.id] && "invisible"]}>
+                    <span class="text-xs text-zinc-300 tracking-tight">updating</span>
+                  </span>
+                </div>
+              </td>
 
-            <td>
-              <div class="flex gap-[8px] items-center">
-                <span class="font-mono">
+              <td>
+                <div class="flex gap-[8px] items-center justify-center">
+                  <HealthStatus.render device_id={device.id} health={device.latest_health} tooltip_position="top" />
+                </div>
+              </td>
+
+              <td>
+                <div class="flex gap-[8px] items-center">
+                  <span class="font-mono">
+                    <%= if is_nil(device.firmware_metadata) do %>
+                      Unknown
+                    <% else %>
+                      {device.firmware_metadata.version}
+                    <% end %>
+                  </span>
+                  <DeviceUpdateStatus.render :if={not is_nil(device.deployment_id)} device={device} />
+                </div>
+              </td>
+
+              <td>
+                <span>
                   <%= if is_nil(device.firmware_metadata) do %>
                     Unknown
                   <% else %>
-                    {device.firmware_metadata.version}
+                    {device.firmware_metadata.platform}
                   <% end %>
                 </span>
-                <DeviceUpdateStatus.render :if={not is_nil(device.deployment_id)} device={device} />
-              </div>
-            </td>
+              </td>
 
-            <td>
-              <span>
-                <%= if is_nil(device.firmware_metadata) do %>
-                  Unknown
-                <% else %>
-                  {device.firmware_metadata.platform}
-                <% end %>
-              </span>
-            </td>
+              <td>
+                <div :if={device.latest_connection} title={connection_established_at(device.latest_connection)}>
+                  {connection_established_at(device.latest_connection)}
+                </div>
+              </td>
 
-            <td>
-              <div :if={device.latest_connection} title={connection_established_at(device.latest_connection)}>
-                {connection_established_at(device.latest_connection)}
-              </div>
-            </td>
-
-            <td>
-              <div class="flex items-center gap-[4px]">
-                <%= if !is_nil(device.tags) do %>
-                  <%= for tag <- device.tags do %>
-                    <span class="tag">{tag}</span>
-                  <% end %>
-                <% end %>
-              </div>
-            </td>
-
-            <%!-- <td class="actions">
-              <div class="">
-                <a class="" data-target="#" id={"actions-#{device.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" phx-click={show_menu("actions-menu-#{device.id}")}>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-                    <path
-                      d="M9.1665 10C9.1665 10.2211 9.2543 10.433 9.41058 10.5893C9.56686 10.7456 9.77882 10.8334 9.99984 10.8334C10.2209 10.8334 10.4328 10.7456 10.5891 10.5893C10.7454 10.433 10.8332 10.2211 10.8332 10C10.8332 9.77903 10.7454 9.56707 10.5891 9.41079C10.4328 9.2545 10.2209 9.16671 9.99984 9.16671C9.77882 9.16671 9.56686 9.2545 9.41058 9.41079C9.2543 9.56707 9.1665 9.77903 9.1665 10ZM9.1665 15.8334C9.1665 16.0544 9.2543 16.2663 9.41058 16.4226C9.56686 16.5789 9.77882 16.6667 9.99984 16.6667C10.2209 16.6667 10.4328 16.5789 10.5891 16.4226C10.7454 16.2663 10.8332 16.0544 10.8332 15.8334C10.8332 15.6124 10.7454 15.4004 10.5891 15.2441C10.4328 15.0878 10.2209 15 9.99984 15C9.77882 15 9.56686 15.0878 9.41058 15.2441C9.2543 15.4004 9.1665 15.6124 9.1665 15.8334ZM9.1665 4.16671C9.1665 4.38772 9.2543 4.59968 9.41058 4.75596C9.56686 4.91224 9.77882 5.00004 9.99984 5.00004C10.2209 5.00004 10.4328 4.91224 10.5891 4.75596C10.7454 4.59968 10.8332 4.38772 10.8332 4.16671C10.8332 3.94569 10.7454 3.73373 10.5891 3.57745C10.4328 3.42117 10.2209 3.33337 9.99984 3.33337C9.77882 3.33337 9.56686 3.42117 9.41058 3.57745C9.2543 3.73373 9.1665 3.94569 9.1665 4.16671Z"
-                      stroke="#A1A1AA"
-                      stroke-width="1.2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </a>
-                <div class="hidden absolute right-[24px] menu-box" id={"actions-menu-#{device.id}"} phx-click-away={hide_menu("actions-menu-#{device.id}")} phx-key="escape" )}>
-                  <.link phx-click="reboot-device" phx-value-device_identifier={device.identifier} class="dropdown-item">
-                    Reboot
-                  </.link>
-                  <div class="dropdown-divider"></div>
-                  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
-                    Console
-                  </.link>
-                  <div class="dropdown-divider"></div>
-                  <div class="dropdown-divider"></div>
-                  <.link phx-click="toggle-device-updates" phx-value-device_identifier={device.identifier} class="dropdown-item">
-                    <span>
-                      {if device.updates_enabled, do: "Disable Updates", else: "Enable Updates"}
-                    </span>
-                  </.link>
-
-                  <div class="dropdown-divider"></div>
-
-                  <%= link to: Routes.device_path(@socket, :export_audit_logs, @org.name, @product.name, device.identifier), class: "dropdown-item", aria: [label: "Download Audit Logs"] do %>
-                    <div class="button-icon download"></div>
-                    <span class="action-text">Download Audit Logs</span>
+              <td>
+                <div class="flex items-center gap-[4px]">
+                  <%= if !is_nil(device.tags) do %>
+                    <%= for tag <- device.tags do %>
+                      <span class="tag">{tag}</span>
+                    <% end %>
                   <% end %>
                 </div>
-              </div>
-            </td> --%>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  <% end %>
+              </td>
+
+              <%!-- <td class="actions">
+                <div class="">
+                  <a class="" data-target="#" id={"actions-#{device.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" phx-click={show_menu("actions-menu-#{device.id}")}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+                      <path
+                        d="M9.1665 10C9.1665 10.2211 9.2543 10.433 9.41058 10.5893C9.56686 10.7456 9.77882 10.8334 9.99984 10.8334C10.2209 10.8334 10.4328 10.7456 10.5891 10.5893C10.7454 10.433 10.8332 10.2211 10.8332 10C10.8332 9.77903 10.7454 9.56707 10.5891 9.41079C10.4328 9.2545 10.2209 9.16671 9.99984 9.16671C9.77882 9.16671 9.56686 9.2545 9.41058 9.41079C9.2543 9.56707 9.1665 9.77903 9.1665 10ZM9.1665 15.8334C9.1665 16.0544 9.2543 16.2663 9.41058 16.4226C9.56686 16.5789 9.77882 16.6667 9.99984 16.6667C10.2209 16.6667 10.4328 16.5789 10.5891 16.4226C10.7454 16.2663 10.8332 16.0544 10.8332 15.8334C10.8332 15.6124 10.7454 15.4004 10.5891 15.2441C10.4328 15.0878 10.2209 15 9.99984 15C9.77882 15 9.56686 15.0878 9.41058 15.2441C9.2543 15.4004 9.1665 15.6124 9.1665 15.8334ZM9.1665 4.16671C9.1665 4.38772 9.2543 4.59968 9.41058 4.75596C9.56686 4.91224 9.77882 5.00004 9.99984 5.00004C10.2209 5.00004 10.4328 4.91224 10.5891 4.75596C10.7454 4.59968 10.8332 4.38772 10.8332 4.16671C10.8332 3.94569 10.7454 3.73373 10.5891 3.57745C10.4328 3.42117 10.2209 3.33337 9.99984 3.33337C9.77882 3.33337 9.56686 3.42117 9.41058 3.57745C9.2543 3.73373 9.1665 3.94569 9.1665 4.16671Z"
+                        stroke="#A1A1AA"
+                        stroke-width="1.2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </a>
+                  <div class="hidden absolute right-[24px] menu-box" id={"actions-menu-#{device.id}"} phx-click-away={hide_menu("actions-menu-#{device.id}")} phx-key="escape" )}>
+                    <.link phx-click="reboot-device" phx-value-device_identifier={device.identifier} class="dropdown-item">
+                      Reboot
+                    </.link>
+                    <div class="dropdown-divider"></div>
+                    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
+                      Console
+                    </.link>
+                    <div class="dropdown-divider"></div>
+                    <div class="dropdown-divider"></div>
+                    <.link phx-click="toggle-device-updates" phx-value-device_identifier={device.identifier} class="dropdown-item">
+                      <span>
+                        {if device.updates_enabled, do: "Disable Updates", else: "Enable Updates"}
+                      </span>
+                    </.link>
+
+                    <div class="dropdown-divider"></div>
+
+                    <%= link to: Routes.device_path(@socket, :export_audit_logs, @org.name, @product.name, device.identifier), class: "dropdown-item", aria: [label: "Download Audit Logs"] do %>
+                      <div class="button-icon download"></div>
+                      <span class="action-text">Download Audit Logs</span>
+                    <% end %>
+                  </div>
+                </div>
+              </td> --%>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </.async_result>
 </div>
 
 <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16 z-40">

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -24,7 +24,7 @@
         {@total_entries}
       </div>
     </div>
-    <form :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} class="flex items-center h-full" phx-change="update-filters">
+    <form :if={has_results?(@devices, @currently_filtering)} class="flex items-center h-full" phx-change="update-filters">
       <div class="grid grid-cols-1 h-full">
         <input
           type="text"
@@ -48,13 +48,13 @@
         </svg>
       </div>
     </form>
-    <.button :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org.name}/#{@product.name}/devices/export"} download>
+    <.button :if={has_results?(@devices, @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org.name}/#{@product.name}/devices/export"} download>
       <.icon name="export" /> Export
     </.button>
     <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"} aria-label="Add new device">
       <.icon name="add" /> Add Device
     </.button>
-    <.button :if={@devices.ok? && (Enum.any?(@devices.result) || @currently_filtering)} type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
+    <.button :if={has_results?(@devices, @currently_filtering)} type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
       <.icon name="filter" /> Filters
     </.button>
   </div>

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -720,6 +720,13 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> JS.hide(transition: "fade-out", to: "##{id}")
   end
 
+  def fade_in(selector) do
+    JS.show(
+      to: selector,
+      transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
+    )
+  end
+
   defp update_flash_for_moving_deployment_group(
          socket,
          updated_count,

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -473,9 +473,13 @@ defmodule NervesHubWeb.Live.Devices.Index do
       filters: transform_deployment_filter(socket.assigns.current_filters)
     }
 
-    socket
-    |> assign(:devices, AsyncResult.loading())
-    |> assign(:device_statuses, AsyncResult.loading())
+    if socket.assigns[:devices] && socket.assigns.devices.ok? do
+      socket
+    else
+      socket
+      |> assign(:devices, AsyncResult.loading())
+      |> assign(:device_statuses, AsyncResult.loading())
+    end
     |> start_async(:update_device_list, fn ->
       %{page: Devices.filter(product, user, opts), opts: paginate_opts}
     end)

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -505,6 +505,11 @@ defmodule NervesHubWeb.Live.Devices.Index do
   def handle_async(:update_device_list, {:exit, reason}, socket) do
     %{devices: devices, device_statuses: device_statuses} = socket.assigns
 
+    message =
+      "Live.Devices.Index.handle_async:update_device_list failed due to exit: #{inspect(reason)}"
+
+    {:ok, _} = Sentry.capture_message(message, result: :none)
+
     socket
     |> assign(:devices, AsyncResult.failed(devices, {:exit, reason}))
     |> assign(:device_statuses, AsyncResult.ok(device_statuses, {:exit, reason}))

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -13,6 +13,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHub.Products.Product
   alias NervesHub.Tracker
 
+  alias Phoenix.LiveView.AsyncResult
   alias Phoenix.LiveView.JS
   alias Phoenix.Socket.Broadcast
 
@@ -239,17 +240,15 @@ defmodule NervesHubWeb.Live.Devices.Index do
     selected_devices = socket.assigns.selected_devices
 
     selected_devices =
-      if Enum.count(selected_devices) > 0 do
+      if !socket.assigns.devices.ok? || Enum.count(selected_devices) > 0 do
         []
       else
-        Enum.map(socket.assigns.devices, & &1.id)
+        Enum.map(socket.assigns.devices.result, & &1.id)
       end
 
-    socket =
-      socket
-      |> assign(:selected_devices, selected_devices)
-
-    {:noreply, socket}
+    socket
+    |> assign(:selected_devices, selected_devices)
+    |> noreply()
   end
 
   def handle_event("deselect-all", _, socket) do
@@ -474,7 +473,16 @@ defmodule NervesHubWeb.Live.Devices.Index do
       filters: transform_deployment_filter(socket.assigns.current_filters)
     }
 
-    page = Devices.filter(product, user, opts)
+    socket
+    |> assign(:devices, AsyncResult.loading())
+    |> assign(:device_statuses, AsyncResult.loading())
+    |> start_async(:update_device_list, fn ->
+      %{page: Devices.filter(product, user, opts), opts: paginate_opts}
+    end)
+  end
+
+  def handle_async(:update_device_list, {:ok, %{page: page, opts: paginate_opts}}, socket) do
+    %{devices: devices, device_statuses: device_statuses} = socket.assigns
 
     statuses =
       Enum.into(page.entries, %{}, fn device ->
@@ -484,11 +492,22 @@ defmodule NervesHubWeb.Live.Devices.Index do
       end)
 
     socket
-    |> assign(:device_statuses, statuses)
-    |> assign_display_devices(page)
+    |> assign(:devices, AsyncResult.ok(devices, page.entries))
+    |> assign(:device_statuses, AsyncResult.ok(device_statuses, statuses))
+    |> device_pagination_assigns(paginate_opts, page)
+    |> noreply()
   end
 
-  defp assign_display_devices(%{assigns: %{paginate_opts: paginate_opts}} = socket, page) do
+  def handle_async(:update_device_list, {:exit, reason}, socket) do
+    %{devices: devices, device_statuses: device_statuses} = socket.assigns
+
+    socket
+    |> assign(:devices, AsyncResult.failed(devices, {:exit, reason}))
+    |> assign(:device_statuses, AsyncResult.ok(device_statuses, {:exit, reason}))
+    |> noreply()
+  end
+
+  defp device_pagination_assigns(socket, paginate_opts, page) do
     paginate_opts =
       paginate_opts
       |> Map.put(:page_number, page.current_page)
@@ -496,7 +515,6 @@ defmodule NervesHubWeb.Live.Devices.Index do
       |> Map.put(:total_pages, page.total_pages)
 
     socket
-    |> assign(:devices, page.entries)
     |> assign(:total_entries, page.total_count)
     |> assign(:paginate_opts, paginate_opts)
   end

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -781,4 +781,8 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   defp maybe_assign_available_deployment_groups_for_filtered_platform(socket),
     do: assign(socket, :available_deployment_groups_for_filtered_platform, [])
+
+  defp has_results?(%AsyncResult{} = device_async, currently_filtering?) do
+    device_async.ok? && (Enum.any?(device_async.result) || currently_filtering?)
+  end
 end

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -1,432 +1,465 @@
-<%= if @devices == [] && !@currently_filtering do %>
-  <div class="no-results-blowup-wrapper">
-    <img src="/images/device.svg" alt="No devices" />
-    <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any devices yet</h3>
-    <div class="mt-3">
-      <.link class="btn btn-outline-light btn-action" aria-label="Add new device" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"}>
-        <div class="button-icon add"></div>
-        <span class="action-text">Add your first Device</span>
-      </.link>
+<.async_result :let={devices} assign={@devices}>
+  <:loading>
+    <div class="no-results-blowup-wrapper">
+      <img src="/images/device.svg" alt="No devices" />
+      <h3 style="margin-top: 2.75rem">Loading devices...</h3>
     </div>
-    <p class="mt-3">
-      Or follow <a class="strong inline" target="_blank" rel="noopener noreferrer" href="https://docs.nerves-hub.org/nerves-hub/setup/devices">these steps</a> to add a device using the terminal.
-    </p>
-  </div>
-<% else %>
-  <div class="action-row">
-    <div class="flex-row align-items-center">
-      <h1 class="mr-3 mb-0">Devices</h1>
-      <button
-        class={"btn btn-outline-light btn-action #{if @show_filters, do: "btn-filter-hide", else: "btn-filter-show"}"}
-        type="button"
-        phx-click="toggle-filters"
-        phx-value-toggle={to_string(@show_filters)}
-      >
-        <span class="action-text">
-          {if @show_filters, do: "Hide Filters", else: "Show Filters"}
-        </span>
-        <span class="button-icon filter"></span>
-      </button>
-      <p class="ml-2" style="opacity: 0.7;">
-        {@total_entries} devices found <span :if={Enum.count(@selected_devices) > 0}>({Enum.count(@selected_devices)} selected)</span>
+  </:loading>
+  <:failed :let={_failure}>
+    <div class="no-results-blowup-wrapper">
+      <img src="/images/device.svg" alt="No devices" />
+      <h3 style="margin-top: 2.75rem">There was an error loading the device for {@product.name}</h3>
+    </div>
+  </:failed>
+
+  <%= if Enum.empty?(devices) && !@currently_filtering do %>
+    <div class="no-results-blowup-wrapper">
+      <img src="/images/device.svg" alt="No devices" />
+      <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any devices yet</h3>
+      <div class="mt-3">
+        <.link class="btn btn-outline-light btn-action" aria-label="Add new device" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"}>
+          <div class="button-icon add"></div>
+          <span class="action-text">Add your first Device</span>
+        </.link>
+      </div>
+      <p class="mt-3">
+        Or follow <a class="strong inline" target="_blank" rel="noopener noreferrer" href="https://docs.nerves-hub.org/nerves-hub/setup/devices">these steps</a> to add a device using the terminal.
       </p>
     </div>
-    <div>
-      <a class="btn btn-outline-light btn-action" aria-label="Add new device" href={Routes.product_path(@socket, :devices_export, @org.name, @product.name)}>
-        <div class="button-icon download"></div>
-        <span class="action-text">Export</span>
-      </a>
-      <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"} class="btn btn-outline-light btn-action" aria-label="Add new device">
-        <div class="button-icon add"></div>
-        <span class="action-text">Add Device</span>
-      </.link>
+  <% else %>
+    <div class="action-row">
+      <div class="flex-row align-items-center">
+        <h1 class="mr-3 mb-0">Devices</h1>
+        <button
+          class={"btn btn-outline-light btn-action #{if @show_filters, do: "btn-filter-hide", else: "btn-filter-show"}"}
+          type="button"
+          phx-click="toggle-filters"
+          phx-value-toggle={to_string(@show_filters)}
+        >
+          <span class="action-text">
+            {if @show_filters, do: "Hide Filters", else: "Show Filters"}
+          </span>
+          <span class="button-icon filter"></span>
+        </button>
+        <p class="ml-2" style="opacity: 0.7;">
+          {@total_entries} devices found <span :if={Enum.count(@selected_devices) > 0}>({Enum.count(@selected_devices)} selected)</span>
+        </p>
+      </div>
+      <div>
+        <a class="btn btn-outline-light btn-action" aria-label="Add new device" href={Routes.product_path(@socket, :devices_export, @org.name, @product.name)}>
+          <div class="button-icon download"></div>
+          <span class="action-text">Export</span>
+        </a>
+        <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"} class="btn btn-outline-light btn-action" aria-label="Add new device">
+          <div class="button-icon add"></div>
+          <span class="action-text">Add Device</span>
+        </.link>
+      </div>
     </div>
-  </div>
 
-  <div class="action-row btn-group-toggle" style="justify-content: flex-end; display: flex; gap: 4px;">
-    <%= for size <- @paginate_opts.page_sizes do %>
-      <button phx-click="set-paginate-opts" phx-value-page-size={size} class={"btn btn-secondary btn-sm #{if size == @paginate_opts.page_size, do: "active"}"}>
-        {size}
-      </button>
+    <div class="action-row btn-group-toggle" style="justify-content: flex-end; display: flex; gap: 4px;">
+      <%= for size <- @paginate_opts.page_sizes do %>
+        <button phx-click="set-paginate-opts" phx-value-page-size={size} class={"btn btn-secondary btn-sm #{if size == @paginate_opts.page_size, do: "active"}"}>
+          {size}
+        </button>
+      <% end %>
+    </div>
+    <%= if @show_filters do %>
+      <div class="filter-wrapper">
+        <h4 class="color-white mb-2">Filters</h4>
+        <form id="filter-form" phx-change="update-filters" class="filter-form device-filters">
+          <div class="form-group">
+            <label for="input_id">ID</label>
+            <input type="text" name="device_id" id="input_id" class="form-control" value={@current_filters[:device_id]} phx-debounce="500" />
+          </div>
+          <div class="form-group">
+            <label for="input_connection">Connection</label>
+            <div class="pos-rel">
+              <select name="connection" id="input_connection" class="form-control">
+                <option {selected?(@current_filters, :connection, "")} value="">All</option>
+                <option {selected?(@current_filters, :connection, "connected")} value="connected">Connected</option>
+                <option {selected?(@current_filters, :connection, "disconnected")} value="disconnected">Disconnected</option>
+                <option {selected?(@current_filters, :connection, "not_seen")} value="not_seen">Not Seen</option>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="connection_type">Connection Type</label>
+            <div class="pos-rel">
+              <select name="connection_type" id="connection_type" class="form-control">
+                <option {selected?(@current_filters, :connection_type, "")} value="">All</option>
+                <option {selected?(@current_filters, :connection_type, "cellular")} value="cellular">Cellular</option>
+                <option {selected?(@current_filters, :connection_type, "ethernet")} value="ethernet">Ethernet</option>
+                <option {selected?(@current_filters, :connection_type, "wifi")} value="wifi">WiFi</option>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="deployment_id">Deployment Group</label>
+            <select name="deployment_id" id="deployment_id" class="form-control">
+              <option {selected?(@current_filters, :deployment_id, "")} value="">All</option>
+              <%= for deployment_group <- @deployment_groups do %>
+                <option {selected?(@current_filters, :deployment_id, deployment_group.id)} value={deployment_group.id}>{deployment_group.name}</option>
+              <% end %>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="input_health">Firmware Updates</label>
+            <div class="pos-rel">
+              <select name="updates" id="input_health" class="form-control">
+                <option {selected?(@current_filters, :updates, "")} value="">All</option>
+                <option {selected?(@current_filters, :updates, "enabled")} value="enabled">Enabled</option>
+                <option {selected?(@current_filters, :updates, "penalty-box")} value="penalty-box">Penalty Box</option>
+                <option {selected?(@current_filters, :updates, "disabled")} value="disabled">Disabled</option>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="input_firmware">Firmware</label>
+            <div class="pos-rel">
+              <select name="firmware_version" id="input_firmware" class="form-control">
+                <option {selected?(@current_filters, :firmware_version, "")} value="">All</option>
+                <%= for version <- @firmware_versions do %>
+                  <option {selected?(@current_filters, :firmware_version, version)}>{version}</option>
+                <% end %>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="platform">Platform</label>
+            <div class="pos-rel">
+              <select name="platform" id="platform" class="form-control">
+                <option {selected?(@current_filters, :platform, "")} value="">All</option>
+                <%= for platform <- @platforms do %>
+                  <option {selected?(@current_filters, :platform, platform)} value={platform}>{if platform, do: platform, else: "Unknown"}</option>
+                <% end %>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="input_tags">Tags</label>
+            <input type="text" name="tag" id="input_tags" class="form-control" value={@current_filters[:tag]} phx-debounce="500" />
+          </div>
+          <div class="form-group">
+            <label for="has_no_tags">Untagged</label>
+            <div class="pos-rel">
+              <select name="has_no_tags" id="has_no_tags" class="form-control">
+                <option {selected?(@current_filters, :has_no_tags, false)} value="false">All</option>
+                <option {selected?(@current_filters, :has_no_tags, true)} value="true">Only untagged</option>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="alarm_status">Alarm Status</label>
+            <div class="pos-rel">
+              <select name="alarm_status" id="alarm_status" class="form-control">
+                <option {selected?(@current_filters, :alarm_status, "")} value="">All</option>
+                <option {selected?(@current_filters, :alarm_status, "with")} value="with">Has Alarms</option>
+                <option {selected?(@current_filters, :alarm_status, "without")} value="without">No alarms</option>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="alarm">Alarm</label>
+            <div class="pos-rel">
+              <select name="alarm" id="alarm" class="form-control">
+                <option {selected?(@current_filters, :alarm, "")} value="">All</option>
+                <%= for alarm <- @current_alarms do %>
+                  <option value={alarm} {selected?(@current_filters, :alarm, alarm)}>{alarm}</option>
+                <% end %>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="metrics_key">Metrics</label>
+            <div class="pos-rel">
+              <select name="metrics_key" id="metrics_key" class="form-control">
+                <option {selected?(@current_filters, :metrics_key, "")} value="">All</option>
+                <option :for={key <- @metrics_keys} value={key} {selected?(@current_filters, :metrics_key, key)}>{key}</option>
+              </select>
+              <div class="select-icon"></div>
+            </div>
+          </div>
+          <div :if={@current_filters.metrics_key != ""} class="form-group">
+            <label for="metrics_operator">Operator</label>
+            <select name="metrics_operator" id="metrics_operator" class="form-control">
+              <option {selected?(@current_filters, :metrics_operator, "gt")} value="gt">Greater Than</option>
+              <option {selected?(@current_filters, :metrics_operator, "lt")} value="lt">Less than</option>
+            </select>
+            <div class="select-icon"></div>
+          </div>
+          <div :if={@current_filters.metrics_key != ""} class="form-group">
+            <label for="metrics_value">Value</label>
+            <input type="number" name="metrics_value" id="metrics_value" class="form-control" value={@current_filters[:metrics_value]} phx-debounce="100" />
+          </div>
+        </form>
+        <button class="btn btn-secondary" type="button" phx-click="reset-filters">Reset Filters</button>
+      </div>
     <% end %>
-  </div>
-  <%= if @show_filters do %>
-    <div class="filter-wrapper">
-      <h4 class="color-white mb-2">Filters</h4>
-      <form id="filter-form" phx-change="update-filters" class="filter-form device-filters">
-        <div class="form-group">
-          <label for="input_id">ID</label>
-          <input type="text" name="device_id" id="input_id" class="form-control" value={@current_filters[:device_id]} phx-debounce="500" />
-        </div>
-        <div class="form-group">
-          <label for="input_connection">Connection</label>
-          <div class="pos-rel">
-            <select name="connection" id="input_connection" class="form-control">
-              <option {selected?(@current_filters, :connection, "")} value="">All</option>
-              <option {selected?(@current_filters, :connection, "connected")} value="connected">Connected</option>
-              <option {selected?(@current_filters, :connection, "disconnected")} value="disconnected">Disconnected</option>
-              <option {selected?(@current_filters, :connection, "not_seen")} value="not_seen">Not Seen</option>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="connection_type">Connection Type</label>
-          <div class="pos-rel">
-            <select name="connection_type" id="connection_type" class="form-control">
-              <option {selected?(@current_filters, :connection_type, "")} value="">All</option>
-              <option {selected?(@current_filters, :connection_type, "cellular")} value="cellular">Cellular</option>
-              <option {selected?(@current_filters, :connection_type, "ethernet")} value="ethernet">Ethernet</option>
-              <option {selected?(@current_filters, :connection_type, "wifi")} value="wifi">WiFi</option>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="deployment_id">Deployment Group</label>
-          <select name="deployment_id" id="deployment_id" class="form-control">
-            <option {selected?(@current_filters, :deployment_id, "")} value="">All</option>
-            <%= for deployment_group <- @deployment_groups do %>
-              <option {selected?(@current_filters, :deployment_id, deployment_group.id)} value={deployment_group.id}>{deployment_group.name}</option>
-            <% end %>
-          </select>
-        </div>
-        <div class="form-group">
-          <label for="input_health">Firmware Updates</label>
-          <div class="pos-rel">
-            <select name="updates" id="input_health" class="form-control">
-              <option {selected?(@current_filters, :updates, "")} value="">All</option>
-              <option {selected?(@current_filters, :updates, "enabled")} value="enabled">Enabled</option>
-              <option {selected?(@current_filters, :updates, "penalty-box")} value="penalty-box">Penalty Box</option>
-              <option {selected?(@current_filters, :updates, "disabled")} value="disabled">Disabled</option>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="input_firmware">Firmware</label>
-          <div class="pos-rel">
-            <select name="firmware_version" id="input_firmware" class="form-control">
-              <option {selected?(@current_filters, :firmware_version, "")} value="">All</option>
-              <%= for version <- @firmware_versions do %>
-                <option {selected?(@current_filters, :firmware_version, version)}>{version}</option>
-              <% end %>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="input_platform">Platform</label>
-          <div class="pos-rel">
-            <select name="platform" id="platform" class="form-control">
-              <option {selected?(@current_filters, :platform, "")} value="">All</option>
-              <%= for platform <- @platforms do %>
-                <option {selected?(@current_filters, :platform, platform)}>{if platform, do: platform, else: "Unknown"}</option>
-              <% end %>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="input_tags">Tags</label>
-          <input type="text" name="tag" id="input_tags" class="form-control" value={@current_filters[:tag]} phx-debounce="500" />
-        </div>
-        <div class="form-group">
-          <label for="has_no_tags">Untagged</label>
-          <div class="pos-rel">
-            <select name="has_no_tags" id="has_no_tags" class="form-control">
-              <option {selected?(@current_filters, :has_no_tags, false)} value="false">All</option>
-              <option {selected?(@current_filters, :has_no_tags, true)} value="true">Only untagged</option>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="alarm_status">Alarm Status</label>
-          <div class="pos-rel">
-            <select name="alarm_status" id="alarm_status" class="form-control">
-              <option {selected?(@current_filters, :alarm_status, "")} value="">All</option>
-              <option {selected?(@current_filters, :alarm_status, "with")} value="with">Has Alarms</option>
-              <option {selected?(@current_filters, :alarm_status, "without")} value="without">No alarms</option>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="alarm">Alarm</label>
-          <div class="pos-rel">
-            <select name="alarm" id="alarm" class="form-control">
-              <option {selected?(@current_filters, :alarm, "")} value="">All</option>
-              <%= for alarm <- @current_alarms do %>
-                <option {selected?(@current_filters, :alarm, alarm)}>{alarm}</option>
-              <% end %>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="metrics">Metrics</label>
-          <div class="pos-rel">
-            <select name="metrics_key" id="metrics_key" class="form-control">
-              <option {selected?(@current_filters, :metrics_key, "")} value="">All</option>
-              <%= for key <- @metrics_keys do %>
-                <option {selected?(@current_filters, :metrics_key, key)}>{key}</option>
-              <% end %>
-            </select>
-            <div class="select-icon"></div>
-          </div>
-        </div>
-        <div :if={@current_filters.metrics_key != ""} class="form-group">
-          <label for="metrics_operator">Operator</label>
-          <select name="metrics_operator" id="metrics_operator" class="form-control">
-            <option {selected?(@current_filters, :metrics_operator, "gt")} value="gt">Greater Than</option>
-            <option {selected?(@current_filters, :metrics_operator, "lt")} value="lt">Less than</option>
-          </select>
-          <div class="select-icon"></div>
-        </div>
-        <div :if={@current_filters.metrics_key != ""} class="form-group">
-          <label for="metrics_value">Value</label>
-          <input type="number" name="metrics_value" id="metrics_value" class="form-control" value={@current_filters[:metrics_value]} phx-debounce="100" />
-        </div>
-      </form>
-      <button class="btn btn-secondary" type="button" phx-click="reset-filters">Reset Filters</button>
-    </div>
-  <% end %>
 
-  <div class={if length(@selected_devices) == 0, do: "hidden"}>
-    <div class="filter-wrapper">
-      <div class="flex-row">
-        <h4 class="color-white mb-2 flex-row align-items-center flex-grow">Bulk Actions <span class="help-text ml-2">{length(@selected_devices)} selected</span></h4>
+    <div class={if length(@selected_devices) == 0, do: "hidden"}>
+      <div class="filter-wrapper">
+        <div class="flex-row">
+          <h4 class="color-white mb-2 flex-row align-items-center flex-grow">Bulk Actions <span class="help-text ml-2">{length(@selected_devices)} selected</span></h4>
 
-        <button class="btn btn-outline-light btn-action btn-secondary" type="button" phx-click="deselect-all">Deselect All</button>
-      </div>
+          <button class="btn btn-outline-light btn-action btn-secondary" type="button" phx-click="deselect-all">Deselect All</button>
+        </div>
 
-      <div class="row mt-2">
-        <form id="move-product" class="col-lg-4" phx-change="target-product" phx-submit="move-devices-product">
-          <label for="move_to_product">Move device(s) to product:</label>
-          <div class="flex-row align-items-center">
-            <div class="flex-grow pos-rel">
-              <select name="product" id="move_to_product" class="form-control">
-                <option value=""></option>
-                <%= for org <- @user.orgs, products = org.products, length(products) > 0 do %>
-                  <optgroup label={org.name}>
-                    <%= for product <- products, product.id != @product.id do %>
-                      <option {target_selected?(@target_product, product.name)} value={"#{org.id}:#{product.id}:#{product.name}"}>{product.name}</option>
-                    <% end %>
-                  </optgroup>
-                <% end %>
-              </select>
-              <div class="select-icon"></div>
-            </div>
+        <div class="row mt-2">
+          <form id="move-product" class="col-lg-4" phx-change="target-product" phx-submit="move-devices-product">
+            <label for="move_to_product">Move device(s) to product:</label>
+            <div class="flex-row align-items-center">
+              <div class="flex-grow pos-rel">
+                <select name="product" id="move_to_product" class="form-control">
+                  <option value=""></option>
+                  <%= for org <- @user.orgs, products = org.products, length(products) > 0 do %>
+                    <optgroup label={org.name}>
+                      <%= for product <- products, product.id != @product.id do %>
+                        <option {target_selected?(@target_product, product.name)} value={"#{org.id}:#{product.id}:#{product.name}"}>{product.name}</option>
+                      <% end %>
+                    </optgroup>
+                  <% end %>
+                </select>
+                <div class="select-icon"></div>
+              </div>
 
-            <button class="btn btn-outline-light btn-action btn-primary ml-1" type="submit" data-confirm={move_alert(@target_product)} {unless @target_product, do: [disabled: true], else: []}>
-              Move
-            </button>
-          </div>
-        </form>
-
-        <form id="bulk-tag-input" class="col-lg-4" phx-submit="tag-devices" phx-change="validate-tags">
-          <label for="input_set_tags">Set tag(s) to:</label>
-          <div class="flex-row align-items-center">
-            <div class="flex-grow">
-              <input type="text" name="tags" id="input_set_tags" class="form-control" value={@current_filters[:tag]} phx-debounce="500" />
-            </div>
-            <button
-              class="btn btn-outline-light btn-action btn-primary ml-1"
-              type="submit"
-              data-confirm="This will update tags on all selected devices"
-              {if @valid_tags && @device_tags != "", do: [], else: [disabled: true]}
-            >
-              Set
-            </button>
-          </div>
-          <div class={if @valid_tags, do: "hidden"}><span class="has-error"> Tags Cannot Contain Spaces </span></div>
-        </form>
-
-        <form :if={Enum.any?(@available_deployment_groups_for_filtered_platform)} id="move-deployment" class="col-lg-4" phx-change="target-deployment-group" phx-submit="move-devices-deployment-group">
-          <label for="move_to_deployment_group">Move device(s) to deployment group:</label>
-          <div class="flex-row align-items-center">
-            <div class="flex-grow pos-rel">
-              <select name="deployment_group" id="move_to_deployment_group" class="form-control">
-                <option value=""></option>
-                <%= for deployment_group <- @available_deployment_groups_for_filtered_platform do %>
-                  <option value={deployment_group.id} {if @target_deployment_group && @target_deployment_group.id == deployment_group.id, do: [selected: true], else: []}>
-                    {deployment_group.name}
-                  </option>
-                <% end %>
-              </select>
-              <div class="select-icon"></div>
-            </div>
-
-            <button
-              class="btn btn-outline-light btn-action btn-primary ml-1"
-              type="submit"
-              data-confirm={"This will move all selected devices to #{@target_deployment_group && @target_deployment_group.name}. Continue?"}
-              id="move-deployment-group-submit"
-              {unless @target_deployment_group, do: [disabled: true], else: []}
-            >
-              Move
-            </button>
-          </div>
-        </form>
-      </div>
-
-      <div class="row mt-2">
-        <div class="col-lg-12">
-          <label>Firmware Updates</label>
-
-          <div class="flex-row flex-gap-1">
-            <form class="inline-block" id="disable-updates" phx-submit="disable-updates-for-devices">
-              <button class="btn btn-outline-light btn-action" type="submit" data-confirm="This will disable updates for all selected devices" phx-click="disable-updates-for-devices">
-                <span class="button-icon firmware-disabled"></span>
-                <span class="action-text">Disable</span>
+              <button class="btn btn-outline-light btn-action btn-primary ml-1" type="submit" data-confirm={move_alert(@target_product)} {unless @target_product, do: [disabled: true], else: []}>
+                Move
               </button>
-            </form>
+            </div>
+          </form>
 
-            <form class="inline-block" id="enable-updates" phx-submit="enable-updates-for-devices">
-              <button class="btn btn-outline-light btn-action" type="submit" data-confirm="This will enable updates for all selected devices" phx-click="enable-updates-for-devices">
-                <span class="button-icon firmware-enabled"></span>
-                <span class="action-text">Enable</span>
+          <form id="bulk-tag-input" class="col-lg-4" phx-submit="tag-devices" phx-change="validate-tags">
+            <label for="input_set_tags">Set tag(s) to:</label>
+            <div class="flex-row align-items-center">
+              <div class="flex-grow">
+                <input type="text" name="tags" id="input_set_tags" class="form-control" value={@current_filters[:tag]} phx-debounce="500" />
+              </div>
+              <button
+                class="btn btn-outline-light btn-action btn-primary ml-1"
+                type="submit"
+                data-confirm="This will update tags on all selected devices"
+                {if @valid_tags && @device_tags != "", do: [], else: [disabled: true]}
+              >
+                Set
               </button>
-            </form>
+            </div>
+            <div class={if @valid_tags, do: "hidden"}><span class="has-error"> Tags Cannot Contain Spaces </span></div>
+          </form>
 
-            <form class="inline-block" id="clear-penalty-box" phx-submit="clear-penalty-box-for-devices">
-              <button class="btn btn-outline-light btn-action" type="submit" data-confirm="This will clear the penalty box all selected devices" phx-click="clear-penalty-box-for-devices">
-                <span class="button-icon firmware-enabled"></span>
-                <span class="action-text">Clear Penalty box</span>
+          <form
+            :if={Enum.any?(@available_deployment_groups_for_filtered_platform)}
+            id="move-deployment"
+            class="col-lg-4"
+            phx-change="target-deployment-group"
+            phx-submit="move-devices-deployment-group"
+          >
+            <label for="move_to_deployment_group">Move device(s) to deployment group:</label>
+            <div class="flex-row align-items-center">
+              <div class="flex-grow pos-rel">
+                <select name="deployment_group" id="move_to_deployment_group" class="form-control">
+                  <option value=""></option>
+                  <%= for deployment_group <- @available_deployment_groups_for_filtered_platform do %>
+                    <option value={deployment_group.id} {if @target_deployment_group && @target_deployment_group.id == deployment_group.id, do: [selected: true], else: []}>
+                      {deployment_group.name}
+                    </option>
+                  <% end %>
+                </select>
+                <div class="select-icon"></div>
+              </div>
+
+              <button
+                class="btn btn-outline-light btn-action btn-primary ml-1"
+                type="submit"
+                data-confirm={"This will move all selected devices to #{@target_deployment_group && @target_deployment_group.name}. Continue?"}
+                id="move-deployment-group-submit"
+                {unless @target_deployment_group, do: [disabled: true], else: []}
+              >
+                Move
               </button>
-            </form>
+            </div>
+          </form>
+        </div>
+
+        <div class="row mt-2">
+          <div class="col-lg-12">
+            <label>Firmware Updates</label>
+
+            <div class="flex-row flex-gap-1">
+              <form class="inline-block" id="disable-updates" phx-submit="disable-updates-for-devices">
+                <button class="btn btn-outline-light btn-action" type="submit" data-confirm="This will disable updates for all selected devices" phx-click="disable-updates-for-devices">
+                  <span class="button-icon firmware-disabled"></span>
+                  <span class="action-text">Disable</span>
+                </button>
+              </form>
+
+              <form class="inline-block" id="enable-updates" phx-submit="enable-updates-for-devices">
+                <button class="btn btn-outline-light btn-action" type="submit" data-confirm="This will enable updates for all selected devices" phx-click="enable-updates-for-devices">
+                  <span class="button-icon firmware-enabled"></span>
+                  <span class="action-text">Enable</span>
+                </button>
+              </form>
+
+              <form class="inline-block" id="clear-penalty-box" phx-submit="clear-penalty-box-for-devices">
+                <button class="btn btn-outline-light btn-action" type="submit" data-confirm="This will clear the penalty box all selected devices" phx-click="clear-penalty-box-for-devices">
+                  <span class="button-icon firmware-enabled"></span>
+                  <span class="action-text">Clear Penalty box</span>
+                </button>
+              </form>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <table class="table table-sm table-hover">
-    <thead>
-      <tr>
-        <th>
-          <input class="checkbox" title="Check/uncheck all" {[checked: Enum.count(@selected_devices) == Enum.count(@devices)]} id="toggle-all" name="toggle-all" type="checkbox" phx-click="select-all" />
-        </th>
-        {devices_table_header("Identifier", "identifier", @current_sort, @sort_direction)}
-        <th>Firmware</th>
-        <th>Platform</th>
-        {devices_table_header("Added", "inserted_at", @current_sort, @sort_direction)}
-        {devices_table_header("Seen", "connection_last_seen_at", @current_sort, @sort_direction)}
-        {devices_table_header("Tags", "tags", @current_sort, @sort_direction)}
-        <th></th>
-      </tr>
-    </thead>
-    <%= for device <- @devices do %>
-      <tr class={
-        if device.id in @selected_devices do
-          "selected-row"
-        end
-      }>
-        <td>
-          <input class="checkbox" {if device.id in @selected_devices, do: [checked: true], else: []} type="checkbox" id={"#{device.id}-select"} phx-value-id={device.id} phx-click="select" />
-        </td>
-        <td>
-          <div class="mobile-label help-text">Identifier</div>
-          <div class="device-id-with-icon">
-            <%= if @device_statuses[device.identifier] == "online" do %>
-              <img src="/images/icons/check.svg" alt="connected" class="table-icon" />
-            <% else %>
-              <span title={last_seen_at_status(device.latest_connection)}>
-                <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
-              </span>
-            <% end %>
-            <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
-              {device.identifier}
-            </.link>
-          </div>
-        </td>
-
-        <td>
-          <div class="mobile-label help-text">Firmware</div>
-          <div>
-            <%= if is_nil(device.firmware_metadata) do %>
-              <span class="color-white-50">Unknown</span>
-            <% else %>
-              <span class="badge">
-                {device.firmware_metadata.version}
-              </span>
-            <% end %>
-          </div>
-        </td>
-
-        <td>
-          <div class="mobile-label help-text">Platform</div>
-          <div>
-            <%= if is_nil(device.firmware_metadata) do %>
-              <span class="color-white-50">Unknown</span>
-            <% else %>
-              <span class="badge">
-                {device.firmware_metadata.platform}
-              </span>
-            <% end %>
-          </div>
-        </td>
-
-        <td>
-          <div class="mobile-label help-text">Added</div>
-          <div title={NaiveDateTime.to_iso8601(device.inserted_at)}>
-            {Timex.from_now(device.inserted_at)}
-          </div>
-        </td>
-
-        <td>
-          <div class="mobile-label help-text">Seen</div>
-          <div :if={device.latest_connection} title={last_seen_at(device.latest_connection)}>
-            {last_seen_at(device.latest_connection)}
-          </div>
-        </td>
-
-        <td>
-          <div class="mobile-label help-text">Tags</div>
-          <div>
-            <%= if !is_nil(device.tags) do %>
-              <%= for tag <- device.tags do %>
-                <span class="badge">{tag}</span>
-              <% end %>
-            <% end %>
-          </div>
-        </td>
-
-        <td class="actions">
-          <div class="mobile-label help-text">Actions</div>
-          <div class="dropdown options">
-            <a class="dropdown-toggle options" data-target="#" id={device.identifier} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <div class="mobile-label pr-2">Open</div>
-              <img src="/images/icons/more.svg" alt="options" />
-            </a>
-            <div class="dropdown-menu dropdown-menu-right">
-              <.link phx-click="reboot-device" phx-value-device_identifier={device.identifier} class="dropdown-item">
-                Reboot
-              </.link>
-              <div class="dropdown-divider"></div>
-              <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
-                Console
-              </.link>
-              <div class="dropdown-divider"></div>
-              <div class="dropdown-divider"></div>
-              <.link phx-click="toggle-device-updates" phx-value-device_identifier={device.identifier} class="dropdown-item">
-                <span>
-                  {if device.updates_enabled, do: "Disable Updates", else: "Enable Updates"}
+    <table class="table table-sm table-hover">
+      <thead>
+        <tr>
+          <th>
+            <label for="toggle-all" class="hidden">
+              Select all devices
+            </label>
+            <input
+              class="checkbox"
+              title="Check/uncheck all"
+              {[checked: Enum.count(@selected_devices) == Enum.count(devices)]}
+              id="toggle-all"
+              name="toggle-all"
+              type="checkbox"
+              phx-click="select-all"
+            />
+          </th>
+          {devices_table_header("Identifier", "identifier", @current_sort, @sort_direction)}
+          <th>Firmware</th>
+          <th>Platform</th>
+          {devices_table_header("Added", "inserted_at", @current_sort, @sort_direction)}
+          {devices_table_header("Seen", "connection_last_seen_at", @current_sort, @sort_direction)}
+          {devices_table_header("Tags", "tags", @current_sort, @sort_direction)}
+          <th></th>
+        </tr>
+      </thead>
+      <%= for device <- devices do %>
+        <tr class={
+          if device.id in @selected_devices do
+            "selected-row"
+          end
+        }>
+          <td>
+            <label for={"#{device.id}-select"} class="hidden">
+              Select device {device.identifier}
+            </label>
+            <input class="checkbox" {if device.id in @selected_devices, do: [checked: true], else: []} type="checkbox" id={"#{device.id}-select"} phx-value-id={device.id} phx-click="select" />
+          </td>
+          <td>
+            <div class="mobile-label help-text">Identifier</div>
+            <div class="device-id-with-icon">
+              <%= if @device_statuses.result[device.identifier] == "online" do %>
+                <img src="/images/icons/check.svg" alt="connected" class="table-icon" />
+              <% else %>
+                <span title={last_seen_at_status(device.latest_connection)}>
+                  <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
                 </span>
+              <% end %>
+              <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
+                {device.identifier}
               </.link>
+            </div>
+          </td>
 
-              <div class="dropdown-divider"></div>
-
-              <%= link to: Routes.device_path(@socket, :export_audit_logs, @org.name, @product.name, device.identifier), class: "dropdown-item", aria: [label: "Download Audit Logs"] do %>
-                <div class="button-icon download"></div>
-                <span class="action-text">Download Audit Logs</span>
+          <td>
+            <div class="mobile-label help-text">Firmware</div>
+            <div>
+              <%= if is_nil(device.firmware_metadata) do %>
+                <span class="color-white-50">Unknown</span>
+              <% else %>
+                <span class="badge">
+                  {device.firmware_metadata.version}
+                </span>
               <% end %>
             </div>
-          </div>
-        </td>
-      </tr>
-    <% end %>
-  </table>
-  {pagination_links(@paginate_opts)}
-<% end %>
+          </td>
+
+          <td>
+            <div class="mobile-label help-text">Platform</div>
+            <div>
+              <%= if is_nil(device.firmware_metadata) do %>
+                <span class="color-white-50">Unknown</span>
+              <% else %>
+                <span class="badge">
+                  {device.firmware_metadata.platform}
+                </span>
+              <% end %>
+            </div>
+          </td>
+
+          <td>
+            <div class="mobile-label help-text">Added</div>
+            <div title={NaiveDateTime.to_iso8601(device.inserted_at)}>
+              {Timex.from_now(device.inserted_at)}
+            </div>
+          </td>
+
+          <td>
+            <div class="mobile-label help-text">Seen</div>
+            <div :if={device.latest_connection} title={last_seen_at(device.latest_connection)}>
+              {last_seen_at(device.latest_connection)}
+            </div>
+          </td>
+
+          <td>
+            <div class="mobile-label help-text">Tags</div>
+            <div>
+              <%= if !is_nil(device.tags) do %>
+                <%= for tag <- device.tags do %>
+                  <span class="badge">{tag}</span>
+                <% end %>
+              <% end %>
+            </div>
+          </td>
+
+          <td class="actions">
+            <div class="mobile-label help-text">Actions</div>
+            <div class="dropdown options">
+              <a class="dropdown-toggle options" data-target="#" id={device.identifier} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <div class="mobile-label pr-2">Open</div>
+                <img src="/images/icons/more.svg" alt="options" />
+              </a>
+              <div class="dropdown-menu dropdown-menu-right">
+                <.link phx-click="reboot-device" phx-value-device_identifier={device.identifier} class="dropdown-item">
+                  Reboot
+                </.link>
+                <div class="dropdown-divider"></div>
+                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
+                  Console
+                </.link>
+                <div class="dropdown-divider"></div>
+                <div class="dropdown-divider"></div>
+                <.link phx-click="toggle-device-updates" phx-value-device_identifier={device.identifier} class="dropdown-item">
+                  <span>
+                    {if device.updates_enabled, do: "Disable Updates", else: "Enable Updates"}
+                  </span>
+                </.link>
+
+                <div class="dropdown-divider"></div>
+
+                <%= link to: Routes.device_path(@socket, :export_audit_logs, @org.name, @product.name, device.identifier), class: "dropdown-item", aria: [label: "Download Audit Logs"] do %>
+                  <div class="button-icon download"></div>
+                  <span class="action-text">Download Audit Logs</span>
+                <% end %>
+              </div>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+    {pagination_links(@paginate_opts)}
+  <% end %>
+</.async_result>

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -12,14 +12,14 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
     Endpoint.subscribe("device:#{device.id}")
   end
 
-  test "Initially shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
-    %{device: device} = fixture
+  test "shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
+    %{device: device, org: org, product: product} = fixture
 
-    conn
-    |> visit(device_index_path(fixture))
-    |> assert_has("h3", text: "Loading devices...")
-    # and then loads the device list after a second
-    |> assert_has("div a", text: device.identifier, timeout: 1000)
+    {:ok, lv, html} = live(conn, "/org/#{org.name}/#{product.name}/devices")
+
+    assert html =~ "Loading devices..."
+
+    assert render_async(lv) =~ device.identifier
   end
 
   describe "handle_event" do

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -12,20 +12,32 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
     Endpoint.subscribe("device:#{device.id}")
   end
 
+  test "Initially shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
+    %{device: device} = fixture
+
+    conn
+    |> visit(device_index_path(fixture))
+    |> assert_has("h3", text: "Loading devices...")
+    # and then loads the device list after a second
+    |> assert_has("div a", text: device.identifier, timeout: 1000)
+  end
+
   describe "handle_event" do
     test "filters devices by exact identifier", %{conn: conn, fixture: fixture} do
       %{device: device, firmware: firmware, org: org, product: product} = fixture
 
       device2 = Fixtures.device_fixture(org, product, firmware)
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      assert html =~ device2.identifier
-
-      change = render_change(view, "update-filters", %{"device_id" => device.identifier})
-      assert change =~ device.identifier
-      refute change =~ device2.identifier
-      assert change =~ "1 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> fill_in("ID", with: device.identifier)
+      |> assert_has("div", text: "1 devices found", timeout: 1_000)
+      |> assert_has("div a", text: device.identifier)
+      |> refute_has("div a", text: device2.identifier)
     end
 
     test "filters devices by wrong identifier", %{conn: conn, fixture: fixture} do
@@ -33,69 +45,76 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       device2 = Fixtures.device_fixture(org, product, firmware)
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      assert html =~ device2.identifier
-
-      change = render_change(view, "update-filters", %{"device_id" => "foo"})
-      refute change =~ device.identifier
-      refute change =~ device2.identifier
-      assert change =~ "0 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div a", text: device.identifier, timeout: 1000)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> fill_in("ID", with: "foo")
+      |> assert_has("div", text: "0 devices found", timeout: 1000)
     end
 
     test "filters devices by prefix identifier", %{conn: conn, fixture: fixture} do
       %{device: device} = fixture
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-
-      assert render_change(view, "update-filters", %{"device_id" => "device-"}) =~
-               device.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div a", text: device.identifier, timeout: 1000)
+      |> click_button("Show Filters")
+      |> fill_in("ID", with: "device-")
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
     end
 
     test "filters devices by suffix identifier", %{conn: conn, fixture: fixture} do
       %{device: device} = fixture
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      "device-" <> tail = device.identifier
+      "device-" <> just_the_tail = device.identifier
 
-      assert render_change(view, "update-filters", %{"device_id" => tail}) =~
-               device.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div a", text: device.identifier, timeout: 1000)
+      |> click_button("Show Filters")
+      |> fill_in("ID", with: just_the_tail)
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
     end
 
     test "filters devices by middle identifier", %{conn: conn, fixture: fixture} do
       %{device: device} = fixture
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-
-      assert render_change(view, "update-filters", %{"device_id" => "ice-"}) =~
-               device.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div a", text: device.identifier, timeout: 1000)
+      |> click_button("Show Filters")
+      |> fill_in("ID", with: "ice-")
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
     end
 
     test "filters devices by tag", %{conn: conn, fixture: fixture} do
-      %{device: _device, firmware: firmware, org: org, product: product} = fixture
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
 
       device2 = Fixtures.device_fixture(org, product, firmware, %{tags: ["filtertest"]})
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device2.identifier
-
-      refute render_change(view, "update-filters", %{"tag" => "filtertest-noshow"}) =~
-               device2.identifier
-
-      assert render_change(view, "update-filters", %{"tag" => "filtertest"}) =~
-               device2.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> fill_in("Tags", with: "filtertest-noshow")
+      |> assert_has("div", text: "0 devices found", timeout: 1_000)
+      |> refute_has("div a", text: device2.identifier)
+      |> fill_in("Tags", with: "filtertest")
+      |> assert_has("div", text: "1 devices found", timeout: 1_000)
+      |> assert_has("div a", text: device2.identifier)
     end
 
     test "filters devices by metrics", %{conn: conn, fixture: fixture} do
       %{device: device, firmware: firmware, org: org, product: product} = fixture
 
       device2 = Fixtures.device_fixture(org, product, firmware, %{})
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      assert html =~ device2.identifier
 
       # Add metrics for device2, sleep between to secure order.
       Devices.Metrics.save_metric(%{device_id: device2.id, key: "cpu_temp", value: 36})
@@ -104,73 +123,87 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       :timer.sleep(100)
       Devices.Metrics.save_metric(%{device_id: device2.id, key: "load_1min", value: 3})
 
-      change =
-        render_change(view, "update-filters", %{
-          "metrics_key" => "cpu_temp",
-          "metrics_operator" => "gt",
-          "metrics_value" => "37"
-        })
-
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> select("Metrics", option: "cpu_temp")
+      |> assert_has("label", text: "Operator", timeout: 1000)
+      |> select("Operator", option: "Greater Than")
+      |> assert_has("label", text: "Value", timeout: 1000)
+      |> fill_in("Value", with: "37")
       # Show only show device2, which has a value greater than 37 on most recent cpu_temp metric.
-      assert change =~ device2.identifier
-      refute change =~ device.identifier
-
-      change2 =
-        render_change(view, "update-filters", %{
-          "metrics_key" => "cpu_temp",
-          "metrics_operator" => "lt",
-          "metrics_value" => "37"
-        })
-
+      |> assert_has("div", text: "1 devices found", timeout: 1_000)
+      |> assert_has("div a", text: device2.identifier)
+      |> refute_has("div a", text: device.identifier)
+      |> select("Metrics", option: "cpu_temp")
+      |> assert_has("label", text: "Operator", timeout: 1000)
+      |> select("Operator", option: "Less than")
+      |> assert_has("label", text: "Value", timeout: 1000)
+      |> fill_in("Value", with: "37")
       # Should not show any device since the query is for values less than 37
-      refute change2 =~ device2.identifier
-      refute change2 =~ device.identifier
+      |> assert_has("div", text: "0 devices found", timeout: 1_000)
+      |> refute_has("div a", text: device2.identifier)
+      |> refute_has("div a", text: device.identifier)
     end
 
     test "filters devices by several tags", %{conn: conn, fixture: fixture} do
-      %{device: _device, firmware: firmware, org: org, product: product} = fixture
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
 
       device2 =
         Fixtures.device_fixture(org, product, firmware, %{tags: ["filtertest", "testfilter"]})
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device2.identifier
-
-      refute render_change(view, "update-filters", %{"tag" => "filtertest-noshow"}) =~
-               device2.identifier
-
-      assert render_change(view, "update-filters", %{"tag" => "filtertest"}) =~
-               device2.identifier
-
-      assert render_change(view, "update-filters", %{"tag" => "filtertest, testfilter"}) =~
-               device2.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> fill_in("Tags", with: "filtertest-noshow")
+      |> assert_has("div", text: "0 devices found", timeout: 1_000)
+      |> refute_has("div a", text: device2.identifier)
+      |> fill_in("Tags", with: "filtertest")
+      |> assert_has("div", text: "1 devices found", timeout: 1_000)
+      |> assert_has("div a", text: device2.identifier)
+      |> fill_in("Tags", with: "filtertest, testfilter")
+      |> assert_has("div", text: "1 devices found", timeout: 1_000)
+      |> assert_has("div a", text: device2.identifier)
     end
 
     test "filters devices with no tags", %{conn: conn, fixture: fixture} do
-      %{device: _device, firmware: firmware, org: org, product: product} = fixture
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
 
       device2 = Fixtures.device_fixture(org, product, firmware, %{tags: nil})
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device2.identifier
-
-      refute render_change(view, "update-filters", %{"tag" => "doesntmatter"}) =~
-               device2.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div a", text: device.identifier, timeout: 1000)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> fill_in("Tags", with: "doesntmatter")
+      |> assert_has("div", text: "0 devices found", timeout: 1000)
+      |> refute_has("div a", text: device2.identifier)
     end
 
     test "filters devices with only untagged", %{conn: conn, fixture: fixture} do
-      %{device: _device, firmware: firmware, org: org, product: product} = fixture
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
 
       device2 = Fixtures.device_fixture(org, product, firmware, %{tags: nil})
       device3 = Fixtures.device_fixture(org, product, firmware, %{tags: ["foo"]})
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device2.identifier
-      assert html =~ device3.identifier
-
-      change = render_change(view, "update-filters", %{"has_no_tags" => "true"})
-      assert change =~ device2.identifier
-      refute change =~ device3.identifier
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "3 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> assert_has("div a", text: device3.identifier)
+      |> click_button("Show Filters")
+      |> select("Untagged", option: "Only untagged")
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device2.identifier)
+      |> refute_has("div a", text: device3.identifier)
     end
 
     test "filters devices with alarms", %{conn: conn, fixture: fixture} do
@@ -178,18 +211,19 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       device2 = Fixtures.device_fixture(org, product, firmware)
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      assert html =~ device2.identifier
-      assert html =~ "2 devices found"
-
       device_health = %{"device_id" => device.id, "data" => %{"alarms" => %{"SomeAlarm" => []}}}
       assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
 
-      change = render_change(view, "update-filters", %{"alarm_status" => "with"})
-      assert change =~ device.identifier
-      refute change =~ device2.identifier
-      assert change =~ "1 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> select("Alarm Status", option: "Has Alarms")
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> refute_has("div a", text: device2.identifier)
     end
 
     test "filters devices without alarms", %{conn: conn, fixture: fixture} do
@@ -197,18 +231,19 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       device2 = Fixtures.device_fixture(org, product, firmware)
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      assert html =~ device2.identifier
-      assert html =~ "2 devices found"
-
       device_health = %{"device_id" => device.id, "data" => %{"alarms" => %{"SomeAlarm" => []}}}
       assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
 
-      change = render_change(view, "update-filters", %{"alarm_status" => "without"})
-      refute change =~ device.identifier
-      assert change =~ device2.identifier
-      assert change =~ "1 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> select("Alarm Status", option: "No alarms")
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device2.identifier)
+      |> refute_has("div a", text: device.identifier)
     end
 
     test "filters devices with specific alarm", %{conn: conn, fixture: fixture} do
@@ -216,19 +251,21 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       device2 = Fixtures.device_fixture(org, product, firmware)
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ device.identifier
-      assert html =~ device2.identifier
-      assert html =~ "2 devices found"
-
       alarm = "SomeAlarm"
       device_health = %{"device_id" => device.id, "data" => %{"alarms" => %{alarm => []}}}
       assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
 
-      change = render_change(view, "update-filters", %{"alarm" => alarm})
-      assert change =~ device.identifier
-      refute change =~ device2.identifier
-      assert change =~ "1 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> select("Alarm", option: alarm)
+      |> assert_path(device_index_path(fixture), query_params: %{alarm: alarm})
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> refute_has("div a", text: device2.identifier)
     end
 
     test "filters devices by deployment group", %{conn: conn, fixture: fixture} do
@@ -245,23 +282,27 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       Repo.update!(Ecto.Changeset.change(device, deployment_id: deployment_group.id))
 
-      {:ok, view, _html} = live(conn, device_index_path(fixture))
-
-      change = render_change(view, "update-filters", %{"deployment_id" => deployment_group.id})
-      assert change =~ device.identifier
-      refute change =~ device2.identifier
-      assert change =~ "1 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> click_button("Show Filters")
+      |> select("Deployment Group", option: deployment_group.name)
+      |> assert_has("div", text: "1 devices found", timeout: 1_000)
+      |> assert_has("div a", text: device.identifier)
+      |> refute_has("div a", text: device2.identifier)
     end
 
     test "filters devices by no deployment", %{conn: conn, fixture: %{device: device} = fixture} do
       refute device.deployment_id
 
-      {:ok, view, _html} = live(conn, device_index_path(fixture))
-
-      # -1 is a UI concern that indicates we're filtering for devices that have no deployment
-      change = render_change(view, "update-filters", %{"deployment_id" => "-1"})
-      assert change =~ device.identifier
-      assert change =~ "1 devices found"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("span", text: "Show Filters", timeout: 1000)
+      |> click_button("Show Filters")
+      |> select("Deployment Group", option: "All")
+      |> assert_has("div", text: "1 devices found", timeout: 1000)
     end
 
     test "select device", %{conn: conn, fixture: fixture} do
@@ -270,13 +311,12 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       device2 = Fixtures.device_fixture(org, product, firmware, %{tags: nil})
       _device3 = Fixtures.device_fixture(org, product, firmware, %{tags: ["foo"]})
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ "3 devices found"
-      refute html =~ "(1 selected)"
-
-      change = render_change(view, "select", %{"id" => device2.id})
-      assert change =~ "3 devices found"
-      assert change =~ "(1 selected)"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "3 devices found", timeout: 1000)
+      |> refute_has("div", text: "(1 selected)")
+      |> check("Select device #{device2.identifier}")
+      |> assert_has("div", text: "(1 selected)")
     end
 
     test "select/deselect all devices", %{conn: conn, fixture: fixture} do
@@ -285,16 +325,15 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       _device2 = Fixtures.device_fixture(org, product, firmware, %{tags: nil})
       _device3 = Fixtures.device_fixture(org, product, firmware, %{tags: ["foo"]})
 
-      {:ok, view, html} = live(conn, device_index_path(fixture))
-      assert html =~ "3 devices found"
-
-      change = render_change(view, "select-all", %{})
-      assert change =~ "3 devices found"
-      assert change =~ "(3 selected)"
-
-      change = render_change(view, "select-all", %{})
-      assert change =~ "3 devices found"
-      refute change =~ "selected)"
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "3 devices found", timeout: 1000)
+      |> check("Select all devices")
+      |> assert_has("div", text: "3 devices found")
+      |> assert_has("div", text: "(3 selected)")
+      |> uncheck("Select all devices")
+      |> assert_has("div", text: "3 devices found")
+      |> refute_has("div", text: "selected)")
     end
   end
 
@@ -304,7 +343,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
-      |> assert_has("h1", text: "Devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
       |> assert_has("span", text: "beta")
       |> assert_has("span", text: "beta-edge")
       |> unwrap(fn view ->
@@ -312,7 +351,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       end)
       |> fill_in("Set tag(s) to:", with: "moussaka")
       |> click_button("Set")
-      |> assert_has("span", text: "moussaka")
+      |> assert_has("span", text: "moussaka", timeout: 1_000)
     end
 
     test "add multiple devices to deployment in old UI",
@@ -332,12 +371,12 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       refute device2.deployment_id
 
       conn
-      |> visit(
-        "/org/#{org.name}/#{product.name}/devices?platform=#{deployment_group.firmware.platform}"
-      )
-      |> unwrap(fn view ->
-        render_change(view, "select-all", %{"id" => device.id})
-      end)
+      |> visit(device_index_path(fixture))
+      |> assert_has("div", text: "2 devices found", timeout: 1000)
+      |> click_button("Show Filters")
+      |> select("Platform", option: deployment_group.firmware.platform)
+      |> assert_has("div", text: "2 devices found", timeout: 1_000)
+      |> check("Select all devices")
       |> assert_has("span", text: "2 selected")
       |> select("Move device(s) to deployment group:",
         option: deployment_group.name,

--- a/test/nerves_hub_web/live/devices/new_test.exs
+++ b/test/nerves_hub_web/live/devices/new_test.exs
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.Live.Devices.NewTest do
       |> click_button("Add Device")
       |> assert_path("/org/#{org.name}/#{product.name}/devices")
       |> assert_has("div", text: "Device created successfully.")
-      |> assert_has("a", text: "aaabbbccc111222333")
+      |> assert_has("a", text: "aaabbbccc111222333", timeout: 1000)
     end
 
     test "creates a device with an identifier and tags", %{conn: conn, org: org, product: product} do
@@ -32,7 +32,7 @@ defmodule NervesHubWeb.Live.Devices.NewTest do
       |> click_button("Add Device")
       |> assert_path("/org/#{org.name}/#{product.name}/devices")
       |> assert_has("div", text: "Device created successfully.")
-      |> assert_has("span", text: "josh")
+      |> assert_has("span", text: "josh", timeout: 1000)
       |> assert_has("span", text: "lars")
     end
   end

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -15,7 +15,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       |> put_session("new_ui", true)
       |> live("/org/#{org.name}/#{product.name}/devices")
 
-    assert html =~ "Loading devices ..."
+    assert html =~ "Loading..."
 
     assert render_async(lv) =~ device.identifier
   end

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -1,21 +1,23 @@
 defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
   use NervesHubWeb.ConnCase.Browser, async: false
+  use Mimic
 
   alias NervesHub.Fixtures
-
   alias NervesHub.Repo
 
   alias NervesHubWeb.Endpoint
 
-  test "Initially shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
+  test "shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
     %{device: device, org: org, product: product} = fixture
 
-    conn
-    |> put_session("new_ui", true)
-    |> visit("/org/#{org.name}/#{product.name}/devices")
-    |> assert_has("span", text: "Loading devices ...")
-    # and then loads the device list after a second
-    |> assert_has("div a", text: device.identifier, timeout: 1000)
+    {:ok, lv, html} =
+      conn
+      |> put_session("new_ui", true)
+      |> live("/org/#{org.name}/#{product.name}/devices")
+
+    assert html =~ "Loading devices ..."
+
+    assert render_async(lv) =~ device.identifier
   end
 
   describe "bulk adding devices to deployment group" do

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -7,6 +7,17 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
 
   alias NervesHubWeb.Endpoint
 
+  test "Initially shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
+    %{device: device, org: org, product: product} = fixture
+
+    conn
+    |> put_session("new_ui", true)
+    |> visit("/org/#{org.name}/#{product.name}/devices")
+    |> assert_has("span", text: "Loading devices ...")
+    # and then loads the device list after a second
+    |> assert_has("div a", text: device.identifier, timeout: 1000)
+  end
+
   describe "bulk adding devices to deployment group" do
     test "add multiple devices to deployment in new UI",
          %{conn: conn, fixture: fixture} do
@@ -30,6 +41,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       |> visit(
         "/org/#{org.name}/#{product.name}/devices?platform=#{deployment_group.firmware.platform}"
       )
+      |> assert_has("div", text: "2", timeout: 1000)
       |> check("Select all devices")
       |> assert_has("div", text: "2 devices selected")
       |> within("form#deployment-move", fn session ->

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -41,7 +41,7 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> fill_in("Name", with: "MyAmazingProduct")
       |> click_button("Create Product")
       |> assert_path("/org/#{org.name}/MyAmazingProduct/devices")
-      |> assert_has("h3", text: "MyAmazingProduct doesn’t have any devices yet")
+      |> assert_has("h3", text: "MyAmazingProduct doesn’t have any devices yet", timeout: 1000)
     end
 
     test "product name accepts spaces", %{conn: conn, org: org} do
@@ -51,7 +51,10 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> fill_in("Name", with: "My Amazing Product")
       |> click_button("Create Product")
       |> assert_path("/org/#{org.name}/My Amazing Product/devices")
-      |> assert_has("h3", text: "My Amazing Product doesn’t have any devices yet")
+      |> assert_has("h3",
+        text: "My Amazing Product doesn’t have any devices yet",
+        timeout: 1000
+      )
     end
 
     test "trims whitespace around the product name, and creates a new product when given a non blank name",
@@ -62,7 +65,10 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> fill_in("Name", with: "  My Amazing Product  ")
       |> click_button("Create Product")
       |> assert_path("/org/#{org.name}/My Amazing Product/devices")
-      |> assert_has("h3", text: "My Amazing Product doesn’t have any devices yet")
+      |> assert_has("h3",
+        text: "My Amazing Product doesn’t have any devices yet",
+        timeout: 1000
+      )
     end
 
     test "trims extra whitespace in the product name, and creates a new product when given a non blank name",
@@ -73,7 +79,10 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> fill_in("Name", with: "  My  Amazing  Product  ")
       |> click_button("Create Product")
       |> assert_path("/org/#{org.name}/My Amazing Product/devices")
-      |> assert_has("h3", text: "My Amazing Product doesn’t have any devices yet")
+      |> assert_has("h3",
+        text: "My Amazing Product doesn’t have any devices yet",
+        timeout: 1000
+      )
     end
   end
 


### PR DESCRIPTION
This updates both the old and new UI to support the use of `assign_async` for the device list page.

I've adjusted tests, and added some extra one.

The current UI shows a loading message, but we can change this to use faded ghost data.