### PR TITLE
Relax user role for device event channel

### DIFF
--- a/lib/nerves_hub_web/channels/device_events_stream_channel.ex
+++ b/lib/nerves_hub_web/channels/device_events_stream_channel.ex
@@ -48,7 +48,7 @@ defmodule NervesHubWeb.DeviceEventsStreamChannel do
         false
 
       org_user ->
-        Authorization.authorized?(:"device:console", org_user)
+        Authorization.authorized?(:"device:view", org_user)
     end
   end
 end

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -30,6 +30,7 @@ defmodule NervesHubWeb.Helpers.Authorization do
 
   def authorized?(:"device:create", %OrgUser{role: role}), do: role_check(:manage, role)
   def authorized?(:"device:update", %OrgUser{role: role}), do: role_check(:manage, role)
+  def authorized?(:"device:view", %OrgUser{role: role}), do: role_check(:view, role)
 
   def authorized?(:"device:set-deployment-group", %OrgUser{role: role}),
     do: role_check(:manage, role)

--- a/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
@@ -67,6 +67,11 @@ defmodule NervesHubWeb.DeviceEventsStreamChannelTest do
 
   defp device_fixture(user, device_params) do
     org = Fixtures.org_fixture(user)
+    {:ok, org_user} = Accounts.get_org_user(org, user)
+
+    # Use the lowest permissioned org user possible for the channel.
+    {:ok, _updated_org_user} = Accounts.change_org_user_role(org_user, :view)
+
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org, user)
 


### PR DESCRIPTION
The device event channel is read only and simply forwards events, no need for it to map to a manage role.