### PR TITLE
Add alias mix check to run various CI checks

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -162,7 +162,14 @@ defmodule NervesHub.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "ecto.migrate.reset": ["ecto.drop", "ecto.create", "ecto.migrate"],
       "ecto.migrate.redo": ["ecto.rollback", "ecto.migrate"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"],
+      # Runs most of the non-test CI checks for you
+      check: [
+        "compile --warnings-as-errors",
+        "format --check-formatted",
+        "deps.unlock --check-unused",
+        "dialyzer --format github --format dialyxir"
+      ]
     ]
   end
 


### PR DESCRIPTION
The idea is to make it easier to run a quick check before throwing things at CI. And rechecking and all that is just easier, you might forget some of the checks you intended to run as well, this we can keep updating.

cspell is not in there, it will come