### PR TITLE
Don't require tags when updating deployment group, changeset refactor

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -252,7 +252,7 @@ defmodule NervesHub.ManagedDeployments do
         changeset =
           deployment_group
           |> DeploymentGroup.with_firmware()
-          |> DeploymentGroup.changeset(params)
+          |> DeploymentGroup.update_changeset(params)
           |> Ecto.Changeset.put_change(:total_updating_devices, device_count)
 
         case Repo.update(changeset) do
@@ -363,7 +363,7 @@ defmodule NervesHub.ManagedDeployments do
 
   @spec create_deployment_group(map()) :: {:ok, DeploymentGroup.t()} | {:error, Changeset.t()}
   def create_deployment_group(params) do
-    changeset = DeploymentGroup.creation_changeset(%DeploymentGroup{}, params)
+    changeset = DeploymentGroup.create_changeset(%DeploymentGroup{}, params)
 
     case Repo.insert(changeset) do
       {:ok, deployment_group} ->

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -87,13 +87,6 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
 
   def create_changeset(%DeploymentGroup{} = deployment, params) do
     base_changeset(deployment, params)
-    |> validate_change(:is_active, fn :is_active, is_active ->
-      if is_active do
-        [is_active: "cannot be true on creation"]
-      else
-        []
-      end
-    end)
   end
 
   def update_changeset(%DeploymentGroup{} = deployment, params) do

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -85,52 +85,19 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     timestamps()
   end
 
-  def creation_changeset(%DeploymentGroup{} = deployment, params) do
-    # set product_id by getting it from firmware
-    with_product_id = handle_product_id(deployment, params)
-
-    deployment
-    |> cast(with_product_id, @required_fields ++ @optional_fields)
-    |> validate_required(@required_fields)
-    |> unique_constraint(:name, name: :deployments_product_id_name_index)
+  def create_changeset(%DeploymentGroup{} = deployment, params) do
+    base_changeset(deployment, params)
     |> validate_change(:is_active, fn :is_active, is_active ->
-      creation_errors(:is_active, is_active)
+      if is_active do
+        [is_active: "cannot be true on creation"]
+      else
+        []
+      end
     end)
   end
 
-  defp creation_errors(:is_active, is_active) do
-    if is_active do
-      [is_active: "cannot be true on creation"]
-    else
-      []
-    end
-  end
-
-  defp handle_product_id(%DeploymentGroup{}, %{firmware: %Firmware{product_id: p_id}} = params) do
-    params |> Map.put(:product_id, p_id)
-  end
-
-  defp handle_product_id(%DeploymentGroup{firmware: %Firmware{product_id: p_id}}, params) do
-    params |> Map.put(:product_id, p_id)
-  end
-
-  defp handle_product_id(%DeploymentGroup{} = d, %{firmware_id: f_id} = params) do
-    handle_product_id(d, params |> Map.put(:firmware, Firmware |> Repo.get!(f_id)))
-  end
-
-  defp handle_product_id(%DeploymentGroup{firmware_id: nil}, params) do
-    params
-  end
-
-  defp handle_product_id(%DeploymentGroup{} = d, params) do
-    handle_product_id(d |> with_firmware(), params)
-  end
-
-  def changeset(%DeploymentGroup{} = deployment, params) do
-    deployment
-    |> cast(params, @required_fields ++ @optional_fields)
-    |> validate_required(@required_fields)
-    |> unique_constraint(:name, name: :deployments_product_id_name_index)
+  def update_changeset(%DeploymentGroup{} = deployment, params) do
+    base_changeset(deployment, params)
     |> prepare_changes(fn changeset ->
       if changeset.changes[:firmware_id] do
         put_change(changeset, :current_updated_devices, 0)
@@ -138,6 +105,13 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
         changeset
       end
     end)
