### PR TITLE
Handle `ArgumentError`s from `Plug.Crypto.non_executable_binary_to_term`

### DIFF
--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -114,6 +114,17 @@ defmodule NervesHubWeb.DeviceSocket do
 
         {:error, :invalid_auth}
     end
+  rescue
+    e in ArgumentError ->
+      headers = Map.new(x_headers)
+
+      :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
+        auth: :shared_secrets,
+        reason: e,
+        product_key: Map.get(headers, "x-nh-key", "*empty*")
+      })
+
+      {:error, :invalid_auth}
   end
 
   def connect(_params, _socket, _connect_info) do


### PR DESCRIPTION
This was found in the NervesCloud Sentry.

If an invalid device identifier, this this case an Erlang term, is encoded in the shared secret auth,  `Plug.Crypto.non_executable_binary_to_term/2` correctly catches it, but an error is raised which we don't handle nicely.

This PR rescues `ArgumentError`s, logs a message, and rejects the auth request.