### PR TITLE
Remove default subscriptions setup when a device connects

### DIFF
--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -62,6 +62,11 @@ defmodule NervesHubWeb.ConsoleChannel do
   def handle_info({:after_join, payload}, socket) do
     socket = assign(socket, :version, payload["console_version"])
 
+    # all devices are lumped into a `console` topic (the name used in join/3)
+    # this can be a security issue as pubsub messages can be sent to all connected devices
+    # additionally, this topic isn't needed or used, so we can unsubscribe from it
+    socket.endpoint.unsubscribe("console")
+
     socket.endpoint.subscribe("device:console:#{socket.assigns.device.id}")
 
     socket.endpoint.broadcast!(

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -54,6 +54,11 @@ defmodule NervesHubWeb.DeviceChannel do
 
     deployment_channel = deployment_channel(device)
 
+    # all devices are lumped into a `device` topic (the name used in join/3)
+    # this can be a security issue as pubsub messages can be sent to all connected devices
+    # additionally, this topic isn't needed or used, so we can unsubscribe from it
+    unsubscribe("device")
+
     subscribe("device:#{device.id}")
     subscribe(deployment_channel)
 

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -25,8 +25,13 @@ defmodule NervesHubWeb.ExtensionsChannel do
       send(self(), :init_extensions)
     end
 
+    # all devices are lumped into a `extensions` topic (the name used in join/3)
+    # this can be a security issue as pubsub messages can be sent to all connected devices
+    # additionally, this topic isn't needed or used, so we can unsubscribe from it
+    :ok = socket.endpoint.unsubscribe("extensions")
+
     topic = "device:#{socket.assigns.device.id}:extensions"
-    :ok = PubSub.subscribe(NervesHub.PubSub, topic)
+    :ok = socket.endpoint.subscribe(topic)
 
     {:ok, attach_list, socket}
   end


### PR DESCRIPTION
All devices, when connecting to a topic ("device", "console", "extensions"), are lumped into a PubSub topic using the channel name (the name used in join/3).

Since these names are generic, what ends up happening is that every device is subscribed to a shared topic name that has fastlaning enabled, meaning messages can be sent directly to devices.

I believe this could be a slight security issue, as pubsub messages can be sent to all connected devices with just a simple:

```elixir
Phoenix.Channel.Server.broadcast(NervesHub.PubSub, "device", "any_event_name", %{just: "a payload"})
```

Additionally, this topic isn't needed or used, so we can unsubscribe from it.