### PR TITLE
Encapsulate device communications into a new module, `DeviceLink`

### DIFF
--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -1,0 +1,191 @@
+defmodule NervesHub.DeviceLink do
+  @moduledoc """
+  Encapsulation of device connection workflow logic
+  """
+
+  alias NervesHub.Archives
+  alias NervesHub.AuditLogs.DeviceTemplates
+  alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Device
+  alias NervesHub.Firmwares
+  alias NervesHub.ManagedDeployments
+
+  alias Phoenix.Channel.Server, as: ChannelServer
+
+  @spec join(Device.t(), connection_reference :: String.t(), params :: map()) :: {:ok, Device.t()} | {:error, any()}
+  def join(device, ref_id, params) do
+    with {:ok, device} <- update_firmware_metadata(device, params),
+         :ok <- update_connection_metadata(ref_id, %{"device_api_version" => params["device_api_version"]}),
+         :ok <- maybe_clear_inflight_update(device, params) do
+      device = refresh_deployment_group(device)
+      {:ok, device}
+    else
+      err -> {:error, err}
+    end
+  end
+
+  @spec after_join(Device.t(), connection_reference :: String.t(), params :: map()) :: :ok | {:error, any()}
+  def after_join(device, reference_id, params) do
+    with :ok <- maybe_send_public_keys(device, params),
+         :ok <- maybe_send_archive(device, params["device_api_version"], reference_id),
+         :ok <- maybe_request_extensions(device, params["device_api_version"]) do
+      announce_online(device, reference_id)
+    end
+  rescue
+    err -> {:error, err}
+  end
+
+  @spec update_connection_metadata(reference_id :: String.t(), metadata :: map()) :: :ok
+  def update_connection_metadata(reference_id, metadata) do
+    :ok = Connections.merge_update_metadata(reference_id, metadata)
+  end
+
+  @spec status_update(device :: Device.t(), status :: String.t()) :: :ok
+  def status_update(device, status) do
+    # a temporary hook into failed updates
+    if String.contains?(status, "fwup error") do
+      # if there was an error during updating, clear the inflight update
+      Devices.clear_inflight_update(device)
+    end
+
+    :ok
+  end
+
+  @spec firmware_update_progress(device :: Device.t(), percent :: integer()) :: :ok
+  def firmware_update_progress(device, percent) do
+    topic = "device:#{device.identifier}:internal"
+
+    :ok =
+      ChannelServer.broadcast_from!(NervesHub.PubSub, self(), topic, "fwup_progress", %{
+        device_id: device.id,
+        percent: percent
+      })
+  end
+
+  @spec maybe_send_archive(
+          device :: Device.t(),
+          device_api_version :: String.t(),
+          reference_id :: String.t(),
+          opts :: Keyword.t()
+        ) :: :ok
+  def maybe_send_archive(device, device_api_version, reference_id, opts \\ [])
+
+  def maybe_send_archive(%{deployment_id: nil}, _device_api_version, _reference_id, _opts), do: :ok
+
+  def maybe_send_archive(device, device_api_version, reference_id, opts) do
+    opts = Keyword.validate!(opts, audit_log: false)
+    updates_enabled = device.updates_enabled && !Devices.device_in_penalty_box?(device)
+    version_match = Version.match?(device_api_version, ">= 2.0.0")
+
+    if updates_enabled && version_match do
+      if archive = Archives.archive_for_deployment_group(device.deployment_id) do
+        if opts[:audit_log],
+          do:
+            DeviceTemplates.audit_device_archive_update_triggered(
+              device,
+              archive,
+              reference_id
+            )
+
+        broadcast(device, "archive", %{
+          size: archive.size,
+          uuid: archive.uuid,
+          version: archive.version,
+          description: archive.description,
+          platform: archive.platform,
+          architecture: archive.architecture,
+          uploaded_at: archive.inserted_at,
+          url: Archives.url(archive)
+        })
+      end
+    end
+
+    :ok
+  end
+
+  defp announce_online(device, reference_id) do
+    # Update the connection to say that we are fully up and running
+    Connections.device_connected(device, reference_id)
+    # tell the orchestrator that we are online
+    Devices.deployment_device_online(device)
+  end
+
+  defp refresh_deployment_group(device) do
+    device
+    |> ManagedDeployments.verify_deployment_group_membership()
+    |> ManagedDeployments.set_deployment_group()
+    |> Map.put(:deployment_group, nil)
+  end
+
+  defp maybe_send_public_keys(device, params) do
+    Enum.each(["fwup_public_keys", "archive_public_keys"], fn key_type ->
+      if params[key_type] == "on_connect" do
+        org_keys = NervesHub.Accounts.list_org_keys(device.org_id, false)
+
+        broadcast(device, key_type, %{keys: Enum.map(org_keys, & &1.key)})
+      end
+    end)
+
+    :ok
+  end
+
+  defp maybe_clear_inflight_update(_device, %{"currently_downloading_uuid" => _uuid}), do: :ok
+
+  defp maybe_clear_inflight_update(device, _) do
+    Devices.clear_inflight_update(device)
+    :ok
+  end
+
+  defp maybe_request_extensions(device, device_api_version) do
+    if Version.match?(device_api_version, ">= 2.2.0"), do: broadcast(device, "extensions:get", %{})
+    :ok
+  end
+
+  # The reported firmware is the same as what we already know about
+  defp update_firmware_metadata(
+         %Device{firmware_metadata: %{uuid: uuid}} = device,
+         %{"nerves_fw_uuid" => uuid} = params
+       ) do
+    validation_status = fetch_validation_status(params)
+    auto_revert_detected? = firmware_auto_revert_detected?(params)
+
+    Devices.update_firmware_metadata(device, nil, validation_status, auto_revert_detected?)
+  end
+
+  # A new UUID is being reported from an update
+  defp update_firmware_metadata(%{firmware_metadata: previous_metadata} = device, params) do
+    with {:ok, metadata} <- Firmwares.metadata_from_device(params),
+         validation_status = fetch_validation_status(params),
+         auto_revert_detected? = firmware_auto_revert_detected?(params),
+         {:ok, device} <-
+           Devices.update_firmware_metadata(device, metadata, validation_status, auto_revert_detected?) do
+      Devices.firmware_update_successful(device, previous_metadata)
+    end
+  end
+
+  defp fetch_validation_status(params) do
+    params
+    |> Map.get("meta", %{})
+    |> Map.get("firmware_validated")
+    |> case do
+      true -> :validated
+      false -> :not_validated
+      nil -> :unknown
+    end
+  end
+
+  defp firmware_auto_revert_detected?(params) do
+    params
+    |> Map.get("meta", %{})
+    |> Map.get("firmware_auto_revert_detected", false)
+  end
+
+  defp topic(%Device{id: id}) do
+    "device:#{id}"
+  end
+
+  defp broadcast(device, event, payload) do
+    :ok = ChannelServer.broadcast(NervesHub.PubSub, topic(device), event, payload)
+  end
+end

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -67,10 +67,10 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connected(Device.t(), non_neg_integer()) :: :ok | :error
-  def device_connected(device, id) do
+  @spec device_connected(Device.t(), connection_id :: binary()) :: :ok | :error
+  def device_connected(device, connection_id) do
     DeviceConnection
