### PR TITLE
Track firmware delta generation in more detail

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -63,6 +63,7 @@ config :nerves_hub, Oban,
     delete_firmware: 1,
     device: 1,
     firmware_delta_builder: 2,
+    firmware_delta_timeout: 1,
     truncate: 1,
     # temporary, will remove in November
     truncation: 1
@@ -74,6 +75,7 @@ config :nerves_hub, Oban,
      crontab: [
        {"0 * * * *", NervesHub.Workers.ScheduleOrgAuditLogTruncation},
        {"*/1 * * * *", NervesHub.Workers.CleanStaleDeviceConnections},
+       {"* * * * *", NervesHub.Workers.FirmwareDeltaTimeout},
        {"1,16,31,46 * * * *", NervesHub.Workers.DeleteOldDeviceConnections},
        {"*/5 * * * *", NervesHub.Workers.ExpireInflightUpdates},
        {"*/15 * * * *", NervesHub.Workers.DeviceHealthTruncation}

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1734,7 +1734,7 @@ defmodule NervesHub.Devices do
            {:delta_updatable, delta_updatable?(device, target)},
          {:firmware, {:ok, source}} <-
            {:firmware, Firmwares.get_firmware_by_product_id_and_uuid(product_id, source_uuid)},
-         {:delta, {:ok, delta}} <-
+         {:delta, {:ok, %{status: :completed} = delta}} <-
            {:delta, Firmwares.get_firmware_delta_by_source_and_target(source, target)} do
       Logger.info(
         "Delivering firmware delta",
@@ -1762,6 +1762,17 @@ defmodule NervesHub.Devices do
           device_id: device.id,
           source_firmware: source_uuid,
           target_firmware: target.uuid
+        )
+
+        Firmwares.get_firmware_url(target)
+
+      {:delta, {:ok, %{status: status} = delta}} ->
+        Logger.info(
+          "Delivering full firmware as delta had status #{status}",
+          device_id: device.id,
+          source_firmware: source_uuid,
+          target_firmware: target.uuid,
+          delta: delta.id
         )
 
         Firmwares.get_firmware_url(target)

--- a/lib/nerves_hub/firmwares/firmware_delta.ex
+++ b/lib/nerves_hub/firmwares/firmware_delta.ex
@@ -8,22 +8,12 @@ defmodule NervesHub.Firmwares.FirmwareDelta do
   alias __MODULE__
 
   @type t :: %__MODULE__{}
-  @optional_params []
-  @required_params [
-    :source_id,
-    :target_id,
-    :upload_metadata,
-    :tool,
-    :tool_metadata,
-    :size,
-    :source_size,
-    :target_size
-  ]
 
   schema "firmware_deltas" do
     belongs_to(:source, Firmware)
     belongs_to(:target, Firmware)
 
+    field(:status, Ecto.Enum, values: [:processing, :completed, :failed, :timed_out])
     field(:tool, :string)
     # Metadata about the delta that the update tool needs to operate
     field(:tool_metadata, :map)
@@ -35,10 +25,124 @@ defmodule NervesHub.Firmwares.FirmwareDelta do
     timestamps()
   end
 
-  def changeset(%FirmwareDelta{} = firmware_delta, params) do
+  @spec start_changeset(source_id :: integer(), target_id :: integer()) :: Ecto.Changeset.t()
+  def start_changeset(source_id, target_id) do
+    params = %{
+      status: :processing,
+      source_id: source_id,
+      target_id: target_id,
+      tool: "pending",
+      tool_metadata: %{},
+      upload_metadata: %{}
+    }
+
+    %FirmwareDelta{}
+    |> cast(params, [:status, :source_id, :target_id, :tool, :tool_metadata, :upload_metadata])
+    |> validate_required([
+      :status,
+      :source_id,
+      :target_id,
+      :tool,
+      :tool_metadata,
+      :upload_metadata
+    ])
+    |> unique_constraint(:unique_firmware_delta, name: :source_id_target_id_unique_index)
+    |> foreign_key_constraint(:source_id, name: :firmware_deltas_source_id_fkey)
+    |> foreign_key_constraint(:target_id, name: :firmware_deltas_target_id_fkey)
+  end
+
+  @spec complete_changeset(
+          firmware_delta :: FirmwareDelta.t(),
+          tool :: String.t(),
+          size :: non_neg_integer(),
+          source_size :: non_neg_integer(),
+          target_size :: non_neg_integer(),
+          tool_metadata :: map(),
+          upload_metadata :: map()
+        ) :: Ecto.Changeset.t()
+  def complete_changeset(
+        %FirmwareDelta{} = firmware_delta,
+        tool,
+        size,
+        source_size,
+        target_size,
+        tool_metadata,
+        upload_metadata
+      ) do
     firmware_delta
-    |> cast(params, @required_params ++ @optional_params)
-    |> validate_required(@required_params)
+    |> cast(
+      %{
+        status: :completed,
+        tool: tool,
+        size: size,
+        source_size: source_size,
+        target_size: target_size,
+        tool_metadata: tool_metadata,
+        upload_metadata: upload_metadata
+      },
+      [
+        :status,
+        :tool,
+        :size,
+        :source_size,
+        :target_size,
+        :tool_metadata,
+        :upload_metadata
+      ]
+    )
+    |> validate_required([
+      :status,
+      :tool,
+      :size,
+      :source_size,
+      :target_size,
+      :tool_metadata,
+      :upload_metadata
+    ])
+    |> unique_constraint(:unique_firmware_delta, name: :source_id_target_id_unique_index)
+    |> foreign_key_constraint(:source_id, name: :firmware_deltas_source_id_fkey)
+    |> foreign_key_constraint(:target_id, name: :firmware_deltas_target_id_fkey)
+  end
+
+  @spec fail_changeset(FirmwareDelta.t()) :: Ecto.Changeset.t()
+  def fail_changeset(%FirmwareDelta{} = firmware_delta) do
+    firmware_delta
+    |> cast(%{status: :failed}, [:status])
+    |> validate_required([:status])
+  end
+
+  @spec time_out_changeset(FirmwareDelta.t()) :: Ecto.Changeset.t()
+  def time_out_changeset(%FirmwareDelta{} = firmware_delta) do
+    firmware_delta
+    |> cast(%{status: :timed_out}, [:status])
+    |> validate_required([:status])
+  end
+
+  @spec create_changeset(FirmwareDelta.t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(%FirmwareDelta{} = firmware_delta, params) do
+    firmware_delta
+    |> cast(params, [
+      :source_id,
+      :target_id,
+      :status,
+      :upload_metadata,
+      :tool,
+      :tool_metadata,
+      :size,
+      :source_size,
+      :target_size
+    ])
+    |> validate_required([
+      :source_id,
+      :target_id,
+      :status,
+      :upload_metadata,
+      :tool,
+      :tool_metadata,
+      :size,
+      :source_size,
+      :target_size
+    ])
     |> unique_constraint(:unique_firmware_delta, name: :source_id_target_id_unique_index)
     |> foreign_key_constraint(:source_id, name: :firmware_deltas_source_id_fkey)
     |> foreign_key_constraint(:target_id, name: :firmware_deltas_target_id_fkey)

--- a/lib/nerves_hub/firmwares/update_tool/fwup.ex
+++ b/lib/nerves_hub/firmwares/update_tool/fwup.ex
@@ -301,9 +301,10 @@ defmodule NervesHub.Firmwares.UpdateTool.Fwup do
         |> Unzip.LocalFile.open()
         |> Unzip.new()
 
-      unzip
-      |> Unzip.file_stream!("meta.conf")
-      |> Enum.into(stream, &IO.iodata_to_binary/1)
+      _ =
+        unzip
+        |> Unzip.file_stream!("meta.conf")
+        |> Enum.into(stream, &IO.iodata_to_binary/1)
 
       {:ok, path}
     rescue

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -8,10 +8,10 @@ defmodule NervesHub.ManagedDeployments do
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
   alias NervesHub.Filtering, as: CommonFiltering
+  alias NervesHub.Firmwares
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias NervesHub.ManagedDeployments.Distributed.Orchestrator, as: DistributedOrchestrator
   alias NervesHub.Products.Product
-  alias NervesHub.Workers.FirmwareDeltaBuilder
   alias Phoenix.Channel.Server, as: PhoenixChannelServer
 
   alias NervesHub.Repo
@@ -314,7 +314,7 @@ defmodule NervesHub.ManagedDeployments do
     )
     |> Enum.uniq()
     |> Enum.each(fn {source_id, target_id} ->
-      FirmwareDeltaBuilder.start(source_id, target_id)
+      Firmwares.attempt_firmware_delta(source_id, target_id)
     end)
   end
 

--- a/lib/nerves_hub/workers/firmware_delta_timeout.ex
+++ b/lib/nerves_hub/workers/firmware_delta_timeout.ex
@@ -1,0 +1,16 @@
+defmodule NervesHub.Workers.FirmwareDeltaTimeout do
+  use Oban.Worker,
+    max_attempts: 5,
+    queue: :firmware_delta_timeout
+
+  alias NervesHub.Firmwares
+
+  @delta_generation_timeout 120_000
+
+  @impl Oban.Worker
+  def perform(_) do
+    _ = Firmwares.time_out_firmware_delta_generations(@delta_generation_timeout, :second)
+
+    :ok
+  end
+end

--- a/priv/repo/migrations/20250716192310_firmware_deltas_add_status_field.exs
+++ b/priv/repo/migrations/20250716192310_firmware_deltas_add_status_field.exs
@@ -1,0 +1,17 @@
+defmodule NervesHub.Repo.Migrations.FirmwareDeltasAddStatusField do
+  use Ecto.Migration
+
+  def up do
+    alter table(:firmware_deltas) do
+      add :status, :string
+    end
+    execute "UPDATE firmware_deltas SET status = 'completed'"
+  end
+
+  def down do
+    alter table(:firmware_deltas) do
+      remove :status, :string
+    end
+    execute "DELETE firmware_deltas WHERE status != 'completed'"
+  end
+end

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -3,14 +3,17 @@ defmodule NervesHub.FirmwaresTest do
   use Mimic
 
   alias Ecto.Changeset
+  import Ecto.Query
 
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.UpdateTool.Fwup, as: UpdateToolDefault
   alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Firmwares.FirmwareDelta
   alias NervesHub.Firmwares.Upload.File, as: UploadFile
   alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias NervesHub.Support.Fwup
+  alias NervesHub.Workers.FirmwareDeltaBuilder
 
   setup do
     user = Fixtures.user_fixture()
@@ -253,15 +256,18 @@ defmodule NervesHub.FirmwaresTest do
   end
 
   describe "create_firmware_delta/2" do
+    @tag :tmp_dir
     test "creates a new firmware delta when one doesn't exist", %{
       firmware: source,
       org_key: org_key,
-      product: product
+      product: product,
+      tmp_dir: tmp_dir
     } do
       target = Fixtures.firmware_fixture(org_key, product)
       source_url = "http://somefilestore.com/source.fw"
       target_url = "http://somefilestore.com/target.fw"
-      firmware_delta_path = "/path/to/firmware_delta.fw"
+      firmware_delta_path = Path.join(tmp_dir, "firmware_delta.fw")
+      File.cp!("test/fixtures/fwup/mixed.conf", firmware_delta_path)
 
       expect(UploadFile, :download_file, fn ^source -> {:ok, source_url} end)
       expect(UploadFile, :download_file, fn ^target -> {:ok, target_url} end)
@@ -284,7 +290,8 @@ defmodule NervesHub.FirmwaresTest do
         :ok
       end)
 
