### PR TITLE
Add information about available deltas to deployment summary

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -23,6 +23,15 @@ defmodule NervesHub.Firmwares do
 
   defp firmware_upload_config(), do: Application.fetch_env!(:nerves_hub, :firmware_upload)
 
+  @spec get_deltas_by_target_firmware(firmware :: Firmware.t()) :: [FirmwareDelta.t()]
+  def get_deltas_by_target_firmware(firmware) do
+    FirmwareDelta
+    |> where([fd], fd.target_id == ^firmware.id)
+    |> preload(:source)
+    |> preload(:target)
+    |> Repo.all()
+  end
+
   @spec count(Product.t()) :: non_neg_integer()
   def count(product) do
     Firmware
@@ -399,7 +408,7 @@ defmodule NervesHub.Firmwares do
     {:ok, target_url} = firmware_upload_config().download_file(target_firmware)
 
     case delta_updater().create_firmware_delta_file(source_url, target_url) do
-      {:ok, firmware_delta_path} ->
+      {:ok, firmware_delta_path, metadata} ->
         firmware_delta_filename = Path.basename(firmware_delta_path)
 
         result =
@@ -411,7 +420,7 @@ defmodule NervesHub.Firmwares do
                      insert_firmware_delta(%{
                        source_id: source_firmware.id,
                        target_id: target_firmware.id,
-                       upload_metadata: upload_metadata
+                       upload_metadata: Map.merge(metadata, upload_metadata)
                      }),
                    {:ok, firmware_delta} <- get_firmware_delta(firmware_delta.id),
                    :ok <-

--- a/lib/nerves_hub/firmwares/delta_updater.ex
+++ b/lib/nerves_hub/firmwares/delta_updater.ex
@@ -10,7 +10,7 @@ defmodule NervesHub.Firmwares.DeltaUpdater do
   Called to create a firmware delta file on the local filesystem
   """
   @callback create_firmware_delta_file(String.t(), String.t()) ::
-              {:ok, String.t()} | {:error, term()}
+              {:ok, String.t(), map()} | {:error, term()}
 
   @doc """
   Called to cleanup any files or directories create during the firmware delta creation process.

--- a/lib/nerves_hub/firmwares/delta_updater/default.ex
+++ b/lib/nerves_hub/firmwares/delta_updater/default.ex
@@ -65,6 +65,9 @@ defmodule NervesHub.Firmwares.DeltaUpdater.Default do
     _ = File.mkdir_p(target_work_dir)
     _ = File.mkdir_p(output_work_dir)
 
+    %{size: source_size} = File.stat!(source_path)
+    %{size: target_size} = File.stat!(target_path)
+
     {_, 0} = System.cmd("unzip", ["-qq", source_path, "-d", source_work_dir], env: [])
     {_, 0} = System.cmd("unzip", ["-qq", target_path, "-d", target_work_dir], env: [])
 
@@ -127,7 +130,10 @@ defmodule NervesHub.Firmwares.DeltaUpdater.Default do
       ]
       |> Enum.each(&add_to_zip(&1, output_work_dir, output_path))
 
-      {:ok, output_path}
+      {:ok, %{size: size}} = File.stat(output_path)
+
+      {:ok, output_path,
+       %{"size" => size, "source_size" => source_size, "target_size" => target_size}}
     end
   end
 

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -1,12 +1,28 @@
 defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
   use NervesHubWeb, :live_component
 
+  alias NervesHub.Firmwares
   alias NervesHub.Devices
 
+  import NervesHubWeb.LayoutView,
+    only: [humanize_size: 1]
+
   def update(%{update_inflight_info: true}, socket) do
+    %{product: product} = socket.assigns
     deployment_group = socket.assigns.deployment_group
 
     inflight_updates = Devices.inflight_updates_for(deployment_group)
+
+    socket =
+      if product.delta_updatable do
+        assign(
+          socket,
+          :deltas,
+          Firmwares.get_deltas_by_target_firmware(deployment_group.firmware)
+        )
+      else
+        assign(socket, :deltas, nil)
+      end
 
     socket
     |> assign(:inflight_updates, inflight_updates)
