### PR TITLE
Move delta_updatable setting to deployment group

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -794,13 +794,13 @@ defmodule NervesHub.Devices do
   @spec delta_updatable?(
           source :: Firmware.t(),
           target :: Firmware.t(),
-          Product.t(),
+          DeploymentGroup.t(),
           fwup_version :: String.t()
         ) :: boolean()
-  def delta_updatable?(nil, _target, _product, _fwup_version), do: false
+  def delta_updatable?(nil, _target, _deployment_group, _fwup_version), do: false
 
-  def delta_updatable?(source, target, product, fwup_version) do
-    product.delta_updatable and
+  def delta_updatable?(source, target, deployment_group, fwup_version) do
+    deployment_group.delta_updatable and
       target.delta_updatable and
       source.delta_updatable and
       Version.match?(fwup_version, @min_fwup_delta_updatable_version)
@@ -1722,7 +1722,7 @@ defmodule NervesHub.Devices do
   @spec get_delta_or_firmware_url(String.t(), Firmware.t() | DeploymentGroup.t()) ::
           {:ok, String.t()} | {:error, :failure}
   def get_delta_or_firmware_url(device_firmware_uuid, %DeploymentGroup{
-        product: %{delta_updatable: true},
+        delta_updatable: true,
         firmware: target_firmware
       }) do
     # Get firmware delta URL if available but otherwise deliver full firmware

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -354,14 +354,20 @@ defmodule NervesHub.ManagedDeployments do
     end)
   end
 
-  defp maybe_trigger_delta_generation(deployment_group, changeset) do
-    # Firmware changed on active deployment
-    if Map.has_key?(changeset.changes, :firmware_id) do
-      if deployment_group.delta_updatable do
-        trigger_delta_generation_for_deployment_group(deployment_group)
-      end
-    end
-  end
+  defp maybe_trigger_delta_generation(
+         %{delta_updatable: true} = deployment_group,
+         %{changes: %{firmware_id: _}} = _changeset
+       ),
+       do: trigger_delta_generation_for_deployment_group(deployment_group)
+
+  defp maybe_trigger_delta_generation(
+         deployment_group,
+         %{changes: %{delta_updatable: true}} = _changeset
+       ),
+       do: trigger_delta_generation_for_deployment_group(deployment_group)
+
+  defp maybe_trigger_delta_generation(_deployment_group, _changeset),
+    do: :ok
 
   defp trigger_delta_generation_for_deployment_group(deployment_group) do
     NervesHub.Devices.get_device_firmware_for_delta_generation_by_deployment_group(

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -41,7 +41,8 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     :connecting_code,
     :total_updating_devices,
     :current_updated_devices,
-    :queue_management
+    :queue_management,
+    :delta_updatable
   ]
 
   @derive {Phoenix.Param, key: :name}
@@ -72,6 +73,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     field(:current_updated_devices, :integer, default: 0)
     field(:inflight_update_expiration_minutes, :integer, default: 60)
     field(:queue_management, Ecto.Enum, values: [:FIFO, :LIFO], default: :FIFO)
+    field(:delta_updatable, :boolean, default: false)
 
     # TODO: (nshoes) this column is unused, remove after 1st March
     # field(:recalculation_type, Ecto.Enum, values: [:device, :calculator_queue], default: :device)

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -104,25 +104,6 @@ defmodule NervesHub.Products do
   end
 
   @doc """
-  Updates a product.
-
-  ## Examples
-
-      iex> update_product(product, %{field: new_value})
-      {:ok, %Product{}}
-
-      iex> update_product(product, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  @spec update_product(Product.t(), map()) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()}
-  def update_product(%Product{} = product, attrs) do
-    product
-    |> Product.update_changeset(attrs)
-    |> Repo.update()
-  end
-
-  @doc """
   Deletes a Product.
 
   ## Examples

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -13,7 +13,6 @@ defmodule NervesHub.Products do
   alias NervesHub.Extensions
   alias NervesHub.Products.Product
   alias NervesHub.Products.SharedSecretAuth
-  alias NervesHub.Workers.FirmwareDeltaBuilder
 
   alias NimbleCSV.RFC4180, as: CSV
 