-      Firmwares.create_firmware_delta(source, target)
+      assert {:ok, firmware_delta} = Firmwares.start_firmware_delta(source, target)
+      Firmwares.generate_firmware_delta(firmware_delta, source, target)
 
       assert {:ok, _firmware_delta} =
                Firmwares.get_firmware_delta_by_source_and_target(source, target)
@@ -313,9 +320,10 @@ defmodule NervesHub.FirmwaresTest do
 
       expect(UpdateToolDefault, :cleanup_firmware_delta_files, fn _p -> :ok end)
 
-      Firmwares.create_firmware_delta(source, target)
+      assert {:ok, firmware_delta} = Firmwares.start_firmware_delta(source.id, target.id)
+      Firmwares.generate_firmware_delta(firmware_delta, source, target)
 
-      assert {:error, :not_found} =
+      assert {:ok, %FirmwareDelta{status: :failed}} =
                Firmwares.get_firmware_delta_by_source_and_target(source, target)
     end
 
@@ -331,14 +339,83 @@ defmodule NervesHub.FirmwaresTest do
       expect(UploadFile, :download_file, fn ^source -> {:ok, source_url} end)
       expect(UploadFile, :download_file, fn ^target -> {:ok, target_url} end)
 
+      # Force error
       expect(UpdateToolDefault, :create_firmware_delta_file, fn ^source_url, ^target_url ->
         {:error, :delta_not_created}
       end)
 
