### PR TITLE
New UI: Fix broken certificate download

### DIFF
--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -187,7 +187,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
               </div>
             </div>
             <div class="flex gap-2">
-              <.link class="flex px-3 py-1.5 gap-2 rounded bg-zinc-800 border border-zinc-600" href={~p"/org/#{@org}/#{@product}/devices/#{@device}/certificate/#{certificate}/download"} download>
+              <.link class="flex px-3 py-1.5 gap-2 rounded bg-zinc-800 border border-zinc-600" href={~p"/org/#{@org}/#{@product}/devices/#{@device}/certificate/#{certificate.serial}/download"} download>
                 <svg class="w-5 h-5" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path
                     d="M6.66671 16.6667H5.00004C4.07957 16.6667 3.33337 15.9205 3.33337 15V5.00004C3.33337 4.07957 4.07957 3.33337 5.00004 3.33337H12.643C13.085 3.33337 13.509 3.50897 13.8215 3.82153L16.1786 6.17855C16.4911 6.49111 16.6667 6.91504 16.6667 7.35706V15C16.6667 15.9205 15.9205 16.6667 15 16.6667H13.3334M6.66671 16.6667V12.5H13.3334V16.6667M6.66671 16.6667H13.3334M6.66671 6.66671V9.16671H9.16671V6.66671H6.66671Z"

--- a/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
@@ -1,7 +1,8 @@
 defmodule NervesHubWeb.NewUi.Devices.SettingsTabTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
   alias NervesHub.Devices
   alias NervesHubWeb.Components.Utils
-  use NervesHubWeb.ConnCase.Browser, async: false
 
   setup %{conn: conn} do
     [conn: init_test_session(conn, %{"new_ui" => true})]

--- a/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
@@ -1,0 +1,33 @@
+defmodule NervesHubWeb.NewUi.Devices.SettingsTabTest do
+  alias NervesHub.Devices
+  alias NervesHubWeb.Components.Utils
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  setup %{conn: conn} do
+    [conn: init_test_session(conn, %{"new_ui" => true})]
+  end
+
+  describe "certificates" do
+    test "download certificate", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      [certificate] = Devices.get_device_certificates(device)
+
+      result =
+        conn
+        |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
+        |> assert_has("div", text: "Certificates")
+        |> assert_has("div", text: "Serial: #{Utils.format_serial(certificate.serial)}")
+        |> unwrap(fn view ->
+          view
+          |> element("a[download]")
+          |> render_click()
+        end)
+
+      assert result.conn.resp_body =~ "-----BEGIN CERTIFICATE-----"
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug where device certificates could not be downloaded by changing the target link to use certificates serial number.
Also adds a test for downloading certificates in new UI.