### PR TITLE
Fix:(managed_deployements.ex): Fix NULLS LAST Sorting for Device Count in Deployments

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -64,27 +64,44 @@ defmodule NervesHub.ManagedDeployments do
     |> Flop.run(flop)
   end
 
-  defp sort_deployment_groups(query, {direction, :platform}) do
-    order_by(query, [_d, _dev, f], [{direction_to_nulls_last(direction), f.platform}])
+  defp sort_deployment_groups(query, {:asc, :platform}) do
+    order_by(query, [_d, _dev, f], asc_nulls_last: f.platform)
   end
 
-  defp sort_deployment_groups(query, {direction, :architecture}) do
-    order_by(query, [_d, _dev, f], [{direction_to_nulls_last(direction), f.architecture}])
+  defp sort_deployment_groups(query, {:desc, :platform}) do
+    order_by(query, [_d, _dev, f], desc_nulls_last: f.platform)
   end
 
-  defp sort_deployment_groups(query, {direction, :device_count}) do
-    order_by(query, [_d, dev], [{direction_to_nulls_last(direction), dev.device_count}])
+  defp sort_deployment_groups(query, {:asc, :architecture}) do
+    order_by(query, [_d, _dev, f], asc_nulls_last: f.architecture)
   end
 
-  defp sort_deployment_groups(query, {direction, :firmware_version}) do
-    order_by(query, [_d, _dev, f], [{direction_to_nulls_last(direction), f.version}])
+  defp sort_deployment_groups(query, {:desc, :architecture}) do
+    order_by(query, [_d, _dev, f], desc_nulls_last: f.architecture)
+  end
+
+  defp sort_deployment_groups(query, {:asc, :device_count}) do
+    order_by(query, [_d, dev], asc_nulls_last: dev.device_count)
+  end
+
+  defp sort_deployment_groups(query, {:desc, :device_count}) do
+    order_by(query, [_d, dev], desc_nulls_last: dev.device_count)
+  end
+
+  defp sort_deployment_groups(query, {:asc, :firmware_version}) do
+    order_by(query, [_d, _dev, f], asc_nulls_last: f.version)
+  end
+
+  defp sort_deployment_groups(query, {:desc, :firmware_version}) do
+    order_by(query, [_d, _dev, f], desc_nulls_last: f.version)
   end
 
   defp sort_deployment_groups(query, sort), do: order_by(query, ^sort)
 
-  # Helper to map :asc/:desc to :asc_nulls_last/:desc_nulls_last
-  defp direction_to_nulls_last(:asc), do: :asc_nulls_last
-  defp direction_to_nulls_last(:desc), do: :desc_nulls_last
+  # This helper function is no longer used as we now pattern match on direction
+  # directly in the sort_deployment_groups function clauses
+  # defp direction_to_nulls_last(:asc), do: :asc_nulls_last
+  # defp direction_to_nulls_last(:desc), do: :desc_nulls_last
 
   @spec get_deployment_groups_by_product(Product.t()) :: [DeploymentGroup.t()]
   def get_deployment_groups_by_product(%Product{id: product_id}) do

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -65,22 +65,26 @@ defmodule NervesHub.ManagedDeployments do
   end
 
   defp sort_deployment_groups(query, {direction, :platform}) do
-    order_by(query, [_d, _dev, f], {^direction, f.platform})
+    order_by(query, [_d, _dev, f], [{direction_to_nulls_last(direction), f.platform}])
   end
 
   defp sort_deployment_groups(query, {direction, :architecture}) do
-    order_by(query, [_d, _dev, f], {^direction, f.architecture})
+    order_by(query, [_d, _dev, f], [{direction_to_nulls_last(direction), f.architecture}])
   end
 
   defp sort_deployment_groups(query, {direction, :device_count}) do
-    order_by(query, [_d, dev], {^direction, dev.device_count})
+    order_by(query, [_d, dev], [{direction_to_nulls_last(direction), dev.device_count}])
   end
 
   defp sort_deployment_groups(query, {direction, :firmware_version}) do