+  end
+
+  defp base_changeset(%DeploymentGroup{} = deployment, params) do
+    deployment
+    |> cast(params, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> unique_constraint(:name, name: :deployments_product_id_name_index)
     |> validate_conditions()
   end
 
@@ -159,32 +133,44 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
 
   def with_product(query), do: preload(query, :product)
 
-  defp validate_conditions(changeset, _options \\ []) do
-    validate_change(changeset, :conditions, fn :conditions, conditions ->
-      types = %{tags: {:array, :string}, version: :string}
+  defp validate_conditions(changeset) do
+    validate_change(changeset, :conditions, fn
+      :conditions, conditions when conditions == %{} ->
+        [conditions: "can't be blank"]
 
-      version =
-        case Map.get(conditions, "version") do
-          "" -> nil
-          v -> v
-        end
+      :conditions, %{"version" => nil} ->
+        [version: "can't be blank"]
 
-      conditions = Map.put(conditions, "version", version)
+      :conditions, conditions ->
+        types = %{tags: {:array, :string}, version: :string}
+        # merge the new conditions with the existing ones so that we can
+        # update tags and version independently
+        conditions = Map.merge(changeset.data.conditions || %{}, conditions)
 
-      changeset =
-        {%{}, types}
-        |> cast(conditions, Map.keys(types))
-        |> validate_required([:tags])
-        |> validate_length(:tags, min: 1)
-        |> validate_change(:version, fn :version, version ->
-          if not is_nil(version) and Version.parse_requirement(version) == :error do
-            [version: "Must be valid Elixir version requirement string"]
-          else
-            []
-          end
-        end)
+        changeset =
+          {%{}, types}
+          # allow "" as valid value for `version`
+          |> cast(conditions, Map.keys(types), empty_values: [nil])
+          |> validate_required([:tags])
+          |> validate_change(
+            :version,
+            fn
+              :version, "" ->
+                []
 
-      changeset.errors
+              :version, nil ->
+                [version: "can't be nil"]
+
+              :version, version ->
+                if Version.parse_requirement(version) == :error do
+                  [version: "must be valid Elixir version requirement string"]
+                else
+                  []
+                end
+            end
+          )
+
+        changeset.errors
     end)
   end
 end

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -14,7 +14,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
     archives = Archives.all_by_product(assigns.deployment_group.product)
     firmwares = Firmwares.get_firmwares_for_deployment_group(assigns.deployment_group)
 
-    changeset = DeploymentGroup.changeset(assigns.deployment_group, %{})
+    changeset = DeploymentGroup.update_changeset(assigns.deployment_group, %{})
 
     socket
     |> assign(assigns)

--- a/lib/nerves_hub_web/controllers/api/deployment_group_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_group_controller.ex
@@ -13,7 +13,7 @@ defmodule NervesHubWeb.API.DeploymentGroupController do
   plug(:validate_role, [org: :manage] when action in [:create, :update, :delete])
   plug(:validate_role, [org: :view] when action in [:index, :show])
 
-  @whitelist_fields [:name, :org_id, :firmware_id, :conditions, :is_active]
+  @whitelist_fields [:name, :org_id, :firmware_id, :conditions, :is_active, :product_id]
 
   operation(:index, summary: "List all Deployment Groups for a Product")
 
@@ -33,6 +33,7 @@ defmodule NervesHubWeb.API.DeploymentGroupController do
         with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
              params <- Map.put(params, "firmware_id", firmware.id),
              params <- Map.put(params, "org_id", org.id),
+             params <- Map.put(params, "product_id", product.id),
              params <- whitelist(params, @whitelist_fields),
              {:ok, deployment_group} <- ManagedDeployments.create_deployment_group(params) do
           DeploymentGroupTemplates.audit_deployment_created(user, deployment_group)

--- a/lib/nerves_hub_web/live/deployment_groups/edit.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/edit.ex
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Edit do
     archives = Archives.all_by_product(deployment_group.product)
     firmwares = Firmwares.get_firmwares_for_deployment_group(deployment_group)
 
-    changeset = DeploymentGroup.changeset(deployment_group, %{}) |> tags_to_string()
+    changeset = DeploymentGroup.update_changeset(deployment_group, %{}) |> tags_to_string()
 
     socket
     |> assign(:archives, archives)

--- a/lib/nerves_hub_web/live/deployment_groups/index-new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index-new.html.heex
@@ -41,7 +41,7 @@
         </svg>
       </div>
     </form>
-    <.button type="link" navigate={~p"/org/#{@org}/#{@product}/deployments/newz"} aria-label="Add a new deployment group">
+    <.button type="link" navigate={~p"/org/#{@org}/#{@product}/deployment_groups/newz"} aria-label="Add a new deployment group">
       <.icon name="add" /> Create Deployment Group
     </.button>
     <.button type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>

--- a/lib/nerves_hub_web/live/deployment_groups/new.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/new.ex
@@ -72,6 +72,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.New do
     |> Firmwares.get_firmware(params[:firmware_id])
     |> case do
       {:ok, firmware} ->
+        params = Map.put(params, :product_id, firmware.product_id)
         {firmware, ManagedDeployments.create_deployment_group(params)}
 
       {:error, :not_found} ->

--- a/lib/nerves_hub_web/live/deployment_groups/newz.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/newz.ex
@@ -85,6 +85,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Newz do
     |> Firmwares.get_firmware(params[:firmware_id])
     |> case do
       {:ok, firmware} ->
+        params = Map.put(params, :product_id, firmware.product_id)
         {firmware, ManagedDeployments.create_deployment_group(params)}
 
       {:error, :not_found} ->

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -386,7 +386,8 @@ defmodule NervesHubWeb.Router do
 
       live("/org/:org_name/:product_name/deployment_groups", Live.DeploymentGroups.Index)
       live("/org/:org_name/:product_name/deployments/new", Live.DeploymentGroups.New)
-      live("/org/:org_name/:product_name/deployments/newz", Live.DeploymentGroups.Newz)
+
+      live("/org/:org_name/:product_name/deployment_groups/newz", Live.DeploymentGroups.Newz)
 
       live(
         "/org/:org_name/:product_name/deployment_groups/:name",

--- a/priv/repo/add_org_id.exs
+++ b/priv/repo/add_org_id.exs
@@ -55,7 +55,7 @@ IO.puts "\n"
   from(d in Deployment, where: is_nil(d.org_id), preload: [:product])
   |> Repo.all()
   |> Enum.reduce({[], []}, fn deployment_group, {success, errors} ->
-    DeploymentGroup.creation_changeset(deployment_group, %{org_id: deployment_group.product.org_id})
+    DeploymentGroup.update_changeset(deployment_group, %{org_id: deployment_group.product.org_id})
     |> Repo.update()
     |> case do
       {:ok, deployment_group} ->

--- a/test/nerves_hub/managed_deployments/deployment_group_test.exs
+++ b/test/nerves_hub/managed_deployments/deployment_group_test.exs
@@ -1,0 +1,195 @@
+defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Fixtures
+  alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.Repo
+
+  describe "shared changeset validations" do
+    setup do
+      deployment_group = %DeploymentGroup{
+        org_id: 1,
+        firmware_id: 1,
+        name: "Bestest Devices",
+        conditions: %{
+          "tags" => ["foo"],
+          "version" => "1.2.3"
+        },
+        is_active: true,
+        product_id: 1,
+        concurrent_updates: 1000,
+        inflight_update_expiration_minutes: 10
+      }
+
+      %{deployment_group: deployment_group, functions: [:create_changeset, :update_changeset]}
+    end
+
+    test "cannot clear conditions", %{
+      deployment_group: deployment_group,
+      functions: functions
+    } do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{}
+            }
+          ])
+
+        refute changeset.valid?
+        refute Enum.empty?(errors_on(changeset).conditions)
+      end
+    end
+
+    test "tags can be cleared", %{deployment_group: deployment_group, functions: functions} do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{"version" => "1.2.0", "tags" => []}
+            }
+          ])
+
+        assert changeset.valid?
+      end
+    end
+
+    test "tags can be updated independently of version", %{
+      deployment_group: deployment_group,
+      functions: functions
+    } do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{"tags" => []}
+            }
+          ])
+
+        assert changeset.valid?
+      end
+    end
+
+    test "version can be updated independently of tags", %{
+      deployment_group: deployment_group,
+      functions: functions
+    } do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{"version" => "10.3.4"}
+            }
+          ])
+
+        assert changeset.valid?
+      end
+    end
+
+    test "version can be an empty string", %{
+      deployment_group: deployment_group,
+      functions: functions
+    } do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{"version" => "", "tags" => []}
+            }
+          ])
+
+        assert changeset.valid?
+      end
+    end
+
+    test "version cannot be nil", %{deployment_group: deployment_group, functions: functions} do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{"version" => nil, "tags" => []}
+            }
+          ])
+
+        refute changeset.valid?
+        assert errors_on(changeset).version == ["can't be blank"]
+      end
+    end
+
+    test "version must be a valid Elixir.Version", %{
+      deployment_group: deployment_group,
+      functions: functions
+    } do
+      for function <- functions do
+        changeset =
+          apply(DeploymentGroup, function, [
+            deployment_group,
+            %{
+              conditions: %{"version" => "1.2.3.5.6", "tags" => []}
+            }
+          ])
+
+        refute changeset.valid?
+        assert errors_on(changeset).version == ["must be valid Elixir version requirement string"]
+      end
+    end
+  end
+
+  describe "create_changeset/2" do
+    setup do
+      deployment_group = %DeploymentGroup{
+        org_id: 1,
+        firmware_id: 1,
+        name: "Bestest Devices",
+        conditions: %{
+          "tags" => ["foo"],
+          "version" => "1.2.3"
+        },
+        product_id: 1,
+        concurrent_updates: 1000,
+        inflight_update_expiration_minutes: 10
+      }
+
+      %{deployment_group: deployment_group}
+    end
+
+    test "is_active must be false", %{deployment_group: deployment_group} do
+      changeset =
+        DeploymentGroup.create_changeset(deployment_group, %{
+          is_active: true
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset).is_active == ["cannot be true on creation"]
+    end
+  end
+
+  describe "update_changeset/2" do
+    setup do
+      Fixtures.standard_fixture()
+    end
+
+    test "current_updated_devices is reset when firmware changes", %{
+      deployment_group: deployment_group,
+      org_key: org_key,
+      product: product
+    } do
+      new_firmware = Fixtures.firmware_fixture(org_key, product)
+
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          "firmware_id" => new_firmware.id
+        })
+
+      assert changeset.valid?
+      deployment_group = Repo.update!(changeset)
+      assert deployment_group.current_updated_devices == 0
+    end
+  end
+end

