### PR TITLE
Make sure the Orchestrator is notified when devices are added to it

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -11,6 +11,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.AuditLogs
   alias NervesHub.AuditLogs.DeviceTemplates
   alias NervesHub.Certificate
+  alias NervesHub.DeploymentOrchestratorEvents
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
@@ -938,6 +939,9 @@ defmodule NervesHub.Devices do
 
     DeviceEvents.deployment_assigned(device)
 
+    # let the orchestrator know that a device has been added to the deployment group
+    DeploymentOrchestratorEvents.device_added(device)
+
     deployment_group = Repo.preload(deployment_group, :firmware)
     Map.put(device, :deployment_group, deployment_group)
   end
@@ -1088,7 +1092,7 @@ defmodule NervesHub.Devices do
         Repo.delete(inflight_update)
 
         # let the orchestrator know that an inflight update completed
-        deployment_device_updated(device)
+        DeploymentOrchestratorEvents.device_updated(device)
       end
 
     _ = UpdateStats.log_update(device, previous_metadata)
@@ -1111,29 +1115,7 @@ defmodule NervesHub.Devices do
       firmware_uuid: firmware_uuid
     }
 
-    _ =
-      ChannelServer.broadcast(
-        NervesHub.PubSub,
-        "orchestrator:deployment:#{device.deployment_id}",
-        "device-online",
-        payload
-      )
-
-    :ok
-  end
-
-  def deployment_device_updated(%Device{deployment_id: nil}) do
-    :ok
-  end
-
-  def deployment_device_updated(device) do
-    _ =
-      ChannelServer.broadcast(
-        NervesHub.PubSub,
-        "orchestrator:deployment:#{device.deployment_id}",
-        "device-updated",
-        %{}
-      )
+    DeploymentOrchestratorEvents.device_online(device, payload)
 
     :ok
   end
@@ -1275,12 +1257,7 @@ defmodule NervesHub.Devices do
       {:ok, device} = result ->
         _ =
           if device.deployment_id do
-            ChannelServer.broadcast(
-              NervesHub.PubSub,
-              "orchestrator:deployment:#{device.deployment_id}",
-              "device-updated",
-              %{}
-            )
+            DeploymentOrchestratorEvents.device_updated(device)
           end
 
         result
@@ -1360,6 +1337,9 @@ defmodule NervesHub.Devices do
       |> Repo.update_all([set: [deployment_id: id]], timeout: to_timeout(minute: 2))
 
     :ok = Enum.each(device_ids, &DeviceEvents.updated(%Device{id: &1}))
+
+    # let the orchestrator know that some devices have been added to the deployment group
+    DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
 
     {:ok, %{updated: devices_updated_count, ignored: length(device_ids) - devices_updated_count}}
   end

--- a/lib/nerves_hub/events/deployment_orchestrator_events.ex
+++ b/lib/nerves_hub/events/deployment_orchestrator_events.ex
@@ -1,0 +1,41 @@
+defmodule NervesHub.DeploymentOrchestratorEvents do
+  @moduledoc """
+  Encapsulation of events to be sent to the Deployment Orchestrator
+  """
+
+  alias NervesHub.Devices.Device
+  alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias Phoenix.Channel.Server, as: ChannelServer
+
+  def device_updated(device) do
+    broadcast(device, "device-updated", %{})
+  end
+
+  def device_online(device, payload) do
+    broadcast(device, "device-online", payload)
+  end
+
+  def device_added(device) do
+    broadcast(device, "device-added", %{})
+  end
+
+  def bulk_devices_added(deployment) do
+    broadcast(deployment, "bulk-devices-added", %{})
+  end
+
+  def deployment_group_deactivated(deployment) do
+    broadcast(deployment, "deactivated", %{})
+  end
+
+  def topic(%DeploymentGroup{id: id}) do
+    "orchestrator:deployment:#{id}"
+  end
+
+  def topic(%Device{deployment_id: id}) do
+    "orchestrator:deployment:#{id}"
+  end
+
+  defp broadcast(device_or_deployment, event, payload) do
+    :ok = ChannelServer.broadcast(NervesHub.PubSub, topic(device_or_deployment), event, payload)
+  end
+end

--- a/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
+++ b/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
@@ -304,8 +304,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
     end
   end
 
-  @decorate with_span("ManagedDeployments.Distributed.Orchestrator.handle_info:deployment/device-update")
-  def handle_info(%Broadcast{topic: "orchestrator:deployment:" <> _, event: "device-updated"}, state) do
+  @decorate with_span("ManagedDeployments.Distributed.Orchestrator.handle_info:deployment/device-added-or-updated")
+  def handle_info(%Broadcast{topic: "orchestrator:deployment:" <> _, event: event}, state)
+      when event in ["device-added", "device-updated", "bulk-devices-added"] do
     maybe_trigger_update(state)
   end
 


### PR DESCRIPTION
This improves when the Orchestrator is notified of device additions, both for single-device and bulk additions.