### PR TITLE
Fix the ability to send manual delta updates, and add a test

### DIFF
--- a/lib/nerves_hub/events/device_events.ex
+++ b/lib/nerves_hub/events/device_events.ex
@@ -73,9 +73,17 @@ defmodule NervesHub.DeviceEvents do
     end)
   end
 
-  def manual_update(device, firmware, user) do
+  def manual_update(device, firmware, user, opts \\ []) do
     Repo.transact(fn ->
-      {:ok, url} = Firmwares.get_firmware_url(firmware)
+      url =
+        if opts[:delta] do
+          {:ok, url} = Devices.get_delta_or_firmware_url(device, firmware)
+          url
+        else
+          {:ok, url} = Firmwares.get_firmware_url(firmware)
+          url
+        end
+
       {:ok, meta} = Firmwares.metadata_from_firmware(firmware)
       {:ok, device} = Devices.disable_updates(device, user)
 

--- a/lib/nerves_hub/firmwares/upload/file.ex
+++ b/lib/nerves_hub/firmwares/upload/file.ex
@@ -62,13 +62,12 @@ defmodule NervesHub.Firmwares.Upload.File do
 
     common_path =
       Path.join([
-        key_prefix(),
         Integer.to_string(org_id),
         source_firmware_uuid,
         "#{target_firmware_uuid}.delta.fw"
       ])
 
-    local_path = Path.join([config[:local_path], common_path])
+    local_path = Path.join([config[:local_path], key_prefix(), common_path])
 
     port =
       if Enum.member?([443, 80], web_config[:url][:port]),

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -372,12 +372,13 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
                 <label for="firmware" class="hidden">Firmware</label>
                 <select
                   id="firmware"
-                  phx-update="ignore"
                   name="uuid"
                   class="col-start-1 row-start-1 appearance-none border rounded border-zinc-600 bg-zinc-900 py-1.5 pl-3 pr-8 text-sm text-zinc-400 focus:outline focus:outline-1 focus:-outline-offset-1 focus:outline-indigo-500"
                 >
                   <option value="">Select a version</option>
-                  <option :for={firmware <- @firmwares} value={firmware.uuid}>{firmware.version} ({String.slice(firmware.uuid, 0..7)})</option>
+                  <option :for={firmware <- @firmwares} value={firmware.uuid} selected={@selected_firmware && firmware.uuid == @selected_firmware}>
+                    {firmware.version} ({String.slice(firmware.uuid, 0..7)})
+                  </option>
                 </select>
               </div>
 
@@ -385,8 +386,8 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
                 :if={@delta_available?}
                 type="button"
                 disabled={disconnected?(@device_connection)}
-                aria-label="Send firmware update"
-                data-confirm="Are you sure you want to send this firmware to the device?"
+                aria-label="Send delta firmware update"
+                data-confirm="Are you sure you want to send this delta firmware to the device?"
                 phx-value-uuid={@selected_firmware}
                 phx-click="push-delta"
               >
@@ -669,7 +670,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
       "Manually sending firmware delta for updating from #{device.firmware_metadata.uuid} to #{firmware.uuid} to #{device.identifier}"
     )
 
-    DeviceEvents.manual_update(device, firmware, user)
+    DeviceEvents.manual_update(device, firmware, user, delta: true)
 
     socket
     |> assign(:device, device)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -167,7 +167,11 @@ defmodule NervesHub.Fixtures do
     firmware
   end
 
-  def firmware_delta_fixture(%Firmwares.Firmware{id: source_id}, %Firmwares.Firmware{id: target_id, org_id: org_id}) do
+  def firmware_delta_fixture(%Firmwares.Firmware{id: source_id, uuid: source_uuid}, %Firmwares.Firmware{
+        id: target_id,
+        org_id: org_id,
+        uuid: target_uuid
+      }) do
     delta_metadata = %{
       "size" => 5,
       "source_size" => 7,
@@ -184,7 +188,7 @@ defmodule NervesHub.Fixtures do
         size: 500,
         source_size: 700,
         target_size: 1000,
-        upload_metadata: Map.merge(delta_metadata, @uploader.metadata(org_id, "#{Ecto.UUID.generate()}.fw"))
+        upload_metadata: Map.merge(delta_metadata, @uploader.delta_metadata(org_id, source_uuid, target_uuid))
       })
 
     firmware_delta


### PR DESCRIPTION
I borked the update firmware payload sent to device when sending a manual update.

This PR fixes this, plus as a test for future safety.