### PR TITLE
Reinstate deployment group columns temporarily

### DIFF
--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -74,6 +74,10 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     # TODO: (nshoes) this column is unused, remove after 1st March
     # field(:recalculation_type, Ecto.Enum, values: [:device, :calculator_queue], default: :device)
 
+    # TODO: (nshoes) this column is unused, remove after 1st July
+    field(:failure_rate_seconds, :integer, default: 300)
+    field(:failure_rate_amount, :integer, default: 5)
+
     field(:device_count, :integer, virtual: true)
 
     # TODO: (joshk) this column is unused, remove after 1st May

--- a/priv/repo/migrations/20250625171954_add_rate_and_thresholds_to_deployments_temporarily.exs
+++ b/priv/repo/migrations/20250625171954_add_rate_and_thresholds_to_deployments_temporarily.exs
@@ -1,0 +1,10 @@
+defmodule NervesHub.Repo.Migrations.AddRateAndThresholdsToDeploymentsTemporarily do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add(:failure_rate_seconds, :integer, default: 300)
+      add(:failure_rate_amount, :integer, default: 5)
+    end
+  end
+end


### PR DESCRIPTION
I recently removed these columns from application code _and_ the database. This makes deployments a pain. Bringing them back temporarily so we can deploy then remove them later.