### PR TITLE
Move device connection pubsub updates to the `Connections` context

### DIFF
--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -6,6 +6,22 @@ defmodule NervesHub.Tracker do
   alias NervesHub.Devices.Device
   alias NervesHub.Repo
 
+  def heartbeat(%Device{} = device) do
+    _ =
+      Phoenix.Channel.Server.broadcast(
+        NervesHub.PubSub,
+        "device:#{device.identifier}:internal",
+        "connection:heartbeat",
+        %{}
+      )
+
+    :ok
+  end
+
+  def connecting(%Device{} = device) do
+    publish(device.identifier, "connecting")
+  end
+
   def online(%{} = device) do
     online(device.identifier)
   end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -110,9 +110,7 @@ defmodule NervesHubWeb.DeviceChannel do
   # Let the deployment orchestrator know that we are online
   def handle_info(:announce_online, socket) do
     # Update the connection to say that we are fully up and running
-    Connections.device_connected(socket.assigns.reference_id)
-    # Tell the tracker that we are online
-    NervesHub.Tracker.online(socket.assigns.device)
+    Connections.device_connected(socket.assigns.device, socket.assigns.reference_id)
     # tell the orchestrator that we are online
     Devices.deployment_device_online(socket.assigns.device)
 

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -73,8 +73,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device1.id, device1.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device1, device1.product_id)
+    :ok = Connections.device_connected(device1, connection.id)
     Devices.deployment_device_online(device1)
 
     # sent when a device is a assigned a deployment group
@@ -88,8 +88,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic2)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device2, device2.product_id)
+    :ok = Connections.device_connected(device2, connection.id)
     Devices.deployment_device_online(device2)
 
     # and check that device2 was told to update
@@ -100,8 +100,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic3)
 
     device3 = Devices.update_deployment_group(device3, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device3.id, device3.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device3, device3.product_id)
+    :ok = Connections.device_connected(device3, connection.id)
     Devices.deployment_device_online(device3)
 
     # and check that device3 isn't told to update as the concurrent limit has been reached
@@ -120,12 +120,12 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       ManagedDeployments.update_deployment_group(deployment_group, %{concurrent_updates: 1})
 
     device = Devices.update_deployment_group(device, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device, device.product_id)
+    :ok = Connections.device_connected(device, connection.id)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device2, device2.product_id)
+    :ok = Connections.device_connected(device2, connection.id)
 
     topic1 = "device:#{device.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
@@ -154,8 +154,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     # bring the second device 'online'
     Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device2, device2.product_id)
+    :ok = Connections.device_connected(device2, connection.id)
 
     # sent by the device after its updated
     assert_receive %Broadcast{topic: ^topic2, event: "deployment_updated"}, 500
@@ -225,8 +225,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
 
-    {:ok, connection} = Connections.device_connecting(device1.id, device1.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device1, device1.product_id)
+    :ok = Connections.device_connected(device1, connection.id)
 
     Devices.deployment_device_online(device1)
 
@@ -252,8 +252,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       Devices.update_device(device2, %{firmware_metadata: %{"uuid" => firmware.uuid}})
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device2, device2.product_id)
+    :ok = Connections.device_connected(device2, connection.id)
     Devices.deployment_device_online(device2)
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-online"}, 500
@@ -296,8 +296,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     device1 = Devices.update_deployment_group(device1, deployment_group)
     {:ok, device1} = Devices.update_device(device1, %{updates_enabled: false})
 
-    {:ok, connection} = Connections.device_connecting(device1.id, device1.product_id)
-    :ok = Connections.device_connected(connection.id)
+    {:ok, connection} = Connections.device_connecting(device1, device1.product_id)
+    :ok = Connections.device_connected(device1, connection.id)
 
     Devices.deployment_device_online(device1)
 

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -96,9 +96,9 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert html =~ "offline"
 
       {:ok, connection} =
-        Connections.device_connecting(fixture.device.id, fixture.device.product_id)
+        Connections.device_connecting(fixture.device, fixture.device.product_id)
 
-      :ok = Connections.device_connected(connection.id)
+      :ok = Connections.device_connected(fixture.device, connection.id)
 
       send(view.pid, %Broadcast{event: "connection:change", payload: %{status: "online"}})
 
@@ -262,8 +262,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
-      :ok = Connections.device_connected(connection.id)
+      {:ok, connection} = Connections.device_connecting(device, device.product_id)
+      :ok = Connections.device_connected(device, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{}})
 
       conn
@@ -278,8 +278,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "location" => %{"error_code" => "BOOP", "error_description" => "BEEP"}
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
-      :ok = Connections.device_connected(connection.id)
+      {:ok, connection} = Connections.device_connecting(device, device.product_id)
+      :ok = Connections.device_connected(device, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
@@ -300,8 +300,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         }
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.product_id)
-      :ok = Connections.device_connected(connection.id)
+      {:ok, connection} = Connections.device_connecting(device, device.product_id)
+      :ok = Connections.device_connected(device, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn


### PR DESCRIPTION
While the Tracker gets a rewrite, this improves a bit of code I came across where we announce a device online twice, once in the `DeviceSocket` and once in `DeviceChannel`.

I still send two, but now I send `connecting` and `online`.

I've also encapsulated all connection related pubsub messages to `Tracker`, and the `Connections` context is the primary user of Tracker.