### PR TITLE
Improve the logging for duplicate device identifier connection errors

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -325,7 +325,7 @@ defmodule NervesHub.Devices do
   end
 
   @spec get_or_create_device(Products.SharedSecretAuth.t(), String.t()) ::
-          {:ok, Device.t()} | {:error, :not_found}
+          {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
   def get_or_create_device(%Products.SharedSecretAuth{} = auth, identifier) do
     with {:error, :not_found} <-
            get_active_device(product_id: auth.product_id, identifier: identifier),

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -72,7 +72,10 @@ defmodule NervesHub.Logger do
         event: "nerves_hub.devices.invalid_auth",
         auth: to_string(metadata[:auth]),
         reason: inspect(metadata[:reason]),
-        product_key: metadata[:product_key]
+        org_id: metadata[:org_id],
+        product_id: metadata[:product_id],
+        product_key: metadata[:product_key],
+        device_identifier: metadata[:device_identifier]
       }
       |> Map.reject(fn {_key, val} -> is_nil(val) end)
 

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -74,8 +74,8 @@ defmodule NervesHub.Logger do
         reason: inspect(metadata[:reason]),
         org_id: metadata[:org_id],
         product_id: metadata[:product_id],
-        product_key: metadata[:product_key],
-        device_identifier: metadata[:device_identifier]
+        shared_key: metadata[:shared_key],
+        identifier: metadata[:device_identifier]
       }
       |> Map.reject(fn {_key, val} -> is_nil(val) end)
 

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -122,6 +122,15 @@ defmodule NervesHubWeb.DeviceSocket do
 
         {:error, :invalid_auth}
 
+      {:error, :expired} ->
+        :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
+          auth: :shared_secrets,
+          reason: :signature_expired,
+          product_key: Map.get(headers, "x-nh-key", "*empty*")
+        })
+
+        {:error, :invalid_auth}
+
       error ->
         :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
           auth: :shared_secrets,

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -117,7 +117,7 @@ defmodule NervesHubWeb.DeviceSocket do
           reason: :duplicate_device_identifier,
           org_id: org_id,
           product_id: product_id,
-          device_identifier: identifier
+          identifier: identifier
         })
 
         {:error, :invalid_auth}
@@ -126,7 +126,7 @@ defmodule NervesHubWeb.DeviceSocket do
         :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
           auth: :shared_secrets,
           reason: :signature_expired,
-          product_key: Map.get(headers, "x-nh-key", "*empty*")
+          shared_key: Map.get(headers, "x-nh-key", "*empty*")
         })
 
         {:error, :invalid_auth}
@@ -135,7 +135,7 @@ defmodule NervesHubWeb.DeviceSocket do
         :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
           auth: :shared_secrets,
           reason: error,
-          product_key: Map.get(headers, "x-nh-key", "*empty*")
+          shared_key: Map.get(headers, "x-nh-key", "*empty*")
         })
 
         {:error, :invalid_auth}
@@ -147,7 +147,7 @@ defmodule NervesHubWeb.DeviceSocket do
       :telemetry.execute([:nerves_hub, :devices, :invalid_auth], %{count: 1}, %{
         auth: :shared_secrets,
         reason: e,
-        product_key: Map.get(headers, "x-nh-key", "*empty*")
+        shared_key: Map.get(headers, "x-nh-key", "*empty*")
       })
 
       {:error, :invalid_auth}


### PR DESCRIPTION
Improve the logging for duplicate device identifiers from:

```
2025-08-14T00:45:50Z app[48e4199b764518] iad level=info msg="Device auth failed" reason="{:error, #Ecto.Changeset<action: :insert, changes: %{status: :registered, extensions: #Ecto.Changeset<action: :insert, changes: %{}, errors: [], data: #NervesHub.Extensions.DeviceExtensionsSetting<>, valid?: true, ...>, identifier: \"abc123\", org_id: 123, priority_updates: false, product_id: 123, update_attempts: [], updates_enabled: true}, errors: [identifier: {\"has already been taken\", [constraint: :unique, constraint_name: \"devices_identifier_index\"]}], data: #NervesHub.Devices.Device<>, valid?: false, ...>}" auth=shared_secrets event=nerves_hub.devices.invalid_auth product_key=nhp_abc123
```

to

```
2025-08-14T00:45:50Z app[48e4199b764518] iad [info]ts=2025-08-14T00:45:50.910 level=info msg="Device auth failed" auth=shared_secrets event=nerves_hub.devices.invalid_auth org_id=123 product_id=123 identifier=abc123
```

and expired shared secret signatures from:

`reason="{:error, :expired}"` to `reason="signature_expired"`