-    |> where(id: ^id)
+    |> where(id: ^connection_id)
     |> where([dc], not (dc.status == :disconnected))
     |> Repo.update_all(
       set: [

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -9,6 +9,9 @@ defmodule NervesHubWeb.DeviceChannel do
   - identify
   - reboot
   - update (scheduled and manual)
+  - archive (but sent from within the channel process)
+  - fwup_public_keys (but sent from within the channel process)
+  - archive_public_keys (but sent from within the channel process)
 
   # Intercepted Messages
 
@@ -19,13 +22,8 @@ defmodule NervesHubWeb.DeviceChannel do
   use Phoenix.Channel
   use OpenTelemetryDecorator
 
-  alias NervesHub.Archives
-  alias NervesHub.AuditLogs.DeviceTemplates
+  alias NervesHub.DeviceLink
   alias NervesHub.Devices
-  alias NervesHub.Devices.Connections
-  alias NervesHub.Devices.Device
-  alias NervesHub.Firmwares
-  alias NervesHub.ManagedDeployments
   alias NervesHub.Repo
   alias Phoenix.Socket.Broadcast
 
@@ -34,22 +32,21 @@ defmodule NervesHubWeb.DeviceChannel do
   intercept(["updated", "deployment_updated"])
 
   @decorate with_span("Channels.DeviceChannel.join")
-  def join("device:" <> _device_id, params, %{assigns: %{device: device}} = socket) do
+  def join("device:" <> _device_id, params, %{assigns: %{device: device, reference_id: reference_id}} = socket) do
     Logger.metadata(device_id: device.id, device_identifier: device.identifier)
 
     params = maybe_sanitize_device_api_version(params)
 
-    case update_metadata(device, params) do
+    case DeviceLink.join(device, reference_id, params) do
       {:ok, device} ->
-        send(self(), {:after_join, params})
-
         socket =
           socket
           |> assign(:currently_downloading_uuid, params["currently_downloading_uuid"])
           |> assign(:update_started?, !!params["currently_downloading_uuid"])
-          |> assign(:device, device)
+          |> assign(:device_api_version, params["device_api_version"])
+          |> update_device(device)
 
-        maybe_clear_inflight_update(device, !!params["currently_downloading_uuid"])
+        send(self(), {:after_join, params})
 
         {:ok, socket}
 
@@ -64,56 +61,9 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  defp maybe_sanitize_device_api_version(%{"device_api_version" => version} = params) do
-    case Version.parse(version) do
-      {:ok, _} ->
-        params
-
-      :error ->
-        Logger.warning("[DeviceChannel] invalid device_api_version value - #{inspect(params["device_api_version"])}")
-        Map.put(params, "device_api_version", "0.0.0")
-    end
-  end
-
-  defp maybe_sanitize_device_api_version(params) do
-    Logger.warning("[DeviceChannel] device_api_version is missing from the connection params")
-    Map.put(params, "device_api_version", "0.0.0")
-  end
-
-  @decorate with_span("Channels.DeviceChannel.handle_info:after_join")
-  def handle_info({:after_join, params}, %{assigns: %{device: device}} = socket) do
-    device =
-      device
-      |> ManagedDeployments.verify_deployment_group_membership()
-      |> ManagedDeployments.set_deployment_group()
-      |> Map.put(:deployment_group, nil)
-
-    maybe_send_public_keys(device, socket, params)
-
-    socket =
-      socket
-      |> update_device(device)
-      |> assign_api_version(params)
-      |> maybe_send_archive()
-
-    send(self(), :announce_online)
-
-    # Request device extension capabilities if possible
-    # Earlier versions of nerves_hub_link don't have a fallback for unknown messages,
-    # so check version before requesting extensions
-    if safe_to_request_extensions?(socket.assigns.device_api_version),
-      do: push(socket, "extensions:get", %{})
-
-    {:noreply, socket}
-  end
-
-  # Let the deployment orchestrator know that we are online
-  def handle_info(:announce_online, socket) do
-    # Update the connection to say that we are fully up and running
-    Connections.device_connected(socket.assigns.device, socket.assigns.reference_id)
-    # tell the orchestrator that we are online
-    Devices.deployment_device_online(socket.assigns.device)
-
+  def handle_info({:after_join, params}, socket) do
+    %{device: device, reference_id: reference_id} = socket.assigns
+    :ok = DeviceLink.after_join(device, reference_id, params)
     {:noreply, socket}
   end
 
@@ -124,7 +74,9 @@ defmodule NervesHubWeb.DeviceChannel do
 
   # listen for notifications about archive updates for deployments
   def handle_info(%Broadcast{event: "archives/updated"}, socket) do
-    {:noreply, maybe_send_archive(socket, audit_log: true)}
+    %{device: device, device_api_version: device_api_version, reference_id: reference_id} = socket.assigns
+    DeviceLink.maybe_send_archive(device, device_api_version, reference_id, audit_log: true)
+    {:noreply, socket}
   end
 
   def handle_info(:online?, socket) do
@@ -185,23 +137,19 @@ defmodule NervesHubWeb.DeviceChannel do
   def handle_out("updated", _, %{assigns: %{device: device}} = socket) do
     device = Repo.reload(device)
 
-    socket =
-      socket
-      |> update_device(device)
-      |> maybe_send_archive(audit_log: true)
+    %{device_api_version: device_api_version, reference_id: reference_id} = socket.assigns
+    DeviceLink.maybe_send_archive(device, device_api_version, reference_id, audit_log: true)
 
-    {:noreply, socket}
+    {:noreply, update_device(socket, device)}
   end
 
   def handle_out("deployment_updated", payload, socket) do
     device = %{socket.assigns.device | deployment_id: payload.deployment_id}
 
-    socket =
-      socket
-      |> update_device(device)
-      |> maybe_send_archive(audit_log: true)
+    %{device_api_version: device_api_version, reference_id: reference_id} = socket.assigns
+    DeviceLink.maybe_send_archive(device, device_api_version, reference_id, audit_log: true)
 
-    {:noreply, socket}
+    {:noreply, update_device(socket, device)}
   end
 
   def handle_in("firmware_validated", _, %{assigns: %{device: device}} = socket) do
@@ -211,40 +159,21 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   def handle_in("fwup_progress", %{"value" => percent}, %{assigns: %{device: device}} = socket) do
-    device_internal_broadcast!(socket, device, "fwup_progress", %{
-      device_id: device.id,
-      percent: percent
-    })
+    DeviceLink.firmware_update_progress(device, percent)
 
-    # if we know the update has already started, we can move on
-    if socket.assigns.update_started? do
-      {:noreply, socket}
-    else
-      # if this is the first fwup we see, and we didn't know the update had already started,
-      # then mark it as an update attempt
-      #
-      # we don't need to store the result as this information isn't used anywhere else
-      :ok = Devices.update_attempted(device)
-
-      {:noreply, assign(socket, :update_started?, true)}
-    end
+    {:noreply, maybe_update_update_attempts(socket)}
   end
 
   def handle_in("connection_types", %{"values" => types}, socket) do
-    :ok =
-      Connections.merge_update_metadata(socket.assigns.reference_id, %{
-        "connection_types" => types
-      })
+    DeviceLink.update_connection_metadata(socket.assigns.reference_id, %{
+      "connection_types" => types
+    })
 
     {:noreply, socket}
   end
 
   def handle_in("status_update", %{"status" => status}, socket) do
-    # a temporary hook into failed updates
-    if String.contains?(status, "fwup error") do
-      # if there was an error during updating, clear the inflight update
-      reset_updating_status(socket)
-    end
+    DeviceLink.status_update(socket.assigns.device, status)
 
     {:noreply, socket}
   end
@@ -275,12 +204,33 @@ defmodule NervesHubWeb.DeviceChannel do
     {:noreply, socket}
   end
 
-  defp assign_api_version(%{assigns: %{reference_id: ref_id}} = socket, params) do
-    version = Map.get(params, "device_api_version", "1.0.0")
+  defp maybe_sanitize_device_api_version(%{"device_api_version" => version} = params) do
+    case Version.parse(version) do
+      {:ok, _} ->
+        params
 
-    :ok = Connections.merge_update_metadata(ref_id, %{"device_api_version" => version})
+      :error ->
+        Logger.warning("[DeviceChannel] invalid device_api_version value - #{inspect(params["device_api_version"])}")
+        Map.put(params, "device_api_version", "1.0.0")
+    end
+  end
 
-    assign(socket, :device_api_version, version)
+  defp maybe_sanitize_device_api_version(params) do
+    Logger.warning("[DeviceChannel] device_api_version is missing from the connection params")
+    Map.put(params, "device_api_version", "1.0.0")
+  end
+
+  # if we know the update has already started, we can move on
+  def maybe_update_update_attempts(%{update_started?: true} = socket), do: socket
+
+  # if this is the first fwup we see, and we didn't know the update had already started,
+  # then mark it as an update attempt
+  #
+  # we don't need to store the result as this information isn't used anywhere else
+  def maybe_update_update_attempts(socket) do
+    :ok = Devices.update_attempted(socket.assigns.device)
+
+    assign(socket, :update_started?, true)
   end
 
   defp subscribe(topic) when not is_nil(topic) do
@@ -295,73 +245,6 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   defp unsubscribe(nil), do: :ok
-
-  defp device_internal_broadcast!(socket, device, event, payload) do
-    topic = "device:#{device.identifier}:internal"
-    socket.endpoint.broadcast_from!(self(), topic, event, payload)
-  end
-
-  defp maybe_send_public_keys(device, socket, params) do
-    Enum.each(["fwup_public_keys", "archive_public_keys"], fn key_type ->
-      if params[key_type] == "on_connect" do
-        org_keys = NervesHub.Accounts.list_org_keys(device.org_id, false)
-
-        push(socket, key_type, %{
-          keys: Enum.map(org_keys, fn ok -> ok.key end)
-        })
-      end
-    end)
-  end
-
-  # The reported firmware is the same as what we already know about
-  defp update_metadata(%Device{firmware_metadata: %{uuid: uuid}} = device, %{"nerves_fw_uuid" => uuid} = params) do
-    validation_status = fetch_validation_status(params)
-    auto_revert_detected? = firmware_auto_revert_detected?(params)
-
-    Devices.update_firmware_metadata(device, nil, validation_status, auto_revert_detected?)
-  end
-
-  # A new UUID is being reported from an update
-  defp update_metadata(%{firmware_metadata: previous_metadata} = device, params) do
-    with {:ok, metadata} <- Firmwares.metadata_from_device(params),
-         validation_status = fetch_validation_status(params),
-         auto_revert_detected? = firmware_auto_revert_detected?(params),
-         {:ok, device} <-
-           Devices.update_firmware_metadata(device, metadata, validation_status, auto_revert_detected?) do
-      Devices.firmware_update_successful(device, previous_metadata)
-    end
-  end
-
-  defp fetch_validation_status(params) do
-    params
-    |> Map.get("meta", %{})
-    |> Map.get("firmware_validated")
-    |> case do
-      true -> :validated
-      false -> :not_validated
-      nil -> :unknown
-    end
-  end
-
-  defp firmware_auto_revert_detected?(params) do
-    params
-    |> Map.get("meta", %{})
-    |> Map.get("firmware_auto_revert_detected", false)
-  end
-
-  @spec maybe_clear_inflight_update(device :: Device.t(), currently_updating? :: boolean()) :: :ok
-  defp maybe_clear_inflight_update(device, false) do
-    Devices.clear_inflight_update(device)
-    :ok
-  end
-
-  defp maybe_clear_inflight_update(_device, true) do
-    :ok
-  end
-
-  defp reset_updating_status(socket) do
-    Devices.clear_inflight_update(socket.assigns.device)
-  end
 
   defp update_device(socket, device) do
     socket
@@ -387,41 +270,4 @@ defmodule NervesHubWeb.DeviceChannel do
       "deployment:#{device.deployment_id}"
     end
   end
-
-  defp maybe_send_archive(socket, opts \\ [])
-
-  defp maybe_send_archive(%{assigns: %{deployment_id: nil}} = socket, _opts), do: socket
-
-  defp maybe_send_archive(%{assigns: %{device: device}} = socket, opts) do
-    opts = Keyword.validate!(opts, audit_log: false)
-    updates_enabled = device.updates_enabled && !Devices.device_in_penalty_box?(device)
-    version_match = Version.match?(socket.assigns.device_api_version, ">= 2.0.0")
-
-    if updates_enabled && version_match do
-      if archive = Archives.archive_for_deployment_group(device.deployment_id) do
-        if opts[:audit_log],
-          do:
-            DeviceTemplates.audit_device_archive_update_triggered(
-              device,
-              archive,
-              socket.assigns.reference_id
-            )
-
-        push(socket, "archive", %{
-          size: archive.size,
-          uuid: archive.uuid,
-          version: archive.version,
-          description: archive.description,
-          platform: archive.platform,
-          architecture: archive.architecture,
-          uploaded_at: archive.inserted_at,
-          url: Archives.url(archive)
-        })
-      end
-    end
-
-    socket
-  end
-
-  defp safe_to_request_extensions?(version), do: Version.match?(version, ">= 2.2.0")
 end


### PR DESCRIPTION
By encapsulating the logic for managing a connected device, we open up the potential to support MQTT.

This makes the `DeviceChannel` thin and focused on using `DeviceLink` for undertaking the business logic associated with the event at hand. 