### PR TITLE
Enable metrics in Phoenix LiveDashboard

### DIFF
--- a/lib/nerves_hub/statsd_metrics_reporter.ex
+++ b/lib/nerves_hub/statsd_metrics_reporter.ex
@@ -10,64 +10,7 @@ defmodule NervesHub.StatsdMetricsReporter do
          host: statsd_config[:host],
          port: statsd_config[:port],
          formatter: :datadog,
-         metrics: [
-           # NervesHub
-           counter("nerves_hub.devices.connect.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.disconnect.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.duplicate_connection", tags: [:env, :service]),
-           counter("nerves_hub.devices.stale_connections", tags: [:env, :service]),
-           counter("nerves_hub.devices.update.manual.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.update.automatic.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.deployment.penalty_box.check.count",
-             tags: [:env, :service]
-           ),
-           counter("nerves_hub.deployments.trigger_update.count", tags: [:env, :service]),
-           counter("nerves_hub.deployments.trigger_update.device.count", tags: [:env, :service]),
-           counter("nerves_hub.devices.jitp.created.count", tags: [:env, :service]),
-           counter("nerves_hub.device_certificates.created.count", tags: [:env, :service]),
-           last_value("nerves_hub.devices.online.count", tags: [:env, :service, :node]),
-           counter("nerves_hub.rate_limit.accepted.count", tags: [:env, :service]),
-           counter("nerves_hub.rate_limit.pruned.count", tags: [:env, :service]),
-           counter("nerves_hub.rate_limit.rejected.count", tags: [:env, :service]),
-           counter("nerves_hub.ssl.fail.count", tags: [:env, :service]),
-           counter("nerves_hub.ssl.success.count", tags: [:env, :service]),
-           counter("nerves_hub.tracker.exception.count", tags: [:env, :service]),
-           # General
-           counter("phoenix.endpoint.start.count", tags: [:env, :service]),
-           summary("phoenix.endpoint.stop.duration",
-             tags: [:env, :service],
-             unit: {:native, :millisecond}
-           ),
-           summary("phoenix.router_dispatch.stop.duration",
-             tags: [:route, :env, :service],
-             unit: {:native, :millisecond}
-           ),
-           counter("nerves_hub.repo.query.count", tags: [:env, :service]),
-           distribution("nerves_hub.repo.query.idle_time",
-             tags: [:env, :service],
-             unit: {:native, :millisecond}
-           ),
-           distribution("nerves_hub.repo.query.queue_time",
-             tags: [:env, :service],
-             unit: {:native, :millisecond}
-           ),
-           distribution("nerves_hub.repo.query.query_time",
-             tags: [:env, :service],
-             unit: {:native, :millisecond}
-           ),
-           distribution("nerves_hub.repo.query.decode_time",
-             tags: [:env, :service],
-             unit: {:native, :millisecond}
-           ),
-           distribution("nerves_hub.repo.query.total_time",
-             tags: [:env, :service],
-             unit: {:native, :millisecond}
-           ),
-           summary("vm.memory.total", tags: [:env, :service], unit: {:byte, :kilobyte}),
-           summary("vm.total_run_queue_lengths.total", tags: [:env, :service]),
-           summary("vm.total_run_queue_lengths.cpu", tags: [:env, :service]),
-           summary("vm.total_run_queue_lengths.io", tags: [:env, :service])
-         ],
+         metrics: metrics(),
          global_tags: [
            env: Application.get_env(:nerves_hub, :deploy_env),
            dyno: Application.get_env(:nerves_hub, :app),
@@ -77,5 +20,66 @@ defmodule NervesHub.StatsdMetricsReporter do
     else
       []
     end
+  end
+
+  def metrics() do
+    [
+      # NervesHub
+      counter("nerves_hub.devices.connect.count", tags: [:env, :service]),
+      counter("nerves_hub.devices.disconnect.count", tags: [:env, :service]),
+      counter("nerves_hub.devices.duplicate_connection", tags: [:env, :service]),
+      counter("nerves_hub.devices.stale_connections", tags: [:env, :service]),
+      counter("nerves_hub.devices.update.manual.count", tags: [:env, :service]),
+      counter("nerves_hub.devices.update.automatic.count", tags: [:env, :service]),
+      counter("nerves_hub.devices.deployment.penalty_box.check.count",
+        tags: [:env, :service]
+      ),
+      counter("nerves_hub.deployments.trigger_update.count", tags: [:env, :service]),
+      counter("nerves_hub.deployments.trigger_update.device.count", tags: [:env, :service]),
+      counter("nerves_hub.devices.jitp.created.count", tags: [:env, :service]),
+      counter("nerves_hub.device_certificates.created.count", tags: [:env, :service]),
+      last_value("nerves_hub.devices.online.count", tags: [:env, :service, :node]),
+      counter("nerves_hub.rate_limit.accepted.count", tags: [:env, :service]),
+      counter("nerves_hub.rate_limit.pruned.count", tags: [:env, :service]),
+      counter("nerves_hub.rate_limit.rejected.count", tags: [:env, :service]),
+      counter("nerves_hub.ssl.fail.count", tags: [:env, :service]),
+      counter("nerves_hub.ssl.success.count", tags: [:env, :service]),
+      counter("nerves_hub.tracker.exception.count", tags: [:env, :service]),
+      # General
+      counter("phoenix.endpoint.start.count", tags: [:env, :service]),
+      summary("phoenix.endpoint.stop.duration",
+        tags: [:env, :service],
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.router_dispatch.stop.duration",
+        tags: [:route, :env, :service],
+        unit: {:native, :millisecond}
+      ),
+      counter("nerves_hub.repo.query.count", tags: [:env, :service]),
+      distribution("nerves_hub.repo.query.idle_time",
+        tags: [:env, :service],
+        unit: {:native, :millisecond}
+      ),
+      distribution("nerves_hub.repo.query.queue_time",
+        tags: [:env, :service],
+        unit: {:native, :millisecond}
+      ),
+      distribution("nerves_hub.repo.query.query_time",
+        tags: [:env, :service],
+        unit: {:native, :millisecond}
+      ),
+      distribution("nerves_hub.repo.query.decode_time",
+        tags: [:env, :service],
+        unit: {:native, :millisecond}
+      ),
+      distribution("nerves_hub.repo.query.total_time",
+        tags: [:env, :service],
+        unit: {:native, :millisecond}
+      ),
+      summary("vm.memory.total", tags: [:env, :service], unit: {:byte, :kilobyte}),
+      summary("vm.total_run_queue_lengths.total", tags: [:env, :service]),
+      summary("vm.total_run_queue_lengths.cpu", tags: [:env, :service]),
+      summary("vm.total_run_queue_lengths.io", tags: [:env, :service])
+    ]
   end
 end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -398,7 +398,7 @@ defmodule NervesHubWeb.Router do
 
   scope "/" do
     pipe_through([:browser, :logged_in, NervesHubWeb.Plugs.ServerAuth])
-    live_dashboard("/status/dashboard")
+    live_dashboard("/status/dashboard", metrics: NervesHub.StatsdMetricsReporter)
     oban_dashboard("/status/oban", resolver: NervesHubWeb.Plugs.ServerAuth)
   end
 


### PR DESCRIPTION
This change only restructures the StatsdMetricsReporter module so that it can be used with LiveDashboard to show pretty metrics

<img width="1840" height="1167" alt="image" src="https://github.com/user-attachments/assets/62d27e8e-3045-4758-b589-9b5f0b35507f" />