@@ -54,6 +70,21 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
               <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{@deployment_group.firmware}"} class="flex items-center gap-1 pl-1.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
                 <span class="text-xs text-zinc-300 tracking-tight">{@deployment_group.firmware.version} ({String.slice(@deployment_group.firmware.uuid, 0..7)})</span>
               </.link>
+            </div>
+            <div class="flex gap-4 items-center">
+              <span class="text-sm text-nerves-gray-500 w-16">Size:</span>
+              <span class="pl-1 text-xs text-nerves-gray-700">{humanize_size(@deployment_group.firmware.size)}</span>
+            </div>
+            <div :if={assigns[:deltas]} class="flex gap-4 items-center">
+              <span class="text-sm text-nerves-gray-500 w-16">Deltas:</span>
+              <span :for={delta <- @deltas} class="flex items-center gap-1 pl-1.5 pr-2.5 py-0.5 border border-zinc-700 rounded-full bg-zinc-800">
+                <span class="text-xs text-zinc-300 tracking-tight">
+                  {delta.source.version}
+                  <span :if={delta.upload_metadata["size"]}>
+                    - {humanize_size(delta.upload_metadata["size"])}
+                  </span>
+                </span>
+              </span>
             </div>
             <div class="flex gap-4 items-center">
               <span class="text-sm text-nerves-gray-500 w-16">Archive:</span>

--- a/test/nerves_hub/firmwares/delta_updater_test.exs
+++ b/test/nerves_hub/firmwares/delta_updater_test.exs
@@ -168,9 +168,14 @@ defmodule NervesHub.Firmwares.DeltaUpdateTest do
 
     fw_a = build_fw!(Path.join(dir, "a.fw"), fwup_conf_path, data_path_1)
     fw_b = build_fw!(Path.join(dir, "b.fw"), fwup_conf_path, data_path_2)
+    %{size: source_size} = File.stat!(fw_a)
+    %{size: target_size} = File.stat!(fw_b)
 
-    {:ok, delta_path} =
+    {:ok, delta_path,
+     %{"size" => delta_size, "source_size" => ^source_size, "target_size" => ^target_size}} =
       Default.do_delta_file(fw_a, fw_b, Path.join(dir, "delta.fw"), Path.join(dir, "work"))
+
+    assert %{size: ^delta_size} = File.stat!(delta_path)
 
     img_a = complete!(fw_a, Path.join(dir, "a.img"))
     hash_a = sha256sum(img_a)
@@ -202,9 +207,14 @@ defmodule NervesHub.Firmwares.DeltaUpdateTest do
 
     fw_a = build_fw!(Path.join(dir, "a.fw"), fwup_conf_path, data_path_1)
     fw_b = build_fw!(Path.join(dir, "b.fw"), fwup_conf_path, data_path_2)
+    %{size: source_size} = File.stat!(fw_a)
+    %{size: target_size} = File.stat!(fw_b)
 
-    {:ok, delta_path} =
+    {:ok, delta_path,
+     %{"size" => delta_size, "source_size" => ^source_size, "target_size" => ^target_size}} =
       Default.do_delta_file(fw_a, fw_b, Path.join(dir, "delta.fw"), Path.join(dir, "work"))
+
+    assert %{size: ^delta_size} = File.stat!(delta_path)
 
     img_a = complete!(fw_a, Path.join(dir, "a.img"))
     hash_a = sha256sum(img_a)
@@ -236,9 +246,14 @@ defmodule NervesHub.Firmwares.DeltaUpdateTest do
 
     fw_a = build_fw!(Path.join(dir, "a.fw"), fwup_conf_path, data_path_1)
     fw_b = build_fw!(Path.join(dir, "b.fw"), fwup_conf_path, data_path_2)
+    %{size: source_size} = File.stat!(fw_a)
+    %{size: target_size} = File.stat!(fw_b)
 
-    {:ok, delta_path} =
+    {:ok, delta_path,
+     %{"size" => delta_size, "source_size" => ^source_size, "target_size" => ^target_size}} =
       Default.do_delta_file(fw_a, fw_b, Path.join(dir, "delta.fw"), Path.join(dir, "work"))
