### PR TITLE
Stream firmware to file when updating

### DIFF
--- a/lib/nerves_hub/firmwares/update_tool/fwup.ex
+++ b/lib/nerves_hub/firmwares/update_tool/fwup.ex
@@ -373,14 +373,15 @@ defmodule NervesHub.Firmwares.UpdateTool.Fwup do
   defp firmware_upload_config(), do: Application.fetch_env!(:nerves_hub, :firmware_upload)
 
   defp dl!(url, filepath) do
-    # Download and write to file
-    response = Req.get!(url, Application.get_env(:nerves_hub, :firmware_download_options, []))
+    response =
+      Req.get!(
+        url,
+        [into: File.stream!(filepath)] ++ Application.get_env(:nerves_hub, :firmware_download_options, [])
+      )
 
     if response.status != 200 do
       raise "HTTP download failed with status #{response.status}"
     end
-
-    File.write!(filepath, response.body)
 
     :ok
   end


### PR DESCRIPTION
Fixup in response to the catch by @joshk that I missed streaming the firmware directly to a file (allowing us to skip storing things in memory)