-      Firmwares.create_firmware_delta(source, target)
+      assert {:ok, firmware_delta} = Firmwares.start_firmware_delta(source, target)
+      Firmwares.generate_firmware_delta(firmware_delta, source, target)
 
-      assert {:error, :not_found} =
+      assert {:ok, _} =
                Firmwares.get_firmware_delta_by_source_and_target(source, target)
+    end
+
+    @tag :tmp_dir
+    test "firmware deltas progress through status steps", %{
+      firmware: %{id: source_id} = source,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      %{id: target_id} = target = Fixtures.firmware_fixture(org_key, product)
+      firmware_delta_path = Path.join(tmp_dir, "firmware_delta.fw")
+      File.cp!("test/fixtures/fwup/mixed.conf", firmware_delta_path)
+
+      assert {:ok, %FirmwareDelta{status: :processing, tool: "pending"}} =
+               Firmwares.attempt_firmware_delta(source.id, target.id)
+
+      assert_enqueued(
+        args: %{source_id: source_id, target_id: target_id},
+        worker: FirmwareDeltaBuilder,
+        queue: :firmware_delta_builder
+      )
+
+      expect(UpdateToolDefault, :create_firmware_delta_file, fn _, _ ->
+        {:ok,
+         %{
+           filepath: firmware_delta_path,
+           size: 5,
+           source_size: 10,
+           target_size: 15,
+           tool: "fwup",
+           tool_metadata: %{}
+         }}
+      end)
+
+      assert :ok =
+               perform_job(FirmwareDeltaBuilder, %{source_id: source_id, target_id: target_id})
+
+      assert {:ok, %FirmwareDelta{status: :completed, tool: "fwup"}} =
+               Firmwares.get_firmware_delta_by_source_and_target(source, target)
+    end
+  end
+
+  describe "time_out_firmware_delta_generations/1" do
+    test "time out old delta generations but not new ones", %{
+      firmware: source,
+      org_key: org_key,
+      product: product
+    } do
+      t1 = Fixtures.firmware_fixture(org_key, product)
+      t2 = Fixtures.firmware_fixture(org_key, product)
+      t3 = Fixtures.firmware_fixture(org_key, product)
+      t4 = Fixtures.firmware_fixture(org_key, product)
+      {:ok, %{id: d1}} = Firmwares.start_firmware_delta(source, t1)
+      {:ok, %{id: d2}} = Firmwares.start_firmware_delta(source, t2)
+      :timer.sleep(2000)
+      {:ok, %{id: d3}} = Firmwares.start_firmware_delta(source, t3)
+      {:ok, %{id: d4}} = Firmwares.start_firmware_delta(source, t4)
+      Firmwares.time_out_firmware_delta_generations(1000, :millisecond)
+
+      assert [
+               %{id: ^d1, status: :timed_out},
+               %{id: ^d2, status: :timed_out},
+               %{id: ^d3, status: :processing},
+               %{id: ^d4, status: :processing}
+             ] =
+               get_deltas_by_source_firmware(source)
+               |> Enum.sort_by(& &1.id)
     end
   end
 
@@ -353,5 +430,11 @@ defmodule NervesHub.FirmwaresTest do
       {[firmware], _} = Firmwares.filter(product)
       assert firmware.install_count == 3
     end
+  end
+
+  defp get_deltas_by_source_firmware(firmware) do
+    FirmwareDelta
+    |> where([fd], fd.source_id == ^firmware.id)
+    |> Repo.all()
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -189,6 +189,7 @@ defmodule NervesHub.Fixtures do
       Firmwares.insert_firmware_delta(%{
         source_id: source_id,
         target_id: target_id,
+        status: :completed,
         tool_metadata: %{"delta_fwup_version" => "1.13.0"},
         tool: "fwup",
         size: 500,


### PR DESCRIPTION
Add status field to firmware deltas:

- Starting the creation of a firmware delta always creates an entry with status "processing"
- Successfully creating the delta set status "completed"
- Failure sets status "failed"

Add firmware delta generation timeout worker

Fetching firmware deltas can now fall back to full because a delta is not done.