### PR TITLE
Don't run Oban jobs on device nodes

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -28,7 +28,7 @@ defmodule NervesHub.Application do
           {Phoenix.PubSub, name: NervesHub.PubSub},
           {Cluster.Supervisor, [libcluster_topology()]},
           {Task.Supervisor, name: NervesHub.TaskSupervisor},
-          {Oban, Application.fetch_env!(:nerves_hub, Oban)},
+          {Oban, oban_opts()},
           NervesHubWeb.Presence,
           {NervesHub.RateLimit.LogLines,
            [clean_period: :timer.minutes(5), key_older_than: :timer.hours(1)]},
@@ -91,6 +91,18 @@ defmodule NervesHub.Application do
         config: repo_config
       ]
     ]
+  end
+
+  defp oban_opts() do
+    config = Application.fetch_env!(:nerves_hub, Oban)
+
+    case Application.get_env(:nerves_hub, :app) do
+      "device" ->
+        Keyword.put(config, :queues, [])
+
+      _ ->
+        config
+    end
   end
 
   defp ecto_migrations() do


### PR DESCRIPTION
This is to reduce the work the Device nodes are undertaking.