### PR TITLE
Fix incorrect Dialyzer caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
           path: |
-            _build/test
+            priv/plts
 
       - name: Create PLTs
         if: steps.plt_cache.outputs.cache-hit != 'true'
@@ -122,10 +122,10 @@ jobs:
           key: |
             ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
           path: |
-            _build/test
+            priv/plts
 
       - name: Run dialyzer
-        run: mix dialyzer
+        run: mix dialyzer --format github --format dialyxir
 
       - name: Run tests
         run: mix test

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule NervesHub.MixProject do
       dialyzer: [
         flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs],
         plt_add_apps: [:ex_unit, :mix],
-        plt_core_path: "_build/#{Mix.env()}"
+        plt_core_path: "priv/plts",
+        plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
       ]
     ]
   end


### PR DESCRIPTION
Using the `_build` directory was causing errors with beam files being redefined.

The common practice is to use `/priv`

An example of one of the errors I was seeing: https://github.com/nerves-hub/nerves_hub_web/actions/runs/14485042748/job/40629027836#step:10:12