### PR TITLE
Send 503 status when running script and device is unreachable

### DIFF
--- a/lib/nerves_hub_web/controllers/api/script_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/script_controller.ex
@@ -40,6 +40,12 @@ defmodule NervesHubWeb.API.ScriptController do
          {:ok, timeout} <- get_timeout_param(params),
          {:ok, io} <- Scripts.Runner.send(device, command, timeout) do
       text(conn, io)
+    else
+      {:error, reason} ->
+        conn
+        |> put_status(:service_unavailable)
+        |> put_view(NervesHubWeb.API.ErrorJSON)
+        |> render(:"500", %{reason: reason})
     end
   end
 


### PR DESCRIPTION
A 503 status more accurately represents what's happening server-side.