### PR TITLE
Allow firmware uploads from products named with spaces

### DIFF
--- a/lib/nerves_hub_web/dynamic_config_multipart.ex
+++ b/lib/nerves_hub_web/dynamic_config_multipart.ex
@@ -27,10 +27,12 @@ defmodule NervesHubWeb.DynamicConfigMultipart do
   end
 
   defp max_file_size(conn) do
-    if String.match?(conn.request_path, ~r/^\/api\/orgs\/[-\w]+\/products\/[-\w]+\/firmwares$/) do
-      Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
-    else
-      1_000_000
+    case conn.path_info do
+      ["api", "orgs", _org_name, "products", _product_name, "firmwares"] ->
+        Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
+
+      _ ->
+        1_000_000
     end
   end
 end

--- a/lib/nerves_hub_web/dynamic_config_multipart.ex
+++ b/lib/nerves_hub_web/dynamic_config_multipart.ex
@@ -17,13 +17,14 @@ defmodule NervesHubWeb.DynamicConfigMultipart do
     opts
     |> Keyword.put_new(:max_default_size, 1_000_000)
     |> Keyword.put_new_lazy(:max_firmware_size, fn ->
-        Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
+      Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])[:max_size]
     end)
   end
 
   def parse(conn, "multipart", subtype, headers, opts) do
-    opts = @multipart.init([length: max_file_size(conn, opts)] ++ opts)
-    @multipart.parse(conn, "multipart", subtype, headers, opts)
+    plug_opts = Keyword.drop(opts, [:max_default_size, :max_firmware_size])
+    plug_opts = @multipart.init([length: max_file_size(conn, opts)] ++ plug_opts)
+    @multipart.parse(conn, "multipart", subtype, headers, plug_opts)
   end
 
   def parse(conn, _type, _subtype, _headers, _opts) do

--- a/test/nerves_hub_web/dynamic_config_multipart_test.exs
+++ b/test/nerves_hub_web/dynamic_config_multipart_test.exs
@@ -1,0 +1,79 @@
+defmodule NervesHubWeb.DynamicConfigMultipartTest do
+  use NervesHubWeb.APIConnCase
+
+  alias NervesHubWeb.DynamicConfigMultipart
+
+  @reasonable_size 100
+  @firmware_size 1_000_001
+
+  describe "non-firmware paths" do
+    test "allows resonably sized file through" do
+      upload_multipart_file("/somewhere/over/the/rainbow", @reasonable_size)
+    end
+
+    test "returns :too_large error when body exceeds length limit" do
+      assert_raise Plug.Parsers.RequestTooLargeError, fn ->
+        upload_multipart_file("/somewhere/over/the/rainbow", @firmware_size)
+      end
+    end
+  end
+
+  describe "firmware" do
+    test "allows firmware sized file through" do
+      upload_multipart_file("/api/orgs/acme/products/anvil/firmwares", @firmware_size)
+    end
+
+    test "allows firmware sized file through when path contains spaces" do
+      upload_multipart_file("/api/orgs/acme/products/big%20anvil/firmwares", @firmware_size)
+    end
+
+    test "returns :too_large error when multipart body exceeds the firmware limit" do
+      # bring max_size down so it doesn't make a huge file
+      config = Application.get_env(:nerves_hub, NervesHub.Firmwares.Upload, [])
+      :ok = Application.put_env(:nerves_hub, NervesHub.Firmwares.Upload, max_size: 100)
+
+      # reset the config after we're done
+      on_exit(fn ->
+        Application.put_env(:nerves_hub, NervesHub.Firmwares.Upload, config)
+      end)
+
+      assert_raise Plug.Parsers.RequestTooLargeError, fn ->
+        upload_multipart_file("/api/orgs/acme/products/anvil/firmwares", 101)
+      end
+    end
+  end
+
+  def upload_multipart_file(path, filesize) do
+    # create an instance of the parser
+    parser = Plug.Parsers.init(parsers: [DynamicConfigMultipart], pass: ["*/*"])
+
+    # create a multipart payload matching the given filesize
+    {body, boundary} = multipart_file(filesize)
+
+    # run it through our parser
+    Plug.Test.conn(:post, path, body)
+    |> put_req_header("content-type", "multipart/form-data; boundary=#{boundary}")
+    |> Plug.Parsers.call(parser)
+  end
+
+  defp multipart_file(size) do
+    large_content = String.duplicate("a", size)
+
+    boundary = "----TestBoundary123"
+
+    body = """
+    --#{boundary}\r
+    Content-Disposition: form-data; name="title"\r
+    \r
+    Test Upload\r
+    --#{boundary}\r
+    Content-Disposition: form-data; name="file"; filename="large.txt"\r
+    Content-Type: text/plain\r
+    \r
+    #{large_content}\r
+    --#{boundary}--\r
+    """
+
+    {body, boundary}
+  end
+end


### PR DESCRIPTION
Trying to upload some firmware to NH 2.x, I was seeing this:

```shell
$ nh firmware publish some.fw 
NervesHub Host: example.com
Organization:   ACME
NervesHub product: Big Anvil
------------
Organization: ACME
  product:      Big Anvil
  version:      0.1.18
  platform:     bbb
  architecture: arm
  uuid:         229764bc-938a-5509-d311-060497eb3a55
Publish Firmware? yN y  
|==================================================| 100% (23 / 23) MB
Unhandled error: {:error, nil}
```

Looking into the server logs:
```elixir
(Phoenix.Template.UndefinedError) Could not render "413.html" for NervesHubWeb.ErrorView...
*snip*
%{
  reason: %Plug.Parsers.RequestTooLargeError{
    message: "the request is too large...",
    plug_status: 413
  },
  status: 413
...
}
```

Tracked the problem here:
https://github.com/nerves-hub/nerves_hub_web/blob/f1aa6f9db407aaa2d7e15a6b44429ee4a6697e4a/lib/nerves_hub_web/dynamic_config_multipart.ex#L30

If org or product name has non-word characters (and not '-'), then they don't get the larger limit for firmware uploads.

This PR fixes that by pattern matching on `path_info`. If this isn't safe somehow, we can go back and adjust the regex solution.