### PR TITLE
Improve responsivness for top bar

### DIFF
--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -1,13 +1,13 @@
 <div class="h-[56px] shrink-0 flex justify-end bg-base-900 border-b border-base-700 pl-6 items-center">
-  <div class="flex gap-2.5">
+  <div class="flex gap-2.5 items-center">
     <.link navigate={~p"/org/#{@org}/#{@product}/devices"} class="back-link flex gap-2.5 items-center">
       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
         <path d="M4.16671 10L9.16671 5M4.16671 10L9.16671 15M4.16671 10H15.8334" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
-      <span class="text-base-400">All Devices</span>
+      <span class="text-base-400 whitespace-nowrap hidden md:block">All Devices</span>
     </.link>
-    <span class="text-base-400">/</span>
-    <span class="text-zinc-50 font-semibold">{@device.identifier}</span>
+    <span class="text-base-400 hidden lg:block">/</span>
+    <span class="text-zinc-50 font-semibold hidden lg:block">{@device.identifier}</span>
   </div>
 
   <div class="flex items-center gap-2 ml-auto mr-6">

--- a/lib/nerves_hub_web/live/devices/show-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/show-new.html.heex
@@ -82,7 +82,7 @@
 
     <div class="flex items-center gap-2">
       <div class="flex h-7 py-1 px-2 items-center rounded bg-zinc-800">
-        <span class="text-sm text-zinc-400 mr-1">Version:</span>
+        <span class="text-sm text-zinc-400 mr-1 hidden lg:block">Version:</span>
 
         <span :if={is_nil(@device.firmware_metadata)} class="text-sm text-base-300 font-mono">Unknown</span>
 
@@ -101,7 +101,7 @@
       </div>
 
       <div class="flex h-7 py-1 px-2 items-center rounded bg-zinc-800">
-        <span class="text-sm text-zinc-400">Firmware updates:</span>
+        <span class="text-sm text-zinc-400 hidden lg:block">Firmware updates:</span>
         <%= cond do %>
           <% is_nil(@device.deployment_id) -> %>
             <span class="ml-2 mr-1 text-sm text-base-300">N/A</span>


### PR DESCRIPTION
Issue: https://github.com/nerves-hub/nerves_hub_web/issues/1920
  
Changes:  
- Align text/device-name on the right side of 'All devices', vertically centered
- Hide device-name on back-button on narrower screens, also hides 'All devices' on really small screens
- Hide title for version and firmware updates on smaller screens



https://github.com/user-attachments/assets/48e38900-8748-4cf1-99f8-dfab3bf94d71

