### PR TITLE
Deployment Group validations improvements + live socket form recovery

### DIFF
--- a/lib/nerves_hub/archives.ex
+++ b/lib/nerves_hub/archives.ex
@@ -56,6 +56,17 @@ defmodule NervesHub.Archives do
     end
   end
 
+  def get_by_product_and_id(%Product{id: product_id}, id) do
+    Archive
+    |> where([a], a.id == ^id)
+    |> where([a], a.product_id == ^product_id)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      firmware -> {:ok, firmware}
+    end
+  end
+
   @spec get_by_product_and_uuid!(Product.t(), String.t()) :: Archive.t()
   def get_by_product_and_uuid!(product, uuid) do
     Archive

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -144,7 +144,7 @@ defmodule NervesHub.Firmwares do
     |> Enum.reverse()
   end
 
-  @spec get_firmware(Org.t(), integer()) ::
+  @spec get_firmware(Org.t() | Product.t(), integer()) ::
           {:ok, Firmware.t()}
           | {:error, :not_found}
   def get_firmware(_, nil) do
@@ -156,6 +156,17 @@ defmodule NervesHub.Firmwares do
     |> with_product()
     |> where([f], f.id == ^id)
     |> where([f, p], p.org_id == ^org_id)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      firmware -> {:ok, firmware}
+    end
+  end
+
+  def get_firmware(%Product{id: product_id}, id) do
+    Firmware
+    |> where([f], f.id == ^id)
+    |> where([f], f.product_id == ^product_id)
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -330,11 +330,12 @@ defmodule NervesHub.ManagedDeployments do
     Ecto.Changeset.change(%DeploymentGroup{})
   end
 
-  @spec create_deployment_group(map()) :: {:ok, DeploymentGroup.t()} | {:error, Changeset.t()}
-  def create_deployment_group(params) do
-    changeset = DeploymentGroup.create_changeset(%DeploymentGroup{}, params)
-
-    case Repo.insert(changeset) do
+  @spec create_deployment_group(map(), Product.t()) ::
+          {:ok, DeploymentGroup.t()} | {:error, Changeset.t()}
+  def create_deployment_group(params, %Product{} = product) do
+    DeploymentGroup.create_changeset(params, product)
+    |> Repo.insert()
+    |> case do
       {:ok, deployment_group} ->
         deployment_created_event(deployment_group)
 

--- a/lib/nerves_hub_web/controllers/api/deployment_group_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_group_controller.ex
@@ -32,10 +32,7 @@ defmodule NervesHubWeb.API.DeploymentGroupController do
       uuid ->
         with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
              params = Map.put(params, "firmware_id", firmware.id),
-             params = Map.put(params, "org_id", org.id),
-             params = Map.put(params, "product_id", product.id),
-             params = whitelist(params, @whitelist_fields),
-             {:ok, deployment_group} <- ManagedDeployments.create_deployment_group(params) do
+             {:ok, deployment_group} <- ManagedDeployments.create_deployment_group(params, product) do
           DeploymentGroupTemplates.audit_deployment_created(user, deployment_group)
 
           conn

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -39,7 +39,9 @@ defmodule NervesHub.SeedHelpers do
 
     firmwares = firmwares |> List.to_tuple()
 
