### PR TITLE
Fix clickable area of product in orgs list

### DIFF
--- a/lib/nerves_hub_web/live/orgs/index.html.heex
+++ b/lib/nerves_hub_web/live/orgs/index.html.heex
@@ -103,11 +103,13 @@
           </div>
         <% else %>
           <div class="grid grid-cols-2 px-4 pb-4 pt-2 gap-4">
-            <div :for={product <- org.products} class="flex justify-between gap-[16px] p-4 w-full border border-zinc-700 rounded bg-gradient-to-r from-zinc-800/50 to-zinc-800">
+            <.link
+              :for={product <- org.products}
+              navigate={~p"/org/#{org}/#{product}/devices"}
+              class="flex justify-between gap-[16px] p-4 w-full border border-zinc-700 rounded bg-gradient-to-r from-zinc-800/50 to-zinc-800 hover:border-zinc-500 transition-colors"
+            >
               <div class="text-neutral-50 font-semibold text-sm">
-                <.link navigate={~p"/org/#{org}/#{product}/devices"}>
-                  {product.name}
-                </.link>
+                {product.name}
               </div>
               <div class="flex gap-4 text-sm font-medium">
                 <div class="flex items-center gap-1.5">
@@ -119,7 +121,7 @@
                   <span class="text-zinc-400">{get_in(@product_device_info, [product.id, :offline]) || 0}</span>
                 </div>
               </div>
-            </div>
+            </.link>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
You can now click the entire box, not just the text.