### PR TITLE
Fix LiveView warning when uploading device certificates, rehydrate state properly

### DIFF
--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -22,7 +22,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   end
 
   def render(assigns) do
-    device = Repo.preload(assigns.device, :device_certificates)
+    device = Repo.preload(assigns.device, :device_certificates, force: true)
 
     changeset = Ecto.Changeset.change(assigns.device)
 
@@ -431,14 +431,15 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   defp import_cert(%{assigns: %{device: device}} = socket, path) do
     with {:ok, pem_or_der} <- File.read(path),
          {:ok, otp_cert} <- Certificate.from_pem_or_der(pem_or_der),
-         {:ok, db_cert} <- Devices.create_device_certificate(device, otp_cert) do
-      updated = update_in(device.device_certificates, &[db_cert | &1])
+         {:ok, _db_cert} <- Devices.create_device_certificate(device, otp_cert) do
+      updated = Repo.preload(device, :device_certificates)
 
-      assign(socket, :device, updated)
-      |> put_flash(:info, "Certificate Upload Successful")
+      {:ok,
+       assign(socket, :device, updated)
+       |> put_flash(:info, "Certificate Upload Successful")}
     else
       {:error, :malformed} ->
-        put_flash(socket, :error, "Incorrect filetype or malformed certificate")
+        {:ok, put_flash(socket, :error, "Incorrect filetype or malformed certificate")}
 
       {:error, %Ecto.Changeset{errors: errors}} ->
         formatted =
@@ -446,10 +447,10 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
             ["* ", to_string(field), " ", msg]
           end)
 
-        put_flash(socket, :error, IO.iodata_to_binary(["Failed to save:\n", formatted]))
+        {:ok, put_flash(socket, :error, IO.iodata_to_binary(["Failed to save:\n", formatted]))}
 
       err ->
-        put_flash(socket, :error, "Unknown file error - #{inspect(err)}")
+        {:ok, put_flash(socket, :error, "Unknown file error - #{inspect(err)}")}
     end
   end
 


### PR DESCRIPTION
`Phoenix.LiveView. consume_uploaded_entry/3` expects a return of `{:ok, _return}` or `{:postpone, _return}`. We were returning a socket, causing a warning in the logs.

I also fixed an issue when uploading a device certificate. We were previously using `update_in/2`, but on an unloaded Ecto association. This was copied over from the old UI, but this code now sits in a component, and we don't preload device certificates in the parent LiveView. Fixing this uncovered another bug if you deleted the device's last cert and then uploaded a new one. `Repo.preload/3` won't preload on a loaded empty association, so `force: true` is needed.