-    Fixtures.deployment_group_fixture(org_with_keys_and_users, firmwares |> elem(2), %{
+    firmwares
+    |> elem(2)
+    |> Fixtures.deployment_group_fixture(%{
       conditions: %{"version" => "< 1.0.0", "tags" => ["beta"]}
     })
 

--- a/test/nerves_hub/accounts/remove_account_test.exs
+++ b/test/nerves_hub/accounts/remove_account_test.exs
@@ -11,7 +11,7 @@ defmodule NervesHub.Accounts.RemoveAccountTest do
     org_key = Fixtures.org_key_fixture(org, user)
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    Fixtures.deployment_group_fixture(org, firmware)
+    Fixtures.deployment_group_fixture(firmware)
 
     RemoveAccount.remove_account(user.id)
 
@@ -42,7 +42,7 @@ defmodule NervesHub.Accounts.RemoveAccountTest do
     org2_key = Fixtures.org_key_fixture(org2, org_user.user)
     org2_product = Fixtures.product_fixture(org_user.user, org2)
     org2_firmware = Fixtures.firmware_fixture(org2_key, org2_product)
-    Fixtures.deployment_group_fixture(org, org2_firmware)
+    Fixtures.deployment_group_fixture(org2_firmware)
 
     firmware2 = Fixtures.firmware_fixture(org_key, product)
     Fixtures.firmware_delta_fixture(firmware1, firmware2)
@@ -51,7 +51,7 @@ defmodule NervesHub.Accounts.RemoveAccountTest do
     org3_key = Fixtures.org_key_fixture(org3, org_user.user)
     org3_product = Fixtures.product_fixture(org_user.user, org3)
     org3_firmware = Fixtures.firmware_fixture(org3_key, org3_product)
-    Fixtures.deployment_group_fixture(org, org3_firmware)
+    Fixtures.deployment_group_fixture(org3_firmware)
 
     RemoveAccount.remove_account(user.id)
 

--- a/test/nerves_hub/devices/update_stats_test.exs
+++ b/test/nerves_hub/devices/update_stats_test.exs
@@ -18,7 +18,7 @@ defmodule NervesHub.Devices.UpdateStatsTest do
     target_firmware = Fixtures.firmware_fixture(org_key, product, %{version: "2.0.0"})
     other_firmware = Fixtures.firmware_fixture(org_key, product, %{version: "2.0.1"})
 
-    deployment_group = Fixtures.deployment_group_fixture(org, target_firmware, %{is_active: true})
+    deployment_group = Fixtures.deployment_group_fixture(target_firmware, %{is_active: true})
 
     device = Fixtures.device_fixture(org, product, source_firmware, %{status: :provisioned})
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -28,7 +28,7 @@ defmodule NervesHub.DevicesTest do
     product = Fixtures.product_fixture(user, org)
     org_key = Fixtures.org_key_fixture(org, user)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware, %{is_active: true})
+    deployment_group = Fixtures.deployment_group_fixture(firmware, %{is_active: true})
     device = Fixtures.device_fixture(org, product, firmware, %{status: :provisioned})
     device2 = Fixtures.device_fixture(org, product, firmware)
     device3 = Fixtures.device_fixture(org, product, firmware)
@@ -894,7 +894,7 @@ defmodule NervesHub.DevicesTest do
         |> Repo.update!()
 
       deployment_group =
-        Fixtures.deployment_group_fixture(org, new_firmware, %{
+        Fixtures.deployment_group_fixture(new_firmware, %{
           name: "Delta deployment updates",
           is_active: true,
           delta_updatable: true
@@ -1012,7 +1012,7 @@ defmodule NervesHub.DevicesTest do
 
       # create a deployment group for org one with the new firmware
       deployment_group =
-        Fixtures.deployment_group_fixture(org_one, new_firmware_one, %{
+        Fixtures.deployment_group_fixture(new_firmware_one, %{
           name: "Delta deployment updates",
           is_active: true,
           delta_updatable: true

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -74,14 +74,13 @@ defmodule NervesHub.FirmwaresTest do
     end
 
     test "cannot delete firmware when it is referenced by deployment", %{
-      org: org,
       org_key: org_key,
       product: product
     } do
       firmware = Fixtures.firmware_fixture(org_key, product)
       assert File.exists?(firmware.upload_metadata[:local_path])
 
-      Fixtures.deployment_group_fixture(org, firmware, %{name: "a deployment"})
+      Fixtures.deployment_group_fixture(firmware, %{name: "a deployment"})
 
       assert {:error, %Changeset{}} = Firmwares.delete_firmware(firmware)
     end

--- a/test/nerves_hub/managed_deployments/deployment_group_test.exs
+++ b/test/nerves_hub/managed_deployments/deployment_group_test.exs
@@ -3,148 +3,143 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
 
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments.DeploymentGroup
-  alias NervesHub.ManagedDeployments.DeploymentGroup.Conditions
   alias NervesHub.Repo
 
-  describe "shared changeset validations" do
+  describe "create_changeset/2" do
     setup do
-      deployment_group = %DeploymentGroup{
-        org_id: 1,
-        firmware_id: 1,
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user)
+      firmware = Fixtures.firmware_fixture(org_key, product)
+
+      deployment_group_params = %{
         name: "Bestest Devices",
-        conditions: %Conditions{
+        conditions: %{
           tags: ["foo"],
           version: "1.2.3"
         },
-        is_active: true,
-        product_id: 1,
-        concurrent_updates: 1000,
-        inflight_update_expiration_minutes: 10
+        firmware_id: firmware.id
       }
 
-      %{deployment_group: deployment_group, functions: [:create_changeset, :update_changeset]}
+      %{deployment_group_params: deployment_group_params, product: product}
     end
 
-    test "cannot clear conditions", %{
-      deployment_group: deployment_group,
-      functions: functions
+    test "conditions are required", %{
+      deployment_group_params: deployment_group_params,
+      product: product
     } do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: nil
-            }
-          ])
+      changeset =
+        deployment_group_params
+        |> Map.put(:conditions, nil)
+        |> DeploymentGroup.create_changeset(product)
 
-        refute changeset.valid?
-        refute Enum.empty?(errors_on(changeset).conditions)
-      end
+      refute changeset.valid?
+      refute Enum.empty?(errors_on(changeset).conditions)
     end
 
-    test "tags can be cleared", %{deployment_group: deployment_group, functions: functions} do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: %{"version" => "1.2.0", "tags" => []}
-            }
-          ])
+    test "tags can be empty", %{deployment_group_params: deployment_group_params, product: product} do
+      changeset =
+        deployment_group_params
+        |> Map.put(:conditions, %{"version" => "1.2.0", "tags" => []})
+        |> DeploymentGroup.create_changeset(product)
 
-        assert changeset.valid?
-      end
-    end
-
-    test "tags can be updated independently of version", %{
-      deployment_group: deployment_group,
-      functions: functions
-    } do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: %{"tags" => []}
-            }
-          ])
-
-        assert changeset.valid?
-      end
-    end
-
-    test "version can be updated independently of tags", %{
-      deployment_group: deployment_group,
-      functions: functions
-    } do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: %{"version" => "10.3.4"}
-            }
-          ])
-
-        assert changeset.valid?
-      end
+      assert changeset.valid?
     end
 
     test "version can be an empty string", %{
-      deployment_group: deployment_group,
-      functions: functions
+      deployment_group_params: deployment_group_params,
+      product: product
     } do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: %{"version" => "", "tags" => []}
