### PR TITLE
Use `Phoenix.Param` for cleaner URL generation

### DIFF
--- a/lib/nerves_hub/accounts/org.ex
+++ b/lib/nerves_hub/accounts/org.ex
@@ -17,6 +17,7 @@ defmodule NervesHub.Accounts.Org do
   @type id :: pos_integer() | nil
   @type t :: %__MODULE__{id: id()}
 
+  @derive {Phoenix.Param, key: :name}
   schema "orgs" do
     has_many(:org_keys, OrgKey)
     has_many(:products, Product, where: [deleted_at: nil])

--- a/lib/nerves_hub/archives/archive.ex
+++ b/lib/nerves_hub/archives/archive.ex
@@ -21,6 +21,7 @@ defmodule NervesHub.Archives.Archive do
           version: Version.build()
         }
 
+  @derive {Phoenix.Param, key: :uuid}
   schema "archives" do
     belongs_to(:product, Product, where: [deleted_at: nil])
     belongs_to(:org_key, OrgKey)

--- a/lib/nerves_hub/devices/ca_certificate.ex
+++ b/lib/nerves_hub/devices/ca_certificate.ex
@@ -24,6 +24,7 @@ defmodule NervesHub.Devices.CACertificate do
     :last_used
   ]
 
+  @derive {Phoenix.Param, key: :serial}
   schema "ca_certificates" do
     belongs_to(:org, Org, where: [deleted_at: nil])
     belongs_to(:jitp, JITP)

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -33,6 +33,7 @@ defmodule NervesHub.Devices.Device do
   ]
   @required_params [:org_id, :product_id, :identifier]
 
+  @derive {Phoenix.Param, key: :identifier}
   schema "devices" do
     belongs_to(:org, Org)
     belongs_to(:product, Product)

--- a/lib/nerves_hub/firmwares/firmware.ex
+++ b/lib/nerves_hub/firmwares/firmware.ex
@@ -42,6 +42,7 @@ defmodule NervesHub.Firmwares.Firmware do
     :version
   ]
 
+  @derive {Phoenix.Param, key: :uuid}
   schema "firmwares" do
     belongs_to(:org, Org, where: [deleted_at: nil])
     belongs_to(:product, Product, where: [deleted_at: nil])

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -43,6 +43,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     :current_updated_devices
   ]
 
+  @derive {Phoenix.Param, key: :name}
   schema "deployments" do
     belongs_to(:firmware, Firmware)
     belongs_to(:product, Product, where: [deleted_at: nil])

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -17,6 +17,7 @@ defmodule NervesHub.Products.Product do
 
   @type t :: %__MODULE__{}
 
+  @derive {Phoenix.Param, key: :name}
   schema "products" do
     has_many(:devices, Device, where: [deleted_at: nil])
     has_many(:firmwares, Firmware)

--- a/lib/nerves_hub_web/components/deployment_group_page/activity.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/activity.ex
@@ -35,7 +35,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Activity do
             <div class="text-base text-neutral-50 font-medium">Latest activity</div>
 
             <div class="p-1.5 rounded bg-zinc-800 border border-zinc-600">
-              <.link href={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}/audit_logs/download"}>
+              <.link href={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}/audit_logs/download"}>
                 <svg class="w-5 h-5" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path
                     d="M2.5 11.6666V14.1666C2.5 15.0871 3.24619 15.8333 4.16667 15.8333H15.8333C16.7538 15.8333 17.5 15.0871 17.5 14.1666V11.6666M10 4.16663V12.5M10 12.5L13.3333 9.16663M10 12.5L6.66667 9.16663"
@@ -93,7 +93,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Activity do
     params = %{"page_size" => page_size, "page_number" => 1}
 
     url =
-      ~p"/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/activity?#{params}"
+      ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group}/activity?#{params}"
 
     socket
     |> logs_and_pager_assigns(1, String.to_integer(page_size))
@@ -106,7 +106,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Activity do
     %{org: org, product: product, deployment_group: deployment_group} = socket.assigns
 
     url =
-      ~p"/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/activity?#{params}"
+      ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group}/activity?#{params}"
 
     socket
     |> logs_and_pager_assigns(

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -300,9 +300,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
         # to use `push_navigate` here.
         socket
         |> put_flash(:info, "Deployment group updated")
-        |> push_navigate(
-          to: ~p"/org/#{org.name}/#{product.name}/deployment_groups/#{updated.name}"
-        )
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups/#{updated}")
         |> noreply()
 
       {:error, changeset} ->
@@ -327,7 +325,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
 
     socket
     |> put_flash(:info, "Deployment group successfully deleted")
-    |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/deployment_groups")
+    |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups")
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -51,10 +51,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
             <div class="flex gap-4 items-center">
               <span class="text-sm text-nerves-gray-500 w-16">Firmware:</span>
 
-              <.link
-                navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@deployment_group.firmware.uuid}"}
-                class="flex items-center gap-1 pl-1.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800"
-              >
+              <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{@deployment_group.firmware}"} class="flex items-center gap-1 pl-1.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
                 <span class="text-xs text-zinc-300 tracking-tight">{@deployment_group.firmware.version} ({String.slice(@deployment_group.firmware.uuid, 0..7)})</span>
               </.link>
             </div>
@@ -63,7 +60,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
 
               <.link
                 :if={@deployment_group.archive}
-                navigate={~p"/org/#{@org.name}/#{@product.name}/archives/#{@deployment_group.archive.uuid}"}
+                navigate={~p"/org/#{@org}/#{@product}/archives/#{@deployment_group.archive}"}
                 class="flex items-center gap-1 pl-1.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800"
               >
                 <span class="text-xs text-zinc-300 tracking-tight">{@deployment_group.archive.version} ({String.slice(@deployment_group.archive.uuid, 0..7)})</span>
@@ -85,7 +82,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
               </div>
               <div :for={inflight_update <- @inflight_updates} :if={@inflight_updates != []} class="flex gap-4 items-center">
                 <span class="flex h-7 py-1 px-2 items-center rounded bg-zinc-800 text-base-300">
-                  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{inflight_update.device.identifier}"}>
+                  <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{inflight_update.device}"}>
                     {inflight_update.device.identifier}
                   </.link>
                 </span>
@@ -176,7 +173,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
                   <span class="text-sm text-nerves-gray-500">{if @unmatched_device_count == 1, do: "doesn't", else: "don't"} match inside deployment group</span>
                 </div>
                 <%!-- We have no way of filtering by version as of March 2025. When we do we can use this. --%>
-                <%!-- <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices"} class="flex items-center h-6 bg-zinc-800 border border-zinc-700 rounded-full">
+                <%!-- <.link navigate={~p"/org/#{@org}/#{@product}/devices"} class="flex items-center h-6 bg-zinc-800 border border-zinc-700 rounded-full">
                   <.icon name="open" class="stroke-zinc-400" />
                 </.link> --%>
                 <button
@@ -200,7 +197,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
                   <span class="text-sm text-nerves-gray-500">{if @matched_devices_outside_deployment_group_count == 1, do: "matches", else: "match"} outside of deployment group</span>
                 </div>
                 <%!-- We have no way of filtering by version as of March 2025. When we do we can use this. --%>
-                <%!-- <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices"} class="flex items-center h-6 bg-zinc-800 border border-zinc-700 rounded-full">
+                <%!-- <.link navigate={~p"/org/#{@org}/#{@product}/devices"} class="flex items-center h-6 bg-zinc-800 border border-zinc-700 rounded-full">
                   <.icon name="open" class="stroke-zinc-400" />
                 </.link> --%>
                 <button

--- a/lib/nerves_hub_web/components/device_header.ex
+++ b/lib/nerves_hub_web/components/device_header.ex
@@ -72,7 +72,7 @@ defmodule NervesHubWeb.Components.DeviceHeader do
           <%= if is_nil(@device.firmware_metadata) do %>
             <p>Unknown</p>
           <% else %>
-            <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@device.firmware_metadata.uuid}"} class="badge ff-m mt-0">
+            <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{@device.firmware_metadata.uuid}"} class="badge ff-m mt-0">
               {@device.firmware_metadata.version} ({String.slice(@device.firmware_metadata.uuid, 0..7)})
             </.link>
           <% end %>

--- a/lib/nerves_hub_web/components/device_page/activity_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/activity_tab.ex
@@ -38,7 +38,7 @@ defmodule NervesHubWeb.Components.DevicePage.ActivityTab do
             <div class="text-base text-neutral-50 font-medium">Latest activity</div>
 
             <div class="p-1.5 rounded bg-zinc-800 border border-zinc-600">
