### PR TITLE
Fix deployment group tags being merged when editing settings

### DIFF
--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
   alias NervesHub.Firmwares.Firmware
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHubWeb.Components.Utils
 
   @impl Phoenix.LiveComponent
   def update(assigns, socket) do
@@ -94,7 +95,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
             </div>
             <.inputs_for :let={conditions} field={@form[:conditions]}>
               <div class="w-1/2">
-                <.input field={conditions[:tags]} label="Tag(s) distributed to" placeholder="eg. batch-123" />
+                <.input field={conditions[:tags]} value={Utils.tags_to_string(conditions[:tags])} label="Tag(s) distributed to" placeholder="eg. batch-123" />
               </div>
 
               <div class="w-1/2">


### PR DESCRIPTION
Previously they were merged into a single string with no comma separation. Fixes #2393 

https://github.com/user-attachments/assets/2caee870-bfdb-40d2-b08e-0998509e8b51

