### PR TITLE
Device first in line for updates

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -696,6 +696,8 @@ defmodule NervesHub.Devices do
     |> Repo.all()
   end
 
+  @spec update_firmware_metadata(Device.t(), FirmwareMetadata.t() | nil) ::
+          {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
   def update_firmware_metadata(device, nil) do
     {:ok, device}
   end
@@ -705,6 +707,9 @@ defmodule NervesHub.Devices do
     update_device(device, %{firmware_metadata: metadata})
   end
 
+  @type update_device_return :: {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
+  @spec update_device(Device.t(), map()) :: update_device_return
+  @spec update_device(Device.t(), map(), broadcast: boolean()) :: update_device_return
   def update_device(%Device{} = device, params, opts \\ []) do
     changeset = Device.changeset(device, params)
 
@@ -729,7 +734,7 @@ defmodule NervesHub.Devices do
   - not be running the same firmware version associated with the deployment
   - not in the penalty box (based on `updates_blocked_until`)
 
-  The list is ordered by current connection age. Devices that have been online longer
+  The list is ordered by current connection page. Devices that have been online longer
   are updated first.
   """
   @spec available_for_update(DeploymentGroup.t(), non_neg_integer()) :: [Device.t()]
@@ -751,7 +756,10 @@ defmodule NervesHub.Devices do
     |> where([d, firmware: f], fragment("(? #>> '{\"uuid\"}') != ?", d.firmware_metadata, f.uuid))
     |> where([inflight_update: ifu], is_nil(ifu))
     |> where([d], is_nil(d.updates_blocked_until) or d.updates_blocked_until < ^now)
-    |> order_by([latest_connection: lc], asc: lc.established_at)
+    |> order_by([d, latest_connection: lc],
+      desc: d.first_in_line_for_updates,
+      asc: lc.established_at
+    )
     |> limit(^count)
     |> Repo.all()
   end

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -29,7 +29,8 @@ defmodule NervesHub.Devices.Device do
     :deployment_id,
     :status,
     :first_seen_at,
-    :custom_location_coordinates
+    :custom_location_coordinates,
+    :first_in_line_for_updates
   ]
   @required_params [:org_id, :product_id, :identifier]
 
@@ -69,6 +70,7 @@ defmodule NervesHub.Devices.Device do
     field(:updates_enabled, :boolean, default: true)
     field(:update_attempts, {:array, :utc_datetime}, default: [])
     field(:updates_blocked_until, :utc_datetime)
+    field(:first_in_line_for_updates, :boolean, default: false)
 
     field(:deleted_at, :utc_datetime)
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -355,6 +355,7 @@ defmodule NervesHubWeb.DeviceChannel do
   # A new UUID is being reported from an update
   defp update_metadata(device, params) do
     with {:ok, metadata} <- Firmwares.metadata_from_device(params),
+         {:ok, device} <- maybe_update_first_in_line_for_updates(device, metadata),
          {:ok, device} <- Devices.update_firmware_metadata(device, metadata) do
       Devices.firmware_update_successful(device)
     end
@@ -431,4 +432,9 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   defp safe_to_request_extensions?(version), do: Version.match?(version, ">= 2.2.0")
+
+  defp maybe_update_first_in_line_for_updates(device, nil),
+    do: Devices.update_device(device, %{first_in_line_for_updates: true})
+
+  defp maybe_update_first_in_line_for_updates(device, _metadata), do: {:ok, device}
 end

--- a/lib/nerves_hub_web/components/core_components.ex
+++ b/lib/nerves_hub_web/components/core_components.ex
@@ -366,11 +366,14 @@ defmodule NervesHubWeb.CoreComponents do
 
     ~H"""
     <div phx-feedback-for={@name}>
-      <label class="flex items-center gap-4 text-sm font-medium leading-6 text-zinc-300">
+      <span class="flex items-center gap-4 text-sm font-medium leading-6 text-zinc-300">
         <input type="hidden" name={@name} value="false" />
-        <input type="checkbox" id={@id} name={@name} value="true" checked={@checked} class="rounded border-zinc-700 text-zinc-400 focus:ring-0 checked:bg-indigo-500" {@rest} />
-        {@label}
-      </label>
+        <input type="checkbox" id={@name} name={@name} value="true" checked={@checked} class="rounded border-zinc-700 text-zinc-400 focus:ring-0 checked:bg-indigo-500" {@rest} />
+        <label for={@name}>{@label}</label>
+      </span>
+      <%!-- <input type="hidden" name={@name} value="false" />
+      <label for={@name}>{@label}</label>
+      <input type="checkbox" id={@name} name={@name} value="true" checked={@checked} class="rounded border-zinc-700 text-zinc-400 focus:ring-0 checked:bg-indigo-500" {@rest} /> --%>
       <span :if={assigns[:hint] || assigns[:rich_hint]} class="text-xs text-zinc-400">
         {assigns[:hint] || render_slot(assigns[:rich_hint])}
       </span>

--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -71,6 +71,12 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
               <.input field={@settings_form[:description]} label="Description" placeholder="eg. sensor hub at customer X" />
 
               <.input field={@settings_form[:tags]} value={tags_to_string(@settings_form[:tags])} label="Tags" placeholder="eg. batch-123" />
+
+              <.input field={@settings_form[:first_in_line_for_updates]} type="checkbox" label="First in line for updates">
+                <:rich_hint>
+                  Prioritizes this device for updates when part of a deployment group
+                </:rich_hint>
+              </.input>
             </div>
 
             <div class="w-1/2 flex flex-col gap-2">

--- a/lib/nerves_hub_web/controllers/api/schemas/device_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/device_schemas.ex
@@ -45,6 +45,10 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
           description: "Device penalty box expiration timestamp",
           format: :"date-time"
         },
+        first_in_line_for_updates: %Schema{
+          type: :boolean,
+          description: "Prioritizes this device for updates when part of a deployment group"
+        },
         org_name: %Schema{type: :string},
         product_name: %Schema{type: :string},
         last_communication: %Schema{
@@ -81,6 +85,7 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
         },
         "updates_enabled" => true,
         "updates_blocked_until" => "2050-04-20T00:33:09Z",
+        "first_in_line_for_updates" => true,
         "org_name" => "BigCompany",
         "product_name" => "AmazingProduct",
         "last_communication" => "2050-04-20T00:33:09Z"
@@ -129,6 +134,7 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
             },
             "updates_enabled" => true,
             "updates_blocked_until" => "2050-04-20T00:33:09Z",
