### PR TITLE
Rollout options 🎉 🚀 🚢

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,16 +31,17 @@
   ],
   "words": [
     "castore",
-    "chartjs",
     "certifi",
+    "chartjs",
     "circuitboard",
     "citext",
     "clickhouse",
     "clipcopy",
     "comeonin",
     "conzole",
-    "extralight",
+    "evenodd",
     "extn",
+    "extralight",
     "Fastlaned",
     "filelib",
     "filesize",
@@ -88,7 +89,7 @@
     "unprovisioned",
     "validtoken",
     "webgl",
-    "xtermjs",
-    "xdelta"
+    "xdelta",
+    "xtermjs"
   ]
 }

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -70,6 +70,13 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     field(:priority_queue_concurrent_updates, :integer, default: 5)
     field(:priority_queue_firmware_version_threshold, :string)
 
+    field(:release_network_interfaces, {:array, Ecto.Enum},
+      values: [:wifi, :ethernet, :cellular, :unknown],
+      default: []
+    )
+
+    field(:release_tags, Tag, default: [])
+
     field(:device_count, :integer, virtual: true)
 
     # TODO: (joshk) this column is unused, remove after 1st May
@@ -103,7 +110,9 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
       :firmware_id,
       :archive_id,
       :priority_queue_enabled,
-      :priority_queue_firmware_version_threshold
+      :priority_queue_firmware_version_threshold,
+      :release_network_interfaces,
+      :release_tags
     ])
     |> cast_and_validate_numeric_fields(params)
     |> cast_embed(:conditions, required: true, with: &conditions_changeset/2)

--- a/priv/repo/migrations/20260127171826_add_release_network_interfaces_to_deployment_groups.exs
+++ b/priv/repo/migrations/20260127171826_add_release_network_interfaces_to_deployment_groups.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddReleaseNetworkInterfacesToDeploymentGroups do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add :release_network_interfaces, {:array, :string}, default: [], null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260127193950_add_release_tags_to_deployment_groups.exs
+++ b/priv/repo/migrations/20260127193950_add_release_tags_to_deployment_groups.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddReleaseTagsToDeploymentGroups do
+  use Ecto.Migration
+
+  def change do
+    alter table(:deployments) do
+      add :release_tags, {:array, :string}, default: [], null: false
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for specifying rollout options. These constrain releases to the selected network interfaces and/or specified tags:

<img width="1717" height="992" alt="Screenshot 2026-02-04 at 8 26 56 PM" src="https://github.com/user-attachments/assets/9f3325a9-5420-478c-ba1d-1a7bb91cb2cf" />
<img width="1728" height="1000" alt="Screenshot 2026-02-04 at 8 37 17 PM" src="https://github.com/user-attachments/assets/0741485f-b3f9-4b86-8144-d305279e2648" />
