### PR TITLE
Fix rendering tags with invalid deployment group params so errors display properly

### DIFF
--- a/lib/nerves_hub_web/live/deployment_groups/newz.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/newz.ex
@@ -148,15 +148,9 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Newz do
 
   defp inject_conditions_map(params), do: params
 
-  @doc """
-  Convert tags from a list to a comma-separated list (in a string)
-  """
-  def tags_to_string(%Phoenix.HTML.FormField{} = field) do
-    field.value ||
-      %{}
-      |> Map.get("tags", [])
-      |> Enum.join(", ")
-  end
+  def tags_to_string(nil), do: ""
+
+  def tags_to_string(tags), do: Enum.join(tags, ", ")
 
   defp tags_as_list(""), do: []
 

--- a/lib/nerves_hub_web/live/deployment_groups/newz.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/newz.html.heex
@@ -98,7 +98,7 @@
             </div>
             <div class="flex gap-6">
               <div class="w-1/2">
-                <.input field={@form[:tags]} value={tags_to_string(@form[:conditions])} label="Tag(s) distributed to" placeholder="eg. batch-123" />
+                <.input field={@form[:tags]} value={tags_to_string(@form[:conditions].value["tags"])} label="Tag(s) distributed to" placeholder="eg. batch-123" />
               </div>
 
               <div class="w-1/2">

--- a/test/nerves_hub_web/live/new_ui/deployment_groups/new_test.exs
+++ b/test/nerves_hub_web/live/new_ui/deployment_groups/new_test.exs
@@ -45,4 +45,27 @@ defmodule NervesHubWeb.Live.NewUI.DelploymentGroups.NewTest do
     assert deployment_group.firmware_id == fixture.firmware.id
     assert deployment_group.conditions == %{"version" => "1.2.3", "tags" => ["a", "b"]}
   end
+
+  test "errors display for invalid version", %{conn: conn, org: org, product: product} do
+    conn
+    |> fill_in("Name", with: "Canaries")
+    |> select("Platform", option: "platform")
+    |> unwrap(fn view ->
+      render_change(view, "platform-selected", %{
+        "deployment_group" => %{"platform" => "platform"}
+      })
+    end)
+    |> select("Architecture", option: "x86_64")
+    |> unwrap(fn view ->
+      render_change(view, "architecture-selected", %{
+        "deployment_group" => %{"architecture" => "x86_64"}
+      })
+    end)
+    |> select("Firmware", option: "1.0.0", exact_option: false)
+    |> fill_in("Tag(s) distributed to", with: "a, b")
+    |> fill_in("Version requirement", with: "1.0")
+    |> submit()
+    |> assert_path("/org/#{org.name}/#{product.name}/deployment_groups/newz")
+    |> assert_has("p", text: "must be valid Elixir version requirement string")
+  end
 end


### PR DESCRIPTION
I spent way too much time trying to figure out why this was happening, but I've found the solution. When creating a deployment group with invalid params, the formatting call to `tags_to_string/1` doesn't work as expected. It will simply return the `deployment_group.conditions` map, thus blowing up `NervesHubWeb.CoreComponents.input/1` downstream. 

If you feel inclined, please feel free to nerd snipe me 🫡 

