### PR TITLE
Fix filtering by platform in new UI

### DIFF
--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -345,7 +345,7 @@
           </div>
           <div class="mt-6">
             <label class="sidebar-label" for="input_platform">Platform</label>
-            <select class="sidebar-select" name="input_platform" id="input_platform">
+            <select class="sidebar-select" name="platform" id="input_platform">
               <option {selected?(@current_filters, :platform, "")} value="">All</option>
               <%= for platform <- @platforms do %>
                 <option {selected?(@current_filters, :platform, platform)} value={platform}>{if platform, do: platform, else: "Unknown"}</option>

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -49,4 +49,31 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       assert Repo.reload(device2) |> Map.get(:deployment_id)
     end
   end
+
+  describe "filtering devices" do
+    test "by platform", %{conn: conn, fixture: fixture} do
+      %{
+        device: device,
+        org: org,
+        product: product,
+        user: user
+      } = fixture
+
+      org_key = Fixtures.org_key_fixture(org, user)
+      foo_firmware = Fixtures.firmware_fixture(org_key, product, %{platform: "foo"})
+      device2 = Fixtures.device_fixture(org, product, foo_firmware)
+
+      conn
+      |> put_session("new_ui", true)
+      |> visit("/org/#{org.name}/#{product.name}/devices")
+      |> assert_has("a", text: device.identifier)
+      |> assert_has("a", text: device2.identifier)
+      |> select("Platform", option: "foo")
+      |> refute_has("a", text: device.identifier)
+      |> assert_has("a", text: device2.identifier)
+      |> select("Platform", option: "platform")
+      |> assert_has("a", text: device.identifier)
+      |> refute_has("a", text: device2.identifier)
+    end
+  end
 end


### PR DESCRIPTION
Solves #2043. I changed the `name` of the platform select in #2027, which broke filtering from the filter drawer.