### PR TITLE
Change orgs view to make it more obvious that products are shown

### DIFF
--- a/lib/nerves_hub_web/live/orgs/index.html.heex
+++ b/lib/nerves_hub_web/live/orgs/index.html.heex
@@ -44,18 +44,6 @@
             </.link>
           </div>
           <div class="flex items-center gap-6 text-sm">
-            <div class="flex items-center gap-2">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-                <path
-                  d="M2.5 10.8333H17.5M2.5 10.8333V14.1666C2.5 15.0871 3.24619 15.8333 4.16667 15.8333H15.8333C16.7538 15.8333 17.5 15.0871 17.5 14.1666V10.8333M2.5 10.8333L3.85106 5.42907C4.03654 4.68712 4.70318 4.16663 5.46796 4.16663H14.532C15.2968 4.16663 15.9635 4.68712 16.1489 5.42907L17.5 10.8333M5 13.3333H15"
-                  stroke="#71717A"
-                  stroke-width="1.2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-              <span class="text-zinc-400">{Enum.count(org.products)} {if Enum.count(org.products) == 1, do: "product", else: "products"}</span>
-            </div>
             <div class="flex items-center gap-4">
               <div class="flex items-center gap-1.5">
                 <div class="size-2 bg-green-500 rounded-full"></div>
@@ -90,6 +78,7 @@
             </.link>
           </div> --%>
         </div>
+        <h4 class="px-4 pt-2 text-xs font-medium text-zinc-400 uppercase tracking-wide">Products ({Enum.count(org.products)})</h4>
         <%= if Enum.empty?(org.products) do %>
           <div class="px-4 pb-4 pt-2">
             <div class="p-4 border border-zinc-700 rounded bg-zinc-800/30 text-center">


### PR DESCRIPTION
Received feedback that the orgs view didn't make it obvious the blocks were products.

This is a suggested fix.
<img width="1407" height="815" alt="Screenshot_20260216_151758" src="https://github.com/user-attachments/assets/45c626aa-aa99-4236-bacf-128ebe57304c" />

Original is a bit nice-looking I think but less clear:

<img width="1392" height="996" alt="Screenshot_20260216_151815" src="https://github.com/user-attachments/assets/fd294bf4-fb4a-41ee-a0c5-a9efee20db01" />