+            "first_in_line_for_updates" => true,
             "org_name" => "BigCompany",
             "product_name" => "AmazingProduct",
             "last_communication" => "2050-04-20T00:33:09Z"
@@ -161,6 +167,7 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
             },
             "updates_enabled" => true,
             "updates_blocked_until" => "2050-04-20T00:33:09Z",
+            "first_in_line_for_updates" => true,
             "org_name" => "BigCompany",
             "product_name" => "AmazingProduct",
             "last_communication" => "2050-04-20T00:33:09Z"
@@ -181,7 +188,8 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
             description: %Schema{type: :string},
             tags: %Schema{type: :string},
             deployment_group_id: %Schema{type: :integer},
-            updates_enabled: %Schema{type: :boolean}
+            updates_enabled: %Schema{type: :boolean},
+            first_in_line_for_updates: %Schema{type: :boolean}
           },
           required: [:identifier]
         }
@@ -193,7 +201,8 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
           "description" => "Example Device",
           "tags" => "prod, customerJNK",
           "deployment_group_id" => 1,
-          "updates_enabled" => false
+          "updates_enabled" => false,
+          "first_in_line_for_updates" => true
         }
       }
     })
@@ -209,7 +218,8 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
             description: %Schema{type: :string},
             tags: %Schema{type: :string},
             deployment_group_id: %Schema{type: :integer},
-            updates_enabled: %Schema{type: :boolean}
+            updates_enabled: %Schema{type: :boolean},
+            first_in_line_for_updates: %Schema{type: :boolean}
           }
         }
       },
@@ -218,7 +228,8 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
           "description" => "Example Device",
           "tags" => "prod, customerJNK",
           "deployment_group_id" => 1,
-          "updates_enabled" => false
+          "updates_enabled" => false,
+          "first_in_line_for_updates" => true
         }
       }
     })

--- a/priv/repo/migrations/20250515021542_add_first_in_line_updates_to_devices.exs
+++ b/priv/repo/migrations/20250515021542_add_first_in_line_updates_to_devices.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddFirstInLineUpdatesToDevices do
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add(:first_in_line_for_updates, :boolean, default: false, null: false)
+    end
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
+  alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Firmwares
   alias NervesHub.Fixtures
@@ -678,6 +679,55 @@ defmodule NervesHub.DevicesTest do
 
       refute device.deployment_id
       assert_receive %{event: "devices/deployment-cleared"}
+    end
+  end
+
+  describe "available_for_update/2" do
+    test "orders by device.first_in_line_for_updates", %{
+      deployment_group: deployment_group,
+      device: device1,
+      org: org,
+      product: product
+    } do
+      device2 =
+        Fixtures.device_fixture(org, product, deployment_group.firmware, %{
+          first_in_line_for_updates: true
+        })
+
+      device3 = Fixtures.device_fixture(org, product, deployment_group.firmware)
+
+      Enum.each([device1, device2, device3], fn device ->
+        %{id: latest_connection_id} =
+          DeviceConnection.create_changeset(%{
+            product_id: product.id,
+            device_id: device.id,
+            established_at: DateTime.utc_now(),
+            last_seen_at: DateTime.utc_now(),
+            status: :connected
+          })
+          |> Repo.insert!()
+
+        Device
+        |> where(id: ^device.id)
+        |> Repo.update_all(set: [latest_connection_id: latest_connection_id])
+
+        {:ok, device} =
+          Devices.update_firmware_metadata(
+            device,
+            Map.from_struct(%{
+              device.firmware_metadata
+              | uuid: UUIDv7.autogenerate()
+            })
+          )
+
+        {:ok, _} = Devices.update_device(device, %{deployment_id: deployment_group.id})
+      end)
+
+      [device_first_in_line_for_update | _] =
+        devices = Devices.available_for_update(deployment_group, 100)
+
+      assert length(devices) == 3
+      assert device_first_in_line_for_update.id == device2.id
     end
   end
 end

--- a/test/nerves_hub_web/live/new_ui/devices/show/settings_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/show/settings_test.exs
@@ -1,0 +1,26 @@
+defmodule NervesHubWeb.Live.NewUI.Devices.Show.SettingsTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  setup %{conn: conn, fixture: %{device: device}} = context do
+    conn = init_test_session(conn, %{"new_ui" => true})
+
+    Map.put(context, :conn, conn)
+  end
+
+  test "updating first in line for updates", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device,
+    user: user
+  } do
+    refute device.first_in_line_for_updates
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
+    |> check("First in line", exact: false)
+    |> submit()
+
+    assert Repo.reload(device) |> Map.get(:first_in_line_for_updates)
+  end
+end


### PR DESCRIPTION
## Description

## Todo
- [ ] Test devices joining channel with no firmware metadata have `first_in_line_for_udpates` set to `true`