### PR TITLE
Add missing Actor index to Audit Logs table

### DIFF
--- a/priv/repo/migrations/20250804135512_add_actor_index_to_audit_logs.exs
+++ b/priv/repo/migrations/20250804135512_add_actor_index_to_audit_logs.exs
@@ -1,0 +1,10 @@
+defmodule NervesHub.Repo.Migrations.AddActorIndexToAuditLogs do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create_if_not_exists index(:audit_logs, [:actor_type, :actor_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
Add concurrent index on `(actor_type, actor_id)` columns to `audit_logs` table 
to dramatically improve performance of audit log queries for devices and users.

The missing index was causing full table scans on **5M+** record tables, 
resulting in 25+ second query times. With the index, query time drops to ~10ms.


### The Problem
The issue on a line 75
https://github.com/nerves-hub/nerves_hub_web/blob/1191d27ad2b5003fee99c9994c1a052d61304653/lib/nerves_hub/audit_logs.ex#L70-L84


### Existing indexes on audit_logs:
- `audit_logs_org_id_inserted_at_index`: [inserted_at, org_id]  
- `audit_logs_pkey` (PRIMARY KEY): [id]
- `audit_logs_resource_type_resource_id_index`: [resource_id, resource_type]

### Implementation Details
- Uses CREATE INDEX CONCURRENTLY to avoid table locks during deployment
- Uses create_if_not_exists for idempotency 
- Includes proper migration options `(@disable_ddl_transaction, @disable_migration_lock)`

### Performance impact:
- Before: 25+ seconds (Seq Scan on `audit_logs`)
- After: ~10ms (Index Scan on `audit_logs_actor_type_actor_id_index`)

Fixes device page slow loading caused by **AuditLogFeed** component.