### PR TITLE
Org settings: Firmware proxy URL

### DIFF
--- a/lib/nerves_hub/accounts/org.ex
+++ b/lib/nerves_hub/accounts/org.ex
@@ -31,6 +31,10 @@ defmodule NervesHub.Accounts.Org do
     field(:deleted_at, :utc_datetime)
     field(:audit_log_days_to_keep, :integer)
 
+    embeds_one :settings, __MODULE__.Settings do
+      field(:firmware_proxy_url, :string)
+    end
+
     timestamps()
   end
 

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -761,8 +761,8 @@ defmodule NervesHub.Devices do
 
   def resolve_update(%Device{firmware_metadata: fw_meta} = device) do
     Logger.metadata(device_id: device.id, source_firmware_uuid: Map.get(fw_meta, :uuid))
-    {:ok, deployment_group} = ManagedDeployments.get_deployment_group_for_update(device)
     do_resolve_update(device, deployment_group)
+    {:ok, deployment_group} = ManagedDeployments.get_deployment_group(device)
   end
 
   defp do_resolve_update(device, deployment_group) do

--- a/lib/nerves_hub/events/device_events.ex
+++ b/lib/nerves_hub/events/device_events.ex
@@ -84,6 +84,13 @@ defmodule NervesHub.DeviceEvents do
           url
         end
 
+      firmware_url =
+        if opts[:firmware_proxy_url] do
+          opts[:firmware_proxy_url] <> "?firmware=#{Base.url_encode64(url, padding: false)}"
+        else
+          url
+        end
+
       {:ok, meta} = Firmwares.metadata_from_firmware(firmware)
       {:ok, device} = Devices.disable_updates(device, user)
 
@@ -91,7 +98,7 @@ defmodule NervesHub.DeviceEvents do
 
       payload = %UpdatePayload{
         update_available: true,
-        firmware_url: url,
+        firmware_url: firmware_url,
         firmware_meta: meta
       }
 

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -85,33 +85,19 @@ defmodule NervesHub.ManagedDeployments do
     |> Repo.all()
   end
 
-  @spec get_deployment_group_for_update(Device.t()) ::
-          {:ok, DeploymentGroup.t()} | {:error, :not_found}
-  def get_deployment_group_for_update(%Device{deployment_id: deployment_id}) do
-    DeploymentGroup
-    |> where([d], d.id == ^deployment_id)
-    |> join(:left, [d], f in assoc(d, :firmware))
-    |> preload([d, f], firmware: f)
-    |> preload(:product)
-    |> Repo.one()
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      deployment_group ->
-        {:ok, deployment_group}
-    end
-  end
-
-  @spec get_deployment_group(DeploymentGroup.t() | integer()) ::
+  @spec get_deployment_group(DeploymentGroup.t() | Device.t() | integer()) ::
           {:ok, DeploymentGroup.t()} | {:error, :not_found}
   def get_deployment_group(%DeploymentGroup{id: id}), do: get_deployment_group(id)
+
+  def get_deployment_group(%Device{deployment_id: deployment_id}), do: get_deployment_group(deployment_id)
 
   def get_deployment_group(deployment_id) do
     DeploymentGroup
     |> where([d], d.id == ^deployment_id)
     |> join(:left, [d], f in assoc(d, :firmware), as: :firmware)
-    |> preload([firmware: f], firmware: f)
+    |> join(:left, [d], p in assoc(d, :product), as: :product)
+    |> join(:left, [d], o in assoc(d, :org), as: :org)
+    |> preload([d, firmware: f, product: p, org: o], firmware: f, product: p, org: o)
     |> Repo.one()
     |> case do
       nil ->

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -20,7 +20,7 @@ defmodule NervesHub.ManagedDeployments do
 
   @spec should_run_orchestrator() :: [DeploymentGroup.t()]
   def should_run_orchestrator() do
-    DeploymentGroup
+    full_deployment_group_query()
     |> where(is_active: true)
     |> Repo.all()
   end
@@ -92,12 +92,8 @@ defmodule NervesHub.ManagedDeployments do
   def get_deployment_group(%Device{deployment_id: deployment_id}), do: get_deployment_group(deployment_id)
 
   def get_deployment_group(deployment_id) do
-    DeploymentGroup
+    full_deployment_group_query()
     |> where([d], d.id == ^deployment_id)
-    |> join(:left, [d], f in assoc(d, :firmware), as: :firmware)
-    |> join(:left, [d], p in assoc(d, :product), as: :product)
-    |> join(:left, [d], o in assoc(d, :org), as: :org)
-    |> preload([d, firmware: f, product: p, org: o], firmware: f, product: p, org: o)
     |> Repo.one()
     |> case do
       nil ->