-            }
-          ])
+      changeset =
+        deployment_group_params
+        |> Map.put(:conditions, %{"version" => "", "tags" => []})
+        |> DeploymentGroup.create_changeset(product)
 
-        assert changeset.valid?
-      end
+      assert changeset.valid?
     end
 
-    test "a nil version is modified to be blank", %{deployment_group: deployment_group, functions: functions} do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: %{"version" => nil, "tags" => []}
-            }
-          ])
+    test "a nil version is modified to be blank", %{
+      deployment_group_params: deployment_group_params,
+      product: product
+    } do
+      changeset =
+        deployment_group_params
+        |> Map.put(:conditions, %{version: nil, tags: []})
+        |> DeploymentGroup.create_changeset(product)
 
-        assert changeset.valid?
-        assert changeset.changes.conditions.changes.version == ""
-      end
+      assert changeset.valid?
+      assert Enum.empty?(changeset.changes.conditions.changes)
     end
 
     test "version must be a valid Elixir.Version", %{
-      deployment_group: deployment_group,
-      functions: functions
+      deployment_group_params: deployment_group_params,
+      product: product
     } do
-      for function <- functions do
-        changeset =
-          apply(DeploymentGroup, function, [
-            deployment_group,
-            %{
-              conditions: %{"version" => "1.2.3.5.6", "tags" => []}
-            }
-          ])
+      changeset =
+        deployment_group_params
+        |> Map.put(:conditions, %{"version" => "1.2.3.5.6", "tags" => []})
+        |> DeploymentGroup.create_changeset(product)
 