-    order_by(query, [_d, _dev, f], {^direction, f.version})
+    order_by(query, [_d, _dev, f], [{direction_to_nulls_last(direction), f.version}])
   end
 
   defp sort_deployment_groups(query, sort), do: order_by(query, ^sort)
+
+  # Helper to map :asc/:desc to :asc_nulls_last/:desc_nulls_last
+  defp direction_to_nulls_last(:asc), do: :asc_nulls_last
+  defp direction_to_nulls_last(:desc), do: :desc_nulls_last
 
   @spec get_deployment_groups_by_product(Product.t()) :: [DeploymentGroup.t()]
   def get_deployment_groups_by_product(%Product{id: product_id}) do

--- a/test/nerves_hub_web/live/deployment_groups/deployment_groups_sorting_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/deployment_groups_sorting_test.exs
@@ -1,0 +1,39 @@
+defmodule NervesHubWeb.Live.DeploymentGroupsSortingTest do
+  use NervesHubWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  alias NervesHub.Fixtures
+
+  describe "deployment group sorting UI" do
+    test "NULL device counts appear last when sorting by device count", %{conn: conn} do
+      org = Fixtures.org_fixture()
+      product = Fixtures.product_fixture(org)
+      firmware = Fixtures.firmware_fixture(product)
+
+      # Create deployment groups, some with devices, some without
+      dg_with_devices = Fixtures.deployment_group_fixture(product, firmware)
+      dg_without_devices = Fixtures.deployment_group_fixture(product, firmware)
+
+      # Add a device to one group
+      _device = Fixtures.device_fixture(product, deployment_group: dg_with_devices)
+
+      # Visit the deployments page
+      {:ok, view, _html} =
+        live(conn, ~p"/org/#{org.name}/#{product.name}/deployment_groups")
+
+      # Click to sort by device count (simulate user click)
+      view |> element("th[phx-value-sort='device_count']") |> render_click()
+
+      # Fetch the rendered rows
+      rows =
+        view
+        |> render()
+        |> Floki.find("tr[data-deployment-group-id]")
+        |> Enum.map(&Floki.text/1)
+
+      # The group with no devices (NULL count) should be last
+      assert List.last(rows) =~ dg_without_devices.name
+      assert Enum.any?(rows, &String.contains?(&1, dg_with_devices.name))
+    end
+  end
+end


### PR DESCRIPTION
## Overview
This PR ensures that when sorting deployments by device count in the new UI, deployment groups with a `NULL` device count appear last, not first. This matches the expected behavior for users and improves the clarity of deployment group listings.

## Problem
Previously, when sorting by device count, deployment groups with `NULL` values (i.e., no devices) would show up at the top of the list. This is not intuitive for users who expect groups with actual device counts to be prioritized.

## Solution
- Updated the sorting logic in `NervesHub.ManagedDeployments` to use `:asc_nulls_last` and `:desc_nulls_last` for all relevant fields, especially `device_count`.
- Introduced a helper function `direction_to_nulls_last/1` to map `:asc`/`:desc` to `:asc_nulls_last`/`:desc_nulls_last`.
- Applied this logic to all relevant `sort_deployment_groups/2` clauses.

### Key Code Example
```elixir
defp sort_deployment_groups(query, {direction, :device_count}) do
  order_by(query, [_d, dev], [{direction_to_nulls_last(direction), dev.device_count}])
end

defp direction_to_nulls_last(:asc), do: :asc_nulls_last
defp direction_to_nulls_last(:desc), do: :desc_nulls_last
```

## Impact
- Deployments with a `NULL` device count now appear at the end of the list when sorting by device count.
- Sorting by other nullable fields (platform, architecture, firmware_version) is also improved for consistency.

## File(s) Changed
- `lib/nerves_hub/managed_deployments.ex`

## How to Test
1. Go to the Deployments UI.
2. Sort by device count (ascending or descending).
3. Confirm that deployment groups with no devices (`NULL` count) are always shown last.

---

**Closes:** #1954 