@@ -106,6 +102,14 @@ defmodule NervesHub.ManagedDeployments do
       deployment ->
         {:ok, deployment}
     end
+  end
+
+  defp full_deployment_group_query() do
+    DeploymentGroup
+    |> join(:left, [d], f in assoc(d, :firmware), as: :firmware)
+    |> join(:left, [d], p in assoc(d, :product), as: :product)
+    |> join(:left, [d], o in assoc(d, :org), as: :org)
+    |> preload([d, firmware: f, product: p, org: o], firmware: f, product: p, org: o)
   end
 
   @spec get_by_product_and_name!(Product.t(), String.t(), boolean()) :: DeploymentGroup.t()

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -655,17 +655,24 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   def hooked_event("push-update", %{"uuid" => uuid}, socket) do
     authorized!(:"device:push-update", socket.assigns.org_user)
 
-    %{product: product, device: device, user: user} = socket.assigns
+    %{product: product, device: device, user: user, org: org} = socket.assigns
 
     {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(product, uuid)
 
-    Logger.info("Manually sending full firmware for updating from to #{firmware.uuid} to #{device.identifier}")
+    Logger.info("Manually sending full firmware", firmware_uuid: firmware.uuid, device_identifier: device.identifier)
 
-    DeviceEvents.manual_update(device, firmware, user)
+    opts =
+      if proxy_url = get_in(org.settings.firmware_proxy_url) do
+        [firmware_proxy_url: proxy_url]
+      else
+        []
+      end
+
+    {:ok, device} = DeviceEvents.manual_update(device, firmware, user, opts)
 
     socket
     |> assign(:device, device)
-    |> put_flash(:info, "Sending firmware update request.")
+    |> put_flash(:info, "Firmware update request requested.")
     |> halt()
   end
 
@@ -678,15 +685,25 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   def hooked_event("push-delta", %{"uuid" => uuid}, socket) do
     authorized!(:"device:push-update", socket.assigns.org_user)
 
-    %{product: product, device: %Device{} = device, user: user} = socket.assigns
+    %{product: product, device: device, user: user, org: org} = socket.assigns
 
     {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(product, uuid)
 
     Logger.info(
-      "Manually sending firmware delta for updating from #{device.firmware_metadata.uuid} to #{firmware.uuid} to #{device.identifier}"
+      "Manually sending firmware delta",
+      source_uuid: device.firmware_metadata.uuid,
+      target_uuid: firmware.uuid,
+      device_identifier: device.identifier
     )
 
-    DeviceEvents.manual_update(device, firmware, user, delta: true)
+    opts =
+      if proxy_url = get_in(org.settings.firmware_proxy_url) do
+        [firmware_proxy_url: proxy_url]
+      else
+        []
+      end
+
+    {:ok, device} = DeviceEvents.manual_update(device, firmware, user, opts ++ [delta: true])
 
     socket
     |> assign(:device, device)

--- a/priv/repo/migrations/20250919001236_add_org_settings.exs
+++ b/priv/repo/migrations/20250919001236_add_org_settings.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddOrgSettings do
+  use Ecto.Migration
+
+  def change() do
+    alter table("orgs") do
+      add(:settings, :map)
+    end
+  end
+end

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -912,14 +912,4 @@ defmodule NervesHub.ManagedDeploymentsTest do
     assert [] == ManagedDeployments.get_deployment_groups_by_firmware(123)
     assert length(ManagedDeployments.get_deployment_groups_by_firmware(firmware.id)) == 1
   end
-
-  test "get_deployment_group_for_update/1", %{deployment_group: deployment_group} do
-    assert {:ok, %DeploymentGroup{}} =
-             ManagedDeployments.get_deployment_group_for_update(%Device{
-               deployment_id: deployment_group.id
-             })
-
-    assert ManagedDeployments.get_deployment_group_for_update(%Device{deployment_id: 123}) ==
-             {:error, :not_found}
-  end
 end

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -675,6 +675,8 @@ defmodule NervesHubWeb.WebsocketTest do
         })
         |> ManagedDeployments.update_deployment_group(%{is_active: true})
 
+      deployment_group = Repo.preload(deployment_group, :org)
+
       device =
         Fixtures.device_fixture(
           org,

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -264,6 +264,8 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
         deployment_group: deployment_group
       }
     } do
+      deployment_group = Repo.preload(deployment_group, :org)
+
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
       |> assert_has("a", text: device.identifier, timeout: 1000)


### PR DESCRIPTION
This is a customer request that I felt had merit.

A NervesCloud customer requires custom firmware download URLs due to some of the complexities associated with whitelisting URLs with their customers.

This PR addresses this feature request by adding a `settings` field (and embedded schema) to the `Org` schema, adding a `firmware_proxy_url` field, and using this URL when creating the update payloads we send to devices.