### PR TITLE
Fix pure text emails

### DIFF
--- a/lib/nerves_hub/accounts/user_notifier.ex
+++ b/lib/nerves_hub/accounts/user_notifier.ex
@@ -25,8 +25,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       platform_name: platform_name()
     }
 
-    html = ConfirmationTemplate.render(assigns)
-    text = ConfirmationTemplate.text_render(assigns)
+    {html, text} = render(ConfirmationTemplate, assigns)
 
     send_email(user, "#{platform_name()}: Confirm your account", html, text)
   end
@@ -38,8 +37,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       platform_name: platform_name()
     }
 
-    html = PasswordUpdatedTemplate.render(assigns)
-    text = PasswordUpdatedTemplate.text_render(assigns)
+    {html, text} = render(PasswordUpdatedTemplate, assigns)
 
     send_email(user, "#{platform_name()}: Your password has been updated", html, text)
   end
@@ -51,8 +49,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       platform_name: platform_name()
     }
 
-    html = LoginWithGoogleReminderTemplate.render(assigns)
-    text = LoginWithGoogleReminderTemplate.text_render(assigns)
+    {html, text} = render(LoginWithGoogleReminderTemplate, assigns)
 
     send_email(user, "#{platform_name()}: Login with Google", html, text)
   end
@@ -64,8 +61,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       platform_name: platform_name()
     }
 
-    html = PasswordResetTemplate.render(assigns)
-    text = PasswordResetTemplate.text_render(assigns)
+    {html, text} = render(PasswordResetTemplate, assigns)
 
     send_email(user, "#{platform_name()}: Reset your password", html, text)
   end
@@ -76,8 +72,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       platform_name: platform_name()
     }
 
-    html = PasswordResetConfirmationTemplate.render(assigns)
-    text = PasswordResetConfirmationTemplate.text_render(assigns)
+    {html, text} = render(PasswordResetConfirmationTemplate, assigns)
 
     send_email(user, "#{platform_name()}: Your password has been reset", html, text)
   end
@@ -85,8 +80,7 @@ defmodule NervesHub.Accounts.UserNotifier do
   def deliver_welcome_email(user) do
     assigns = %{user_name: user.name, platform_name: platform_name()}
 
-    html = WelcomeTemplate.render(assigns)
-    text = WelcomeTemplate.text_render(assigns)
+    {html, text} = render(WelcomeTemplate, assigns)
 
     send_email(user, "#{platform_name()}: Welcome #{user.name}!", html, text)
   end
@@ -99,8 +93,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       invite_url: invite_url
     }
 
-    html = UserInviteTemplate.render(assigns)
-    text = UserInviteTemplate.text_render(assigns)
+    {html, text} = render(UserInviteTemplate, assigns)
 
     send_email(
       email,
@@ -117,8 +110,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       org_name: org.name
     }
 
-    html = OrgUserAddedTemplate.render(assigns)
-    text = OrgUserAddedTemplate.text_render(assigns)
+    {html, text} = render(OrgUserAddedTemplate, assigns)
 
     send_email(
       user,
@@ -144,8 +136,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       org_name: org.name
     }
 
-    html = TellOrgUserInvitedTemplate.render(assigns)
-    text = TellOrgUserInvitedTemplate.text_render(assigns)
+    {html, text} = render(TellOrgUserInvitedTemplate, assigns)
 
     send_email(
       admin,
@@ -173,8 +164,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       org_name: org.name
     }
 
-    html = TellOrgUserAddedTemplate.render(assigns)
-    text = TellOrgUserAddedTemplate.text_render(assigns)
+    {html, text} = render(TellOrgUserAddedTemplate, assigns)
 
     send_email(
       admin,
@@ -202,8 +192,7 @@ defmodule NervesHub.Accounts.UserNotifier do
       org_name: org.name
     }
 
-    html = TellOrgUserRemovedTemplate.render(assigns)
-    text = TellOrgUserRemovedTemplate.text_render(assigns)
+    {html, text} = render(TellOrgUserRemovedTemplate, assigns)
 
     send_email(
       admin,
@@ -211,6 +200,17 @@ defmodule NervesHub.Accounts.UserNotifier do
       html,
       text
     )
