### PR TITLE
Catch invalid version condition errors

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -468,7 +468,12 @@ defmodule NervesHub.ManagedDeployments do
 
     bad_version =
       if deployment_group.conditions["version"] != "" do
-        !Version.match?(device_version, deployment_group.conditions["version"])
+        try do
+          !Version.match?(device_version, deployment_group.conditions["version"])
+        rescue
+          _ ->
+            true
+        end
       else
         false
       end


### PR DESCRIPTION
Found in the NervesCloud Sentry.

An invalid version got into a DeploymentGroups condition, causing looping errors due to us not catching the error. This at least stops the looping error.