+
+    assert %{size: ^delta_size} = File.stat!(delta_path)
 
     img_a = complete!(fw_a, Path.join(dir, "a.img"))
     hash_a = sha256sum(img_a)
@@ -312,9 +327,14 @@ defmodule NervesHub.Firmwares.DeltaUpdateTest do
 
     fw_a = build_fw!(Path.join(dir, "a.fw"), fwup_conf_path, data_path_1)
     fw_b = build_fw!(Path.join(dir, "b.fw"), fwup_conf_path, data_path_2)
+    %{size: source_size} = File.stat!(fw_a)
+    %{size: target_size} = File.stat!(fw_b)
 
-    {:ok, delta_path} =
+    {:ok, delta_path,
+     %{"size" => delta_size, "source_size" => ^source_size, "target_size" => ^target_size}} =
       Default.do_delta_file(fw_a, fw_b, Path.join(dir, "delta.fw"), Path.join(dir, "work"))
+
+    %{size: ^delta_size} = File.stat!(delta_path)
 
     img_a = complete!(fw_a, Path.join(dir, "a.img"))
     hash_a = sha256sum(img_a)
@@ -362,8 +382,14 @@ defmodule NervesHub.Firmwares.DeltaUpdateTest do
     fw_a = build_fw!(Path.join(dir, "a.fw"), fwup_conf_path, data_path_1)
     fw_b = build_fw!(Path.join(dir, "b.fw"), fwup_conf_path, data_path_2)
 
-    {:ok, delta_path} =
+    %{size: source_size} = File.stat!(fw_a)
+    %{size: target_size} = File.stat!(fw_b)
+
+    {:ok, delta_path,
+     %{"size" => delta_size, "source_size" => ^source_size, "target_size" => ^target_size}} =
       Default.do_delta_file(fw_a, fw_b, Path.join(dir, "delta.fw"), Path.join(dir, "work"))
+
+    assert %{size: ^delta_size} = File.stat!(delta_path)
 
     img_a = complete!(fw_a, Path.join(dir, "a.img"))
     hash_a = sha256sum(img_a)

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -267,7 +267,7 @@ defmodule NervesHub.FirmwaresTest do
       expect(UploadFile, :download_file, fn ^target -> {:ok, target_url} end)
 
       expect(DeltaUpdaterDefault, :create_firmware_delta_file, fn ^source_url, ^target_url ->
-        {:ok, firmware_delta_path}
+        {:ok, firmware_delta_path, %{size: 5}}
       end)
 
       expect(UploadFile, :upload_file, fn ^firmware_delta_path, _ -> :ok end)
@@ -290,7 +290,7 @@ defmodule NervesHub.FirmwaresTest do
       target = Fixtures.firmware_fixture(org_key, product)
 
       expect(DeltaUpdaterDefault, :create_firmware_delta_file, fn _s, _t ->
-        {:ok, "path/to/firmware.fw"}
+        {:ok, "path/to/firmware.fw", %{size: 5}}
       end)
 
       expect(UploadFile, :upload_file, fn _p, _m -> {:error, :failed} end)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -179,11 +179,18 @@ defmodule NervesHub.Fixtures do
         id: target_id,
         org_id: org_id
       }) do
+    delta_metadata = %{
+      "size" => 5,
+      "source_size" => 7,
+      "target_size" => 10
+    }
+
     {:ok, firmware_delta} =
       Firmwares.insert_firmware_delta(%{
         source_id: source_id,
         target_id: target_id,
-        upload_metadata: @uploader.metadata(org_id, "#{Ecto.UUID.generate()}.fw")
+        upload_metadata:
+          Map.merge(delta_metadata, @uploader.metadata(org_id, "#{Ecto.UUID.generate()}.fw"))
       })
 
     firmware_delta


### PR DESCRIPTION
This should let users see that deltas exist.

Also included the size of the delta file as well as the size of the full target firmware. Until we collect stats on how much transfer we save this is at least an indication.

It only shows up for products with deltas enabled. Older generated deltas may not have the size information so they won't show it.