### PR TITLE
Support log event exclusions

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,6 +52,7 @@ config :nerves_hub,
       days_to_keep: String.to_integer(System.get_env("EXTENSIONS_LOGGING_DAYS_TO_KEEP", "3"))
     ]
   ],
+  logger_exclusions: System.get_env("LOGGER_EXCLUSIONS"),
   new_ui: System.get_env("NEW_UI_ENABLED", "true") == "true"
 
 # only set this in :prod as not to override the :dev config

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,7 +52,7 @@ config :nerves_hub,
       days_to_keep: String.to_integer(System.get_env("EXTENSIONS_LOGGING_DAYS_TO_KEEP", "3"))
     ]
   ],
-  logger_exclusions: System.get_env("LOGGER_EXCLUSIONS"),
+  logger_exclusions: System.get_env("LOGGER_EXCLUSIONS", "") |> String.split(","),
   new_ui: System.get_env("NEW_UI_ENABLED", "true") == "true"
 
 # only set this in :prod as not to override the :dev config

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -13,7 +13,7 @@ defmodule NervesHub.Application do
     end
 
     setup_open_telemetry()
-    setup_logging()
+    _ = setup_logging()
 
     children =
       [{Finch, name: Swoosh.Finch}] ++

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -25,12 +25,6 @@ defmodule NervesHub.Logger do
 
   @doc false
   def attach() do
-    exclusions =
-      case Application.get_env(:nerves_hub, :logger_exclusions) do
-        nil -> []
-        exclusions -> String.split(exclusions, ",")
-      end
-
     events =
       [
         [:phoenix, :endpoint, :stop],
@@ -46,7 +40,9 @@ defmodule NervesHub.Logger do
         [:nerves_hub, :ssl, :fail]
       ]
 
-    for event <- events, not Enum.member?(exclusions, Enum.join(event, "_")) do
+    exclusions = Application.get_env(:nerves_hub, :logger_exclusions)
+
+    for event <- events, Enum.join(event, ".") not in exclusions do
       :ok = :telemetry.attach({__MODULE__, event}, event, &__MODULE__.log_event/4, :ok)
     end
   end

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -25,23 +25,30 @@ defmodule NervesHub.Logger do
 
   @doc false
   def attach() do
-    events = [
-      [:phoenix, :endpoint, :stop],
-      [:nerves_hub, :devices, :invalid_auth],
-      [:nerves_hub, :devices, :connect],
-      [:nerves_hub, :devices, :disconnect],
-      [:nerves_hub, :devices, :duplicate_connection],
-      [:nerves_hub, :devices, :update, :automatic],
-      [:nerves_hub, :devices, :update, :successful],
-      [:nerves_hub, :managed_deployments, :set_deployment_group, :none_found],
-      [:nerves_hub, :managed_deployments, :set_deployment_group, :one_found],
-      [:nerves_hub, :managed_deployments, :set_deployment_group, :multiple_found],
-      [:nerves_hub, :ssl, :fail]
-    ]
+    exclusions =
+      case Application.get_env(:nerves_hub, :logger_exclusions) do
+        nil -> []
+        exclusions -> String.split(exclusions, ",")
+      end
 
-    Enum.each(events, fn event ->
+    events =
+      [
+        [:phoenix, :endpoint, :stop],
+        [:nerves_hub, :devices, :invalid_auth],
+        [:nerves_hub, :devices, :connect],
+        [:nerves_hub, :devices, :disconnect],
+        [:nerves_hub, :devices, :duplicate_connection],
+        [:nerves_hub, :devices, :update, :automatic],
+        [:nerves_hub, :devices, :update, :successful],
+        [:nerves_hub, :managed_deployments, :set_deployment_group, :none_found],
+        [:nerves_hub, :managed_deployments, :set_deployment_group, :one_found],
+        [:nerves_hub, :managed_deployments, :set_deployment_group, :multiple_found],
+        [:nerves_hub, :ssl, :fail]
+      ]
+
+    for event <- events, not Enum.member?(exclusions, Enum.join(event, "_")) do
       :ok = :telemetry.attach({__MODULE__, event}, event, &__MODULE__.log_event/4, :ok)
-    end)
+    end
   end
 
   # Phoenix request logging


### PR DESCRIPTION
In some setups, you may not want the full verbosity of events in the logs. This adds a mechanism to include a `LOGGER_EXCLUSIONS` env var with a list of event keys that will be filtered out before telemetry attachment so that they will not be logged as well