### PR TITLE
Only take into account a device's latest connection when processing online and offline counts for products and orgs

### DIFF
--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -27,22 +27,12 @@ defmodule NervesHub.Devices.Connections do
           non_neg_integer() => %{online: non_neg_integer(), offline: non_neg_integer()}
         }
   def get_connection_status_by_orgs(org_ids) when is_list(org_ids) do
-    q =
-      DeviceConnection
-      |> join(:inner, [d], p in assoc(d, :product))
-      |> select([d, p], [p.org_id, count(d.id)])
-      |> where([_, p], p.org_id in ^org_ids)
-      |> group_by([_, p], p.org_id)
-
-    online =
-      q
-      |> where([d], d.status == :connected)
-      |> Repo.all()
-
-    offline =
-      q
-      |> where([d], d.status != :connected)
-      |> Repo.all()
+    %{online: online, offline: offline} =
+      connection_status_base_query()
+      |> where([_, p, _], p.org_id in ^org_ids)
+      |> select([dc, p], [p.org_id, count(dc.id)])
+      |> group_by([_, p, _], p.org_id)
+      |> connection_status_counts()
 
     for org_id <- org_ids, into: %{} do
       {org_id, %{online: 0, offline: 0}}
@@ -58,28 +48,31 @@ defmodule NervesHub.Devices.Connections do
           non_neg_integer() => %{online: non_neg_integer(), offline: non_neg_integer()}
         }
   def get_connection_status_by_products(product_ids) when is_list(product_ids) do
-    q =
-      DeviceConnection
-      |> join(:inner, [d], p in assoc(d, :product))
-      |> select([d, p], [p.id, count(d.id)])
+    %{online: online, offline: offline} =
+      connection_status_base_query()
       |> where([_, p], p.id in ^product_ids)
+      |> select([dc, p], [p.id, count(dc.id)])
       |> group_by([_, p], p.id)
-
-    online =
-      q
-      |> where([d], d.status == :connected)
-      |> Repo.all()
-
-    offline =
-      q
-      |> where([d], d.status != :connected)
-      |> Repo.all()
+      |> connection_status_counts()
 
     for product_id <- product_ids, into: %{} do
       {product_id, %{online: 0, offline: 0}}
     end
     |> to_connection_status(online, :online)
     |> to_connection_status(offline, :offline)
+  end
+
+  defp connection_status_base_query() do
+    DeviceConnection
+    |> join(:inner, [dc], p in assoc(dc, :product))
+    |> join(:inner, [dc], dev in assoc(dc, :device), on: dev.latest_connection_id == dc.id)
+  end
+
+  defp connection_status_counts(query) do
+    %{
+      online: where(query, [dc], dc.status == :connected) |> Repo.all(),
+      offline: where(query, [dc], dc.status != :connected) |> Repo.all()
+    }
   end
 
   defp to_connection_status(start, counts, status) do


### PR DESCRIPTION
Solves #2409

Looking at the entire `device_connections` table when collecting these counts produced incorrect results. We should only be taking a device's `latest_connection` into account, ignoring the old or stale records that will be eventually cleaned up by workers.