### PR TITLE
A small optimization to `Devices.update_attempted/2`

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -913,6 +913,7 @@ defmodule NervesHub.Devices do
     update_device(device, %{updates_blocked_until: blocked_until, update_attempts: []})
   end
 
+  @spec update_attempted(Device.t(), DateTime.t()) :: :ok | {:error, Changeset.t()}
   def update_attempted(device, now \\ DateTime.utc_now()) do
     now = DateTime.truncate(now, :second)
 
@@ -931,8 +932,8 @@ defmodule NervesHub.Devices do
     end)
     |> Repo.transaction()
     |> case do
-      {:ok, %{device: device}} ->
-        {:ok, device}
+      {:ok, _} ->
+        :ok
 
       err ->
         err

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -199,7 +199,7 @@ defmodule NervesHubWeb.DeviceChannel do
       # then mark it as an update attempt
       #
       # we don't need to store the result as this information isn't used anywhere else
-      {:ok, _} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
 
       {:noreply, assign(socket, :update_started?, true)}
     end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -198,19 +198,10 @@ defmodule NervesHubWeb.DeviceChannel do
       # if this is the first fwup we see, and we didn't know the update had already started,
       # then mark it as an update attempt
       #
-      # reload update attempts because they might have been cleared
-      # and we have a cached stale version
-      updated_device = Repo.reload(device)
-      device = %{device | update_attempts: updated_device.update_attempts}
+      # we don't need to store the result as this information isn't used anywhere else
+      {:ok, _} = Devices.update_attempted(device)
 
-      {:ok, device} = Devices.update_attempted(device)
-
-      socket =
-        socket
-        |> assign(:device, device)
-        |> assign(:update_started?, true)
-
-      {:noreply, socket}
+      {:noreply, assign(socket, :update_started?, true)}
     end
   end
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -129,7 +129,7 @@ defmodule NervesHub.DevicesTest do
     firmware = Fixtures.firmware_fixture(org_key, product)
     device = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
 
-    {:ok, device} = Devices.update_attempted(device)
+    :ok = Devices.update_attempted(device)
     {:ok, device} = Devices.enable_updates(device, user)
 
     assert device.updates_enabled
@@ -406,17 +406,19 @@ defmodule NervesHub.DevicesTest do
 
   describe "tracking update attempts and verifying eligibility" do
     test "records the timestamp of an attempt", %{device: device} do
-      {:ok, device} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
+      device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 1
 
-      {:ok, device} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
+      device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 2
     end
 
     test "records and audit log for updating", %{device: device} do
       assert [] = AuditLogs.logs_for(device)
 
-      {:ok, device} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
 
       [audit_log] = AuditLogs.logs_for(device)
 
@@ -424,7 +426,8 @@ defmodule NervesHub.DevicesTest do
     end
 
     test "resets update attempts on successful update", %{device: device} do
-      {:ok, device} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
+      device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 1
 
       {:ok, device} = Devices.firmware_update_successful(device, device.firmware_metadata)
@@ -468,7 +471,7 @@ defmodule NervesHub.DevicesTest do
     test "device updates successfully", %{device: device, deployment_group: deployment_group} do
       {:ok, device} = update_firmware_uuid(device, Ecto.UUID.generate())
 
-      {:ok, device} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
 
       {:ok, device} = Devices.verify_update_eligibility(device, deployment_group)
 
@@ -482,8 +485,10 @@ defmodule NervesHub.DevicesTest do
     } do
       {:ok, device} = update_firmware_uuid(device, Ecto.UUID.generate())
 
-      {:ok, device} = Devices.update_attempted(device)
-      {:ok, device} = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(device)
+
+      device = Repo.reload(device)
 
       {:ok, device} = Devices.verify_update_eligibility(device, deployment_group)
 
@@ -504,9 +509,11 @@ defmodule NervesHub.DevicesTest do
 
       now = DateTime.utc_now()
 
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -3600, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -1200, :second))
-      {:ok, device} = Devices.update_attempted(device, now)
+      :ok = Devices.update_attempted(device, DateTime.add(now, -3600, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -1200, :second))
+      :ok = Devices.update_attempted(device, now)
+
+      device = Repo.reload(device)
 
       {:ok, device} = Devices.verify_update_eligibility(device, deployment_group)
 
@@ -530,12 +537,14 @@ defmodule NervesHub.DevicesTest do
 
       now = DateTime.utc_now()
 
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -3600, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -1200, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -500, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -500, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -500, :second))
-      {:ok, device} = Devices.update_attempted(device, now)
+      :ok = Devices.update_attempted(device, DateTime.add(now, -3600, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -1200, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -500, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -500, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -500, :second))
+      :ok = Devices.update_attempted(device, now)
+
+      device = Repo.reload(device)
 
       {:error, :updates_blocked, device} =
         Devices.verify_update_eligibility(device, deployment_group)
@@ -554,11 +563,13 @@ defmodule NervesHub.DevicesTest do
 
       now = DateTime.utc_now()
 
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -13, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -10, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -5, :second))
-      {:ok, device} = Devices.update_attempted(device, DateTime.add(now, -2, :second))
-      {:ok, device} = Devices.update_attempted(device, now)
+      :ok = Devices.update_attempted(device, DateTime.add(now, -13, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -10, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -5, :second))
+      :ok = Devices.update_attempted(device, DateTime.add(now, -2, :second))
+      :ok = Devices.update_attempted(device, now)
+
+      device = Repo.reload(device)
 
       {:error, :updates_blocked, device} =
         Devices.verify_update_eligibility(device, deployment_group)


### PR DESCRIPTION
The `DeviceChannel` doesn't use the `update_attempts` information, so instead of reloading the device and updating the field via a changeset, I've taken advantage of Postgres's ability to append to the array via and SQL `update` query.