### PR TITLE
Add option for streaming console output through the device code API call

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,8 @@ config :flop, repo: NervesHub.Repo
 config :mime, :types, %{
   "application/pem" => ["pem"],
   "application/crt" => ["crt"],
-  "application/fwup" => ["fw"]
+  "application/fwup" => ["fw"],
+  "text/plain" => ["txt"]
 }
 
 config :nerves_hub, NervesHub.Repo,

--- a/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
+++ b/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
@@ -170,12 +170,21 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
   def code_action(openapi, path_structure) do
     opts = @path_structures[path_structure]
 
+    request_body =
+      OpenApiSpex.Operation.request_body(
+        "Device code request",
+        "application/json",
+        DeviceSchemas.DeviceCodeRequest,
+        required: true
+      )
+
     code_operation =
       device_operation(
-        "Request a Device run some Elixir code in it's console connection",
+        "Request a Device run some Elixir code in it's console connection. If stream is true, the response will be a chunked text/plain stream of console output.",
         :code,
         opts.parameters,
         opts.tags,
+        request_body: request_body,
         response: @empty_response
       )
 

--- a/lib/nerves_hub_web/controllers/api/schemas/device_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/device_schemas.ex
@@ -224,4 +224,28 @@ defmodule NervesHubWeb.API.Schemas.DeviceSchemas do
       }
     })
   end
+
+  defmodule DeviceCodeRequest do
+    OpenApiSpex.schema(%{
+      description: "POST body for sending code to a Device console",
+      type: :object,
+      properties: %{
+        body: %Schema{
+          type: :string,
+          description: "The Elixir code to execute on the device"
+        },
+        stream: %Schema{
+          type: :boolean,
+          description:
+            "If true, subscribe to console output and stream it back. Connection stays open until client disconnects.",
+          default: false
+        }
+      },
+      required: [:body],
+      example: %{
+        "body" => "NervesHubLink.status()",
+        "stream" => false
+      }
+    })
+  end
 end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -72,7 +72,7 @@ defmodule NervesHubWeb.Router do
   end
 
   pipeline :api do
-    plug(:accepts, ["json"])
+    plug(:accepts, ["json", "txt"])
     plug(PutApiSpec, module: NervesHubWeb.ApiSpec)
   end
 
@@ -89,6 +89,7 @@ defmodule NervesHubWeb.Router do
   end
 
   pipeline :api_device do
+    plug(:accepts, ["json", "txt"])
     plug(Device)
   end
 


### PR DESCRIPTION
If streaming is switched on it will subscribe to the results from the console and shove them down the HTTP as chunked responses. This allows a crude but workable console experience on the CLI side. Or just a way to run RingLogger.attach remotely and watch the device.

Required for https://github.com/nerves-hub/nerves_hub_cli/pull/310

Happy to take input on this.

A better implementation would be to have a channel for the **not device** websocket to stream the console and then just send the commands as requests. I think this is an okay step that we could drop later though.