### PR TITLE
Fix device certificate management in new UI

### DIFF
--- a/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/settings_tab_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.NewUi.Devices.SettingsTabTest do
 
   alias NervesHub.Devices
   alias NervesHubWeb.Components.Utils
+  alias NervesHub.Repo
 
   setup %{conn: conn} do
     [conn: init_test_session(conn, %{"new_ui" => true})]
@@ -29,6 +30,21 @@ defmodule NervesHubWeb.NewUi.Devices.SettingsTabTest do
         end)
 
       assert result.conn.resp_body =~ "-----BEGIN CERTIFICATE-----"
+    end
+
+    test "delete certificate", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      [certificate] = Devices.get_device_certificates(device)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/settingz")
+      |> click_button("[phx-click=\"delete-certificate\"]", "")
+
+      refute Repo.reload(certificate)
     end
   end
 end


### PR DESCRIPTION
This PR fixes device certificate uploading and deleting in the new UI and adds a test.

Solves #2234.