### PR TITLE
Update the Phoenix Socket topic mappings (fixes a fastlaning issue)

### DIFF
--- a/lib/nerves_hub_web/channels/device_json_serializer.ex
+++ b/lib/nerves_hub_web/channels/device_json_serializer.ex
@@ -14,27 +14,71 @@ defmodule NervesHubWeb.Channels.DeviceJSONSerializer do
   """
   @behaviour Phoenix.Socket.Serializer
 
+  @push 0
+
+  alias Phoenix.Socket.Message
+
   @impl Phoenix.Socket.Serializer
   def fastlane!(msg) do
     msg
-    |> update_topic()
+    |> remove_device_id_from_topic()
     |> Phoenix.Socket.V2.JSONSerializer.fastlane!()
   end
 
   @impl Phoenix.Socket.Serializer
   def encode!(reply) do
     reply
-    |> update_topic()
+    |> remove_device_id_from_topic()
     |> Phoenix.Socket.V2.JSONSerializer.encode!()
   end
 
   @impl Phoenix.Socket.Serializer
-  defdelegate decode!(raw_message, opts), to: Phoenix.Socket.V2.JSONSerializer
+  def decode!(raw_message, opts) do
+    case Keyword.fetch(opts, :opcode) do
+      {:ok, :text} -> decode_text(raw_message)
+      {:ok, :binary} -> decode_binary(raw_message)
+    end
+    |> add_device_id_to_topic()
+  end
 
-  defp update_topic(msg) do
+  defp decode_text(raw_message) do
+    [join_ref, ref, topic, event, payload | _] = Phoenix.json_library().decode!(raw_message)
+
+    %Message{
+      topic: topic,
+      event: event,
+      payload: payload,
+      ref: ref,
+      join_ref: join_ref
+    }
+  end
+
+  defp decode_binary(
+         <<@push::size(8), join_ref_size::size(8), ref_size::size(8), topic_size::size(8), event_size::size(8),
+           join_ref::binary-size(join_ref_size), ref::binary-size(ref_size), topic::binary-size(topic_size),
+           event::binary-size(event_size), data::binary>>
+       ) do
+    %Message{
+      topic: topic,
+      event: event,
+      payload: {:binary, data},
+      ref: ref,
+      join_ref: join_ref
+    }
+  end
+
+  defp remove_device_id_from_topic(msg) do
     if String.starts_with?(msg.topic, "device:") do
       [topic | _device_id] = String.split(msg.topic, ":")
       %{msg | topic: topic}
+    else
+      msg
+    end
+  end
+
+  defp add_device_id_to_topic(msg) do
+    if msg.topic == "device" && !String.starts_with?(msg.event, "phx_") && msg.event != "heartbeat" do
+      %{msg | topic: "device:#{Process.get(:device_id)}"}
     else
       msg
     end

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -39,9 +39,28 @@ defmodule NervesHubWeb.DeviceSocket do
   def handle_in({payload, opts} = msg, {state, socket}) do
     message = socket.serializer.decode!(payload, opts)
 
+    state = maybe_update_channel_state(state)
     socket = heartbeat(message, socket)
 
     super(msg, {state, socket})
+  end
+
+  # update the channel state mappings so that the socket can route messages based on topics correctly
+  # only the "device" channel mappings are updated as this is the only channel that has changed
+  defp maybe_update_channel_state(%{channels: %{"device" => _}} = state) do
+    {device_channel, channels} = Map.pop(state.channels, "device")
+    {device_channel_pid, _, _} = device_channel
+
+    channels = Map.put(channels, "device:#{Process.get(:device_id)}", device_channel)
+
+    {{_topic, id}, channels_inverse} = Map.pop(state.channels_inverse, device_channel_pid)
+    channels_inverse = Map.put(channels_inverse, device_channel_pid, {"device:#{Process.get(:device_id)}", id})
+
+    %{state | channels: channels, channels_inverse: channels_inverse}
+  end
+
+  defp maybe_update_channel_state(state) do
+    state
   end
 
   @decorate with_span("Channels.DeviceSocket.heartbeat")
@@ -255,6 +274,10 @@ defmodule NervesHubWeb.DeviceSocket do
     })
 
     Tracker.online(device)
+
+    # this is required by `DeviceJSONSerializer` which needs to update the message topic,
+    # allowing for the socket to map messages correctly
+    Process.put(:device_id, device.id)
 
     socket
     |> assign(:device, device)


### PR DESCRIPTION
The Phoenix Socket routes messages between connected clients, and as such, it maintains a map of topics and PIDs to facilitate routing.

With our recent update, which changed the underlying Device subscription from `device` to `device:[id]`, we need to update the mappings held in the Socket state and ensure that the device ID is added to the topic. 

While I'm not super in love with the breadth of these changes, this is required, and I will return to this code and see if there are cleaner options.