-              <.link href={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/audit_logs/download"}>
+              <.link href={~p"/org/#{@org}/#{@product}/devices/#{@device}/audit_logs/download"}>
                 <svg class="w-5 h-5" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path
                     d="M2.5 11.6666V14.1666C2.5 15.0871 3.24619 15.8333 4.16667 15.8333H15.8333C16.7538 15.8333 17.5 15.0871 17.5 14.1666V11.6666M10 4.16663V12.5M10 12.5L13.3333 9.16663M10 12.5L6.66667 9.16663"
@@ -98,8 +98,9 @@ defmodule NervesHubWeb.Components.DevicePage.ActivityTab do
   def hooked_event("set-paginate-opts", %{"page-size" => page_size}, socket) do
     params = %{"page_size" => page_size, "page_number" => 1}
 
-    url =
-      ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/devices/#{socket.assigns.device.identifier}/activity?#{params}"
+    %{org: org, product: product, device: device} = socket.assigns
+
+    url = ~p"/org/#{org}/#{product}/devices/#{device}/activity?#{params}"
 
     socket
     |> logs_and_pager_assigns(1, String.to_integer(page_size))
@@ -110,8 +111,9 @@ defmodule NervesHubWeb.Components.DevicePage.ActivityTab do
   def hooked_event("paginate", %{"page" => page_num}, socket) do
     params = %{"page_size" => socket.assigns.audit_pager.page_size, "page_number" => page_num}
 
-    url =
-      ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/devices/#{socket.assigns.device.identifier}/activity?#{params}"
+    %{org: org, product: product, device: device} = socket.assigns
+
+    url = ~p"/org/#{org}/#{product}/devices/#{device}/activity?#{params}"
 
     socket
     |> logs_and_pager_assigns(

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -277,7 +277,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
             <span :if={is_nil(@device.deployment_group)} class="text-sm text-nerves-gray-500">No assigned deployment group</span>
             <.link
               :if={@device.deployment_group}
-              navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@device.deployment_group.name}"}
+              navigate={~p"/org/#{@org}/#{@product}/deployment_groups/#{@device.deployment_group}"}
               class="flex items-center gap-1 pl-1.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800"
             >
               <svg class="w-1.5 h-1.5" viewBox="0 0 6 6" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -434,7 +434,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
           </div>
 
           <div class="flex p-4 gap-4 items-center border-t border-zinc-700">
-            <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/new"} aria-label="Add a support script">
+            <.button type="link" navigate={~p"/org/#{@org}/#{@product}/scripts/new"} aria-label="Add a support script">
               <.icon name="add" />Add a support script
             </.button>
           </div>

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -256,7 +256,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
 
       types(charts) != types(data) ->
         push_patch(socket,
-          to: ~p"/org/#{org.name}/#{product.name}/devices/#{device.identifier}/healthz"
+          to: ~p"/org/#{org}/#{product}/devices/#{device}/healthz"
         )
 
       true ->

--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -187,11 +187,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
               </div>
             </div>
             <div class="flex gap-2">
-              <.link
-                class="flex px-3 py-1.5 gap-2 rounded bg-zinc-800 border border-zinc-600"
-                href={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/certificate/#{certificate.serial}/download"}
-                download
-              >
+              <.link class="flex px-3 py-1.5 gap-2 rounded bg-zinc-800 border border-zinc-600" href={~p"/org/#{@org}/#{@product}/devices/#{@device}/certificate/#{certificate}/download"} download>
                 <svg class="w-5 h-5" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path
                     d="M6.66671 16.6667H5.00004C4.07957 16.6667 3.33337 15.9205 3.33337 15V5.00004C3.33337 4.07957 4.07957 3.33337 5.00004 3.33337H12.643C13.085 3.33337 13.509 3.50897 13.8215 3.82153L16.1786 6.17855C16.4911 6.49111 16.6667 6.91504 16.6667 7.35706V15C16.6667 15.9205 15.9205 16.6667 15 16.6667H13.3334M6.66671 16.6667V12.5H13.3334V16.6667M6.66671 16.6667H13.3334M6.66671 6.66671V9.16671H9.16671V6.66671H6.66671Z"
@@ -364,7 +360,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
 
     socket
     |> put_flash(:info, "Device permanently destroyed successfully.")
-    |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/devices")
+    |> push_navigate(to: ~p"/org/#{org}/#{product}/devices")
     |> halt()
   end
 

--- a/lib/nerves_hub_web/components/layouts/sidebar.html.heex
+++ b/lib/nerves_hub_web/components/layouts/sidebar.html.heex
@@ -52,7 +52,7 @@
             <h3 class="subtitle ">{org.name}</h3>
           </.link>
           <div :for={product <- org.products} class="my-4">
-            <.link navigate={~p"/org/#{org.name}/#{product.name}/devices"} class="product-picker-product">
+            <.link navigate={~p"/org/#{org}/#{product}/devices"} class="product-picker-product">
               {product.name}
             </.link>
           </div>

--- a/lib/nerves_hub_web/components/navigation.ex
+++ b/lib/nerves_hub_web/components/navigation.ex
@@ -15,7 +15,7 @@ defmodule NervesHubWeb.Components.Navigation do
   def updated_sidebar(assigns) do
     ~H"""
     <ul role="list">
-      <.nav_link label="Devices" path={~p"/org/#{@org.name}/#{@product.name}/devices"} selected={:devices == @selected_tab}>
+      <.nav_link label="Devices" path={~p"/org/#{@org}/#{@product}/devices"} selected={:devices == @selected_tab}>
         <path
           d="M2.5 10.8333H17.5M2.5 10.8333V14.1666C2.5 15.0871 3.24619 15.8333 4.16667 15.8333H15.8333C16.7538 15.8333 17.5 15.0871 17.5 14.1666V10.8333M2.5 10.8333L3.85106 5.42907C4.03654 4.68712 4.70318 4.16663 5.46796 4.16663H14.532C15.2968 4.16663 15.9635 4.68712 16.1489 5.42907L17.5 10.8333M5 13.3333H15"
           stroke-width="1.2"
@@ -23,7 +23,7 @@ defmodule NervesHubWeb.Components.Navigation do
           stroke-linejoin="round"
         />
       </.nav_link>
-      <.nav_link label="Deployment Groups" path={~p"/org/#{@org.name}/#{@product.name}/deployment_groups"} selected={:deployments == @selected_tab}>
+      <.nav_link label="Deployment Groups" path={~p"/org/#{@org}/#{@product}/deployment_groups"} selected={:deployments == @selected_tab}>
         <path
           d="M9.99992 2.5L14.1666 6.66667M9.99992 2.5L5.83325 6.66667M9.99992 2.5V10.8333M11.6667 15.8333C11.6667 16.7538 10.9205 17.5 10 17.5C9.07955 17.5 8.33335 16.7538 8.33335 15.8333C8.33335 14.9129 9.07955 14.1667 10 14.1667C10.9205 14.1667 11.6667 14.9129 11.6667 15.8333Z"
           stroke-width="1.2"
@@ -31,7 +31,7 @@ defmodule NervesHubWeb.Components.Navigation do
           stroke-linejoin="round"
         />
       </.nav_link>
-      <.nav_link label="Firmware" path={~p"/org/#{@org.name}/#{@product.name}/firmware"} selected={:firmware == @selected_tab}>
+      <.nav_link label="Firmware" path={~p"/org/#{@org}/#{@product}/firmware"} selected={:firmware == @selected_tab}>
         <path
           d="M5.83333 6.66659H10M12.5 6.66659H14.1667M14.1667 9.99992H9.16667M6.66667 9.99992H5.83333M5.83333 13.3333H10M12.5 13.3333H14.1667M4.16667 16.6666H15.8333C16.7538 16.6666 17.5 15.9204 17.5 14.9999V4.99992C17.5 4.07944 16.7538 3.33325 15.8333 3.33325H4.16667C3.24619 3.33325 2.5 4.07944 2.5 4.99992V14.9999C2.5 15.9204 3.24619 16.6666 4.16667 16.6666Z"
           stroke-width="1.2"
@@ -39,7 +39,7 @@ defmodule NervesHubWeb.Components.Navigation do
           stroke-linejoin="round"
         />
       </.nav_link>
-      <.nav_link label="Archives" path={~p"/org/#{@org.name}/#{@product.name}/archives"} selected={:archives == @selected_tab}>
+      <.nav_link label="Archives" path={~p"/org/#{@org}/#{@product}/archives"} selected={:archives == @selected_tab}>
         <path
           d="M3.33333 6.66659V14.9999C3.33333 15.9204 4.07953 16.6666 5 16.6666H15C15.9205 16.6666 16.6667 15.9204 16.6667 14.9999V6.66659M3.33333 6.66659H16.6667M3.33333 6.66659C2.8731 6.66659 2.5 6.29349 2.5 5.83325V4.99992C2.5 4.07944 3.24619 3.33325 4.16667 3.33325H15.8333C16.7538 3.33325 17.5 4.07944 17.5 4.99992V5.83325C17.5 6.29349 17.1269 6.66659 16.6667 6.66659M8.33333 9.99992H11.6667"
           stroke-width="1.2"
@@ -47,7 +47,7 @@ defmodule NervesHubWeb.Components.Navigation do
           stroke-linejoin="round"
         />
       </.nav_link>
-      <.nav_link label="Support Scripts" path={~p"/org/#{@org.name}/#{@product.name}/scripts"} selected={:support_scripts == @selected_tab}>
+      <.nav_link label="Support Scripts" path={~p"/org/#{@org}/#{@product}/scripts"} selected={:support_scripts == @selected_tab}>
         <path
           d="M5.83333 6.66675L2.5 10.0001L5.83333 13.3334M14.1667 13.3334L17.5 10.0001L14.1667 6.66675M11.6667 4.16675L8.33333 15.8334"
           stroke-width="1.2"
@@ -55,7 +55,7 @@ defmodule NervesHubWeb.Components.Navigation do
           stroke-linejoin="round"
         />
       </.nav_link>
-      <.nav_link label="Settings" path={~p"/org/#{@org.name}/#{@product.name}/settings"} selected={:settings == @selected_tab}>
+      <.nav_link label="Settings" path={~p"/org/#{@org}/#{@product}/settings"} selected={:settings == @selected_tab}>
         <path
           d="M8.33328 17.5L7.74757 17.6302C7.80857 17.9047 8.05206 18.1 8.33328 18.1V17.5ZM11.6666 17.5V18.1C11.9478 18.1 12.1913 17.9047 12.2523 17.6302L11.6666 17.5ZM11.6666 2.5L12.2523 2.36984C12.1913 2.09532 11.9478 1.9 11.6666 1.9V2.5ZM8.33328 2.5V1.9C8.05206 1.9 7.80857 2.09532 7.74757 2.36984L8.33328 2.5ZM2.67139 12.3066L2.26581 11.8645C2.05857 12.0545 2.01116 12.3631 2.15177 12.6066L2.67139 12.3066ZM4.33805 15.1934L3.81844 15.4934C3.95905 15.7369 4.24994 15.8501 4.51819 15.7657L4.33805 15.1934ZM17.3284 7.69337L17.734 8.13553C17.9413 7.94544 17.9887 7.63691 17.8481 7.39337L17.3284 7.69337ZM15.6618 4.80662L16.1814 4.50662C16.0408 4.26307 15.7499 4.14987 15.4816 4.2343L15.6618 4.80662ZM4.33805 4.80662L4.51819 4.23429C4.24994 4.14987 3.95905 4.26307 3.81844 4.50662L4.33805 4.80662ZM2.67139 7.69337L2.15177 7.39337C2.01116 7.63691 2.05857 7.94544 2.26581 8.13553L2.67139 7.69337ZM15.6618 15.1934L15.4816 15.7657C15.7499 15.8501 16.0408 15.7369 16.1814 15.4934L15.6618 15.1934ZM17.3284 12.3066L17.8481 12.6066C17.9887 12.3631 17.9413 12.0545 17.734 11.8645L17.3284 12.3066ZM15.768 9.12465L15.3625 8.68249C15.2154 8.81739 15.145 9.01659 15.1747 9.21394L15.768 9.12465ZM15.768 10.8753L15.1747 10.786C15.145 10.9834 15.2154 11.1826 15.3625 11.3175L15.768 10.8753ZM13.6414 14.5575L13.8215 13.9851C13.6308 13.9251 13.4227 13.964 13.2665 14.0889L13.6414 14.5575ZM12.1258 15.4339L11.907 14.8752C11.721 14.948 11.5834 15.1087 11.54 15.3037L12.1258 15.4339ZM7.87414 15.4339L8.45985 15.3037C8.41651 15.1087 8.27892 14.948 8.09288 14.8752L7.87414 15.4339ZM6.35851 14.5574L6.73334 14.0889C6.5772 13.964 6.3691 13.9251 6.17837 13.9851L6.35851 14.5574ZM4.23184 10.8753L4.63742 11.3174C4.78449 11.1825 4.85486 10.9833 4.82516 10.786L4.23184 10.8753ZM4.23184 9.1247L4.82516 9.21398C4.85486 9.01664 4.78449 8.81744 4.63742 8.68254L4.23184 9.1247ZM6.35852 5.44255L6.17839 6.01487C6.36912 6.0749 6.57722 6.03598 6.73335 5.91106L6.35852 5.44255ZM7.87414 4.56613L8.09288 5.12483C8.27892 5.05199 8.41651 4.89132 8.45985 4.69629L7.87414 4.56613ZM13.6413 5.44254L13.2665 5.91105C13.4227 6.03596 13.6308 6.07489 13.8215 6.01486L13.6413 5.44254ZM12.1258 4.56613L11.54 4.69629C11.5834 4.89132 11.721 5.05199 11.907 5.12483L12.1258 4.56613ZM8.33328 18.1H11.6666V16.9H8.33328V18.1ZM11.6666 1.9H8.33328V3.1H11.6666V1.9ZM2.15177 12.6066L3.81844 15.4934L4.85767 14.8934L3.191 12.0066L2.15177 12.6066ZM17.8481 7.39337L16.1814 4.50662L15.1422 5.10662L16.8088 7.99337L17.8481 7.39337ZM3.81844 4.50662L2.15177 7.39337L3.191 7.99337L4.85767 5.10662L3.81844 4.50662ZM16.1814 15.4934L17.8481 12.6066L16.8088 12.0066L15.1422 14.8934L16.1814 15.4934ZM15.1747 9.21394C15.2133 9.47001 15.2333 9.73248 15.2333 10H16.4333C16.4333 9.6725 16.4088 9.35035 16.3614 9.03537L15.1747 9.21394ZM16.1736 9.56681L17.734 8.13553L16.9229 7.25121L15.3625 8.68249L16.1736 9.56681ZM15.2333 10C15.2333 10.2675 15.2133 10.53 15.1747 10.786L16.3614 10.9646C16.4088 10.6496 16.4333 10.3275 16.4333 10H15.2333ZM17.734 11.8645L16.1736 10.4332L15.3625 11.3175L16.9229 12.7488L17.734 11.8645ZM13.4612 15.1298L15.4816 15.7657L15.8419 14.621L13.8215 13.9851L13.4612 15.1298ZM13.2665 14.0889C12.8585 14.4154 12.4009 14.6818 11.907 14.8752L12.3445 15.9926C12.9525 15.7545 13.5151 15.4268 14.0162 15.026L13.2665 14.0889ZM12.2523 17.6302L12.7115 15.564L11.54 15.3037L11.0809 17.3698L12.2523 17.6302ZM7.28843 15.564L7.74757 17.6302L8.91899 17.3698L8.45985 15.3037L7.28843 15.564ZM8.09288 14.8752C7.59902 14.6818 7.14138 14.4154 6.73334 14.0889L5.98367 15.0259C6.48473 15.4268 7.04736 15.7545 7.6554 15.9926L8.09288 14.8752ZM4.51819 15.7657L6.53864 15.1298L6.17837 13.9851L4.15792 14.621L4.51819 15.7657ZM4.82516 10.786C4.78663 10.5299 4.76661 10.2675 4.76661 10H3.56661C3.56661 10.3275 3.59113 10.6496 3.63852 10.9646L4.82516 10.786ZM3.82626 10.4331L2.26581 11.8645L3.07696 12.7488L4.63742 11.3174L3.82626 10.4331ZM4.76661 10C4.76661 9.73249 4.78663 9.47004 4.82516 9.21398L3.63852 9.03542C3.59113 9.35039 3.56661 9.67252 3.56661 10H4.76661ZM2.26581 8.13553L3.82627 9.56687L4.63742 8.68254L3.07696 7.2512L2.26581 8.13553ZM6.53866 4.87023L4.51819 4.23429L4.15792 5.37894L6.17839 6.01487L6.53866 4.87023ZM6.73335 5.91106C7.14139 5.58461 7.59903 5.31818 8.09288 5.12483L7.6554 4.00742C7.04737 4.24547 6.48474 4.57318 5.98369 4.97404L6.73335 5.91106ZM7.74757 2.36984L7.28843 4.43597L8.45985 4.69629L8.91899 2.63016L7.74757 2.36984ZM15.4816 4.2343L13.4612 4.87021L13.8215 6.01486L15.8419 5.37894L15.4816 4.2343ZM11.907 5.12483C12.4009 5.31818 12.8585 5.5846 13.2665 5.91105L14.0162 4.97402C13.5151 4.57317 12.9525 4.24547 12.3445 4.00742L11.907 5.12483ZM12.7115 4.43597L12.2523 2.36984L11.0809 2.63016L11.54 4.69629L12.7115 4.43597ZM11.8999 10C11.8999 11.0493 11.0493 11.9 9.99994 11.9V13.1C11.712 13.1 13.0999 11.7121 13.0999 10H11.8999ZM9.99994 11.9C8.9506 11.9 8.09994 11.0493 8.09994 10H6.89994C6.89994 11.7121 8.28786 13.1 9.99994 13.1V11.9ZM8.09994 10C8.09994 8.95066 8.9506 8.1 9.99994 8.1V6.9C8.28786 6.9 6.89994 8.28792 6.89994 10H8.09994ZM9.99994 8.1C11.0493 8.1 11.8999 8.95066 11.8999 10H13.0999C13.0999 8.28792 11.712 6.9 9.99994 6.9V8.1Z"
           fill="#71717A"
@@ -131,7 +131,7 @@ defmodule NervesHubWeb.Components.Navigation do
                       <%= unless Enum.empty?(org.products) do %>
                         <%= for product <- org.products do %>
                           <li>
-                            <.link href={~p"/org/#{org.name}/#{product.name}/devices"} class={"dropdown-item product #{product_classes(@current_path, product.name)}"}>
+                            <.link href={~p"/org/#{org}/#{product}/devices"} class={"dropdown-item product #{product_classes(@current_path, product.name)}"}>
                               {product.name}
                               <div class="active-checkmark"></div>
                             </.link>
@@ -247,7 +247,7 @@ defmodule NervesHubWeb.Components.Navigation do
             </div>
             <.link
               :if={alarms_count = alarms_count(@product)}
-              navigate={~p"/org/#{@org.name}/#{@product.name}/devices?alarm_status=with"}
+              navigate={~p"/org/#{@org}/#{@product}/devices?alarm_status=with"}
               class="navbar-indicator alarms-indicator"
               title="Devices alarming"
               aria-label="Devices alarming"
@@ -288,7 +288,7 @@ defmodule NervesHubWeb.Components.Navigation do
        %{
          title: "Products",
          active: "",
-         href: ~p"/org/#{assigns.org.name}"
+         href: ~p"/org/#{assigns.org}"
        }
      ] ++
        if assigns.org_user.role in User.role_or_higher(:manage) do
@@ -296,22 +296,22 @@ defmodule NervesHubWeb.Components.Navigation do
            %{
              title: "Signing Keys",
              active: "",
-             href: ~p"/org/#{assigns.org.name}/settings/keys"
+             href: ~p"/org/#{assigns.org}/settings/keys"
            },
            %{
              title: "Users",
              active: "",
-             href: ~p"/org/#{assigns.org.name}/settings/users"
+             href: ~p"/org/#{assigns.org}/settings/users"
            },
            %{
              title: "Certificates",
              active: "",
-             href: ~p"/org/#{assigns.org.name}/settings/certificates"
+             href: ~p"/org/#{assigns.org}/settings/certificates"
            },
            %{
              title: "Settings",
              active: "",
-             href: ~p"/org/#{assigns.org.name}/settings"
+             href: ~p"/org/#{assigns.org}/settings"
            }
          ]
        else
@@ -325,39 +325,39 @@ defmodule NervesHubWeb.Components.Navigation do
       %{
         title: "Dashboard",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/dashboard",
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/dashboard",
         deactivated?: Application.get_env(:nerves_hub, :dashboard_enabled) != true
       },
       %{
         title: "Devices",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/devices",
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/devices",
         tab: :devices
       },
       %{
         title: "Firmware",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/firmware"
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/firmware"
       },
       %{
         title: "Archives",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/archives"
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/archives"
       },
       %{
         title: "Deployments",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/deployment_groups"
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/deployment_groups"
       },
       %{
         title: "Scripts",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/scripts"
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/scripts"
       },
       %{
         title: "Settings",
         active: "",
-        href: ~p"/org/#{assigns.org.name}/#{assigns.product.name}/settings"
+        href: ~p"/org/#{assigns.org}/#{assigns.product}/settings"
       }
     ]
     |> Enum.reject(& &1[:deactivated?])

--- a/lib/nerves_hub_web/controllers/deployment_group_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_group_controller.ex
@@ -17,7 +17,7 @@ defmodule NervesHubWeb.DeploymentGroupController do
       [] ->
         conn
         |> put_flash(:error, "No audit logs exist for this deployment group.")
-        |> redirect(to: ~p"/org/#{org.name}/#{product.name}/deployment_groups")
+        |> redirect(to: ~p"/org/#{org}/#{product}/deployment_groups")
 
       audit_logs ->
         audit_logs = AuditLogs.format_for_csv(audit_logs)

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -34,7 +34,7 @@ defmodule NervesHubWeb.DeviceController do
       [] ->
         conn
         |> put_flash(:error, "No audit logs exist for this device.")
-        |> redirect(to: ~p"/org/#{org.name}/#{product.name}/devices")
+        |> redirect(to: ~p"/org/#{org}/#{product}/devices")
 
       audit_logs ->
         audit_logs = AuditLogs.format_for_csv(audit_logs)

--- a/lib/nerves_hub_web/live/archive_templates/list_archives_template.html.heex
+++ b/lib/nerves_hub_web/live/archive_templates/list_archives_template.html.heex
@@ -2,7 +2,7 @@
   <div class="no-results-blowup-wrapper">
     <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any archives yet</h3>
     <div class="flex-row align-items-center mt-3">
-      <.link patch={~p"/org/#{@org.name}/#{@product.name}/archives/upload"} class="btn btn-outline-light" aria-label="Upload archive">
+      <.link patch={~p"/org/#{@org}/#{@product}/archives/upload"} class="btn btn-outline-light" aria-label="Upload archive">
         <span class="button-icon add"></span>
         <span class="action-text">Upload Archive</span>
       </.link>
@@ -11,7 +11,7 @@
 <% else %>
   <div class="action-row">
     <h1>Archives</h1>
-    <.link patch={~p"/org/#{@org.name}/#{@product.name}/archives/upload"} class="btn btn-outline-light" aria-label="Upload archive">
+    <.link patch={~p"/org/#{@org}/#{@product}/archives/upload"} class="btn btn-outline-light" aria-label="Upload archive">
       <span class="button-icon add"></span>
       <span class="action-text">Upload Archive</span>
     </.link>
@@ -33,7 +33,7 @@
       <td>
         <div class="mobile-label help-text">UUID</div>
         <div>
-          <.link patch={~p"/org/#{@org.name}/#{@product.name}/archives/#{archive.uuid}"} class="badge ff-m">{archive.uuid}</.link>
+          <.link patch={~p"/org/#{@org}/#{@product}/archives/#{archive}"} class="badge ff-m">{archive.uuid}</.link>
         </div>
       </td>
       <td>
@@ -72,7 +72,7 @@
             <img src="/images/icons/more.svg" alt="options" />
           </a>
           <div class="dropdown-menu dropdown-menu-right">
-            <.link href={~p"/org/#{@org.name}/#{@product.name}/archives/#{archive.uuid}/download"} class="dropdown-item" download>
+            <.link href={~p"/org/#{@org}/#{@product}/archives/#{archive}/download"} class="dropdown-item" download>
               Download
             </.link>
             <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/archive_templates/list_archives_template_new.html.heex
+++ b/lib/nerves_hub_web/live/archive_templates/list_archives_template_new.html.heex
@@ -61,7 +61,7 @@
           <tr :for={archive <- @archives} class="border-b border-zinc-800">
             <td>
               <div class="flex gap-[8px] items-center">
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/archives/#{archive.uuid}"}>
+                <.link navigate={~p"/org/#{@org}/#{@product}/archives/#{archive}"}>
                   {archive.uuid}
                 </.link>
               </div>
@@ -113,7 +113,7 @@
                     Reboot
                   </.link>
                   <div class="dropdown-divider"></div>
-                  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
+                  <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device.identifier}/console"} class="dropdown-item">
                     Console
                   </.link>
                   <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/archive_templates/show_archive_template.html.heex
+++ b/lib/nerves_hub_web/live/archive_templates/show_archive_template.html.heex
@@ -1,9 +1,9 @@
 <div class="action-row">
-  <.link patch={~p"/org/#{@org.name}/#{@product.name}/archives"} class="back-link">
+  <.link patch={~p"/org/#{@org}/#{@product}/archives"} class="back-link">
     All Archives
   </.link>
   <div class="btn-group" role="group" aria-label="Device Actions">
-    <.link class="btn btn-outline-light btn-action" aria-label="Download" href={~p"/org/#{@org.name}/#{@product.name}/archives/#{@archive.uuid}/download"} download>
+    <.link class="btn btn-outline-light btn-action" aria-label="Download" href={~p"/org/#{@org}/#{@product}/archives/#{@archive}/download"} download>
       <span class="button-icon download"></span>
       <span class="action-text">Download</span>
     </.link>

--- a/lib/nerves_hub_web/live/archive_templates/show_archive_template_new.html.heex
+++ b/lib/nerves_hub_web/live/archive_templates/show_archive_template_new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/archives"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/archives"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
@@ -33,7 +33,7 @@
     </div>
 
     <div class="flex items-center gap-2">
-      <.button type="link" href={~p"/org/#{@org.name}/#{@product.name}/archives/#{@archive.uuid}/download"} download>
+      <.button type="link" href={~p"/org/#{@org}/#{@product}/archives/#{@archive}/download"} download>
         <.icon name="download" />Download
       </.button>
 

--- a/lib/nerves_hub_web/live/archives.ex
+++ b/lib/nerves_hub_web/live/archives.ex
@@ -161,7 +161,7 @@ defmodule NervesHubWeb.Live.Archives do
       {:ok, _} ->
         socket
         |> put_flash(:info, "Archive successfully deleted")
-        |> push_patch(to: ~p"/org/#{org.name}/#{product.name}/archives")
+        |> push_patch(to: ~p"/org/#{org}/#{product}/archives")
         |> noreply()
 
       {:error, changeset} ->
@@ -224,7 +224,7 @@ defmodule NervesHubWeb.Live.Archives do
       stringify_keys(new_params)
       |> Enum.into(current_params)
 
-    ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/archives?#{params}"
+    ~p"/org/#{socket.assigns.org}/#{socket.assigns.product}/archives?#{params}"
   end
 
   defp stringify_keys(params) do
@@ -242,9 +242,7 @@ defmodule NervesHubWeb.Live.Archives do
       {:ok, _firmware} ->
         socket
         |> put_flash(:info, "Archive uploaded successfully.")
-        |> push_patch(
-          to: ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/archives"
-        )
+        |> push_patch(to: ~p"/org/#{socket.assigns.org}/#{socket.assigns.product}/archives")
         |> noreply()
 
       {:error, :no_public_keys} ->

--- a/lib/nerves_hub_web/live/dashboard/index.html.heex
+++ b/lib/nerves_hub_web/live/dashboard/index.html.heex
@@ -6,7 +6,7 @@
         {@product.name} doesn’t have any devices yet.
       </h3>
       <div class="mt-3">
-        <.link class="btn btn-outline-light btn-action" aria-label="Add new device" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"}>
+        <.link class="btn btn-outline-light btn-action" aria-label="Add new device" navigate={~p"/org/#{@org}/#{@product}/devices/new"}>
           <div class="button-icon add"></div>
           <span class="action-text">Add your first Device</span>
         </.link>

--- a/lib/nerves_hub_web/live/deployment_groups/edit.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/edit.ex
@@ -56,9 +56,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Edit do
 
         socket
         |> put_flash(:info, "Deployment Group updated")
-        |> push_navigate(
-          to: ~p"/org/#{org.name}/#{product.name}/deployment_groups/#{updated.name}"
-        )
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups/#{updated}")
         |> noreply()
 
       {:error, changeset} ->

--- a/lib/nerves_hub_web/live/deployment_groups/edit.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/edit.html.heex
@@ -1,4 +1,4 @@
-<.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}"} class="back-link">
+<.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}"} class="back-link">
   Back to Deployment Group
 </.link>
 <h1>Edit Deployment Group</h1>

--- a/lib/nerves_hub_web/live/deployment_groups/index-new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index-new.html.heex
@@ -41,7 +41,7 @@
         </svg>
       </div>
     </form>
-    <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/newz"} aria-label="Add a new deployment group">
+    <.button type="link" navigate={~p"/org/#{@org}/#{@product}/deployments/newz"} aria-label="Add a new deployment group">
       <.icon name="add" /> Create Deployment Group
     </.button>
   </div>
@@ -82,7 +82,7 @@
         <tbody>
           <tr :for={deployment_group <- @entries} class={["border-b border-zinc-800"]}>
             <td>
-              <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{deployment_group.name}"}>
+              <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups/#{deployment_group}"}>
                 <div class="h-[40px] w-full flex gap-[8px] items-center">
                   <svg class={["size-1.5", (deployment_group.is_active && "fill-emerald-500") || "fill-zinc-500"]} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
                     <circle cx="3" cy="3" r="3" />
@@ -107,7 +107,7 @@
 
             <td class="min-w-fit">
               <span class="inline-block h-7 py-1 px-2 items-center rounded bg-zinc-800">
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{deployment_group.firmware.uuid}"} class="flex items-center">
+                <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{deployment_group.firmware}"} class="flex items-center">
                   <span class="text-sm text-base-300 mr-1">{deployment_group.firmware.version} ({String.slice(deployment_group.firmware.uuid, 0..7)})</span>
                   <svg class="w-4 h-4" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path

--- a/lib/nerves_hub_web/live/deployment_groups/index.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.html.heex
@@ -3,7 +3,7 @@
     <img src="/images/deployment.svg" alt="No deployments" />
     <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any deployments configured</h3>
     <div class="mt-3">
-      <.link class="btn btn-outline-light btn-action" aria-label="Setup a deployment" navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/new"}>
+      <.link class="btn btn-outline-light btn-action" aria-label="Setup a deployment" navigate={~p"/org/#{@org}/#{@product}/deployments/new"}>
         <div class="button-icon add"></div>
         <span class="action-text">Setup your first Deployment</span>
       </.link>
@@ -12,7 +12,7 @@
 <% else %>
   <div class="action-row">
     <h1>Deployment Groups</h1>
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployments/new"} class="btn btn-outline-light btn-action" aria-label="Create deployment">
+    <.link navigate={~p"/org/#{@org}/#{@product}/deployments/new"} class="btn btn-outline-light btn-action" aria-label="Create deployment">
       <span class="button-icon add"></span>
       <span class="action-text">Create Deployment</span>
     </.link>
@@ -36,7 +36,7 @@
         <td>
           <div class="mobile-label help-text">Name</div>
           <div>
-            <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{deployment_group.name}"}>{deployment_group.name}</.link>
+            <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups/#{deployment_group}"}>{deployment_group.name}</.link>
           </div>
         </td>
         <td>
@@ -54,7 +54,7 @@
         <td>
           <div class="mobile-label help-text">Firmware version</div>
           <div>
-            <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{deployment_group.firmware.uuid}"}>
+            <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{deployment_group.firmware}"}>
               <span class="badge ff-m">
                 {firmware_simple_display_name(deployment_group.firmware)}
               </span>
@@ -87,7 +87,7 @@
               <img src="/images/icons/more.svg" alt="options" />
             </a>
             <div class="dropdown-menu dropdown-menu-right">
-              <a class="dropdown-item" aria-label="Download Audit Logs" href={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{deployment_group.name}/audit_logs/download"}>
+              <a class="dropdown-item" aria-label="Download Audit Logs" href={~p"/org/#{@org}/#{@product}/deployment_groups/#{deployment_group}/audit_logs/download"}>
                 <div class="button-icon download"></div>
                 <span class="action-text">Download Audit Logs</span>
               </a>

--- a/lib/nerves_hub_web/live/deployment_groups/new.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/new.ex
@@ -17,7 +17,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.New do
         :error,
         "You must upload a firmware version before creating a Deployment Group"
       )
-      |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/firmware/upload")
+      |> push_navigate(to: ~p"/org/#{org}/#{product}/firmware/upload")
       |> ok()
     else
       platforms =
@@ -88,9 +88,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.New do
 
         socket
         |> put_flash(:info, "Deployment Group created")
-        |> push_navigate(
-          to: ~p"/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}"
-        )
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group}")
         |> noreply()
 
       {_firmware, {:error, changeset}} ->

--- a/lib/nerves_hub_web/live/deployment_groups/new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/new.html.heex
@@ -14,7 +14,7 @@
     </div>
 
     <div class="button-submit-wrapper">
-      <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups"} class="btn btn-secondary">
+      <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups"} class="btn btn-secondary">
         Cancel
       </.link>
     </div>
@@ -69,7 +69,7 @@
     </div>
 
     <div class="button-submit-wrapper">
-      <.link class="btn btn-secondary" navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups"}>Back</.link>
+      <.link class="btn btn-secondary" navigate={~p"/org/#{@org}/#{@product}/deployment_groups"}>Back</.link>
       {submit("Create Deployment", class: "btn btn-primary")}
     </div>
   </.form>

--- a/lib/nerves_hub_web/live/deployment_groups/newz.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/newz.ex
@@ -101,9 +101,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Newz do
 
         socket
         |> put_flash(:info, "Deployment Group created")
-        |> push_navigate(
-          to: ~p"/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}"
-        )
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group}")
         |> noreply()
 
       {_firmware, {:error, changeset}} ->

--- a/lib/nerves_hub_web/live/deployment_groups/newz.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/newz.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
@@ -31,7 +31,7 @@
 
   <div :if={@firmware_required} class="h-full pb-16 flex flex-col items-center justify-center gap-4 p-6">
     <span class="text-xl font-medium text-neutral-50">Please upload your first firmware before creating a deployment group.</span>
-    <.link class="underline underline-offset-4 decoration-dotted hover:text-neutral-50" navigate={~p"/org/#{@org.name}/#{@product.name}/firmware"} aria-label="Add a new deployment group">
+    <.link class="underline underline-offset-4 decoration-dotted hover:text-neutral-50" navigate={~p"/org/#{@org}/#{@product}/firmware"} aria-label="Add a new deployment group">
       Go to the firmware page
     </.link>
   </div>

--- a/lib/nerves_hub_web/live/deployment_groups/show-new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/show-new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-end bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
@@ -73,16 +73,16 @@
 
   <div class="flex w-full justify-between px-6 border-b border-zinc-700">
     <div class="flex">
-      <.link class={tab_classes(@tab, :summary)} patch={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}"}>
+      <.link class={tab_classes(@tab, :summary)} patch={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}"}>
         Summary
       </.link>
-      <.link class={tab_classes(@tab, :release_history)} patch={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}/releases"}>
+      <.link class={tab_classes(@tab, :release_history)} patch={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}/releases"}>
         Release History
       </.link>
-      <.link class={tab_classes(@tab, :activity)} patch={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}/activity"}>
+      <.link class={tab_classes(@tab, :activity)} patch={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}/activity"}>
         Activity
       </.link>
-      <.link class={tab_classes(@tab, :settings)} patch={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}/settings"}>
+      <.link class={tab_classes(@tab, :settings)} patch={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}/settings"}>
         Settings
       </.link>
     </div>

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -103,7 +103,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
 
     socket
     |> put_flash(:info, "Deployment Group successfully deleted")
-    |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/deployment_groups")
+    |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups")
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/live/deployment_groups/show.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.html.heex
@@ -1,5 +1,5 @@
 <div class="action-row">
-  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups"} class="back-link">
+  <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups"} class="back-link">
     All Deployment Groups
   </.link>
   <div class="btn-group" role="group" aria-label="Deployment Group Actions">
@@ -8,7 +8,7 @@
       <span class="action-text">Turn {opposite_status(@deployment_group)}</span>
     </.link>
 
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}/edit"} class="btn btn-outline-light btn-action" aria-label="Edit">
+    <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}/edit"} class="btn btn-outline-light btn-action" aria-label="Edit">
       <span class="button-icon edit"></span>
       <span class="action-text">Edit</span>
     </.link>
@@ -27,12 +27,7 @@
       <span class="action-text">Delete</span>
     </.link>
 
-    <.link
-      href={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}/audit_logs/download"}
-      class="btn btn-outline-light btn-action"
-      aria-label="Download Audit Logs"
-      download
-    >
+    <.link href={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}/audit_logs/download"} class="btn btn-outline-light btn-action" aria-label="Download Audit Logs" download>
       <div class="button-icon download"></div>
       <span class="action-text">Download Audit Logs</span>
     </.link>
@@ -78,7 +73,7 @@
         <div>
           <div class="help-text mb-1">Firmware version</div>
           <span>
-            <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@firmware.uuid}"} class="badge ff-m">
+            <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{@firmware}"} class="badge ff-m">
               {firmware_summary(@firmware)}
             </.link>
           </span>
@@ -218,7 +213,7 @@
     <div id="inflight-update-badges">
       <%= for inflight_update <- @inflight_updates do %>
         <span class="ff-m badge">
-          <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{inflight_update.device.identifier}"}>
+          <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{inflight_update.device}"}>
             {inflight_update.device.identifier}
           </.link>
         </span>

--- a/lib/nerves_hub_web/live/devices/device_health.ex
+++ b/lib/nerves_hub_web/live/devices/device_health.ex
@@ -154,7 +154,7 @@ defmodule NervesHubWeb.Live.Devices.DeviceHealth do
 
       types(charts) != types(data) ->
         push_patch(socket,
-          to: ~p"/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health"
+          to: ~p"/org/#{org}/#{product}/devices/#{device}/health"
         )
 
       true ->

--- a/lib/nerves_hub_web/live/devices/device_health.html.heex
+++ b/lib/nerves_hub_web/live/devices/device_health.html.heex
@@ -1,5 +1,5 @@
 <div class="action-row mb-1">
-  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}"} class="back-link">Back to
+  <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{@device}"} class="back-link">Back to
     device </.link>
 </div>
 <HealthHeader.render

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -48,10 +48,10 @@
         </svg>
       </div>
     </form>
-    <.button :if={has_results?(@devices, @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org.name}/#{@product.name}/devices/export"} download>
+    <.button :if={has_results?(@devices, @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org}/#{@product}/devices/export"} download>
       <.icon name="export" /> Export
     </.button>
-    <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"} aria-label="Add new device">
+    <.button type="link" navigate={~p"/org/#{@org}/#{@product}/devices/new"} aria-label="Add new device">
       <.icon name="add" /> Add Device
     </.button>
     <.button :if={has_results?(@devices, @currently_filtering)} type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
@@ -222,7 +222,7 @@
                         </svg> --%>
                     <% end %>
                   </span>
-                  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class="ff-m font-mono">
+                  <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device}"} class="ff-m font-mono">
                     {device.identifier}
                     <span class="clickable-table-row-mask" />
                   </.link>
@@ -295,7 +295,7 @@
                       Reboot
                     </.link>
                     <div class="dropdown-divider"></div>
-                    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
+                    <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device}/console"} class="dropdown-item">
                       Console
                     </.link>
                     <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -17,7 +17,7 @@
       <img src="/images/device.svg" alt="No devices" />
       <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any devices yet</h3>
       <div class="mt-3">
-        <.link class="btn btn-outline-light btn-action" aria-label="Add new device" navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"}>
+        <.link class="btn btn-outline-light btn-action" aria-label="Add new device" navigate={~p"/org/#{@org}/#{@product}/devices/new"}>
           <div class="button-icon add"></div>
           <span class="action-text">Add your first Device</span>
         </.link>
@@ -50,7 +50,7 @@
           <div class="button-icon download"></div>
           <span class="action-text">Export</span>
         </a>
-        <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/new"} class="btn btn-outline-light btn-action" aria-label="Add new device">
+        <.link navigate={~p"/org/#{@org}/#{@product}/devices/new"} class="btn btn-outline-light btn-action" aria-label="Add new device">
           <div class="button-icon add"></div>
           <span class="action-text">Add Device</span>
         </.link>
@@ -368,7 +368,7 @@
                   <img src="/images/icons/cross.svg" alt="offline" class="table-icon" />
                 </span>
               <% end %>
-              <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
+              <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device}"} class={"ff-m #{firmware_update_status(device)}"} title={firmware_update_title(device)}>
                 {device.identifier}
               </.link>
             </div>
@@ -437,7 +437,7 @@
                   Reboot
                 </.link>
                 <div class="dropdown-divider"></div>
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
+                <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device}/console"} class="dropdown-item">
                   Console
                 </.link>
                 <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/devices/new-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/new-new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/devices"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>

--- a/lib/nerves_hub_web/live/devices/new.ex
+++ b/lib/nerves_hub_web/live/devices/new.ex
@@ -27,7 +27,7 @@ defmodule NervesHubWeb.Live.Devices.New do
       {:ok, _device} ->
         socket
         |> put_flash(:info, "Device created successfully.")
-        |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/devices")
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/devices")
         |> noreply()
 
       {:error, changeset} ->

--- a/lib/nerves_hub_web/live/devices/settings.ex
+++ b/lib/nerves_hub_web/live/devices/settings.ex
@@ -47,7 +47,7 @@ defmodule NervesHubWeb.Live.Devices.Settings do
       {:ok, _device} ->
         socket
         |> put_flash(:info, "Device updated")
-        |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/devices/#{device}")
         |> noreply()
 
       {:error, :update_with_audit, changeset, _} ->

--- a/lib/nerves_hub_web/live/devices/settings.html.heex
+++ b/lib/nerves_hub_web/live/devices/settings.html.heex
@@ -1,4 +1,4 @@
-<.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}"} class="back-link">
+<.link navigate={~p"/org/#{@org}/#{@product}/devices/#{@device.identifier}"} class="back-link">
   Back to Device
 </.link>
 <h1>Device Settings</h1>
@@ -188,7 +188,7 @@
             </a>
             <div class="dropdown-menu dropdown-menu-right">
               <%= if mismatch? do %>
-                {link("Organization", class: "dropdown-item", aria_label: "Originating Organization", to: ~p"/org/#{Repo.preload(cert, :org).org.name}")}
+                {link("Organization", class: "dropdown-item", aria_label: "Originating Organization", to: ~p"/org/#{Repo.preload(cert, :org).org}")}
               <% end %>
               <%= if cert.der do %>
                 {link("Download",

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-end bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/devices"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
@@ -81,7 +81,7 @@
 
         <span :if={is_nil(@device.firmware_metadata)} class="text-sm text-base-300 font-mono">Unknown</span>
 
-        <.link :if={@device.firmware_metadata} navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@device.firmware_metadata.uuid}"} class="flex items-center">
+        <.link :if={@device.firmware_metadata} navigate={~p"/org/#{@org}/#{@product}/firmware/#{@device.firmware_metadata.uuid}"} class="flex items-center">
           <span class="text-sm text-base-300 mr-1 font-mono">{@device.firmware_metadata.version} ({String.slice(@device.firmware_metadata.uuid, 0..7)})</span>
           <svg class="w-4 h-4" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path
@@ -203,19 +203,19 @@
 
   <div class="flex w-full justify-between px-6 border-b border-zinc-700">
     <div class="flex">
-      <.link class={tab_classes(@tab, :details)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}"}>
+      <.link class={tab_classes(@tab, :details)} patch={~p"/org/#{@org}/#{@product}/devices/#{@device}"}>
         Details
       </.link>
-      <.link class={tab_classes(@tab, :health)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/healthz"}>
+      <.link class={tab_classes(@tab, :health)} patch={~p"/org/#{@org}/#{@product}/devices/#{@device}/healthz"}>
         Health
       </.link>
-      <.link class={tab_classes(@tab, :activity)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/activity"}>
+      <.link class={tab_classes(@tab, :activity)} patch={~p"/org/#{@org}/#{@product}/devices/#{@device}/activity"}>
         Activity
       </.link>
-      <.link class={tab_classes(@tab, :console)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/conzole"}>
+      <.link class={tab_classes(@tab, :console)} patch={~p"/org/#{@org}/#{@product}/devices/#{@device}/conzole"}>
         Console
       </.link>
-      <.link class={tab_classes(@tab, :settings)} patch={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/settingz"}>
+      <.link class={tab_classes(@tab, :settings)} patch={~p"/org/#{@org}/#{@product}/devices/#{@device}/settingz"}>
         Settings
       </.link>
     </div>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -284,8 +284,9 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def handle_event("paginate", %{"page" => page_num}, socket) do
     params = %{"page_size" => socket.assigns.page_size, "page_number" => page_num}
 
-    url =
-      ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/devices/#{socket.assigns.device.identifier}/activity?#{params}"
+    %{org: org, product: product, device: device} = socket.assigns
+
+    url = ~p"/org/#{org}/#{product}/devices/#{device}/activity?#{params}"
 
     socket
     |> push_patch(to: url)
@@ -341,7 +342,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
     socket
     |> put_flash(:info, "Device destroyed successfully.")
-    |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/devices")
+    |> push_navigate(to: ~p"/org/#{org}/#{product}/devices")
     |> noreply()
   end
 
@@ -483,8 +484,9 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def handle_event("set-paginate-opts", %{"page-size" => page_size}, socket) do
     params = %{"page_size" => page_size, "page_number" => 1}
 
-    url =
-      ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/devices/#{socket.assigns.device.identifier}/activity?#{params}"
+    %{org: org, product: product, device: device} = socket.assigns
+
+    url = ~p"/org/#{org}/#{product}/devices/#{device}/activity?#{params}"
 
     socket
     |> push_patch(to: url)

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -5,7 +5,7 @@
 </div>
 
 <div class="action-row mb-1">
-  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices"} class="back-link">
+  <.link navigate={~p"/org/#{@org}/#{@product}/devices"} class="back-link">
     All Devices
   </.link>
   <div class="btn-group" role="group" aria-label="Device Actions">
@@ -49,7 +49,7 @@
         <span class="button-icon delete"></span>
         <span class="action-text">Delete</span>
       </button>
-      <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/settings"} class="btn btn-outline-light btn-action" aria-label="Edit">
+      <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{@device}/settings"} class="btn btn-outline-light btn-action" aria-label="Edit">
         <span class="button-icon edit"></span>
         <span class="action-text">Settings</span>
       </.link>
@@ -119,7 +119,7 @@
           </div>
         </div>
         <div class="text-right">
-          <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts"}>
+          <.link navigate={~p"/org/#{@org}/#{@product}/scripts"}>
             Add and edit scripts
           </.link>
         </div>
@@ -213,7 +213,7 @@
               </time>
             </div>
             <div>
-              <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{@device.identifier}/health"}>
+              <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{@device}/health"}>
                 Full metrics
               </.link>
             </div>
@@ -231,7 +231,7 @@
           </div>
           <div :if={@deployment_group} class="d-flex flex-row">
             <div class="mr-1">
-              <.link navigate={~p"/org/#{@org.name}/#{@product.name}/deployment_groups/#{@deployment_group.name}"} class="badge">
+              <.link navigate={~p"/org/#{@org}/#{@product}/deployment_groups/#{@deployment_group}"} class="badge">
                 <div class={"deployment-group-state state-#{if @deployment_group.is_active, do: "on", else: "off"}"}>{@deployment_group.name}</div>
               </.link>
             </div>

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -165,7 +165,7 @@ defmodule NervesHubWeb.Live.Firmware do
       {:ok, _} ->
         socket
         |> put_flash(:info, "Firmware successfully deleted")
-        |> push_patch(to: ~p"/org/#{org.name}/#{product.name}/firmware")
+        |> push_patch(to: ~p"/org/#{org}/#{product}/firmware")
         |> noreply()
 
       {:error, changeset} ->
@@ -224,7 +224,7 @@ defmodule NervesHubWeb.Live.Firmware do
       stringify_keys(new_params)
       |> Enum.into(current_params)
 
-    ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/firmware?#{params}"
+    ~p"/org/#{socket.assigns.org}/#{socket.assigns.product}/firmware?#{params}"
   end
 
   defp stringify_keys(params) do
@@ -242,9 +242,7 @@ defmodule NervesHubWeb.Live.Firmware do
       {:ok, _firmware} ->
         socket
         |> put_flash(:info, "Firmware uploaded successfully")
-        |> push_patch(
-          to: ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/firmware"
-        )
+        |> push_patch(to: ~p"/org/#{socket.assigns.org}/#{socket.assigns.product}/firmware")
         |> noreply()
 
       {:error, :no_public_keys} ->

--- a/lib/nerves_hub_web/live/firmware_templates/list_firmware_template.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/list_firmware_template.html.heex
@@ -3,7 +3,7 @@
     <img src="/images/firmware.svg" alt="No products" />
     <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any firmware yet</h3>
     <div class="flex-row align-items-center mt-3">
-      <.link patch={~p"/org/#{@org.name}/#{@product.name}/firmware/upload"} class="btn btn-outline-light" aria-label="Upload firmware">
+      <.link patch={~p"/org/#{@org}/#{@product}/firmware/upload"} class="btn btn-outline-light" aria-label="Upload firmware">
         <span class="button-icon add"></span>
         <span class="action-text">Upload Firmware</span>
       </.link>
@@ -12,7 +12,7 @@
 <% else %>
   <div class="action-row">
     <h1>Firmware</h1>
-    <.link patch={~p"/org/#{@org.name}/#{@product.name}/firmware/upload"} class="btn btn-outline-light btn-action" aria-label="Upload firmware">
+    <.link patch={~p"/org/#{@org}/#{@product}/firmware/upload"} class="btn btn-outline-light btn-action" aria-label="Upload firmware">
       <span class="button-icon add"></span>
       <span class="action-text">Upload Firmware</span>
     </.link>
@@ -35,7 +35,7 @@
         <td>
           <div class="mobile-label help-text">UUID</div>
           <div>
-            <.link patch={~p"/org/#{@org.name}/#{@product.name}/firmware/#{firmware.uuid}"} class="badge ff-m">{firmware.uuid}</.link>
+            <.link patch={~p"/org/#{@org}/#{@product}/firmware/#{firmware}"} class="badge ff-m">{firmware.uuid}</.link>
           </div>
         </td>
         <td>
@@ -74,7 +74,7 @@
               <img src="/images/icons/more.svg" alt="options" />
             </a>
             <div class="dropdown-menu dropdown-menu-right">
-              <.link class="dropdown-item" href={~p"/org/#{@org.name}/#{@product.name}/firmware/#{firmware.uuid}/download"} download>
+              <.link class="dropdown-item" href={~p"/org/#{@org}/#{@product}/firmware/#{firmware}/download"} download>
                 Download
               </.link>
               <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/firmware_templates/list_firmware_template_new.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/list_firmware_template_new.html.heex
@@ -64,7 +64,7 @@
           <tr :for={firmware <- @firmware} class="border-b border-zinc-800">
             <td>
               <div class="flex gap-[8px] items-center">
-                <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware/#{firmware.uuid}"}>
+                <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{firmware}"}>
                   {firmware.uuid}
                 </.link>
               </div>
@@ -120,7 +120,7 @@
                     Reboot
                   </.link>
                   <div class="dropdown-divider"></div>
-                  <.link navigate={~p"/org/#{@org.name}/#{@product.name}/devices/#{device.identifier}/console"} class="dropdown-item">
+                  <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device}/console"} class="dropdown-item">
                     Console
                   </.link>
                   <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/firmware_templates/show_firmware_template.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/show_firmware_template.html.heex
@@ -1,9 +1,9 @@
 <div class="action-row">
-  <.link patch={~p"/org/#{@org.name}/#{@product.name}/firmware"} class="back-link">
+  <.link patch={~p"/org/#{@org}/#{@product}/firmware"} class="back-link">
     All Firmware
   </.link>
   <div class="btn-group" role="group" aria-label="Device Actions">
-    <.link class="btn btn-outline-light btn-action" aria-label="Download" href={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@firmware.uuid}/download"} download>
+    <.link class="btn btn-outline-light btn-action" aria-label="Download" href={~p"/org/#{@org}/#{@product}/firmware/#{@firmware}/download"} download>
       <span class="button-icon download"></span>
       <span class="action-text">Download</span>
     </.link>

--- a/lib/nerves_hub_web/live/firmware_templates/show_firmware_template_new.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/show_firmware_template_new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/firmware"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/firmware"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
@@ -33,7 +33,7 @@
     </div>
 
     <div class="flex items-center gap-2">
-      <.button type="link" href={~p"/org/#{@org.name}/#{@product.name}/firmware/#{@firmware.uuid}/download"} download>
+      <.button type="link" href={~p"/org/#{@org}/#{@product}/firmware/#{@firmware}/download"} download>
         <.icon name="download" />Download
       </.button>
 

--- a/lib/nerves_hub_web/live/firmware_templates/upload_firmware_template.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/upload_firmware_template.html.heex
@@ -12,7 +12,7 @@
       <span :if={@error_message} class="help-block">
         <%= case @error_code do %>
           <% :duplicate_firmware -> %>
-            {@error_message} <a href={"/org/#{@org.name}/#{@product.name}/firmware/#{@uuid}"} target="_blank">View Firmware</a>
+            {@error_message} <a href={"/org/#{@org}/#{@product}/firmware/#{@uuid}"} target="_blank">View Firmware</a>
           <% _ -> %>
             {@error_message}
         <% end %>

--- a/lib/nerves_hub_web/live/org/certificate_authorities.ex
+++ b/lib/nerves_hub_web/live/org/certificate_authorities.ex
@@ -62,7 +62,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
       {:error, :not_found} ->
         socket
         |> put_flash(:error, "Certificate Authority not found")
-        |> push_patch(to: ~p"/org/#{socket.assigns.org.name}/settings/certificates")
+        |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
     end
   end
 
@@ -96,7 +96,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
          {:ok, _cert} <- Devices.update_ca_certificate(cert, params) do
       socket
       |> put_flash(:info, "Certificate Authority updated")
-      |> push_patch(to: ~p"/org/#{socket.assigns.org.name}/settings/certificates")
+      |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
       |> noreply()
     else
       {:error, :not_found} ->
@@ -146,7 +146,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
          {:ok, _ca_certificate} <- Devices.create_ca_certificate(socket.assigns.org, params) do
       socket
       |> put_flash(:info, "Certificate Authority created")
-      |> push_patch(to: ~p"/org/#{socket.assigns.org.name}/settings/certificates")
+      |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
       |> noreply()
     else
       {:error, :empty_cert} ->

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/edit_ca_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/edit_ca_template.html.heex
@@ -62,7 +62,7 @@
   <% end %>
 
   <div class="button-submit-wrapper">
-    <.link class="btn btn-outline-light" patch={~p"/org/#{@org.name}/settings/certificates"}>Cancel</.link>
+    <.link class="btn btn-outline-light" patch={~p"/org/#{@org}/settings/certificates"}>Cancel</.link>
     {submit("Update Certificate", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/list_cas_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/list_cas_template.html.heex
@@ -1,6 +1,6 @@
 <div class="action-row">
   <h1>Certificate Authorities</h1>
-  <.link class="btn btn-outline-light btn-action" aria-label="Add certificate authority" navigate={~p"/org/#{@org.name}/settings/certificates/new"}>
+  <.link class="btn btn-outline-light btn-action" aria-label="Add certificate authority" navigate={~p"/org/#{@org}/settings/certificates/new"}>
     <span class="button-icon add"></span>
     <span class="action-text">Add Certificate Authority</span>
   </.link>
@@ -68,7 +68,7 @@
               <img src="/images/icons/more.svg" alt="options" />
             </a>
             <div :if={authorized?(:"certificate_authority:update", @org_user)} class="dropdown-menu dropdown-menu-right">
-              <.link navigate={~p"/org/#{@org.name}/settings/certificates/#{cert.serial}/edit"} class="dropdown-item">
+              <.link navigate={~p"/org/#{@org}/settings/certificates/#{cert}/edit"} class="dropdown-item">
                 Edit
               </.link>
               <.link

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/new_ca_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/new_ca_template.html.heex
@@ -145,7 +145,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <.link id="back-button" class="btn btn-outline-light" patch={~p"/org/#{@org.name}/settings/certificates"}>Cancel</.link>
+    <.link id="back-button" class="btn btn-outline-light" patch={~p"/org/#{@org}/settings/certificates"}>Cancel</.link>
     {submit("Create Certificate", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/live/org/product_templates/new_product_template.html.heex
+++ b/lib/nerves_hub_web/live/org/product_templates/new_product_template.html.heex
@@ -92,7 +92,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <.link class="btn btn-outline-light" patch={~p"/org/#{@org.name}"}>Cancel</.link>
+    <.link class="btn btn-outline-light" patch={~p"/org/#{@org}"}>Cancel</.link>
     {submit("Create Product", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/live/org/product_templates/products_template.html.heex
+++ b/lib/nerves_hub_web/live/org/product_templates/products_template.html.heex
@@ -3,7 +3,7 @@
     <img src="/images/product.svg" alt="No products" />
     <h3 style="margin-top: 2.75rem">{@org.name} doesn’t have any products yet</h3>
     <div class="flex-row align-items-center mt-3">
-      <.link navigate={~p"/org/#{@org.name}/new"} class="btn btn-outline-light" aria-label="Create new product" role="button">
+      <.link navigate={~p"/org/#{@org}/new"} class="btn btn-outline-light" aria-label="Create new product" role="button">
         <span class="button-icon add"></span>
         <span class="action-text">Create New</span>
       </.link>
@@ -12,7 +12,7 @@
 <% else %>
   <div class="action-row">
     <h1>Products</h1>
-    <.link navigate={~p"/org/#{@org.name}/new"} class="btn btn-outline-light btn-action" aria-label="Create new product" role="button">
+    <.link navigate={~p"/org/#{@org}/new"} class="btn btn-outline-light btn-action" aria-label="Create new product" role="button">
       <div class="button-icon add"></div>
       <span class="action-text">Create New</span>
     </.link>
@@ -20,7 +20,7 @@
 
   <div class="x3-grid">
     <%= for product <- @products do %>
-      <.link navigate={~p"/org/#{@org.name}/#{product.name}/devices"} class="grid-item">
+      <.link navigate={~p"/org/#{@org}/#{product}/devices"} class="grid-item">
         <h3>{product.name}</h3>
       </.link>
     <% end %>

--- a/lib/nerves_hub_web/live/org/products.ex
+++ b/lib/nerves_hub_web/live/org/products.ex
@@ -46,7 +46,7 @@ defmodule NervesHubWeb.Live.Org.Products do
       {:ok, product} ->
         socket
         |> put_flash(:info, "Product created successfully.")
-        |> push_navigate(to: "/org/#{socket.assigns.org.name}/#{product.name}/devices")
+        |> push_navigate(to: ~p"/org/#{socket.assigns.org}/#{product}/devices")
         |> noreply()
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/nerves_hub_web/live/org/settings.ex
+++ b/lib/nerves_hub_web/live/org/settings.ex
@@ -22,7 +22,7 @@ defmodule NervesHubWeb.Live.Org.Settings do
       {:ok, org} ->
         socket
         |> put_flash(:info, "Organization updated")
-        |> push_navigate(to: ~p"/org/#{org.name}/settings")
+        |> push_navigate(to: ~p"/org/#{org}/settings")
         |> noreply()
 
       {:error, changeset} ->

--- a/lib/nerves_hub_web/live/org/settings.html.heex
+++ b/lib/nerves_hub_web/live/org/settings.html.heex
@@ -18,5 +18,5 @@
 <div class="border-bottom border-dark mt-5 mb-2"></div>
 
 <div>
-  <.link patch={~p"/org/#{@org.name}/settings/delete"} class="btn btn-primary">Delete Organization</.link>
+  <.link patch={~p"/org/#{@org}/settings/delete"} class="btn btn-primary">Delete Organization</.link>
 </div>

--- a/lib/nerves_hub_web/live/org/signing_keys.ex
+++ b/lib/nerves_hub_web/live/org/signing_keys.ex
@@ -39,7 +39,7 @@ defmodule NervesHubWeb.Live.Org.SigningKeys do
         {:noreply,
          socket
          |> put_flash(:info, "Signing Key created successfully.")
-         |> push_navigate(to: ~p"/org/#{socket.assigns.org.name}/settings/keys")}
+         |> push_navigate(to: ~p"/org/#{socket.assigns.org}/settings/keys")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :form, to_form(changeset))}

--- a/lib/nerves_hub_web/live/org/signing_keys.html.heex
+++ b/lib/nerves_hub_web/live/org/signing_keys.html.heex
@@ -1,7 +1,7 @@
 <%= if @live_action == :index do %>
   <div class="action-row">
     <h1>Signing Keys</h1>
-    <.link patch={~p"/org/#{@org.name}/settings/keys/new"} class="btn btn-outline-light btn-action" aria-label="Add new signing key">
+    <.link patch={~p"/org/#{@org}/settings/keys/new"} class="btn btn-outline-light btn-action" aria-label="Add new signing key">
       <span class="button-icon add"></span>
       <span class="action-text">Add Key</span>
     </.link>
@@ -58,7 +58,7 @@
     </div>
 
     <div class="button-submit-wrapper">
-      <.link patch={~p"/org/#{@org.name}/settings/keys"} class="btn btn-outline-light">Back</.link>
+      <.link patch={~p"/org/#{@org}/settings/keys"} class="btn btn-outline-light">Back</.link>
       {submit("Create Key", class: "btn btn-primary")}
     </div>
   </.form>

--- a/lib/nerves_hub_web/live/org/user_templates/edit_user_template.html.heex
+++ b/lib/nerves_hub_web/live/org/user_templates/edit_user_template.html.heex
@@ -15,7 +15,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <.link class="btn btn-outline-light" patch={~p"/org/#{@org.name}/settings/users"}>Cancel</.link>
+    <.link class="btn btn-outline-light" patch={~p"/org/#{@org}/settings/users"}>Cancel</.link>
     {submit("Update", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/live/org/user_templates/invite_template.html.heex
+++ b/lib/nerves_hub_web/live/org/user_templates/invite_template.html.heex
@@ -31,7 +31,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <.link class="btn btn-outline-light" patch={~p"/org/#{@org.name}/settings/users"}>Cancel</.link>
+    <.link class="btn btn-outline-light" patch={~p"/org/#{@org}/settings/users"}>Cancel</.link>
     {submit("Send Invitation", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/live/org/user_templates/users_template.html.heex
+++ b/lib/nerves_hub_web/live/org/user_templates/users_template.html.heex
@@ -27,7 +27,7 @@
 
 <div class="action-row">
   <h1>Users</h1>
-  <.link navigate={~p"/org/#{@org.name}/settings/users/invite"} class="btn btn-outline-light btn-action" aria-label="Add new user">
+  <.link navigate={~p"/org/#{@org}/settings/users/invite"} class="btn btn-outline-light btn-action" aria-label="Add new user">
     <span class="button-icon add"></span>
     <span class="action-text">Add New User</span>
   </.link>
@@ -67,7 +67,7 @@
               <img src="/images/icons/more.svg" alt="options" />
             </a>
             <div class="dropdown-menu dropdown-menu-right">
-              <.link patch={~p"/org/#{@org.name}/settings/users/#{org_user.user_id}/edit"} class="dropdown-item">
+              <.link patch={~p"/org/#{@org}/settings/users/#{org_user.user_id}/edit"} class="dropdown-item">
                 Edit
               </.link>
               <div class="dropdown-divider"></div>

--- a/lib/nerves_hub_web/live/org/users.ex
+++ b/lib/nerves_hub_web/live/org/users.ex
@@ -60,7 +60,7 @@ defmodule NervesHubWeb.Live.Org.Users do
         {:noreply,
          socket
          |> put_flash(:info, "User has been invited")
-         |> push_patch(to: ~p"/org/#{socket.assigns.org.name}/settings/users")}
+         |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/users")}
 
       {:ok, %OrgUser{}} ->
         _ =
@@ -74,7 +74,7 @@ defmodule NervesHubWeb.Live.Org.Users do
         {:noreply,
          socket
          |> put_flash(:info, "User has been added to #{socket.assigns.org.name}")
-         |> push_patch(to: ~p"/org/#{socket.assigns.org.name}/settings/users")}
+         |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/users")}
 
       {:error, changeset} ->
         {:noreply, assign(socket, :form, to_form(changeset))}
@@ -112,7 +112,7 @@ defmodule NervesHubWeb.Live.Org.Users do
         {:noreply,
          socket
          |> put_flash(:info, "Role updated")
-         |> push_patch(to: ~p"/org/#{socket.assigns.org.name}/settings/users")}
+         |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/users")}
 
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Error updating role")}

--- a/lib/nerves_hub_web/live/orgs/index-new.html.heex
+++ b/lib/nerves_hub_web/live/orgs/index-new.html.heex
@@ -52,7 +52,7 @@
         <div class="grid grid-cols-2 px-4 pb-4 pt-2 gap-4">
           <div :for={product <- org.products} class="flex justify-between gap-[16px] p-4 w-full border border-zinc-700 rounded bg-gradient-to-r from-zinc-800/50 to-zinc-800">
             <div class="text-neutral-50 font-semibold text-sm">
-              <.link navigate={~p"/org/#{org.name}/#{product.name}/devices"}>
+              <.link navigate={~p"/org/#{org}/#{product}/devices"}>
                 {product.name}
               </.link>
             </div>

--- a/lib/nerves_hub_web/live/orgs/index.html.heex
+++ b/lib/nerves_hub_web/live/orgs/index.html.heex
@@ -13,7 +13,7 @@
   <h1 class="mt-2">Organizations</h1>
   <div class="x3-grid">
     <%= for org <- @user.orgs do %>
-      <.link navigate={~p"/org/#{org.name}"} class="grid-item">
+      <.link navigate={~p"/org/#{org}"} class="grid-item">
         <h3>{org.name}</h3>
         <div class="flex-row">
           <div>

--- a/lib/nerves_hub_web/live/orgs/new.ex
+++ b/lib/nerves_hub_web/live/orgs/new.ex
@@ -22,7 +22,7 @@ defmodule NervesHubWeb.Live.Orgs.New do
         {:noreply,
          socket
          |> put_flash(:info, "Organization created successfully.")
-         |> push_navigate(to: ~p"/org/#{org.name}")}
+         |> push_navigate(to: ~p"/org/#{org}")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :form, to_form(changeset))}

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -78,7 +78,7 @@ defmodule NervesHubWeb.Live.Product.Settings do
       {:ok, _product} ->
         socket
         |> put_flash(:info, "Product deleted successfully.")
-        |> push_navigate(to: ~p"/org/#{socket.assigns.org.name}")
+        |> push_navigate(to: ~p"/org/#{socket.assigns.org}")
         |> noreply()
 
       {:error, _changeset} ->

--- a/lib/nerves_hub_web/live/support_scripts/edit-new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/edit-new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/scripts"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>

--- a/lib/nerves_hub_web/live/support_scripts/edit.ex
+++ b/lib/nerves_hub_web/live/support_scripts/edit.ex
@@ -31,7 +31,7 @@ defmodule NervesHubWeb.Live.SupportScripts.Edit do
       {:ok, _script} ->
         socket
         |> put_flash(:info, "Support Script updated successfully.")
-        |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/scripts")
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/scripts")
         |> noreply()
 
       {:error, changeset} ->
@@ -54,7 +54,7 @@ defmodule NervesHubWeb.Live.SupportScripts.Edit do
       {:ok, _} ->
         socket
         |> put_flash(:info, "Support Script deleted successfully.")
-        |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/scripts")
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/scripts")
         |> noreply()
 
       {:error, _} ->

--- a/lib/nerves_hub_web/live/support_scripts/edit.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/edit.html.heex
@@ -14,7 +14,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts"} class="btn btn-secondary">Back</.link>
+    <.link navigate={~p"/org/#{@org}/#{@product}/scripts"} class="btn btn-secondary">Back</.link>
     {submit("Save Changes", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/live/support_scripts/index-new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/index-new.html.heex
@@ -20,7 +20,7 @@
       {@pager_meta.total_count}
     </div>
 
-    <.button type="link" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/new"} aria-label="Add a support script">
+    <.button type="link" navigate={~p"/org/#{@org}/#{@product}/scripts/new"} aria-label="Add a support script">
       <.icon name="add" />Add Support Script
     </.button>
   </div>
@@ -40,7 +40,7 @@
       <tbody>
         <tr :for={script <- @scripts} class="border-b border-zinc-800">
           <td class="h-[52px]">
-            <.link class="size-full flex items-center" navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/#{script.id}/edit"}>
+            <.link class="size-full flex items-center" navigate={~p"/org/#{@org}/#{@product}/scripts/#{script}/edit"}>
               {script.name}
             </.link>
           </td>

--- a/lib/nerves_hub_web/live/support_scripts/index.ex
+++ b/lib/nerves_hub_web/live/support_scripts/index.ex
@@ -110,7 +110,7 @@ defmodule NervesHubWeb.Live.SupportScripts.Index do
       stringify_keys(new_params)
       |> Enum.into(current_params)
 
-    ~p"/org/#{socket.assigns.org.name}/#{socket.assigns.product.name}/scripts?#{params}"
+    ~p"/org/#{socket.assigns.org}/#{socket.assigns.product}/scripts?#{params}"
   end
 
   defp stringify_keys(params) do

--- a/lib/nerves_hub_web/live/support_scripts/index.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/index.html.heex
@@ -2,7 +2,7 @@
   <div class="no-results-blowup-wrapper">
     <h3 style="margin-top: 2.75rem">{@product.name} doesn’t have any Support Scripts yet</h3>
     <div class="flex-row align-items-center mt-3">
-      <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/new"} class="btn btn-outline-light" aria-label="Create Support Script">
+      <.link navigate={~p"/org/#{@org}/#{@product}/scripts/new"} class="btn btn-outline-light" aria-label="Create Support Script">
         <span class="action-text">Create Support Script</span>
         <span class="button-icon add"></span>
       </.link>
@@ -11,7 +11,7 @@
 <% else %>
   <div class="action-row">
     <h1>Support Scripts</h1>
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/new"} class="btn btn-outline-light btn-action" aria-label="Create Support Script">
+    <.link navigate={~p"/org/#{@org}/#{@product}/scripts/new"} class="btn btn-outline-light btn-action" aria-label="Create Support Script">
       <span class="button-icon add"></span>
       <span class="action-text">Create Support Script</span>
     </.link>
@@ -23,7 +23,7 @@
         {command.name}
       </td>
       <td class="actions">
-        <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts/#{command.id}/edit"} class="btn btn-outline-light btn-action mr-1">
+        <.link navigate={~p"/org/#{@org}/#{@product}/scripts/#{command}/edit"} class="btn btn-outline-light btn-action mr-1">
           Edit
         </.link>
         <.link phx-click="delete-support-script" phx-value-script_id={command.id} class="btn btn-outline-light btn-action" data-confirm="Are you sure?">

--- a/lib/nerves_hub_web/live/support_scripts/new-new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/new-new.html.heex
@@ -1,6 +1,6 @@
 <div class="h-[56px] skrink-0 flex justify-between bg-base-900 border-b border-base-700 pl-6 items-center">
   <div class="flex gap-2.5">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts"} class="back-link flex gap-2.5 items-center">
+    <.link navigate={~p"/org/#{@org}/#{@product}/scripts"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>

--- a/lib/nerves_hub_web/live/support_scripts/new.ex
+++ b/lib/nerves_hub_web/live/support_scripts/new.ex
@@ -25,7 +25,7 @@ defmodule NervesHubWeb.Live.SupportScripts.New do
       {:ok, _script} ->
         socket
         |> put_flash(:info, "Support Script created successfully.")
-        |> push_navigate(to: ~p"/org/#{org.name}/#{product.name}/scripts")
+        |> push_navigate(to: ~p"/org/#{org}/#{product}/scripts")
         |> noreply()
 
       {:error, changeset} ->

--- a/lib/nerves_hub_web/live/support_scripts/new.html.heex
+++ b/lib/nerves_hub_web/live/support_scripts/new.html.heex
@@ -14,7 +14,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <.link navigate={~p"/org/#{@org.name}/#{@product.name}/scripts"} class="btn btn-secondary">Back</.link>
+    <.link navigate={~p"/org/#{@org}/#{@product}/scripts"} class="btn btn-secondary">Back</.link>
     {submit("Add Script", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/nerves_hub_web/templates/layout/_navigation.html.heex
+++ b/lib/nerves_hub_web/templates/layout/_navigation.html.heex
@@ -20,7 +20,7 @@
             <div class="dropdown-divider"></div>
             <%= for org <- @orgs do %>
               <div class="dropdown-submenu">
-                <%= link(to: ~p"/org/#{org.name}", class: "dropdown-item org #{org_classes(@conn, org.name)}", aria_haspopup: "true") do %>
+                <%= link(to: ~p"/org/#{org}", class: "dropdown-item org #{org_classes(@conn, org.name)}", aria_haspopup: "true") do %>
                   {org.name}
                   <div class="active-checkmark"></div>
                 <% end %>
@@ -30,7 +30,7 @@
                   <%= if org.products !== [] do %>
                     <%= for product <- org.products do %>
                       <li>
-                        <.link href={~p"/org/#{org.name}/#{product.name}/devices"} class={"dropdown-item product #{@conn.assigns[:product] == product && "active"}"}>
+                        <.link href={~p"/org/#{org}/#{product}/devices"} class={"dropdown-item product #{@conn.assigns[:product] == product && "active"}"}>
                           {product.name}
                           <div class="active-checkmark"></div>
                         </.link>
@@ -42,7 +42,7 @@
                     <div class="dropdown-divider"></div>
                   <% end %>
 
-                  <a class="btn btn-outline-light mt-2 mb-3 ml-3 mr-3" aria-label="Create product" href={~p"/org/#{org.name}/new"}>
+                  <a class="btn btn-outline-light mt-2 mb-3 ml-3 mr-3" aria-label="Create product" href={~p"/org/#{org}/new"}>
                     <span class="action-text">Create Product</span>
                     <span class="button-icon add"></span>
                   </a>

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -217,32 +217,32 @@ defmodule NervesHubWeb.LayoutView do
       %{
         title: "Devices",
         active: "",
-        href: ~p"/org/#{conn.assigns.org.name}/#{conn.assigns.product.name}/devices"
+        href: ~p"/org/#{conn.assigns.org}/#{conn.assigns.product}/devices"
       },
       %{
         title: "Firmware",
         active: "",
-        href: ~p"/org/#{conn.assigns.org.name}/#{conn.assigns.product.name}/firmware"
+        href: ~p"/org/#{conn.assigns.org}/#{conn.assigns.product}/firmware"
       },
       %{
         title: "Archives",
         active: "",
-        href: ~p"/org/#{conn.assigns.org.name}/#{conn.assigns.product.name}/archives"
+        href: ~p"/org/#{conn.assigns.org}/#{conn.assigns.product}/archives"
       },
       %{
         title: "Deployments",
         active: "",
-        href: ~p"/org/#{conn.assigns.org.name}/#{conn.assigns.product.name}/deployment_groups"
+        href: ~p"/org/#{conn.assigns.org}/#{conn.assigns.product}/deployment_groups"
       },
       %{
         title: "Scripts",
         active: "",
-        href: ~p"/org/#{conn.assigns.org.name}/#{conn.assigns.product.name}/scripts"
+        href: ~p"/org/#{conn.assigns.org}/#{conn.assigns.product}/scripts"
       },
       %{
         title: "Settings",
         active: "",
-        href: ~p"/org/#{conn.assigns.org.name}/#{conn.assigns.product.name}/settings"
+        href: ~p"/org/#{conn.assigns.org}/#{conn.assigns.product}/settings"
       }
     ]
     |> sidebar_active(conn)

--- a/test/nerves_hub_web/controllers/archive_controller_test.exs
+++ b/test/nerves_hub_web/controllers/archive_controller_test.exs
@@ -15,7 +15,7 @@ defmodule NervesHubWeb.ArchiveControllerTest do
       org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
       archive = Fixtures.archive_fixture(org_key, product, %{dir: tmp_dir})
 
-      conn = get(conn, ~p"/org/#{org.name}/#{product.name}/archives/#{archive.uuid}/download")
+      conn = get(conn, ~p"/org/#{org}/#{product}/archives/#{archive}/download")
 
       assert redirected_to(conn) == "/uploads/archives/#{archive.uuid}.fw"
     end

--- a/test/nerves_hub_web/controllers/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/firmware_controller_test.exs
@@ -13,7 +13,7 @@ defmodule NervesHubWeb.FirmwareControllerTest do
       org_key = Fixtures.org_key_fixture(org, user)
       firmware = Fixtures.firmware_fixture(org_key, product)
 
-      conn = get(conn, ~p"/org/#{org.name}/#{product.name}/firmware/#{firmware.uuid}/download")
+      conn = get(conn, ~p"/org/#{org}/#{product}/firmware/#{firmware}/download")
 
       assert redirected_to(conn) == firmware.upload_metadata.public_path
     end

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -394,6 +394,6 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
   end
 
   def device_index_path(%{org: org, product: product}) do
-    ~p"/org/#{org.name}/#{product.name}/devices"
+    ~p"/org/#{org}/#{product}/devices"
   end
 end

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -687,6 +687,6 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   end
 
   def device_show_path(%{device: device, org: org, product: product}) do
-    ~p"/org/#{org.name}/#{product.name}/devices/#{device.identifier}"
+    ~p"/org/#{org}/#{product}/devices/#{device}"
   end
 end

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -80,13 +80,13 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       conn
       |> put_session("new_ui", true)
       |> visit("/org/#{org.name}/#{product.name}/devices")
-      |> assert_has("a", text: device.identifier)
+      |> assert_has("a", text: device.identifier, timeout: 1000)
       |> assert_has("a", text: device2.identifier)
       |> select("Platform", option: "foo")
+      |> assert_has("a", text: device2.identifier, timeout: 1000)
       |> refute_has("a", text: device.identifier)
-      |> assert_has("a", text: device2.identifier)
       |> select("Platform", option: "platform")
-      |> assert_has("a", text: device.identifier)
+      |> assert_has("a", text: device.identifier, timeout: 1000)
       |> refute_has("a", text: device2.identifier)
     end
   end

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -50,7 +50,7 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> assert_has("h1", text: "Create Product")
       |> fill_in("Name", with: "My Amazing Product")
       |> click_button("Create Product")
-      |> assert_path("/org/#{org.name}/My Amazing Product/devices")
+      |> assert_path("/org/#{org.name}/My%20Amazing%20Product/devices")
       |> assert_has("h3",
         text: "My Amazing Product doesn’t have any devices yet",
         timeout: 1000
@@ -64,7 +64,7 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> assert_has("h1", text: "Create Product")
       |> fill_in("Name", with: "  My Amazing Product  ")
       |> click_button("Create Product")
-      |> assert_path("/org/#{org.name}/My Amazing Product/devices")
+      |> assert_path("/org/#{org.name}/My%20Amazing%20Product/devices")
       |> assert_has("h3",
         text: "My Amazing Product doesn’t have any devices yet",
         timeout: 1000
@@ -78,7 +78,7 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       |> assert_has("h1", text: "Create Product")
       |> fill_in("Name", with: "  My  Amazing  Product  ")
       |> click_button("Create Product")
-      |> assert_path("/org/#{org.name}/My Amazing Product/devices")
+      |> assert_path("/org/#{org.name}/My%20Amazing%20Product/devices")
       |> assert_has("h3",
         text: "My Amazing Product doesn’t have any devices yet",
         timeout: 1000


### PR DESCRIPTION
https://hexdocs.pm/phoenix/1.7.21/Phoenix.Param.html

This PR cleans up our URL generation by implementing `Phoenix.Param` for schemas that does use `id`s in the path segments.