### PR TITLE
Reload device after updating extensions

### DIFF
--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -404,6 +404,8 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
 
     case result do
       {:ok, _pf} ->
+        send(self(), :reload_device)
+
         put_flash(
           socket,
           :info,


### PR DESCRIPTION
The current workflow doesn't reload the device after updating extensions, causing the checkboxes to reflect the opposite values until the page is reloaded.