### PR TITLE
Reinstate script controller API endpoint

### DIFF
--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -102,6 +102,7 @@ defmodule NervesHubWeb.Router do
       post("/upgrade", DeviceController, :upgrade)
       delete("/penalty", DeviceController, :penalty)
 
+      get("/scripts", ScriptController, :index)
       post("/scripts/:id", ScriptController, :send)
     end
 

--- a/test/nerves_hub_web/controllers/api/script_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/script_controller_test.exs
@@ -1,0 +1,24 @@
+defmodule NervesHubWeb.API.ScriptControllerTest do
+  use NervesHubWeb.APIConnCase, async: true
+
+  alias NervesHub.Fixtures
+
+  setup context do
+    org_key = Fixtures.org_key_fixture(context.org, context.user)
+    firmware = Fixtures.firmware_fixture(org_key, context.product)
+    device = Fixtures.device_fixture(context.org, context.product, firmware)
+
+    Map.put(context, :device, device)
+  end
+
+  describe "index" do
+    test "lists scripts", %{conn: conn, product: product, device: device, user: user} do
+      script = Fixtures.support_script_fixture(product, user)
+      conn = Map.put(conn, :assigns, %{product: product})
+      conn = get(conn, Routes.api_script_path(conn, :index, device))
+      data = [script_response] = json_response(conn, 200)["data"]
+      assert Enum.count(data) == 1
+      assert script_response["id"] == script.id
+    end
+  end
+end


### PR DESCRIPTION
This was removed in #2057 but is needed.