### PR TITLE
Fix matching device to deployment groups under specific conditions

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -574,7 +574,7 @@ defmodule NervesHub.ManagedDeployments do
           # when deployment group firmware versions are the same,
           # prefer to sort by matchings tag count, then id
           :eq ->
-            if a_matching_tag_count > 0 and b_matching_tag_count > 0 and a_matching_tag_count != b_matching_tag_count do
+            if (a_matching_tag_count > 0 or b_matching_tag_count > 0) and a_matching_tag_count != b_matching_tag_count do
               a_matching_tag_count > b_matching_tag_count
             else
               a_id < b_id

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -711,7 +711,32 @@ defmodule NervesHub.ManagedDeploymentsTest do
                ])
     end
 
-    test "matchings tags are prioritized if deployment groups have the same firmware", state do
+    test "matchings tags are prioritized if deployment groups have the same firmware and one has no tags", state do
+      %{org: org, product: product, firmware: firmware} = state
+
+      %{id: no_tags_deployment_id} =
+        Fixtures.deployment_group_fixture(firmware, %{
+          name: "default",
+          conditions: %{"tags" => [], "version" => "> 0.7.0"}
+        })
+
+      %{id: matching_tags_deployment_id} =
+        Fixtures.deployment_group_fixture(firmware, %{
+          name: "alpha",
+          conditions: %{"tags" => ["alpha"], "version" => "<= 1.1.1"}
+        })
+
+      device = Fixtures.device_fixture(org, product, firmware, %{tags: ["alpha", "testing"]})
+
+      [
+        %{id: ^matching_tags_deployment_id},
+        %{id: ^no_tags_deployment_id}
+      ] =
+        ManagedDeployments.matching_deployment_groups(device)
+    end
+
+    test "the deployment with the most matching tags are prioritized if deployment groups have the same firmware",
+         state do
       %{org: org, product: product, firmware: firmware} = state
 
       %{id: no_tags_deployment_id} =
@@ -726,7 +751,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
           conditions: %{"tags" => ["alpha", "testing"], "version" => "<= 1.1.1"}
         })
 
-      device = Fixtures.device_fixture(org, product, firmware, %{tags: ["alpha", "testing", "foo"]})
+      device = Fixtures.device_fixture(org, product, firmware, %{tags: ["alpha", "testing"]})
 
       [
         %{id: ^matching_tags_deployment_id},


### PR DESCRIPTION
The recent fix in #2435 did not cover a scenario where one deployment group has no tags, and another has matching tags. This ensures that we take into account matching tags if either deployment group has any while sorting.