### PR TITLE
Handle error when creating deltas

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -481,6 +481,10 @@ defmodule NervesHub.Firmwares do
         )
 
         :ok
+
+      # We log the issue in the update tool, so no need to here
+      {:error, :delta_not_created} ->
+        :ok
     end
   end
 

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -318,6 +318,28 @@ defmodule NervesHub.FirmwaresTest do
       assert {:error, :not_found} =
                Firmwares.get_firmware_delta_by_source_and_target(source, target)
     end
+
+    test "update tool errors are handled", %{
+      firmware: source,
+      org_key: org_key,
+      product: product
+    } do
+      target = Fixtures.firmware_fixture(org_key, product)
+      source_url = "http://somefilestore.com/source.fw"
+      target_url = "http://somefilestore.com/target.fw"
+
+      expect(UploadFile, :download_file, fn ^source -> {:ok, source_url} end)
+      expect(UploadFile, :download_file, fn ^target -> {:ok, target_url} end)
+
+      expect(UpdateToolDefault, :create_firmware_delta_file, fn ^source_url, ^target_url ->
+        {:error, :delta_not_created}
+      end)
+
+      Firmwares.create_firmware_delta(source, target)
+
+      assert {:error, :not_found} =
+               Firmwares.get_firmware_delta_by_source_and_target(source, target)
+    end
   end
 
   describe "filter/2" do


### PR DESCRIPTION
Fixes this error:

```
CaseClauseError: no case clause matching: {:error, :delta_not_created}
  File "lib/nerves_hub/firmwares.ex", line 421, in NervesHub.Firmwares.create_firmware_delta/2
  File "lib/nerves_hub/workers/firmware_delta_builder.ex", line 53, in NervesHub.Workers.FirmwareDeltaBuilder.maybe_create_firmware_delta/2
  File "lib/nerves_hub/workers/firmware_delta_builder.ex", line 29, in NervesHub.Workers.FirmwareDeltaBuilder.perform/1
  File "lib/oban/queue/executor.ex", line 145, in Oban.Queue.Executor.perform/1
  File "lib/oban/queue/executor.ex", line 77, in Oban.Queue.Executor.call/1
  File "lib/task/supervised.ex", line 101, in Task.Supervised.invoke_mfa/2
  File "lib/task/supervised.ex", line 36, in Task.Supervised.reply/4
```