--- a/test/nerves_hub/managed_deployments/deployment_group_test.exs
+++ b/test/nerves_hub/managed_deployments/deployment_group_test.exs
@@ -141,35 +141,6 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
     end
   end
 
-  describe "create_changeset/2" do
-    setup do
-      deployment_group = %DeploymentGroup{
-        org_id: 1,
-        firmware_id: 1,
-        name: "Bestest Devices",
-        conditions: %{
-          "tags" => ["foo"],
-          "version" => "1.2.3"
-        },
-        product_id: 1,
-        concurrent_updates: 1000,
-        inflight_update_expiration_minutes: 10
-      }
-
-      %{deployment_group: deployment_group}
-    end
-
-    test "is_active must be false", %{deployment_group: deployment_group} do
-      changeset =
-        DeploymentGroup.create_changeset(deployment_group, %{
-          is_active: true
-        })
-
-      refute changeset.valid?
-      assert errors_on(changeset).is_active == ["cannot be true on creation"]
-    end
-  end
-
   describe "update_changeset/2" do
     setup do
       Fixtures.standard_fixture()

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -50,6 +50,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
       params = %{
         org_id: org.id,
         firmware_id: firmware.id,
+        product_id: firmware.product_id,
         name: "a different name",
         conditions: %{
           "version" => "< 1.0.0",
@@ -75,6 +76,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         name: existing_deployment_group.name,
         org_id: org.id,
         firmware_id: firmware.id,
+        product_id: firmware.product_id,
         conditions: %{
           "version" => "< 1.0.0",
           "tags" => ["beta", "beta-edge"]
@@ -113,6 +115,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       params = %{
         firmware_id: new_firmware.id,
+        product_id: new_firmware.product_id,
         org_id: org.id,
         name: "my deployment",
         conditions: %{
@@ -168,18 +171,18 @@ defmodule NervesHub.ManagedDeploymentsTest do
       %{id: beta_deployment_group_id} =
         Fixtures.deployment_group_fixture(org, firmware, %{
           name: "beta",
-          conditions: %{"tags" => ["beta"]}
+          conditions: %{"tags" => ["beta"], "version" => ""}
         })
 
       %{id: rpi_deployment_group_id} =
         Fixtures.deployment_group_fixture(org, firmware, %{
           name: "rpi",
-          conditions: %{"tags" => ["rpi"]}
+          conditions: %{"tags" => ["rpi"], "version" => ""}
         })
 
       Fixtures.deployment_group_fixture(org, firmware, %{
         name: "rpi0",
-        conditions: %{"tags" => ["rpi0"]}
+        conditions: %{"tags" => ["rpi0"], "version" => ""}
       })
 
       device = Fixtures.device_fixture(org, product, firmware, %{tags: ["beta", "rpi"]})
@@ -199,12 +202,12 @@ defmodule NervesHub.ManagedDeploymentsTest do
       %{id: rpi_deployment_group_id} =
         Fixtures.deployment_group_fixture(org, rpi_firmware, %{
           name: "rpi",
-          conditions: %{"tags" => ["rpi"]}
+          conditions: %{"tags" => ["rpi"], "version" => ""}
         })
 
       Fixtures.deployment_group_fixture(org, rpi0_firmware, %{
         name: "rpi0",
-        conditions: %{"tags" => ["rpi"]}
+        conditions: %{"tags" => ["rpi"], "version" => ""}
       })
 
       device = Fixtures.device_fixture(org, product, rpi_firmware, %{tags: ["beta", "rpi"]})
@@ -222,12 +225,12 @@ defmodule NervesHub.ManagedDeploymentsTest do
       %{id: rpi_deployment_group_id} =
         Fixtures.deployment_group_fixture(org, rpi_firmware, %{
           name: "rpi",
-          conditions: %{"tags" => ["rpi"]}
+          conditions: %{"tags" => ["rpi"], "version" => ""}
         })
 
       Fixtures.deployment_group_fixture(org, rpi0_firmware, %{
         name: "rpi0",
-        conditions: %{"tags" => ["rpi"]}
+        conditions: %{"tags" => ["rpi"], "version" => ""}
       })
 
       device = Fixtures.device_fixture(org, product, rpi_firmware, %{tags: ["beta", "rpi"]})
@@ -423,6 +426,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         ManagedDeployments.create_deployment_group(%{
           org_id: org.id,
           firmware_id: firmware.id,
+          product_id: firmware.product_id,
           name: "Deployment 123",
           is_active: false,
           conditions: %{
@@ -530,6 +534,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         ManagedDeployments.create_deployment_group(%{
           org_id: org.id,
           firmware_id: firmware.id,
+          product_id: firmware.product_id,
           name: "Deployment 123",
           is_active: false,
           conditions: %{
@@ -567,6 +572,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         ManagedDeployments.create_deployment_group(%{
           org_id: org.id,
           firmware_id: firmware.id,
+          product_id: firmware.product_id,
           name: "Deployment 123",
           is_active: false,
           conditions: %{
@@ -609,6 +615,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         ManagedDeployments.create_deployment_group(%{
           org_id: org.id,
           firmware_id: firmware.id,
+          product_id: firmware.product_id,
           name: "Deployment 123",
           is_active: false,
           conditions: %{
@@ -647,6 +654,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         ManagedDeployments.create_deployment_group(%{
           org_id: org.id,
           firmware_id: firmware.id,
+          product_id: firmware.product_id,
           name: "Deployment 123",
           is_active: false,
           conditions: %{
@@ -685,6 +693,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
         ManagedDeployments.create_deployment_group(%{
           org_id: org.id,
           firmware_id: firmware.id,
+          product_id: firmware.product_id,
           name: "Deployment 123",
           is_active: false,
           conditions: %{

--- a/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
@@ -22,6 +22,7 @@ defmodule NervesHubWeb.API.DeploymentGroupControllerTest do
         org_id: context.org.id,
         firmware: firmware.uuid,
         firmware_id: firmware.id,
+        product_id: firmware.product_id,
         conditions: %{
           version: "",
           tags: ["test"]

--- a/test/nerves_hub_web/live/deployment_groups/edit_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/edit_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.EditTest do
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.Repo
 
   test "update the chosen resource, and adds an audit log", %{
     conn: conn,
@@ -64,12 +65,39 @@ defmodule NervesHubWeb.Live.DeploymentGroups.EditTest do
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/edit")
     |> assert_has("h1", text: "Edit Deployment Group")
     |> assert_has("a", text: product.name)
-    |> fill_in("Tag(s) distributed to", with: "")
-    |> fill_in("Version requirement", with: "")
+    |> fill_in("Version requirement", with: "1.2.3.4.5.6")
     |> click_button("Save Change")
     |> assert_path(
       "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/edit"
     )
-    |> assert_has("div", text: "should have at least 1 item(s)")
+    |> assert_has("div", text: "must be valid Elixir version requirement string")
+  end
+
+  test "can clear tags and version", %{
+    conn: conn,
+    user: user,
+    org: org,
+    org_key: org_key,
+    tmp_dir: tmp_dir
+  } do
+    product = Fixtures.product_fixture(user, org)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/edit")
+    |> assert_has("h1", text: "Edit Deployment Group")
+    |> assert_has("a", text: product.name)
+    |> fill_in("Tag(s) distributed to", with: "")
+    |> fill_in("Version requirement", with: "")
+    |> click_button("Save Change")
+    |> assert_path(
+      URI.encode("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}")
+    )
+
+    assert Repo.reload(deployment_group) |> Map.get(:conditions) == %{
+             "version" => "",
+             "tags" => []
+           }
   end
 end

--- a/test/nerves_hub_web/live/new_ui/deployment_groups/new_test.exs
+++ b/test/nerves_hub_web/live/new_ui/deployment_groups/new_test.exs
@@ -1,0 +1,48 @@
+defmodule NervesHubWeb.Live.NewUI.DelploymentGroups.NewTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+  use Mimic
+
+  alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.Repo
+
+  import Ecto.Query, only: [from: 2]
+
+  setup context do
+    conn =
+      context.conn
+      |> put_session("new_ui", true)
+      |> visit("/org/#{context.org.name}/#{context.product.name}/deployment_groups/newz")
+
+    %{context | conn: conn}
+  end
+
+  test "can update only version", %{conn: conn, org: org, product: product, fixture: fixture} do
+    conn
+    |> fill_in("Name", with: "Canaries")
+    |> select("Platform", option: "platform")
+    # Selecting platform should trigger a change event, but it doesn't.
+    # I suspect it has to do with the phx-change event on the select,
+    # instead of the parent form.
+    |> unwrap(fn view ->
+      render_change(view, "platform-selected", %{
+        "deployment_group" => %{"platform" => "platform"}
+      })
+    end)
+    |> select("Architecture", option: "x86_64")
+    # Same as above
+    |> unwrap(fn view ->
+      render_change(view, "architecture-selected", %{
+        "deployment_group" => %{"architecture" => "x86_64"}
+      })
+    end)
+    |> select("Firmware", option: "1.0.0", exact_option: false)
+    |> fill_in("Tag(s) distributed to", with: "a, b")
+    |> fill_in("Version requirement", with: "1.2.3")
+    |> submit()
+    |> assert_path("/org/#{org.name}/#{product.name}/deployment_groups/Canaries")
+
+    deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert deployment_group.firmware_id == fixture.firmware.id
+    assert deployment_group.conditions == %{"version" => "1.2.3", "tags" => ["a", "b"]}
+  end
+end

--- a/test/nerves_hub_web/live/new_ui/deployment_groups/show_test.exs
+++ b/test/nerves_hub_web/live/new_ui/deployment_groups/show_test.exs
@@ -1,0 +1,49 @@
+defmodule NervesHubWeb.Live.NewUI.DelploymentGroups.ShowTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+  use Mimic
+
+  alias NervesHub.Repo
+
+  describe "settings" do
+    setup context do
+      conn =
+        context.conn
+        |> put_session("new_ui", true)
+        |> visit(
+          "/org/#{context.org.name}/#{context.product.name}/deployment_groups/#{context.deployment_group.name}/settings"
+        )
+        |> assert_has("div", text: "General settings")
+
+      %{context | conn: conn}
+    end
+
+    test "can update only version", %{conn: conn, deployment_group: deployment_group} do
+      conn
+      |> fill_in("Version requirement", with: "1.2.3")
+      |> submit()
+
+      deployment_group = Repo.reload(deployment_group)
+      assert deployment_group.conditions["version"] == "1.2.3"
+    end
+
+    test "can update only tags", %{conn: conn, deployment_group: deployment_group} do
+      conn
+      |> fill_in("Tag(s) distributed to", with: "a, b")
+      |> submit()
+
+      deployment_group = Repo.reload(deployment_group)
+      assert deployment_group.conditions["tags"] == ["a", "b"]
+    end
+
+    test "can update tags and version", %{conn: conn, deployment_group: deployment_group} do
+      conn
+      |> fill_in("Tag(s) distributed to", with: "a, b")
+      |> fill_in("Version requirement", with: "1.2.3")
+      |> submit()
+
+      deployment_group = Repo.reload(deployment_group)
+      assert deployment_group.conditions["tags"] == ["a", "b"]
+      assert deployment_group.conditions["version"] == "1.2.3"
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -227,7 +227,7 @@ defmodule NervesHub.Fixtures do
     {is_active, params} = Map.pop(params, :is_active, false)
 
     {:ok, deployment_group} =
-      %{org_id: org.id, firmware_id: firmware.id}
+      %{org_id: org.id, firmware_id: firmware.id, product_id: firmware.product_id}
       |> Enum.into(params)
       |> Enum.into(@deployment_group_params)
       |> ManagedDeployments.create_deployment_group()


### PR DESCRIPTION
This started as an adjustment to deployment group tag validations and ended up being a refactor of deployment group changesets. The core issue is that we handled tag validation differently in the create and update changesets.

When updating a deployment group, tags are required, even though empty tags is a valid state; you can create a deployment group with no tags. This requirement has been removed. In application code, we treat `%{"version" => ""}` as the empty state for `version`. Nothing has stopped us in the changeset or database layer from saving `conditions` to anything but a map with those two keys. Luckily, in SR prod, there are no deployment group rows with one of these keys; it's always both. I added the ability to partially update conditions so you don't have to always provide both keys. This isn't used in application code but is in tests and is a quality-of-life update. 

Shared validations are now reconciled into a base changeset. The create and update changesets then handle their own unique validations. This is all tested and laid out nicely in `NervesHub.ManagedDeployments.DeploymentGroupTest`. I tried a new approach to organizing the tests, looking for feedback.

I then removed the ancient, recursive spaghetti code that  would magically add the `product_id` when creating a deployment group. This has been simplified to requiring the `product_id` to be passed in explicitly. This change avoids a database query when preloading firmware to get `product_id`. The code in question handled a lot of different use cases but preloading was the only one application code used :( In all use cases, the firmware was already loaded making it trivial to pass in `firmware.product_id`.

I also caught a route mistake when creating deployment groups in the new UI.

Some changes I made were already covered by tests; I added tests for the rest. 

I had to update a two-year-old script in `priv/repo`, but I'm thinking the whole thing can be removed, as well as the other script in the same directory. Fine to pull the trigger if someone else double-checks me.