### PR TITLE
Add connection events and console channel to Device Event socket

### DIFF
--- a/lib/nerves_hub_web/channels/device_events_stream_channel.ex
+++ b/lib/nerves_hub_web/channels/device_events_stream_channel.ex
@@ -9,27 +9,84 @@ defmodule NervesHubWeb.DeviceEventsStreamChannel do
   use Phoenix.Channel
 
   alias NervesHub.Accounts
+  alias NervesHub.Devices
   alias NervesHubWeb.Helpers.Authorization
   alias Phoenix.Socket.Broadcast
 
   require Logger
 
   @impl Phoenix.Channel
+  def join("device:console:" <> device_identifier, _params, socket) do
+    # Socket already has authenticated user, just validate device access
+    if console_authorized?(socket.assigns.user, device_identifier) do
+      device = Devices.get_by_identifier!(device_identifier)
+
+      :ok =
+        Phoenix.PubSub.subscribe(NervesHub.PubSub, "user:console:#{device.id}")
+
+      :ok =
+        Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:console:#{device.id}:internal")
+
+      {:ok, assign(socket, receive_console?: true)}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
+  end
+
   def join("device:" <> device_identifier, _params, socket) do
     # Socket already has authenticated user, just validate device access
-    if authorized?(socket.assigns.user, device_identifier) do
+    if status_authorized?(socket.assigns.user, device_identifier) do
       :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device_identifier}:internal")
 
-      {:ok, socket}
+      {:ok, assign(socket, receive_status?: true)}
     else
       {:error, %{reason: "unauthorized"}}
     end
   end
 
   @impl Phoenix.Channel
-  def handle_info(%Broadcast{event: "fwup_progress", payload: %{percent: percent}}, socket) do
+  def handle_info(
+        %Broadcast{event: "fwup_progress", payload: %{percent: percent}},
+        %{assigns: %{receive_status?: true}} = socket
+      ) do
     # Forward the firmware update progress to the connected client
     push(socket, "firmware_update", %{percent: percent})
+
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        %Broadcast{event: "connection:change", payload: %{status: status}},
+        %{assigns: %{receive_status?: true}} = socket
+      ) do
+    push(socket, "connection_change", %{status: status})
+
+    {:noreply, socket}
+  end
+
+  def handle_info(%Broadcast{event: "connection:change"}, %{assigns: %{receive_status?: false}} = socket) do
+    {:noreply, socket}
+  end
+
+  # Ignore any potential console message is not interested
+  def handle_info(%Broadcast{topic: "user:console" <> _}, %{assigns: %{receive_console?: false}} = socket) do
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        %Broadcast{topic: "user:console" <> _, event: "up", payload: %{"data" => data}},
+        %{assigns: %{receive_console?: true}} = socket
+      ) do
+    push(socket, "console_raw", %{data: data})
+
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        %Broadcast{topic: "user:console" <> _, event: "message", payload: payload},
+        %{assigns: %{receive_console?: true}} = socket
+      ) do
+    push(socket, "console_message", payload)
 
     {:noreply, socket}
   end
@@ -40,7 +97,17 @@ defmodule NervesHubWeb.DeviceEventsStreamChannel do
     {:noreply, socket}
   end
 
-  defp authorized?(user, device_identifier) do
+  defp status_authorized?(user, device_identifier) do
+    case Accounts.find_org_user_with_device_identifier(user, device_identifier) do
+      nil ->
+        false
+
+      org_user ->
+        Authorization.authorized?(:"device:view", org_user)
+    end
+  end
+
+  defp console_authorized?(user, device_identifier) do
     case Accounts.find_org_user_with_device_identifier(user, device_identifier) do
       nil ->
         false

--- a/lib/nerves_hub_web/channels/event_stream_socket.ex
+++ b/lib/nerves_hub_web/channels/event_stream_socket.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.EventStreamSocket do
   alias NervesHub.Accounts
 
   channel("device:*", NervesHubWeb.DeviceEventsStreamChannel)
+  channel("device:console:*", NervesHubWeb.DeviceEventsStreamChannel)
 
   @impl Phoenix.Socket
   def connect(params, socket, _connect_info) do

--- a/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
@@ -25,6 +25,29 @@ defmodule NervesHubWeb.DeviceEventsStreamChannelTest do
 
       assert_push("firmware_update", %{percent: 50})
     end
+
+    test "handles console messages" do
+      user = Fixtures.user_fixture()
+
+      device = device_fixture(user, %{identifier: "test-device-123"})
+
+      user_token = Accounts.create_user_api_token(user, "test-token")
+
+      {:ok, socket} = connect(EventStreamSocket, %{"token" => user_token})
+
+      {:ok, _join_reply, _channel} =
+        subscribe_and_join(
+          socket,
+          DeviceEventsStreamChannel,
+          "device:console:#{device.identifier}"
+        )
+
+      NervesHubWeb.Endpoint.broadcast("user:console:#{device.id}", "up", %{"data" => "u"})
+      assert_push("console_raw", %{data: "u"})
+      msg = %{"event" => "foo", "name" => "bar"}
+      NervesHubWeb.Endpoint.broadcast("user:console:#{device.id}", "message", msg)
+      assert_push("console_message", ^msg)
+    end
   end
 
   describe "join/3" do
@@ -63,9 +86,45 @@ defmodule NervesHubWeb.DeviceEventsStreamChannelTest do
                  "device:#{device.identifier}"
                )
     end
+
+    test "authorized users can join the console channel" do
+      user = Fixtures.user_fixture()
+
+      device = device_fixture(user, %{identifier: "test-device-123"})
+
+      user_token = Accounts.create_user_api_token(user, "test-token")
+
+      {:ok, socket} = connect(EventStreamSocket, %{"token" => user_token})
+
+      assert {:ok, _reply, _channel} =
+               subscribe_and_join(
+                 socket,
+                 DeviceEventsStreamChannel,
+                 "device:console:#{device.identifier}"
+               )
+    end
+
+    test "unauthorized user cannot join the console channel" do
+      user = Fixtures.user_fixture()
+      other_user = Fixtures.user_fixture()
+
+      device = device_fixture(user, %{identifier: "test-device-456"})
+
+      other_user_token = Accounts.create_user_api_token(other_user, "test-token")
+
+      # Connect with unauthorized user's token
+      {:ok, socket} = connect(EventStreamSocket, %{"token" => other_user_token})
+
+      assert {:error, %{reason: _reason}} =
+               subscribe_and_join(
+                 socket,
+                 DeviceEventsStreamChannel,
+                 "device:console:#{device.identifier}"
+               )
+    end
   end
 
-  defp device_fixture(user, device_params, tmp_dir) do
+  defp device_fixture(user, device_params, tmp_dir \\ System.tmp_dir()) do
     org = Fixtures.org_fixture(user)
     {:ok, org_user} = Accounts.get_org_user(org, user)
 


### PR DESCRIPTION
Anyone listening to the sidechannel socket for a device now gets connectivity messages.

Added a channel that can be joined to receive console messages.

This is mainly in service of improving nerves_hub_cli. Allowing it to both watch and interact with the console.