### PR TITLE
Quokka config and deprecation fixups

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,7 +8,9 @@
     only: [
       :blocks,
       :comment_directives,
-      :defs
+      :configs,
+      :defs,
+      :deprecations
     ]
   ]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,10 +1,19 @@
 import Config
 
-config :phoenix,
-  json_library: Jason,
-  template_engines: [
-    leex: Phoenix.LiveView.Engine
+# Used by spellweaver
+config :bun, :version, "1.2.18"
+
+# Configure esbuild (the version is required)
+config :esbuild,
+  version: "0.25.2",
+  default: [
+    args:
+      ~w(ui-rework/app.js --bundle --target=es2021 --outdir=../priv/static/assets/ui-rework --external:/fonts/* --external:/images/* --loader:.png=file),
+    cd: Path.expand("../assets", __DIR__),
+    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
+
+config :flop, repo: NervesHub.Repo
 
 config :mime, :types, %{
   "application/pem" => ["pem"],
@@ -12,26 +21,16 @@ config :mime, :types, %{
   "application/fwup" => ["fw"]
 }
 
-##
-# NervesHub
-#
-config :nerves_hub,
-  env: Mix.env(),
-  namespace: NervesHub,
-  ecto_repos: [NervesHub.AnalyticsRepo, NervesHub.Repo]
+config :nerves_hub, NervesHub.Repo,
+  queue_target: 500,
+  queue_interval: 5_000,
+  migration_lock: :pg_advisory_lock
 
-##
-# NervesHub Device
-#
 config :nerves_hub, NervesHubWeb.DeviceEndpoint,
   adapter: Bandit.PhoenixAdapter,
   render_errors: [view: NervesHubWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: NervesHub.PubSub
 
-##
-# NervesHub Web
-#
-# cspell:disable
 config :nerves_hub, NervesHubWeb.Endpoint,
   adapter: Bandit.PhoenixAdapter,
   secret_key_base: "ZH9GG2S5CwIMWXBg92wUuoyKFrjgqaAybHLTLuUk1xZO0HeidcJbnMBSTHDcyhSn",
@@ -44,14 +43,7 @@ config :nerves_hub, NervesHubWeb.Endpoint,
   ],
   pubsub_server: NervesHub.PubSub
 
-# cspell:enable
-##
-# Database and Oban
-#
-config :nerves_hub, NervesHub.Repo,
-  queue_target: 500,
-  queue_interval: 5_000,
-  migration_lock: :pg_advisory_lock
+config :nerves_hub, NervesHubWeb.Gettext, default_locale: "en"
 
 config :nerves_hub, Oban,
   repo: NervesHub.ObanRepo,
@@ -82,21 +74,18 @@ config :nerves_hub, Oban,
      ]}
   ]
 
-config :nerves_hub, NervesHubWeb.Gettext, default_locale: "en"
+config :nerves_hub,
+  env: Mix.env(),
+  namespace: NervesHub,
+  ecto_repos: [NervesHub.AnalyticsRepo, NervesHub.Repo]
+
+config :phoenix,
+  json_library: Jason,
+  template_engines: [
+    leex: Phoenix.LiveView.Engine
+  ]
 
 config :swoosh, :api_client, Swoosh.ApiClient.Finch
-
-config :flop, repo: NervesHub.Repo
-
-# Configure esbuild (the version is required)
-config :esbuild,
-  version: "0.25.2",
-  default: [
-    args:
-      ~w(ui-rework/app.js --bundle --target=es2021 --outdir=../priv/static/assets/ui-rework --external:/fonts/* --external:/images/* --loader:.png=file),
-    cd: Path.expand("../assets", __DIR__),
-    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
-  ]
 
 config :tailwind,
   version: "3.4.3",
@@ -113,9 +102,6 @@ config :ueberauth, Ueberauth,
   providers: [
     google: {Ueberauth.Strategy.Google, [default_scope: "email profile openid"]}
   ]
-
-# Used by spellweaver
-config :bun, :version, "1.2.18"
 
 # Environment specific config
 import_config "#{Mix.env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,23 +3,12 @@ import Config
 # Do not print debug messages in production
 config :logger, level: :info, backends: [:console, Sentry.LoggerBackend]
 
-config :phoenix, logger: false
+config :nerves_hub, NervesHub.ObanRepo, pool_size: 10
+config :nerves_hub, NervesHub.Repo, pool_size: 20
+config :nerves_hub, NervesHubWeb.DeviceEndpoint, server: true
 
-##
-# NervesHub Web
-#
 config :nerves_hub, NervesHubWeb.Endpoint,
   server: true,
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
 
-##
-# NervesHub Device
-#
-config :nerves_hub, NervesHubWeb.DeviceEndpoint, server: true
-
-##
-# Database and Oban
-#
-config :nerves_hub, NervesHub.Repo, pool_size: 20
-
-config :nerves_hub, NervesHub.ObanRepo, pool_size: 10
+config :phoenix, logger: false

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,6 +9,11 @@ if !Enum.member?(["all", "web", "device"], nerves_hub_app) do
   """
 end
 
+config :nerves_hub, :device_socket_drainer,
+  batch_size: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_SIZE", "1000")),
+  batch_interval: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_INTERVAL", "4000")),
+  shutdown: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_SHUTDOWN", "30000"))
+
 config :nerves_hub,
   app: nerves_hub_app,
   deploy_env: System.get_env("DEPLOY_ENV", to_string(config_env())),
@@ -49,25 +54,20 @@ config :nerves_hub,
   ],
   new_ui: System.get_env("NEW_UI_ENABLED", "true") == "true"
 
-config :nerves_hub, :device_socket_drainer,
-  batch_size: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_SIZE", "1000")),
-  batch_interval: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_INTERVAL", "4000")),
-  shutdown: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_SHUTDOWN", "30000"))
-
 # only set this in :prod as not to override the :dev config
 if config_env() == :prod do
-  config :nerves_hub,
-    open_for_registrations: System.get_env("OPEN_FOR_REGISTRATIONS", "false") == "true"
+  config :logfmt_ex, :opts,
+    message_key: "msg",
+    timestamp_key: "ts",
+    timestamp_format: :iso8601
 
   # Configures Elixir's Logger
   config :logger, :default_formatter,
     format: {NervesHub.Logger, :format},
     metadata: :all
 
-  config :logfmt_ex, :opts,
-    message_key: "msg",
-    timestamp_key: "ts",
-    timestamp_format: :iso8601
+  config :nerves_hub,
+    open_for_registrations: System.get_env("OPEN_FOR_REGISTRATIONS", "false") == "true"
 end
 
 if level = System.get_env("LOG_LEVEL") do
@@ -236,14 +236,6 @@ database_ssl_opts =
 if config_env() == :prod do
   database_socket_options = if System.get_env("DATABASE_INET6") == "true", do: [:inet6], else: []
 
-  config :nerves_hub, NervesHub.Repo,
-    url: System.fetch_env!("DATABASE_URL"),
-    ssl: database_ssl_opts,
-    pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE", "20")),
-    pool_count: String.to_integer(System.get_env("DATABASE_POOL_COUNT", "1")),
-    socket_options: database_socket_options,
-    queue_target: 5000
-
   oban_pool_size =
     System.get_env("OBAN_DATABASE_POOL_SIZE") || System.get_env("DATABASE_POOL_SIZE", "20")
 
@@ -251,6 +243,14 @@ if config_env() == :prod do
     url: System.fetch_env!("DATABASE_URL"),
     ssl: database_ssl_opts,
     pool_size: String.to_integer(oban_pool_size),
+    socket_options: database_socket_options,
+    queue_target: 5000
+
+  config :nerves_hub, NervesHub.Repo,
+    url: System.fetch_env!("DATABASE_URL"),
+    ssl: database_ssl_opts,
+    pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE", "20")),
+    pool_count: String.to_integer(System.get_env("DATABASE_POOL_COUNT", "1")),
     socket_options: database_socket_options,
     queue_target: 5000
 
@@ -266,10 +266,10 @@ if config_env() == :prod do
 
     config :nerves_hub, NervesHub.AnalyticsRepo, url: clickhouse_url
 
-    config :nerves_hub, analytics_enabled: true
-
     config :nerves_hub,
       analytics_auto_migrator: System.get_env("ANALYTICS_AUTO_MIGRATOR", "true") == "true"
+
+    config :nerves_hub, analytics_enabled: true
   else
     config :nerves_hub, analytics_enabled: false
   end
@@ -283,13 +283,10 @@ if config_env() == :prod do
 
   case firmware_upload do
     "S3" ->
-      config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.S3
-
-      config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.S3
-
-      config :nerves_hub, NervesHub.Uploads.S3, bucket: System.fetch_env!("S3_BUCKET_NAME")
-
       config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: System.fetch_env!("S3_BUCKET_NAME")
+      config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.S3
+      config :nerves_hub, NervesHub.Uploads.S3, bucket: System.fetch_env!("S3_BUCKET_NAME")
+      config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.S3
 
       if System.get_env("S3_ACCESS_KEY_ID") do
         config :ex_aws, :s3,
@@ -323,19 +320,19 @@ if config_env() == :prod do
     "local" ->
       local_path = System.get_env("FIRMWARE_UPLOAD_PATH")
 
-      config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.File
-
-      config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
-
       config :nerves_hub, NervesHub.Firmwares.Upload.File,
         enabled: true,
         public_path: "/firmware",
         local_path: local_path
 
+      config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
+
       config :nerves_hub, NervesHub.Uploads.File,
         enabled: true,
         local_path: local_path,
         public_path: "/uploads"
+
+      config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.File
 
     other ->
       raise """
@@ -390,6 +387,8 @@ if config_env() == :prod do
   end
 end
 
+config :opentelemetry, :resource, service: %{name: nerves_hub_app}
+
 config :sentry,
   dsn: System.get_env("SENTRY_DSN_URL"),
   environment_name: System.get_env("DEPLOY_ENV", to_string(config_env())),
@@ -409,14 +408,7 @@ config :sentry,
     ]
   ]
 
-config :opentelemetry, :resource, service: %{name: nerves_hub_app}
-
 if otlp_endpoint = System.get_env("OTLP_ENDPOINT") do
-  config :opentelemetry_exporter,
-    otlp_protocol: :http_protobuf,
-    otlp_endpoint: otlp_endpoint,
-    otlp_headers: [{System.get_env("OTLP_AUTH_HEADER"), System.get_env("OTLP_AUTH_HEADER_VALUE")}]
-
   otlp_sampler_ratio =
     if ratio = System.get_env("OTLP_SAMPLER_RATIO") do
       String.to_float(ratio)
@@ -424,6 +416,11 @@ if otlp_endpoint = System.get_env("OTLP_ENDPOINT") do
 
   config :opentelemetry,
     sampler: {:parent_based, %{root: {NervesHub.Telemetry.FilteredSampler, otlp_sampler_ratio}}}
+
+  config :opentelemetry_exporter,
+    otlp_protocol: :http_protobuf,
+    otlp_endpoint: otlp_endpoint,
+    otlp_headers: [{System.get_env("OTLP_AUTH_HEADER"), System.get_env("OTLP_AUTH_HEADER_VALUE")}]
 else
   config :opentelemetry, traces_exporter: :none
 end
@@ -434,12 +431,12 @@ if host = System.get_env("STATSD_HOST") do
     port: String.to_integer(System.get_env("STATSD_PORT", "8125"))
 end
 
+config :nerves_hub, NervesHub.RateLimit,
+  limit: System.get_env("DEVICE_CONNECT_RATE_LIMIT", "100") |> String.to_integer()
+
 config :nerves_hub, :audit_logs,
   enabled: System.get_env("TRUNCATE_AUDIT_LOGS_ENABLED", "false") == "true",
   default_days_kept: String.to_integer(System.get_env("TRUNCATE_AUDIT_LOGS_DEFAULT_DAYS_KEPT", "30"))
-
-config :nerves_hub, NervesHub.RateLimit,
-  limit: System.get_env("DEVICE_CONNECT_RATE_LIMIT", "100") |> String.to_integer()
 
 config :nerves_hub,
   enable_google_auth: !is_nil(System.get_env("GOOGLE_CLIENT_ID"))

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,18 +5,34 @@ config :bcrypt_elixir, log_rounds: 4
 # Print only warnings and errors during test
 config :logger, level: :warning
 
-##
-# NervesHub Web
-#
-config :nerves_hub, NervesHubWeb.Endpoint,
-  http: [port: 4100],
-  server: true,
-  secret_key_base: "x7Vj9rmmRke//ctlapsPNGHXCRTnArTPbfsv6qX4PChFT9ARiNR5Ua8zoRilNCmX",
-  live_view: [signing_salt: "FnV9rP_c2BL11dvh"]
+config :nerves_hub, NervesHub.AnalyticsRepo,
+  url: System.get_env("CLICKHOUSE_URL", "http://default:@localhost:8123/default")
 
-##
-# NervesHub Device
-#
+config :nerves_hub, NervesHub.Firmwares.Upload.File,
+  local_path: System.tmp_dir(),
+  public_path: "/firmware"
+
+config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: "mybucket"
+
+config :nerves_hub, NervesHub.ObanRepo,
+  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_test"),
+  ssl: false,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 10
+
+config :nerves_hub, NervesHub.RateLimit, limit: 100
+
+config :nerves_hub, NervesHub.Repo,
+  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_test"),
+  ssl: false,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 10,
+  queue_target: 2000
+
+config :nerves_hub, NervesHub.SwooshMailer, adapter: Swoosh.Adapters.Test
+config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
+config :nerves_hub, NervesHub.Uploads.File, local_path: System.tmp_dir(), public_path: "/uploads"
+
 config :nerves_hub, NervesHubWeb.DeviceEndpoint,
   code_reloader: false,
   check_origin: false,
@@ -38,61 +54,24 @@ config :nerves_hub, NervesHubWeb.DeviceEndpoint,
     ]
   ]
 
-##
-# Firmware uploader
-#
-config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.File
-
-config :nerves_hub, NervesHub.Firmwares.Upload.S3, bucket: "mybucket"
-
-config :nerves_hub, NervesHub.Firmwares.Upload.File,
-  local_path: System.tmp_dir(),
-  public_path: "/firmware"
-
-config :nerves_hub, NervesHub.Uploads, backend: NervesHub.Uploads.File
-
-config :nerves_hub, NervesHub.Uploads.File,
-  local_path: System.tmp_dir(),
-  public_path: "/uploads"
-
-##
-# Database and Oban
-#
-config :nerves_hub, NervesHub.Repo,
-  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_test"),
-  ssl: false,
-  pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 10,
-  queue_target: 2000
-
-config :nerves_hub, NervesHub.ObanRepo,
-  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_test"),
-  ssl: false,
-  pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 10
-
-config :nerves_hub, NervesHub.AnalyticsRepo,
-  url: System.get_env("CLICKHOUSE_URL", "http://default:@localhost:8123/default")
-
-config :nerves_hub, analytics_enabled: true
-
-config :nerves_hub, Oban, testing: :manual
-
-##
-# Other
-#
 config :nerves_hub, NervesHubWeb.DeviceSocket,
   shared_secrets: [
     enabled: true
   ]
 
-config :nerves_hub, NervesHub.SwooshMailer, adapter: Swoosh.Adapters.Test
+config :nerves_hub, NervesHubWeb.Endpoint,
+  http: [port: 4100],
+  server: true,
+  secret_key_base: "x7Vj9rmmRke//ctlapsPNGHXCRTnArTPbfsv6qX4PChFT9ARiNR5Ua8zoRilNCmX",
+  live_view: [signing_salt: "FnV9rP_c2BL11dvh"]
 
-config :nerves_hub, NervesHub.RateLimit, limit: 100
-
-config :sentry, environment_name: :test
-
-config :phoenix_test, :endpoint, NervesHubWeb.Endpoint
+config :nerves_hub, Oban, testing: :manual
+config :nerves_hub, analytics_enabled: true
+config :nerves_hub, firmware_upload: NervesHub.Firmwares.Upload.File
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
+
+config :phoenix_test, :endpoint, NervesHubWeb.Endpoint
+
+config :sentry, environment_name: :test

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -30,7 +30,7 @@ defmodule NervesHub.Application do
           {Task.Supervisor, name: NervesHub.TaskSupervisor},
           {Oban, oban_opts()},
           NervesHubWeb.Presence,
-          {NervesHub.RateLimit.LogLines, [clean_period: :timer.minutes(5), key_older_than: :timer.hours(1)]},
+          {NervesHub.RateLimit.LogLines, [clean_period: to_timeout(minute: 5), key_older_than: to_timeout(hour: 1)]},
           {PartitionSupervisor, child_spec: Task.Supervisor, name: NervesHub.AnalyticsEventsProcessing}
         ] ++
         deployments_orchestrator(deploy_env()) ++

--- a/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
+++ b/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
@@ -61,7 +61,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
       PubSub.subscribe(NervesHub.PubSub, "orchestrator:deployment:#{deployment_group.id}")
 
     # trigger every two minutes, plus a jitter between 1 and 10 seconds, as a back up
-    interval = :timer.seconds(120 + :rand.uniform(20))
+    interval = to_timeout(second: 120 + :rand.uniform(20))
     _ = :timer.send_interval(interval, :trigger_interval)
 
     {:ok, deployment_group} = ManagedDeployments.get_deployment_group(deployment_group)

--- a/lib/nerves_hub/managed_deployments/distributed/orchestrator_registration.ex
+++ b/lib/nerves_hub/managed_deployments/distributed/orchestrator_registration.ex
@@ -26,7 +26,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorRegistration do
 
   @impl GenServer
   def init(_) do
-    Process.send_after(self(), :start_orchestrators, :timer.seconds(3))
+    Process.send_after(self(), :start_orchestrators, to_timeout(second: 3))
     {:ok, nil}
   end
 

--- a/lib/nerves_hub/metrics_poller.ex
+++ b/lib/nerves_hub/metrics_poller.ex
@@ -4,7 +4,7 @@ defmodule NervesHub.MetricsPoller do
      measurements: [
        {NervesHub.MetricsPoller, :report_device_count, []}
      ],
-     period: :timer.seconds(60),
+     period: to_timeout(second: 60),
      name: :nerves_hub_poller}
   end
 


### PR DESCRIPTION
Configs are now alphabetized automatically and deprecations removed (in this case just using the native `to_timeout` instead of the erlang `:timer`.