### PR TITLE
Fix device index refresh list callback

### DIFF
--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -471,19 +471,20 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> noreply()
   end
 
-  def handle_info(:refresh_device_list, socket) do
-    if socket.assigns.visible? do
-      Tracer.with_span "NervesHubWeb.Live.Devices.Index.refresh_device_list" do
-        Process.send_after(self(), :refresh_device_list, @list_refresh_time)
-
-        socket
-        |> safe_refresh()
-        |> noreply()
-      end
+  def handle_info(:refresh_device_list, %{assigns: %{visible?: true}} = socket) do
+    Tracer.with_span "NervesHubWeb.Live.Devices.Index.refresh_device_list" do
+      Process.send_after(self(), :refresh_device_list, @list_refresh_time)
 
       socket
+      |> safe_refresh()
       |> noreply()
     end
+
+    noreply(socket)
+  end
+
+  def handle_info(:refresh_device_list, socket) do
+    noreply(socket)
   end
 
   def handle_info(:live_refresh, socket) do

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -21,6 +21,35 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
     assert render_async(lv) =~ device.identifier
   end
 
+  describe "refreshing device list" do
+    test "refreshes when page is visible", %{conn: conn, fixture: fixture} do
+      %{device: device, org: org, product: product} = fixture
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices")
+      |> assert_has("span", text: device.firmware_metadata.version, timeout: 1000)
+      |> unwrap(fn view ->
+        # TODO: (nshoes)
+        # The original intent of this test was to update the firmware version and allow the
+        # liveview to refresh and assert on the new version. However, PhoenixTest doesn't seem
+        # to trigger the `Phoenix.LiveView.handle_async/3` callback, making testing
+        # the refreshed results impossible.
+        #
+        # As it stands, this test just makes sure there's no regression in the `refresh_device_list`
+        # message handling.
+
+        # {:ok, device} =
+        #   Devices.update_device(device, %{
+        #     firmware_metadata: %{Map.from_struct(device.firmware_metadata) | version: "2.0.0"}
+        #   })
+
+        send(view.pid, :refresh_device_list)
+
+        render(view)
+      end)
+    end
+  end
+
   describe "device connection status updates" do
     setup context do
       Map.merge(context, %{offline_indicator_color: "#71717A", online_indicator_color: "#10B981"})


### PR DESCRIPTION
This fixes a `nil` return in a LiveView callback when the device list is refreshed and the page isn't visible.