-        refute changeset.valid?
-        assert errors_on(changeset).conditions.version == ["must be valid Elixir version requirement string"]
-      end
+      refute changeset.valid?
+      assert errors_on(changeset).conditions.version == ["must be valid Elixir version requirement string"]
     end
   end
 
   describe "update_changeset/2" do
     setup do
       Fixtures.standard_fixture()
+    end
+
+    test "cannot clear conditions", %{deployment_group: deployment_group} do
+      changeset = DeploymentGroup.update_changeset(deployment_group, %{conditions: nil})
+
+      refute changeset.valid?
+      refute Enum.empty?(errors_on(changeset).conditions)
+    end
+
+    test "tags can be cleared", %{deployment_group: deployment_group} do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{conditions: %{"version" => "1.2.0", "tags" => []}})
+
+      assert changeset.valid?
+    end
+
+    test "tags can be updated independently of version", %{
+      deployment_group: deployment_group
+    } do
+      changeset = DeploymentGroup.update_changeset(deployment_group, %{conditions: %{"tags" => []}})
+      assert changeset.valid?
+    end
+
+    test "version can be updated independently of tags", %{deployment_group: deployment_group} do
+      changeset = DeploymentGroup.update_changeset(deployment_group, %{conditions: %{"version" => "10.3.4"}})
+      assert changeset.valid?
+    end
+
+    test "version can be an empty string", %{deployment_group: deployment_group} do
+      changeset = DeploymentGroup.update_changeset(deployment_group, %{conditions: %{"version" => "", "tags" => []}})
+      assert changeset.valid?
+    end
+
+    test "a nil version is modified to be blank", %{deployment_group: deployment_group} do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          conditions: %{version: nil, tags: []}
+        })
+
+      assert changeset.valid?
+      assert changeset.changes.conditions.changes.version == ""
+    end
+
+    test "version must be a valid Elixir.Version", %{deployment_group: deployment_group} do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          conditions: %{"version" => "1.2.3.5.6", "tags" => []}
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset.changes.conditions).version == ["must be valid Elixir version requirement string"]
     end
 
     test "current_updated_devices is reset when firmware changes", %{
@@ -162,6 +157,42 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
       assert changeset.valid?
       deployment_group = Repo.update!(changeset)
       assert deployment_group.current_updated_devices == 0
+    end
+
+    test "firmware cannot be from a different org", %{
+      deployment_group: deployment_group
+    } do
+      new_user = Fixtures.user_fixture(%{email: "user2@test.com"})
+      new_org = Fixtures.org_fixture(new_user, %{name: "org2"})
+      new_product = Fixtures.product_fixture(new_user, new_org)
+      new_org_key = Fixtures.org_key_fixture(new_org, new_user)
+      new_firmware = Fixtures.firmware_fixture(new_org_key, new_product)
+
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          "firmware_id" => new_firmware.id
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset) == %{firmware_id: ["does not exist"]}
+    end
+
+    test "archive cannot be from a different org", %{
+      deployment_group: deployment_group
+    } do
+      new_user = Fixtures.user_fixture(%{email: "user2@test.com"})
+      new_org = Fixtures.org_fixture(new_user, %{name: "org2"})
+      new_product = Fixtures.product_fixture(new_user, new_org)
+      new_org_key = Fixtures.org_key_fixture(new_org, new_user)
+      new_archive = Fixtures.archive_fixture(new_org_key, new_product)
+
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          "archive_id" => new_archive.id
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset) == %{archive_id: ["invalid archive"]}
     end
   end
 end

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -24,7 +24,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     firmware = Fixtures.firmware_fixture(org_key, product)
 
     {:ok, deployment_group} =
-      Fixtures.deployment_group_fixture(org, firmware, %{is_active: true})
+      Fixtures.deployment_group_fixture(firmware, %{is_active: true})
       |> ManagedDeployments.update_deployment_group_status(:ready)
 
     device = Fixtures.device_fixture(org, product, firmware, %{status: :provisioned})

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -464,7 +464,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     device = NervesHub.Repo.preload(device, :org)
 
     new_deployment_group =
