### PR TITLE
When matching deployment groups with a device, prioritize matching tags

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -571,9 +571,10 @@ defmodule NervesHub.ManagedDeployments do
           :lt ->
             false
 
+          # when deployment group firmware versions are the same,
+          # prefer to sort by matchings tag count, then id
           :eq ->
-            # when versions are the same, prefer to sort by matchings tag count, then id
-            if a_matching_tag_count > 0 or b_matching_tag_count > 0 do
+            if a_matching_tag_count > 0 and b_matching_tag_count > 0 and a_matching_tag_count != b_matching_tag_count do
               a_matching_tag_count > b_matching_tag_count
             else
               a_id < b_id


### PR DESCRIPTION
When attemptig to find matching deployment groups for a device, we do not take into consideration how many tags match. This PR addresses the issue by checking tag count when sorting. 

I originally went down the path of leveraging our Postgres function `semver_match` to query and sort, but there's a bit more work to do there before we can.

