### PR TITLE
Update FWUP due to a broken zlib download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,8 @@ RUN git clone https://github.com/fwup-home/fwup /tmp/fwup
 
 WORKDIR /tmp/fwup
 
-RUN git checkout v1.13.2 && \
+# pinning to 428350a as it fixes dependency download URL issues
+RUN git checkout 428350a && \
     ./scripts/download_deps.sh && \
     ./scripts/build_deps.sh && \
     ./autogen.sh && \


### PR DESCRIPTION
This updates FWUP to 1.5.0, and pins to a recent commit in `main` which includes a fix for the zlib download URL (a required dep when building a static version of FWUP)