### PR TITLE
Revise device index pagination

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -128,13 +128,7 @@ defmodule NervesHub.Devices do
     |> Repo.one!()
   end
 
-  @spec filter(Product.t(), User.t(), map()) :: %{
-          entries: list(Device.t()),
-          current_page: non_neg_integer(),
-          page_size: non_neg_integer(),
-          total_pages: non_neg_integer(),
-          total_count: non_neg_integer()
-        }
+  @spec filter(Product.t(), User.t(), map()) :: {[Device.t()], Flop.Meta.t()}
   def filter(product, user, opts) do
     base_query =
       Device
@@ -148,21 +142,11 @@ defmodule NervesHub.Devices do
       |> preload([latest_connection: lc], latest_connection: lc)
       |> preload([latest_health: lh], latest_health: lh)
 
-    {entries, meta} =
-      CommonFiltering.filter(
-        base_query,
-        product,
-        opts
-      )
-
-    meta
-    |> Map.take([
-      :current_page,
-      :page_size,
-      :total_pages,
-      :total_count
-    ])
-    |> Map.put(:entries, entries)
+    CommonFiltering.filter(
+      base_query,
+      product,
+      opts
+    )
   end
 
   def get_minimal_device_location_by_product(product) do

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -522,13 +522,6 @@
   </div>
 </div>
 
-<div class="sticky bottom-0 h-16 flex flex-row border-0 bg-base-950 border-t border-t-base-700 px-6 py-4 z-10">
-  <%= for size <- @paginate_opts.page_sizes do %>
-    <button :if={size <= @total_entries} phx-click="set-paginate-opts" phx-value-page-size={size} class={"pager-button #{if size == @paginate_opts.page_size, do: "active-page"}"}>
-      {size}
-    </button>
-  <% end %>
-  <div class="ml-auto">
-    {reworked_pager(@paginate_opts)}
-  </div>
-</div>
+<%= if @devices.ok? do %>
+  <Pager.render_with_page_sizes pager={@pager_meta} />
+<% end %>

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -156,7 +156,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       |> visit("/org/#{org.name}/#{product.name}/devices")
       |> assert_has("a", text: first_device.identifier, timeout: 1000)
       |> assert_has("button", text: "25", timeout: 1000)
-      |> refute_has("button", text: "50", timeout: 1000)
+      |> assert_has("button", text: "50", timeout: 1000)
       |> assert_has("button", text: "2", timeout: 1000)
       |> click_button("button[phx-click='paginate'][phx-value-page='2']", "2")
       |> refute_has("a", text: first_device.identifier, timeout: 1000)


### PR DESCRIPTION
I was originally looking into an issue with the displayed entries per page for devices, but quickly found out that other resource indexes don't have the same problem. Devices index uses a custom pagination implementation, which was close to our `Pager` component implementation, but without some fixes. I only needed to tidy up a few functions to make everything work.

We have good tests around the devices index so I don't think there's a need for additional tests. I checked the old UI as well, pagination still works.