### PR TITLE
Device filter inflight

### DIFF
--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -110,10 +110,16 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
             </div>
             <div class="flex flex-col gap-3">
               <div :if={@inflight_updates == []} class="flex gap-4 items-center">
-                <span class="text-sm text-nerves-gray-500">No devices are currently updating</span>
+                <span class="text-sm text-nerves-gray-500">No devices are currently updating.</span>
               </div>
               <div :if={@inflight_updates != []} class="flex gap-4 items-center">
-                <span class="text-sm text-nerves-gray-500"><span class="font-semibold">{Enum.count(@inflight_updates)}</span> device(s) are currently updating</span>
+                <span class="text-sm text-nerves-gray-500">
+                  <span class="font-semibold">{Enum.count(@inflight_updates)}</span>
+                  device(s) are currently updating.
+                  <.link class="text-base-300 underline" navigate={~p"/org/#{@org}/#{@product}/devices?#{[only_updating: true, sort: "connection_established_at", sort_direction: "desc"]}"}>
+                    View details
+                  </.link>
+                </span>
               </div>
               <div :for={inflight_update <- @inflight_updates} :if={@inflight_updates != []} class="flex gap-4 items-center">
                 <span class="flex h-7 py-1 px-2 items-center rounded bg-zinc-800 text-base-300">

--- a/lib/nerves_hub_web/live/devices/index-new.html.heex
+++ b/lib/nerves_hub_web/live/devices/index-new.html.heex
@@ -408,6 +408,7 @@
       {"Only deleted devices", "only"}
     ]}
   />
+  <:filter attr="only_updating" label="Update status" type={:select} values={[{"All", "false"}, {"Updating", "true"}]} />
 </FilterSidebar.render>
 
 <div class="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 mb-[119px] sm:pl-16 z-40">

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -47,7 +47,8 @@ defmodule NervesHubWeb.Live.Devices.Index do
     deployment_id: "",
     is_pinned: false,
     search: "",
-    display_deleted: "exclude"
+    display_deleted: "exclude",
+    only_updating: false
   }
 
   @filter_types %{
@@ -69,7 +70,8 @@ defmodule NervesHubWeb.Live.Devices.Index do
     deployment_id: :string,
     is_pinned: :boolean,
     search: :string,
-    display_deleted: :string
+    display_deleted: :string,
+    only_updating: :boolean
   }
 
   @default_page 1


### PR DESCRIPTION
This should allow watching updates as they happen. It'll be a lot better if we land the changes to live updating. But this adds the filter and a link on the summary page whenever devices are actively updating.