### PR TITLE
Relax null constraint on user_tokens.old_token

### DIFF
--- a/priv/repo/migrations/20250414150132_remove_null_constraint_from_user_tokens_old_token.exs
+++ b/priv/repo/migrations/20250414150132_remove_null_constraint_from_user_tokens_old_token.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.RemoveNullConstraintFromUserTokensOldToken do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_tokens) do
+      modify(:old_token, :string, null: true)
+    end
+  end
+end

--- a/test/nerves_hub/accounts/accounts_test.exs
+++ b/test/nerves_hub/accounts/accounts_test.exs
@@ -294,6 +294,24 @@ defmodule NervesHub.AccountsTest do
     assert {%{id: ^id}, _user_token} = Repo.one!(query)
   end
 
+  describe "create_user_session_token/1" do
+    test "it creates a session token for the user", %{user: user} do
+      token = Accounts.create_user_session_token(user)
+      user_by_token = Accounts.get_user_by_session_token(token)
+      assert user.id == user_by_token.id
+
+      {:ok, user_token} = Accounts.get_user_token(token)
+      assert user_token.context == "session"
+      assert user_token.token
+    end
+
+    test "it sets a note on the user_token", %{user: user} do
+      token = Accounts.create_user_session_token(user, "A nice note")
+      {:ok, user_token} = Accounts.get_user_token(token)
+      assert user_token.note == "A nice note"
+    end
+  end
+
   describe "UserToken CRCs" do
     test "if the crc doesn't match, return :crc_mismatch", %{user: user} do
       token = Accounts.create_user_api_token(user, "Test token")


### PR DESCRIPTION
`old_token` needs to be able to be `NULL` when creating `user_tokens`. 