### PR TITLE
Don't clean up the async assign on the console tab

### DIFF
--- a/lib/nerves_hub_web/components/device_page/console_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/console_tab.ex
@@ -14,10 +14,6 @@ defmodule NervesHubWeb.Components.DevicePage.ConsoleTab do
     |> cont()
   end
 
-  def cleanup() do
-    [:console_active?]
-  end
-
   def hooked_info(%Broadcast{event: "file-data/start", payload: payload}, socket) do
     if socket.assigns.user.id == payload.uploaded_by do
       put_flash(socket, :info, "Upload started.")


### PR DESCRIPTION
Fixes a `missing async assign :console_active?` error when the assign is cleaned up before it is populated.