-      Fixtures.deployment_group_fixture(device.org, firmware, %{name: "Super Deployment"})
+      Fixtures.deployment_group_fixture(firmware, %{name: "Super Deployment"})
 
     Devices.update_deployment_group(device, new_deployment_group)
 
@@ -590,7 +590,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
         version: "0.0.1"
       })
 
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     params = Enum.into(device_params, %{tags: ["beta", "beta-edge"]})
 
@@ -612,7 +612,9 @@ defmodule NervesHubWeb.DeviceChannelTest do
     org_key = Fixtures.org_key_fixture(org, user)
     archive = %{uuid: archive_uuid} = Fixtures.archive_fixture(org_key, product)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: System.tmp_dir()})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware, %{archive_id: archive.id})
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
+
+    ManagedDeployments.update_deployment_group(deployment_group, %{archive_id: archive.id})
 
     {device, _firmware, _deployment_group} =
       device_fixture(user, %{identifier: "123", deployment_id: deployment_group.id})

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -407,7 +407,7 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
         version: "0.0.1"
       })
 
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     params = Enum.into(device_params, %{tags: ["beta", "beta-edge"]})
 

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -666,7 +666,7 @@ defmodule NervesHubWeb.WebsocketTest do
         |> Repo.preload([:product])
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, firmware, %{
+        Fixtures.deployment_group_fixture(firmware, %{
           name: "a different name",
           conditions: %{
             "version" => "<= 1.0.0",
@@ -769,7 +769,7 @@ defmodule NervesHubWeb.WebsocketTest do
         })
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, firmware, %{
+        Fixtures.deployment_group_fixture(firmware, %{
           name: "Every Device",
           conditions: %{
             "version" => "<= 1.0.0",
@@ -836,7 +836,7 @@ defmodule NervesHubWeb.WebsocketTest do
         })
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, firmware, %{
+        Fixtures.deployment_group_fixture(firmware, %{
           name: "a different name",
           conditions: %{
             "version" => "<= 1.0.0",
@@ -902,7 +902,7 @@ defmodule NervesHubWeb.WebsocketTest do
         })
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, target_firmware, %{
+        Fixtures.deployment_group_fixture(target_firmware, %{
           name: "Every Device",
           conditions: %{
             "version" => "<= 1.0.0",
@@ -1134,15 +1134,14 @@ defmodule NervesHubWeb.WebsocketTest do
       archive = Fixtures.archive_fixture(org_key, product, %{dir: tmp_dir})
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, firmware, %{
+        Fixtures.deployment_group_fixture(firmware, %{
           name: "beta",
           conditions: %{
             "version" => "<= 1.0.0",
             "tags" => ["beta"]
-          },
-          archive_id: archive.id
+          }
         })
-        |> ManagedDeployments.update_deployment_group(%{is_active: true})
+        |> ManagedDeployments.update_deployment_group(%{is_active: true, archive_id: archive.id})
 
       device =
         Fixtures.device_fixture(
@@ -1188,15 +1187,14 @@ defmodule NervesHubWeb.WebsocketTest do
       archive = Fixtures.archive_fixture(org_key, product, %{dir: tmp_dir})
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, firmware, %{
+        Fixtures.deployment_group_fixture(firmware, %{
           name: "beta",
           conditions: %{
             "version" => "<= 1.0.0",
             "tags" => ["beta"]
-          },
-          archive_id: archive.id
+          }
         })
-        |> ManagedDeployments.update_deployment_group(%{is_active: true})
+        |> ManagedDeployments.update_deployment_group(%{is_active: true, archive_id: archive.id})
 
       device =
         Fixtures.device_fixture(
@@ -1246,7 +1244,7 @@ defmodule NervesHubWeb.WebsocketTest do
         |> Repo.preload([:product])
 
       {:ok, deployment_group} =
-        Fixtures.deployment_group_fixture(org, firmware, %{
+        Fixtures.deployment_group_fixture(firmware, %{
           name: "beta",
           conditions: %{
             "version" => "<= 1.0.0",

--- a/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
@@ -234,7 +234,7 @@ defmodule NervesHubWeb.API.DeploymentGroupControllerTest do
   defp create_deployment_group(%{user: user, org: org, product: product}) do
     org_key = Fixtures.org_key_fixture(org, user)
     firmware = Fixtures.firmware_fixture(org_key, product)
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
     {:ok, %{deployment_group: deployment_group}}
   end
 end

--- a/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
@@ -89,7 +89,7 @@ defmodule NervesHubWeb.API.FirmwareControllerTest do
       product: product,
       firmware: firmware
     } do
-      Fixtures.deployment_group_fixture(org, firmware)
+      Fixtures.deployment_group_fixture(firmware)
 
       conn =
         delete(

--- a/test/nerves_hub_web/live/deployment_groups/index_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/index_test.exs
@@ -155,7 +155,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.IndexTest do
       deployment_group: deployment_group
     } do
       for i <- 1..26 do
-        Fixtures.deployment_group_fixture(org, deployment_group.firmware, %{
+        Fixtures.deployment_group_fixture(deployment_group.firmware, %{
           name: "Deployment-group-#{i}"
         })
       end

--- a/test/nerves_hub_web/live/deployment_groups/new_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/new_test.exs
@@ -56,7 +56,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.NewTest do
         |> render_submit(%{deployment_group: %{"firmware_id" => -1}})
       end)
       |> assert_path("/org/#{org.name}/#{product.name}/deployment_groups/new")
-      |> assert_has("div", text: "Invalid firmware selected")
+      |> assert_has("p", text: "does not exist")
     end
 
     test "redirects to firmware upload firmware_id is passed and no firmwares are found" do

--- a/test/nerves_hub_web/live/deployment_groups/show_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show_test.exs
@@ -18,7 +18,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}")
@@ -44,7 +44,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
     %Device{} = Devices.update_deployment_group(device, deployment_group)
 
     # deleted devices shouldn't be included in the count
@@ -74,7 +74,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/settings")
@@ -100,7 +100,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
     device = Fixtures.device_fixture(org, product, firmware)
 
     device = Devices.update_deployment_group(device, deployment_group)
@@ -133,7 +133,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}")
@@ -177,7 +177,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     _device1 =
       Fixtures.device_fixture(org, product, firmware, %{
@@ -205,7 +205,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     device1 =
       Fixtures.device_fixture(org, product, firmware, %{
@@ -242,7 +242,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.ShowTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     device1 =
       Fixtures.device_fixture(org, product, firmware, %{

--- a/test/nerves_hub_web/live/firmware_test.exs
+++ b/test/nerves_hub_web/live/firmware_test.exs
@@ -60,7 +60,7 @@ defmodule NervesHubWeb.Live.FirmwareTest do
       firmware = Fixtures.firmware_fixture(org_key, product)
 
       # Create a deployment from the firmware
-      Fixtures.deployment_group_fixture(org, firmware)
+      Fixtures.deployment_group_fixture(firmware)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/firmware/#{firmware.uuid}")

--- a/test/nerves_hub_web/live/new_ui/deployment_groups/settings_test.exs
+++ b/test/nerves_hub_web/live/new_ui/deployment_groups/settings_test.exs
@@ -70,7 +70,7 @@ defmodule NervesHubWeb.Live.NewUI.DeploymentGroups.SettingsTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     conn =
       conn
@@ -109,7 +109,7 @@ defmodule NervesHubWeb.Live.NewUI.DeploymentGroups.SettingsTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/settings")
@@ -130,7 +130,7 @@ defmodule NervesHubWeb.Live.NewUI.DeploymentGroups.SettingsTest do
   } do
     product = Fixtures.product_fixture(user, org)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    deployment_group = Fixtures.deployment_group_fixture(org, firmware)
+    deployment_group = Fixtures.deployment_group_fixture(firmware)
 
     conn
     |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/settings")

--- a/test/nerves_hub_web/live/new_ui/deployment_groups/show_test.exs
+++ b/test/nerves_hub_web/live/new_ui/deployment_groups/show_test.exs
@@ -24,7 +24,7 @@ defmodule NervesHubWeb.Live.NewUI.DeploymentGroups.ShowTest do
       Fixtures.firmware_fixture(org_key, product, %{version: "2.0.0", dir: tmp_dir})
 
     deployment_group =
-      Fixtures.deployment_group_fixture(org, target_firmware, %{
+      Fixtures.deployment_group_fixture(target_firmware, %{
         is_active: true,
         name: "Coolest Deployment"
       })

--- a/test/nerves_hub_web/live/new_ui/devices/show_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/show_test.exs
@@ -137,12 +137,12 @@ defmodule NervesHubWeb.Live.NewUI.Devices.ShowTest do
         Fixtures.firmware_fixture(org_key2, product, %{platform: "Vulture", architecture: "arm"})
 
       mismatched_firmware_deployment_group =
-        Fixtures.deployment_group_fixture(org, mismatched_firmware, %{
+        Fixtures.deployment_group_fixture(mismatched_firmware, %{
           name: "Vulture Deployment 2025"
         })
 
       deployment_group2 =
-        Fixtures.deployment_group_fixture(org, firmware, %{name: "Beta Deployment"})
+        Fixtures.deployment_group_fixture(firmware, %{name: "Beta Deployment"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -166,12 +166,12 @@ defmodule NervesHubWeb.Live.NewUI.Devices.ShowTest do
       firmware2 = Fixtures.firmware_fixture(org_key2, product2)
 
       deployment_group_from_product2 =
-        Fixtures.deployment_group_fixture(org, firmware2, %{
+        Fixtures.deployment_group_fixture(firmware2, %{
           name: "Vulture Deployment 2025"
         })
 
       deployment_group2 =
-        Fixtures.deployment_group_fixture(org, firmware, %{name: "Beta Deployment"})
+        Fixtures.deployment_group_fixture(firmware, %{name: "Beta Deployment"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -222,14 +222,14 @@ defmodule NervesHub.Fixtures do
     archive
   end
 
-  def deployment_group_fixture(%Org{} = org, %Firmwares.Firmware{} = firmware, params \\ %{}) do
+  def deployment_group_fixture(%Firmwares.Firmware{} = firmware, params \\ %{}) do
     {is_active, params} = Map.pop(params, :is_active, false)
 
     {:ok, deployment_group} =
-      %{org_id: org.id, firmware_id: firmware.id, product_id: firmware.product_id}
-      |> Enum.into(params)
+      params
+      |> Map.put(:firmware_id, firmware.id)
       |> Enum.into(@deployment_group_params)
-      |> ManagedDeployments.create_deployment_group()
+      |> ManagedDeployments.create_deployment_group(%Product{id: firmware.product_id})
 
     {:ok, deployment_group} =
       ManagedDeployments.update_deployment_group(deployment_group, %{is_active: is_active})
@@ -433,7 +433,7 @@ defmodule NervesHub.Fixtures do
     product = product_fixture(user, org, %{name: "Hop"})
     org_key = org_key_fixture(org, user, dir)
     firmware = firmware_fixture(org_key, product, %{dir: dir})
-    deployment_group = deployment_group_fixture(org, firmware)
+    deployment_group = deployment_group_fixture(firmware)
     device = device_fixture(org, product, firmware)
     %{db_cert: device_certificate} = device_certificate_fixture(device)
 


### PR DESCRIPTION
The core of this PR is focused on Deployment Group settings form recovery, with the following highlights also addressed:

- Remove the use of `whitelist`ing params from Deployment Group controllers (thats what changesets are for)
- Fix an issue where firmware or archives from another Org could be assigned to a Deployment
- An overhaul of the Deployment Group validations, including addressing an issue where some fields could be set to negative values
- Use `assoc_constraint` to make sure firmware, archives, and the associated product and org exist
- Remove a duplicated device count `prepare_changes`