### PR TITLE
Add a firmware validation filter when checking which devices are available for updating

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -727,6 +727,7 @@ defmodule NervesHub.Devices do
     |> join(:left, [d], ifu in InflightUpdate, on: d.id == ifu.device_id, as: :inflight_update)
     |> where(deployment_id: ^deployment_group.id)
     |> where(updates_enabled: true)
+    |> where([d], d.firmware_validation_status in [:validated, :unknown])
     |> where([latest_connection: lc], lc.status == :connected)
     |> where([d], not is_nil(d.firmware_metadata))
     |> where([d, firmware: f], fragment("(? #>> '{\"uuid\"}') != ?", d.firmware_metadata, f.uuid))

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -20,7 +20,7 @@ defmodule NervesHub.Devices.Device do
 
   @type t :: %__MODULE__{}
 
-  @type firmware_validation_statuses :: :validated | :not_validated | :unknown | :not_supported
+  @type firmware_validation_statuses :: :validated | :not_validated | :unknown
 
   @optional_params [
     :description,
@@ -75,8 +75,8 @@ defmodule NervesHub.Devices.Device do
     embeds_one(:firmware_metadata, FirmwareMetadata, on_replace: :update)
 
     field(:firmware_validation_status, Ecto.Enum,
-      values: [:validated, :not_validated, :unknown, :not_supported],
-      default: :not_supported
+      values: [:validated, :not_validated, :unknown],
+      default: :unknown
     )
 
     field(:firmware_auto_revert_detected, :boolean, default: false)

--- a/priv/repo/migrations/20250928002340_change_default_firmware_validation_status.exs
+++ b/priv/repo/migrations/20250928002340_change_default_firmware_validation_status.exs
@@ -1,0 +1,13 @@
+defmodule NervesHub.Repo.Migrations.ChangeDefaultFirmwareValidationStatus do
+  use Ecto.Migration
+
+  def up() do
+    execute(
+      "UPDATE devices SET firmware_validation_status = 'unknown' WHERE firmware_validation_status = 'not_supported'"
+    )
+  end
+
+  def down() do
+    # noop
+  end
+end

--- a/priv/repo/migrations/20250928010530_index_firmware_validation_status.exs
+++ b/priv/repo/migrations/20250928010530_index_firmware_validation_status.exs
@@ -1,0 +1,15 @@
+defmodule NervesHub.Repo.Migrations.IndexFirmwareValidationStatus do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    execute(
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS devices_firmware_validation_status_idx ON devices(firmware_validation_status);"
+    )
+  end
+
+  def down() do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS devices_firmware_validation_status_idx;")
+  end
+end

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -176,6 +176,44 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     assert_receive %Broadcast{topic: ^topic2, event: "update"}, 500
   end
 
+  test "doesn't try to update devices whos firmware is not validated", %{
+    product: product,
+    deployment_group: deployment_group,
+    org_key: org_key,
+    device: device
+  } do
+    # only allow for 1 update at a time
+    {:ok, deployment_group} =
+      ManagedDeployments.update_deployment_group(deployment_group, %{concurrent_updates: 1})
+
+    device = Devices.update_deployment_group(device, deployment_group)
+    {:ok, device} = Devices.update_device(device, %{firmware_validation_status: "not_validated"})
+    {:ok, connection} = Connections.device_connecting(device, device.product_id)
+    :ok = Connections.device_connected(device, connection.id)
+
+    topic1 = "device:#{device.id}"
+    Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
+
+    deployment_group_topic = "orchestrator:deployment:#{deployment_group.id}"
+    Phoenix.PubSub.subscribe(NervesHub.PubSub, deployment_group_topic)
+
+    {:ok, _pid} =
+      start_supervised(%{
+        id: "Orchestrator##{deployment_group.id}",
+        start: {Orchestrator, :start_link, [deployment_group, false]},
+        restart: :temporary
+      })
+
+    # create new firmware and update the deployment group with it
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    {:ok, _deployment_group} =
+      ManagedDeployments.update_deployment_group(deployment_group, %{firmware_id: firmware.id})
+
+    # check that the device is not told to update
+    refute_receive %Broadcast{topic: ^topic1, event: "update"}, 1_000
+  end
+
   test "the orchestrator doesn't 'trigger' if the device that came online is up-to-date", %{
     deployment_group: deployment_group,
     org_key: org_key,


### PR DESCRIPTION
If you have a device that has just come online and is yet to validate its firmware, and then another firmware is assigned to the deployment, its possible for that device to be sent the update even though Fwup will reject the update attempt until the firmware is validated.

Because Link doesn't send these errors to hub, the InflightUpdate is left in limbo, causing the device to not be sent the update for an hour, when the InflightUpdate is cleared away.

For devices that aren't sending firmware validation information to Hub (older Link versions), the filter allows for devices we don't know the validation status of, which just keeps the status quo logic.