### PR TITLE
Ensure User Token V1 continues to work for now

### DIFF
--- a/lib/nerves_hub_web/plugs/api/user.ex
+++ b/lib/nerves_hub_web/plugs/api/user.ex
@@ -9,8 +9,8 @@ defmodule NervesHubWeb.API.Plugs.AuthenticateUser do
 
   def call(conn, _opts) do
     with {:ok, token} <- get_req_token(conn),
-         {:ok, user} <- Accounts.fetch_user_by_api_token(token),
-         :ok <- Accounts.mark_last_used(token) do
+         {:ok, user, user_token} <- Accounts.fetch_user_by_api_token(token),
+         :ok <- Accounts.mark_last_used(user_token) do
       assign(conn, :user, user)
     else
       _ ->

--- a/test/nerves_hub_web/plugs/api/user_test.exs
+++ b/test/nerves_hub_web/plugs/api/user_test.exs
@@ -2,7 +2,13 @@ defmodule NervesHubWeb.API.Plugs.UserTest do
   use ExUnit.Case, async: false
   use NervesHubWeb.APIConnCase
 
+  alias NervesHub.Accounts
+  alias NervesHub.Repo
+  alias NervesHub.Support.Utils
+
   test "can use API token auth", %{user: user, user_token: token} do
+    {:ok, user_token} = Accounts.get_user_token(token)
+
     conn =
       build_conn()
       |> put_req_header("authorization", "token #{token}")
@@ -24,6 +30,36 @@ defmodule NervesHubWeb.API.Plugs.UserTest do
              "email" => user.email,
              "name" => user.name
            }
+
+    assert user_token.last_used != Repo.reload!(user_token).last_used
+  end
+
+  test "can use V1 API token auth", %{user: user} do
+    user_token = Utils.create_v1_user_token!(user)
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", "token #{user_token.old_token}")
+      |> put_req_header("accept", "application/json")
+      |> get("/api/users/me")
+
+    assert json_response(conn, 200)["data"] == %{
+             "email" => user.email,
+             "name" => user.name
+           }
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{user_token.old_token}")
+      |> put_req_header("accept", "application/json")
+      |> get("/api/users/me")
+
+    assert json_response(conn, 200)["data"] == %{
+             "email" => user.email,
+             "name" => user.name
+           }
+
+    assert user_token.last_used != Repo.reload!(user_token).last_used
   end
 
   test "rejects unknown API token" do


### PR DESCRIPTION
The previous adjustment to updating UserTokens (#2024) was broken for V1 tokens. Specifically, the code to mark the `last_used` field when used in an API request would only consider the format of the new tokens and request would fail even though the old token was successfully verified.

This changes to remove extra verification of the token format before marking last_used. Instead, it returns the `UserToken` along with the user in the verification query and then updates that record separately.

It also adds an API integration test to confirm requests with the old tokens will continue to work for now