@@ -105,20 +104,6 @@ defmodule NervesHub.Products do
   end
 
   @doc """
-  Toggle the delta updates attribute for a product.
-
-  ## Examples
-
-      iex> toggle_delta_updates(product)
-      {:ok, %Product{}}
-
-  """
-  @spec toggle_delta_updates(Product.t()) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()}
-  def toggle_delta_updates(%Product{} = product) do
-    update_product(product, %{delta_updatable: !product.delta_updatable})
-  end
-
-  @doc """
   Updates a product.
 
   ## Examples
@@ -132,27 +117,9 @@ defmodule NervesHub.Products do
   """
   @spec update_product(Product.t(), map()) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()}
   def update_product(%Product{} = product, attrs) do
-    result =
-      product
-      |> Product.update_changeset(attrs)
-      |> Repo.update()
-
-    case result do
-      {:ok, %{delta_updatable: true} = new_product} when product.delta_updatable == false ->
-        :ok = trigger_delta_generation_for_product(new_product)
-        result
-
-      _ ->
-        result
-    end
-  end
-
-  defp trigger_delta_generation_for_product(product) do
-    NervesHub.Devices.get_device_firmware_for_delta_generation_by_product(product.id)
-    |> Enum.uniq()
-    |> Enum.each(fn {source_id, target_id} ->
-      FirmwareDeltaBuilder.start(source_id, target_id)
-    end)
+    product
+    |> Product.update_changeset(attrs)
+    |> Repo.update()
   end
 
   @doc """

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -13,7 +13,6 @@ defmodule NervesHub.Products.Product do
   alias NervesHub.Scripts.Script
 
   @required_params [:name, :org_id]
-  @optional_params [:delta_updatable]
 
   @type t :: %__MODULE__{}
 
@@ -34,7 +33,6 @@ defmodule NervesHub.Products.Product do
 
     field(:name, :string)
     field(:deleted_at, :utc_datetime)
-    field(:delta_updatable, :boolean, default: false)
     embeds_one(:extensions, ProductExtensionsSetting, on_replace: :update)
 
     field(:device_count, :integer, virtual: true)
@@ -50,7 +48,7 @@ defmodule NervesHub.Products.Product do
   @doc false
   def changeset(product, params) do
     product
-    |> cast(params, @required_params ++ @optional_params)
+    |> cast(params, @required_params)
     |> cast_embed(:extensions)
     |> update_change(:name, &trim/1)
     |> validate_required(@required_params)
@@ -58,7 +56,7 @@ defmodule NervesHub.Products.Product do
   end
 
   def update_changeset(product, params) do
-    cast(product, params, @optional_params)
+    cast(product, params, [])
   end
 
   def delete_changeset(product, _params \\ %{}) do

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -55,10 +55,6 @@ defmodule NervesHub.Products.Product do
     |> unique_constraint(:name, name: :products_org_id_name_index)
   end
 
-  def update_changeset(product, params) do
-    cast(product, params, [])
-  end
-
   def delete_changeset(product, _params \\ %{}) do
     deleted_at = DateTime.truncate(DateTime.utc_now(), :second)
 

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -35,9 +35,15 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
             <div class="text-base text-neutral-50 font-medium">General settings</div>
           </div>
 
-          <div class="flex flex-col p-6 gap-6">
-            <div class="w-1/2">
+          <div class="flex p-6 gap-6">
+            <div class="w-1/2 flex flex-col gap-6">
               <.input field={@form[:name]} label="Name" placeholder="Production" />
+              <.input field={@form[:delta_updatable]} type="checkbox" label="Delta updates" phx-click="toggle-delta-updates">
+            <:rich_hint>
+              Check out the <.link class="underline" href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank">NervesHub documentation</.link>
+              for more information on delta updates.
+            </:rich_hint>
+          </.input>
             </div>
           </div>
         </div>

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -39,11 +39,11 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
             <div class="w-1/2 flex flex-col gap-6">
               <.input field={@form[:name]} label="Name" placeholder="Production" />
               <.input field={@form[:delta_updatable]} type="checkbox" label="Delta updates" phx-click="toggle-delta-updates">
-            <:rich_hint>
-              Check out the <.link class="underline" href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank">NervesHub documentation</.link>
-              for more information on delta updates.
-            </:rich_hint>
-          </.input>
+                <:rich_hint>
+                  Check out the <.link class="underline" href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank">NervesHub documentation</.link>
+                  for more information on delta updates.
+                </:rich_hint>
+              </.input>
             </div>
           </div>
         </div>

--- a/lib/nerves_hub_web/controllers/api/deployment_group_json.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_group_json.ex
@@ -15,7 +15,8 @@ defmodule NervesHubWeb.API.DeploymentGroupJSON do
       is_active: deployment_group.is_active,
       state: if(deployment_group.is_active, do: "on", else: "off"),
       firmware_uuid: deployment_group.firmware.uuid,
-      conditions: deployment_group.conditions
+      conditions: deployment_group.conditions,
+      delta_updatable: deployment_group.delta_updatable
     }
   end
 end

--- a/lib/nerves_hub_web/controllers/api/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/product_controller.ex
@@ -10,7 +10,7 @@ defmodule NervesHubWeb.API.ProductController do
   tags(["Products"])
   security([%{}, %{"bearer_auth" => []}])
 
-  plug(:validate_role, [org: :admin] when action in [:create, :delete, :update])
+  plug(:validate_role, [org: :admin] when action in [:create, :delete])
   plug(:validate_role, [org: :view] when action in [:show])
 
   operation(:index,
@@ -117,39 +117,6 @@ defmodule NervesHubWeb.API.ProductController do
   def delete(%{assigns: %{product: product}} = conn, _params) do
     with {:ok, %Product{}} <- Products.delete_product(product) do
       send_resp(conn, :no_content, "")
-    end
-  end
-
-  operation(:update,
-    summary: "Update an Organizations Product",
-    parameters: [
-      org_name: [
-        in: :path,
-        description: "Organization Name",
-        type: :string,
-        example: "example_org"
-      ],
-      product_name: [
-        in: :path,
-        description: "Product Name",
-        type: :string,
-        example: "example_product"
-      ]
-    ],
-    request_body: {
-      "Product update request body",
-      "application/json",
-      ProductSchemas.ProductUpdateRequest,
-      required: true
-    },
-    responses: [
-      ok: {"Product response", "application/json", ProductSchemas.Product}
-    ]
-  )
-
-  def update(%{assigns: %{product: product}} = conn, %{"product" => params}) do
-    with {:ok, product} <- Products.update_product(product, params) do
-      render(conn, :show, product: product)
     end
   end
 end

--- a/lib/nerves_hub_web/controllers/api/product_json.ex
+++ b/lib/nerves_hub_web/controllers/api/product_json.ex
@@ -11,8 +11,7 @@ defmodule NervesHubWeb.API.ProductJSON do
 
   def product(product) do
     %{
-      name: product.name,
-      delta_updatable: product.delta_updatable
+      name: product.name
     }
   end
 end

--- a/lib/nerves_hub_web/controllers/api/schemas/product_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/product_schemas.ex
@@ -13,7 +13,6 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
           type: :string,
           pattern: ~r/[a-zA-Z][a-zA-Z0-9_]+/
         },
-        delta_updatable: %Schema{type: :boolean, description: "Delta Firmware updates enabled"},
         inserted_at: %Schema{
           type: :string,
           description: "Creation timestamp",
@@ -28,7 +27,6 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
       example: %{
         "id" => 123,
         "name" => "Example Product",
-        "delta_updatable" => true,
         "inserted_at" => "2017-09-12T12:34:55Z",
         "updated_at" => "2017-09-12T12:34:55Z"
       }
@@ -47,14 +45,12 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
           %{
             "id" => 123,
             "name" => "Example Product",
-            "delta_updatable" => true,
             "inserted_at" => "2017-09-12T12:34:55Z",
             "updated_at" => "2017-09-13T10:11:12Z"
           },
           %{
             "id" => 246,
             "name" => "Another Example Product",
-            "delta_updatable" => false,
             "inserted_at" => "2019-09-12T12:34:55Z",
             "updated_at" => "2019-09-13T10:11:12Z"
           }
@@ -70,8 +66,7 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
       properties: %{
         product: %Schema{
           properties: %{
-            name: %Schema{type: :string},
-            delta_updatable: %Schema{type: :boolean}
+            name: %Schema{type: :string}
           },
           required: [:name]
         }
@@ -91,15 +86,7 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
       type: :object,
       properties: %{
         product: %Schema{
-          properties: %{
-            delta_updatable: %Schema{type: :boolean}
-          }
-        }
-      },
-      required: [:delta_updatable],
-      example: %{
-        "product" => %{
-          "delta_updatable" => "false"
+          properties: %{}
         }
       }
     })

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -53,6 +53,10 @@ defmodule NervesHubWeb.Helpers.Authorization do
   def authorized?(:"deployment_group:create", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"deployment_group:update", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"deployment_group:toggle", %OrgUser{role: role}), do: role_check(:manage, role)
+
+  def authorized?(:"deployment_group:toggle_delta_updates", %OrgUser{role: role}),
+    do: role_check(:manage, role)
+
   def authorized?(:"deployment_group:delete", %OrgUser{role: role}), do: role_check(:manage, role)
 
   def authorized?(:"support_script:create", %OrgUser{role: role}), do: role_check(:manage, role)

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -92,6 +92,21 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
     |> noreply()
   end
 
+  def handle_event("toggle-delta-updates", _params, socket) do
+    authorized!(:"deployment_group:toggle_delta_updates", socket.assigns.org_user)
+
+    {:ok, deployment_group} =
+      ManagedDeployments.toggle_delta_updates(socket.assigns.deployment_group)
+
+    socket
+    |> assign(:deployment_group, deployment_group)
+    |> put_flash(
+      :info,
+      "Delta updates #{(deployment_group.delta_updatable && "enabled") || "disabled"} successfully."
+    )
+    |> noreply()
+  end
+
   def handle_event("delete", _params, socket) do
     authorized!(:"deployment_group:delete", socket.assigns.org_user)
 

--- a/lib/nerves_hub_web/live/product/settings-new.html.heex
+++ b/lib/nerves_hub_web/live/product/settings-new.html.heex
@@ -26,13 +26,6 @@
       <div class="flex p-6 gap-6">
         <div class="w-1/2 flex flex-col gap-6">
           <.input field={@form[:name]} label="Name" hint="Once created, a product name cannot be changed" disabled />
-
-          <.input field={@form[:delta_updatable]} type="checkbox" label="Delta updates" phx-click="toggle-delta-updates">
-            <:rich_hint>
-              Check out the <.link class="underline" href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank">NervesHub documentation</.link>
-              for more information on delta updates.
-            </:rich_hint>
-          </.input>
         </div>
       </div>
     </div>

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -21,13 +21,6 @@ defmodule NervesHubWeb.Live.Product.Settings do
     {:ok, socket}
   end
 
-  def handle_event("update", %{"product" => params}, socket) do
-    authorized!(:"product:update", socket.assigns.org_user)
-
-    {:ok, product} = Products.update_product(socket.assigns.product, params)
-    {:noreply, assign(socket, :product, product)}
-  end
-
   def handle_event("add-shared-secret", _params, socket) do
     authorized!(:"product:update", socket.assigns.org_user)
 

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -21,20 +21,6 @@ defmodule NervesHubWeb.Live.Product.Settings do
     {:ok, socket}
   end
 
-  def handle_event("toggle-delta-updates", _params, socket) do
-    authorized!(:"product:update", socket.assigns.org_user)
-
-    {:ok, product} = Products.toggle_delta_updates(socket.assigns.product)
-
-    socket
-    |> assign(:product, product)
-    |> put_flash(
-      :info,
-      "Delta updates #{(product.delta_updatable && "enabled") || "disabled"} successfully."
-    )
-    |> noreply()
-  end
-
   def handle_event("update", %{"product" => params}, socket) do
     authorized!(:"product:update", socket.assigns.org_user)
 

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -9,25 +9,6 @@
   <input type="text" name="product_name" id="product_name_input" value={@product.name} disabled={true} class="form-control" />
 </div>
 
-<div class="form-group">
-  <div class="help-text tooltip-label help-tooltip">
-    <label class="tooltip-label">
-      Firmware updates
-    </label>
-    <span class="tooltip-info mb-1"></span>
-    <span class="tooltip-text">
-      Check out the documentation at
-      <a href="https://docs.nerves-hub.org" target="_blank" class="inline">
-        https://docs.nerves-hub.org
-      </a>
-      for more information about
-      <a href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank" class="inline">
-        delta updates
-      </a>
-    </span>
-  </div>
-</div>
-
 <div class="border-bottom border-dark mt-2 mb-4"></div>
 
 <div class="container pl-0 mb-2">

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -26,23 +26,6 @@
       </a>
     </span>
   </div>
-  <.form for={@form} phx-change="update" phx-submit="update">
-    <div class="flex-row align-items-center">
-      <input type="hidden" name="product[delta_updatable]" value="false" />
-      <input
-        type="checkbox"
-        id="delta_updatable_input"
-        name="product[delta_updatable]"
-        value="true"
-        checked={Phoenix.HTML.Form.normalize_value("checkbox", @product.delta_updatable)}
-        class="form-control checkbox"
-        disabled={!authorized?(:"product:update", @org_user)}
-      />
-      <label for="delta_updatable_input" class="color-white pl-1 m-0">
-        Enable delta firmware updates
-      </label>
-    </div>
-  </.form>
 </div>
 
 <div class="border-bottom border-dark mt-2 mb-4"></div>

--- a/lib/nerves_hub_web/live/products/new-new.html.heex
+++ b/lib/nerves_hub_web/live/products/new-new.html.heex
@@ -9,7 +9,6 @@
           <div class="w-full flex flex-col gap-6">
             <.input field={@form[:name]} label="Name" placeholder="ellipsis, umbrella, .." />
             <p>Once created, a product name cannot be changed.</p>
-            <input type="hidden" name="product[delta_updatable]" value="true" />
             <input :for={{key, _description} <- @available_extensions} type="hidden" name={"product[extensions][#{key}]"} value="true" />
           </div>
         </div>

--- a/lib/nerves_hub_web/live/products/new.html.heex
+++ b/lib/nerves_hub_web/live/products/new.html.heex
@@ -24,23 +24,6 @@
   </div>
 
   <div class="form-group">
-    <label for="delta_updatable_input" class="tooltip-label">
-      <span>Firmware updates</span>
-      <span class="tooltip-info"></span>
-      <span class="tooltip-text">
-        Check out the documentation at <a href="https://docs.nerves-hub.org" target="_blank" class="inline">https://docs.nerves-hub.org </a>
-        for more information about <a href="https://docs.nerves-hub.org/nerves-hub/setup/firmware#delta-updates" target="_blank" class="inline">delta updates</a>
-      </span>
-    </label>
-    <div class="flex-row align-items-center">
-      {checkbox(f, :delta_updatable, class: "form-control checkbox", id: "delta_updatable_input")}
-      <label for="delta_updatable_input" class="color-white pl-1 m-0">Enable delta firmware updates</label>
-    </div>
-
-    <div class="has-error">{error_tag(f, :delta_updatable)}</div>
-  </div>
-
-  <div class="form-group">
     <div class="container pl-0 mb-2">
       <div class="row align-items-center">
         <div class="col col-6">

--- a/priv/repo/migrations/20250611082642_move_delta_updatable_to_deployment_group.exs
+++ b/priv/repo/migrations/20250611082642_move_delta_updatable_to_deployment_group.exs
@@ -5,5 +5,10 @@ defmodule NervesHub.Repo.Migrations.MoveDeltaUpdatableToDeploymentGroup do
     alter table(:deployments) do
       add :delta_updatable, :boolean, default: false
     end
+
+    alter table(:products) do
+      remove :delta_updatable
+    end
   end
+
 end

--- a/priv/repo/migrations/20250611082642_move_delta_updatable_to_deployment_group.exs
+++ b/priv/repo/migrations/20250611082642_move_delta_updatable_to_deployment_group.exs
@@ -3,7 +3,7 @@ defmodule NervesHub.Repo.Migrations.MoveDeltaUpdatableToDeploymentGroup do
 
   def change do
     alter table(:deployments) do
-      add :delta_updatable, :boolean, default: false
+      add :delta_updatable, :boolean, default: false, null: false
     end
 
     alter table(:products) do

--- a/priv/repo/migrations/20250611082642_move_delta_updatable_to_deployment_group.exs
+++ b/priv/repo/migrations/20250611082642_move_delta_updatable_to_deployment_group.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.MoveDeltaUpdatableToDeploymentGroup do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add :delta_updatable, :boolean, default: false
+    end
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -380,25 +380,24 @@ defmodule NervesHub.DevicesTest do
 
   test "delta_updatable?", %{
     firmware: source,
-    product: product,
     deployment_group: deployment_group
   } do
     fwup_version = @valid_fwup_version
     %{firmware: target} = Repo.preload(deployment_group, :firmware)
 
-    assert Devices.delta_updatable?(source, target, product, fwup_version) == false
+    assert Devices.delta_updatable?(source, target, deployment_group, fwup_version) == false
 
     source = Ecto.Changeset.change(source, delta_updatable: true) |> Repo.update!()
     target = Ecto.Changeset.change(target, delta_updatable: true) |> Repo.update!()
 
-    assert product.delta_updatable == true
+    assert deployment_group.delta_updatable == true
     assert source.delta_updatable == true
     assert target.delta_updatable == true
 
-    assert Devices.delta_updatable?(source, target, product, fwup_version) == true
+    assert Devices.delta_updatable?(source, target, deployment_group, fwup_version) == true
 
     # case where the source firmware does not exist
-    assert Devices.delta_updatable?(nil, target, product, fwup_version) == false
+    assert Devices.delta_updatable?(nil, target, deployment_group, fwup_version) == false
   end
 
   test "matches_deployment_group? works when device and/or deployment tags are nil", %{

--- a/test/nerves_hub_web/live/new_ui/deployment_groups/show_test.exs
+++ b/test/nerves_hub_web/live/new_ui/deployment_groups/show_test.exs
@@ -17,6 +17,18 @@ defmodule NervesHubWeb.Live.NewUI.DelploymentGroups.ShowTest do
       %{context | conn: conn}
     end
 
+    test "toggle delta updates", %{conn: conn, deployment_group: deployment_group} do
+      # Delta updates are enabled in deployment group fixture
+      assert deployment_group.delta_updatable
+
+      conn
+      |> check("Delta updates")
+      |> assert_has("div", text: "Delta updates disabled successfully.")
+
+      deployment_group = Repo.reload(deployment_group)
+      refute deployment_group.delta_updatable
+    end
+
     test "can update only version", %{conn: conn, deployment_group: deployment_group} do
       conn
       |> fill_in("Version requirement", with: "1.2.3")

--- a/test/nerves_hub_web/live/product/settings_test.exs
+++ b/test/nerves_hub_web/live/product/settings_test.exs
@@ -4,24 +4,9 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
   alias NervesHub.Fixtures
   alias NervesHub.Products
 
-  describe "update product" do
-    test "delta firmware updates", %{conn: conn, org: org, user: user} do
-      product = Fixtures.product_fixture(user, org, %{delta_updatable: false})
-      refute product.delta_updatable
-
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/settings")
-      |> assert_has("h1", text: "Product Settings")
-      |> check("Enable delta firmware updates")
-
-      product = NervesHub.Repo.reload(product)
-      assert product.delta_updatable
-    end
-  end
-
   describe "delete product" do
     test "soft deletes the product", %{conn: conn, org: org, user: user} do
-      product = Fixtures.product_fixture(user, org, %{delta_updatable: false})
+      product = Fixtures.product_fixture(user, org)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/settings")
@@ -57,7 +42,7 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
     test "add shared secret", %{conn: conn, org: org, user: user} do
       Application.put_env(:nerves_hub, NervesHubWeb.DeviceSocket, shared_secrets: [enabled: true])
 
-      product = Fixtures.product_fixture(user, org, %{delta_updatable: false})
+      product = Fixtures.product_fixture(user, org)
 
       conn =
         conn
@@ -72,7 +57,7 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
     test "deactivate shared secret", %{conn: conn, org: org, user: user} do
       Application.put_env(:nerves_hub, NervesHubWeb.DeviceSocket, shared_secrets: [enabled: true])
 
-      product = Fixtures.product_fixture(user, org, %{delta_updatable: false})
+      product = Fixtures.product_fixture(user, org)
 
       {:ok, _} = Products.create_shared_secret_auth(product)
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -35,7 +35,6 @@ defmodule NervesHub.Fixtures do
   @device_params %{tags: ["beta", "beta-edge"], extensions: %{health: true, geo: true}}
   @product_params %{
     name: "valid product",
-    delta_updatable: true,
     extensions: %{health: true, geo: true, logging: true}
   }
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -29,7 +29,8 @@ defmodule NervesHub.Fixtures do
       "version" => "<= 1.0.0",
       "tags" => ["beta", "beta-edge"]
     },
-    is_active: false
+    is_active: false,
+    delta_updatable: true
   }
   @device_params %{tags: ["beta", "beta-edge"], extensions: %{health: true, geo: true}}
   @product_params %{


### PR DESCRIPTION
Adds `delta_updatable` field to `DeploymentGroup` and removes it from `Product`.

All product update functions are also deleted since Product has no more fields that can be updated (name cannot be changed, and extensions are embedded).