### PR TITLE
Fix scripts index API endpoint

### DIFF
--- a/lib/nerves_hub_web/controllers/api/script_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/script_controller.ex
@@ -11,9 +11,9 @@ defmodule NervesHubWeb.API.ScriptController do
 
   operation(:index, summary: "List all Support Scripts for a Product")
 
-  def index(%{assigns: %{product: product}} = conn, _params) do
+  def index(%{assigns: %{device: device}} = conn, _params) do
     conn
-    |> assign(:scripts, Scripts.all_by_product(product))
+    |> assign(:scripts, Scripts.all_by_product(device.product))
     |> render(:index)
   end
 

--- a/test/nerves_hub_web/controllers/api/script_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/script_controller_test.exs
@@ -14,7 +14,6 @@ defmodule NervesHubWeb.API.ScriptControllerTest do
   describe "index" do
     test "lists scripts", %{conn: conn, product: product, device: device, user: user} do
       script = Fixtures.support_script_fixture(product, user)
-      conn = Map.put(conn, :assigns, %{product: product})
       conn = get(conn, Routes.api_script_path(conn, :index, device))
       data = [script_response] = json_response(conn, 200)["data"]
       assert Enum.count(data) == 1


### PR DESCRIPTION
I mistakenly modified the `conn.assigns` in the ScriptsController test, which doesn't reflect how the real world works. This PR uses `device.product` instead of relying on the product being in `conn.assigns`. I verified this works locally with Postman.