### PR TITLE
Fix `push-available-update`, and add some tests for the future

### DIFF
--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -607,7 +607,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
 
     %{device: device, user: user} = socket.assigns
 
-    deployment_group = NervesHub.Repo.preload(device.deployment_group, :firmware)
+    deployment_group = NervesHub.Repo.preload(device.deployment_group, [:firmware, :org])
 
     case Devices.told_to_update(device, deployment_group) do
       {:ok, _inflight_update} ->


### PR DESCRIPTION
With the addition of `firmware_proxy_url` in #2354 , the ability to skip the queue was broken and was only discovered from a Sentry error.

This PR fixes the bork, and adds some tests for `Skip the queue`, which we were lacking.