### PR TITLE
Set a default table engine suited for hosted Clickhouse installs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -269,9 +269,16 @@ end
 
 if config_env() == :prod do
   if clickhouse_url = System.get_env("CLICKHOUSE_URL") do
+    # Required for Clickhouse Cloud (https://github.com/plausible/analytics/discussions/3497)
+    # (using a default order will cause issues for the migration table)
+    config :ecto_ch, default_table_engine: "MergeTree"
+
     config :nerves_hub, NervesHub.AnalyticsRepo, url: clickhouse_url
 
     config :nerves_hub, analytics_enabled: true
+
+    config :nerves_hub,
+      analytics_auto_migrator: System.get_env("ANALYTICS_AUTO_MIGRATOR", "true") == "true"
   else
     config :nerves_hub, analytics_enabled: false
   end

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -79,15 +79,13 @@ defmodule NervesHub.Application do
       Supervisor.child_spec(
         {Ecto.Migrator,
          repos: [NervesHub.Repo],
-         skip: Application.get_env(:nerves_hub, :database_auto_migrator) != true,
-         id: NervesHub.RepoMigrator},
+         skip: Application.get_env(:nerves_hub, :database_auto_migrator) != true},
         id: :repo_migrator
       ),
       Supervisor.child_spec(
         {Ecto.Migrator,
          repos: [NervesHub.AnalyticsRepo],
-         skip: Application.get_env(:nerves_hub, :analytics_auto_migrator) != true,
-         id: NervesHub.AnalyticsRepoMigrator},
+         skip: Application.get_env(:nerves_hub, :analytics_auto_migrator) != true},
         id: :analytics_repo_migrator
       )
     ]

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -86,7 +86,8 @@ defmodule NervesHub.Application do
       Supervisor.child_spec(
         {Ecto.Migrator,
          repos: [NervesHub.AnalyticsRepo],
-         skip: Application.get_env(:nerves_hub, :analytics_enabled) != true},
+         skip: Application.get_env(:nerves_hub, :analytics_auto_migrator) != true,
+         id: NervesHub.AnalyticsRepoMigrator},
         id: :analytics_repo_migrator
       )
     ]


### PR DESCRIPTION
Otherwise the creation of the schema table fails, causing the application to fail to start.