### PR TITLE
Fix visual issue with rounded corners on pinned devices table

### DIFF
--- a/lib/nerves_hub_web/components/pinned_devices.ex
+++ b/lib/nerves_hub_web/components/pinned_devices.ex
@@ -21,16 +21,16 @@ defmodule NervesHubWeb.Components.PinnedDevices do
             <table class="">
               <thead>
                 <tr>
-                  <th>Identifier</th>
+                  <th class="rounded-tl">Identifier</th>
                   <th>Health</th>
                   <th>Firmware</th>
                   <th>Platform</th>
                   <th>Tags</th>
-                  <th>Project</th>
+                  <th class="rounded-tr">Project</th>
                 </tr>
               </thead>
               <tbody>
-                <tr :for={device <- @devices} class="border-b border-zinc-800 relative">
+                <tr :for={device <- @devices} class="border-b last:border-0 border-zinc-800 relative last:rounded-b">
                   <td>
                     <div class="flex gap-[8px] items-center">
                       <span title="status">


### PR DESCRIPTION
The square background would slightly clip the rounded edges on the header. Similar issue with the bottom border.

Before:
![Screenshot_20250624_210122](https://github.com/user-attachments/assets/ba5c4929-2a98-43f6-a7d8-0d19c78af1cf)

After:
![Screenshot_20250624_210102](https://github.com/user-attachments/assets/894d46d2-2407-423f-815c-2829c7cba311)
