### PR TITLE
Scroll pinned-device tags when there are too many

### DIFF
--- a/assets/ui-rework/app.css
+++ b/assets/ui-rework/app.css
@@ -265,6 +265,11 @@
     z-index: 10;
     max-height: 52px;
   }
+
+  .scrollable-table-cell {
+    overflow-y: scroll;
+    scrollbar-width: none;
+  }
 }
 
 html {

--- a/assets/ui-rework/app.css
+++ b/assets/ui-rework/app.css
@@ -266,9 +266,36 @@
     max-height: 52px;
   }
 
-  .scrollable-table-cell {
+  .scrollable-inner {
     overflow-y: scroll;
     scrollbar-width: none;
+  }
+
+  .pinned-device-tag-gradient-mask {
+    position: absolute;
+    top: 0;
+    right: 16px;
+    width: 50px;
+    height: 100%;
+    background-image: linear-gradient(
+      to right,
+      rgba(24, 24, 27, 0),
+      rgba(24, 24, 27, 1)
+    );
+  }
+
+  .device-show-tag-gradient-mask {
+    position: absolute;
+    top: 0;
+    right: 16px;
+    width: 50px;
+    height: 100%;
+    z-index: 1;
+    background-image: linear-gradient(
+      to right,
+      rgba(24, 24, 27, 0),
+      rgba(24, 24, 27, 1)
+    );
   }
 }
 

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -228,7 +228,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
 
         <div class="flex flex-col pb-4 rounded border border-zinc-700 bg-zinc-900 shadow-device-details-content">
           <div class="h-14 pl-4 pr-3 flex items-center text-neutral-50 font-medium leading-6">
-            General info
+            General Info
           </div>
           <div class="flex flex-col gap-3">
             <div :if={@device.description != ""} class="min-h-7 px-4 flex gap-4 items-center">
@@ -241,10 +241,11 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
               <span class="text-sm text-zinc-300">{NaiveDateTime.to_string(@device.inserted_at)}</span>
             </div>
 
-            <div class="min-h-7 flex px-4 gap-4 items-center">
+            <div class="min-h-7 flex px-4 gap-4 items-center relative">
               <span class="text-sm text-nerves-gray-500">Tags:</span>
               <span :if={is_nil(@device.tags)} class="text-sm text-nerves-gray-500">No Tags</span>
-              <span :if={@device.tags} class="flex gap-1">
+              <span class="device-show-tag-gradient-mask" />
+              <span :if={@device.tags} class="flex gap-1 max-w-full text-nowrap relative scrollable-inner">
                 <span :for={tag <- @device.tags || []} class="text-sm text-zinc-300 px-2 py-1 border border-zinc-800 bg-zinc-800 rounded">{tag}</span>
               </span>
             </div>

--- a/lib/nerves_hub_web/components/pinned_devices.ex
+++ b/lib/nerves_hub_web/components/pinned_devices.ex
@@ -96,8 +96,8 @@ defmodule NervesHubWeb.Components.PinnedDevices do
                     </span>
                   </td>
 
-                  <td>
-                    <div class="flex items-center gap-[4px]">
+                  <td class="max-w-[250px] scrollable-table-cell">
+                    <div class="flex items-center text-nowrap gap-[4px]">
                       <%= if !is_nil(device.tags) do %>
                         <%= for tag <- device.tags do %>
                           <span class="tag">{tag}</span>

--- a/lib/nerves_hub_web/components/pinned_devices.ex
+++ b/lib/nerves_hub_web/components/pinned_devices.ex
@@ -96,8 +96,9 @@ defmodule NervesHubWeb.Components.PinnedDevices do
                     </span>
                   </td>
 
-                  <td class="max-w-[250px] scrollable-table-cell">
-                    <div class="flex items-center text-nowrap gap-[4px]">
+                  <td class="max-w-[250px] relative">
+                    <span class="pinned-device-tag-gradient-mask" />
+                    <div class="flex items-center text-nowrap gap-[4px] scrollable-inner">
                       <%= if !is_nil(device.tags) do %>
                         <%= for tag <- device.tags do %>
                           <span class="tag">{tag}</span>

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -268,7 +268,7 @@
               </td>
 
               <td>
-                <div class="flex items-center gap-[4px]">
+                <div class="flex items-center gap-[4px] text-nowrap">
                   <%= if !is_nil(device.tags) do %>
                     <%= for tag <- device.tags do %>
                       <span class="tag">{tag}</span>


### PR DESCRIPTION
Too many tags for a pinned device breaks the layout. The text should not wrap and it should be scrollable.

Before:
<img width="1014" alt="CleanShot 2025-04-30 at 12 25 23@2x" src="https://github.com/user-attachments/assets/cd261de6-abcd-4294-af3d-e9cab3cc10f0" />


After:
![CleanShot 2025-04-30 at 12 24 54](https://github.com/user-attachments/assets/85ba6294-cbed-42a5-b509-d8aa0c1eea78)
