### PR TITLE
Fix the deployment progress progress bar html/css

### DIFF
--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -55,8 +55,8 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
         <div class="flex text-xl text-neutral-50 font-medium leading-6 h-10 justify-center items-center">All devices are up to date!</div>
       </div>
 
-      <div :if={@waiting_for_update_count > 0} class="relative w-full h-24 box-content flex items-center justify-center rounded border border-zinc-700 bg-zinc-900">
-        <div class="absolute top-0 w-full items-center justify-center rounded overflow-visible z-20">
+      <div :if={@waiting_for_update_count > 0} class="w-full h-24 box-content flex items-center justify-center rounded border border-zinc-700 bg-zinc-900">
+        <div class="relative top-0 w-full items-center justify-center rounded overflow-visible z-20">
           <div
             :if={@deployment_group.is_active}
             class="z-40 absolute -top-px border-t rounded-tl border-success-500"


### PR DESCRIPTION
**Before:**

<img width="1249" height="264" alt="Screenshot 2025-09-09 at 10 34 21 AM" src="https://github.com/user-attachments/assets/a826d342-b1df-4762-84f0-51560ae8b232" />

**After:**

<img width="1248" height="304" alt="Screenshot 2025-09-09 at 10 34 28 AM" src="https://github.com/user-attachments/assets/357ce397-ab86-412d-a3cd-3bfc9072bb2c" />

(Don't worry about the text saying 0 updating but the bar being at 50%, that was me editing the css for screenshotting)