+  end
+
+  def render(module, assigns) do
+    html = module.render(assigns)
+
+    text =
+      module.text_render(assigns)
+      |> Phoenix.HTML.Safe.to_iodata()
+      |> IO.iodata_to_binary()
+
+    {html, text}
   end
 
   defp send_email(%User{} = user, subject, html, text) do

--- a/lib/nerves_hub/emails/confirmation_template.ex
+++ b/lib/nerves_hub/emails/confirmation_template.ex
@@ -16,6 +16,5 @@ defmodule NervesHub.Emails.ConfirmationTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/login_with_google_reminder_template.ex
+++ b/lib/nerves_hub/emails/login_with_google_reminder_template.ex
@@ -16,6 +16,5 @@ defmodule NervesHub.Emails.LoginWithGoogleReminderTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/org_user_added_template.ex
+++ b/lib/nerves_hub/emails/org_user_added_template.ex
@@ -12,6 +12,5 @@ defmodule NervesHub.Emails.OrgUserAddedTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/password_reset_confirmation_template.ex
+++ b/lib/nerves_hub/emails/password_reset_confirmation_template.ex
@@ -14,6 +14,5 @@ defmodule NervesHub.Emails.PasswordResetConfirmationTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/password_reset_template.ex
+++ b/lib/nerves_hub/emails/password_reset_template.ex
@@ -14,6 +14,5 @@ defmodule NervesHub.Emails.PasswordResetTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/password_updated_template.ex
+++ b/lib/nerves_hub/emails/password_updated_template.ex
@@ -16,6 +16,5 @@ defmodule NervesHub.Emails.PasswordUpdatedTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/tell_org_user_added_template.ex
+++ b/lib/nerves_hub/emails/tell_org_user_added_template.ex
@@ -12,6 +12,5 @@ defmodule NervesHub.Emails.TellOrgUserAddedTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/tell_org_user_invited_template.ex
+++ b/lib/nerves_hub/emails/tell_org_user_invited_template.ex
@@ -12,6 +12,5 @@ defmodule NervesHub.Emails.TellOrgUserInvitedTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/tell_org_user_removed_template.ex
+++ b/lib/nerves_hub/emails/tell_org_user_removed_template.ex
@@ -12,6 +12,5 @@ defmodule NervesHub.Emails.TellOrgUserRemovedTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/user_invite_template.ex
+++ b/lib/nerves_hub/emails/user_invite_template.ex
@@ -16,6 +16,5 @@ defmodule NervesHub.Emails.UserInviteTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/nerves_hub/emails/welcome_template.ex
+++ b/lib/nerves_hub/emails/welcome_template.ex
@@ -12,6 +12,5 @@ defmodule NervesHub.Emails.WelcomeTemplate do
 
     <ClosingBlock.text_support_section />
     """noformat
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/test/nerves_hub_web/controllers/oauth_controller_test.exs
+++ b/test/nerves_hub_web/controllers/oauth_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWeb.OAuthControllerTest do
-  use NervesHubWeb.ConnCase.Browser, async: true
+  use NervesHubWeb.ConnCase.Browser, async: false
   use Mimic
 
   alias NervesHub.Accounts.User
@@ -9,74 +9,80 @@ defmodule NervesHubWeb.OAuthControllerTest do
 
   import Swoosh.TestAssertions
 
-  setup do
-    Application.put_env(:nerves_hub_web, :google_auth_enabled, true)
+  describe "google auth enabled" do
+    setup do
+      Application.put_env(:nerves_hub, :enable_google_auth, true)
 
-    on_exit(fn ->
-      Application.put_env(:nerves_hub_web, :google_auth_enabled, false)
-    end)
-  end
+      on_exit(fn ->
+        Application.put_env(:nerves_hub, :enable_google_auth, false)
+      end)
+    end
 
-  test "does not show google auth button if not enabled" do
-    Application.put_env(:nerves_hub_web, :google_auth_enabled, false)
+    test "shows google auth button if enabled" do
+      build_conn()
+      |> visit(~p"/login")
+      |> assert_has("h1", with: "Sign in to your account")
+      |> assert_has("span", with: "Or create a new account with")
+      |> assert_has("span", with: "Google")
+    end
 
-    build_conn()
-    |> visit(~p"/login")
-    |> assert_has("h1", with: "Sign in to your account")
-    |> refute_has("span", text: "Or create a new account with")
-    |> refute_has("span", text: "Google")
-  end
+    test "create new account successfully" do
+      Mimic.stub(Ueberauth, :call, fn conn, _routes ->
+        google_auth = Fixtures.ueberauth_google_success_fixture()
+        assigns = Map.put(conn.assigns, :ueberauth_auth, google_auth)
+        %{conn | assigns: assigns}
+      end)
 
-  test "shows google auth button if enabled" do
-    build_conn()
-    |> visit(~p"/login")
-    |> assert_has("h1", with: "Sign in to your account")
-    |> assert_has("span", with: "Or create a new account with")
-    |> assert_has("span", with: "Google")
-  end
+      build_conn()
+      |> visit(~p"/auth/google/callback?state=dummy&code=dummy&scope=email+profile&prompt=none")
+      |> assert_path("/orgs")
+      |> assert_has("div", with: "Welcome back!")
 
-  test "create new account successfully" do
-    Mimic.stub(Ueberauth, :call, fn conn, _routes ->
+      assert_email_sent(subject: "NervesHub: Welcome Jane Person!")
+    end
+
+    test "shows the failure page if an error occurs" do
+      Mimic.stub(Ueberauth, :call, fn conn, _routes ->
+        assigns = Map.put(conn.assigns, :ueberauth_failure, true)
+        %{conn | assigns: assigns}
+      end)
+
+      build_conn()
+      |> visit(~p"/auth/google/callback?state=dummy&code=dummy&scope=email+profile&prompt=none")
+      |> assert_has("h1", with: "We were unable to sign you in.")
+    end
+
+    test "doesn't send a reset password email if the user logged in with Google" do
       google_auth = Fixtures.ueberauth_google_success_fixture()
-      assigns = Map.put(conn.assigns, :ueberauth_auth, google_auth)
-      %{conn | assigns: assigns}
-    end)
 
-    build_conn()
-    |> visit(~p"/auth/google/callback?state=dummy&code=dummy&scope=email+profile&prompt=none")
-    |> assert_path("/orgs")
-    |> assert_has("div", with: "Welcome back!")
+      {:ok, user} =
+        %User{}
+        |> User.oauth_changeset(google_auth)
+        |> Repo.insert()
 
-    assert_email_sent(subject: "NervesHub: Welcome Jane Person!")
+      build_conn()
+      |> visit(~p"/password-reset")
+      |> assert_has("h1", with: "Reset your password")
+      |> fill_in("Email", with: user.email)
+      |> submit()
+      |> assert_path(~p"/password-reset")
+      |> assert_has("h1", with: "Time to check your email")
+
+      assert_email_sent(subject: "NervesHub: Login with Google")
+    end
   end
 
-  test "shows the failure page if an error occurs" do
-    Mimic.stub(Ueberauth, :call, fn conn, _routes ->
-      assigns = Map.put(conn.assigns, :ueberauth_failure, true)
-      %{conn | assigns: assigns}
-    end)
+  describe "google auth disabled" do
+    setup do
+      Application.put_env(:nerves_hub, :enable_google_auth, false)
+    end
 
-    build_conn()
-    |> visit(~p"/auth/google/callback?state=dummy&code=dummy&scope=email+profile&prompt=none")
-    |> assert_has("h1", with: "We were unable to sign you in.")
-  end
-
-  test "doesn't send a reset password email if the user logged in with Google" do
-    google_auth = Fixtures.ueberauth_google_success_fixture()
-
-    {:ok, user} =
-      %User{}
-      |> User.oauth_changeset(google_auth)
-      |> Repo.insert()
-
-    build_conn()
-    |> visit(~p"/password-reset")
-    |> assert_has("h1", with: "Reset your password")
-    |> fill_in("Email", with: user.email)
-    |> submit()
-    |> assert_path(~p"/password-reset")
-    |> assert_has("h1", with: "Time to check your email")
-
-    assert_email_sent(subject: "NervesHub: Login with Google")
+    test "does not show google auth button if not enabled" do
+      build_conn()
+      |> visit(~p"/login")
+      |> assert_has("h1", with: "Sign in to your account")
+      |> refute_has("span", text: "Or create a new account with")
+      |> refute_has("span", text: "Google")
+    end
   end
 end


### PR DESCRIPTION
My recent updates to the emails missed a crucial `IO.iodata_to_binary()` when processing the content of the pure text emails.

This PR fixes that, removes some email duplication, and fixes a test related to the new oauth login pages.