### PR TITLE
Fix firmware install count column when viewing firmwares

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -86,7 +86,7 @@ defmodule NervesHub.Firmwares do
       Device
       |> select([d], %{
         firmware_uuid: fragment("? ->> 'uuid'", d.firmware_metadata),
-        install_count: count(fragment("? ->> 'uuid'", d.firmware_metadata), :distinct)
+        install_count: count(fragment("? ->> 'uuid'", d.firmware_metadata))
       })
       |> where([d], not is_nil(d.firmware_metadata))
       |> where([d], not is_nil(fragment("? ->> 'uuid'", d.firmware_metadata)))

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -303,4 +303,17 @@ defmodule NervesHub.FirmwaresTest do
                Firmwares.get_firmware_delta_by_source_and_target(source, target)
     end
   end
+
+  describe "filter/2" do
+    test "counts the number of devices that have the firmware installed", %{
+      org: org,
+      firmware: firmware,
+      product: product
+    } do
+      _device_2 = Fixtures.device_fixture(org, product, firmware)
+      _device_3 = Fixtures.device_fixture(org, product, firmware)
+      {[firmware], _} = Firmwares.filter(product)
+      assert firmware.install_count == 3
+    end
+  end
 end


### PR DESCRIPTION
The `:distinct` on the `count` would always return 0 or 1 when it should be counting all the device rows.

<img width="255" alt="CleanShot 2025-05-06 at 12 48 35@2x" src="https://github.com/user-attachments/assets/606d228b-418a-447f-af7a-2788c6debbd8" />
