### PR TITLE
Fix deleting and destroying devices

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -235,7 +235,6 @@ defmodule NervesHub.Devices do
   def get_device_by_identifier!(org, identifier, preload_assoc \\ nil)
       when is_binary(identifier) do
     get_device_by_identifier_query(org, identifier, preload_assoc)
-    |> Repo.exclude_deleted()
     |> Repo.one!()
   end
 

--- a/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
@@ -3,32 +3,60 @@ defmodule NervesHubWeb.NewUi.Devices.SettingsTabTest do
 
   alias NervesHub.Devices
   alias NervesHubWeb.Components.Utils
+  alias NervesHub.Repo
 
   setup %{conn: conn} do
     [conn: init_test_session(conn, %{"new_ui" => true})]
   end
 
-  describe "certificates" do
-    test "download certificate", %{
-      conn: conn,
-      org: org,
-      product: product,
-      device: device
-    } do
-      [certificate] = Devices.get_device_certificates(device)
+  test "download certificate", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device
+  } do
+    [certificate] = Devices.get_device_certificates(device)
 
-      result =
-        conn
-        |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
-        |> assert_has("div", text: "Certificates")
-        |> assert_has("div", text: "Serial: #{Utils.format_serial(certificate.serial)}")
-        |> unwrap(fn view ->
-          view
-          |> element("a[download]")
-          |> render_click()
-        end)
+    result =
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
+      |> assert_has("div", text: "Certificates")
+      |> assert_has("div", text: "Serial: #{Utils.format_serial(certificate.serial)}")
+      |> unwrap(fn view ->
+        view
+        |> element("a[download]")
+        |> render_click()
+      end)
 
-      assert result.conn.resp_body =~ "-----BEGIN CERTIFICATE-----"
-    end
+    assert result.conn.resp_body =~ "-----BEGIN CERTIFICATE-----"
+  end
+
+  test "deleting device", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device
+  } do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
+    |> click_button("Delete device")
+    |> assert_has("div", text: "Device is deleted and must be restored to use.")
+
+    assert Repo.reload(device) |> Map.get(:deleted_at)
+  end
+
+  test "destroying device", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device
+  } do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
+    |> click_button("Delete device")
+    |> click_button("Permanently delete device")
+    |> assert_has("div", text: "Device permanently destroyed successfully.")
+
+    refute Repo.reload(device)
   end
 end


### PR DESCRIPTION
Destroying devices in the UI is impossible with the addition of filtering out soft-deleted devices in `Devices. get_device_by_identifier!/3`. I just wanted to unblock the delete -> destroy device workflow in the new UI, but this function is used in a few places and I think we need to double-check what we want to do:

- `NervesHubWeb.Live.Devices.Settings` on mount:
  - Okay if a soft-deleted device is returned here, obviously 
- `NervesHubWeb.Live.Devices.DeviceHealth` on mount:
  - This is a tab when viewing a device in the new UI; maybe we should add a redirect to the settings page? It makes sense to only allow the Settings tab to be viewable on a soft-deleted device.
- `NervesHubWeb.Live.Devices.Show` on mount:
  - Same as above
- `NervesHubWeb.API.Plugs.Device`, scoped to `/devices/:identifier` routes:
  - You can soft-delete through the `/delete` route, but there's no route to destroy. I vote that we either 1.) convert this route to a destroy action and don't allow soft-deleted devices to be queryable or 2.) add a destroy action and allow soft-deleted devices to be queryable. 