### PR TITLE
Firmware connected to Releases can't be deleted

### DIFF
--- a/lib/nerves_hub/firmwares/firmware.ex
+++ b/lib/nerves_hub/firmwares/firmware.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Firmwares.Firmware do
   alias NervesHub.Accounts.Org
   alias NervesHub.Accounts.OrgKey
   alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.ManagedDeployments.DeploymentRelease
   alias NervesHub.Products.Product
 
   @type t :: %Firmware{
@@ -50,7 +51,9 @@ defmodule NervesHub.Firmwares.Firmware do
     belongs_to(:org, Org, where: [deleted_at: nil])
     belongs_to(:product, Product, where: [deleted_at: nil])
     belongs_to(:org_key, OrgKey)
+
     has_many(:deployment_groups, DeploymentGroup)
+    has_many(:deployment_releases, DeploymentRelease)
 
     field(:architecture, :string)
     field(:author, :string)
@@ -97,6 +100,7 @@ defmodule NervesHub.Firmwares.Firmware do
   def delete_changeset(%Firmware{} = firmware) do
     firmware
     |> change()
+    |> no_assoc_constraint(:deployment_releases, message: "Firmware has associated deployment releases")
     |> no_assoc_constraint(:deployment_groups, message: "Firmware has associated deployments")
   end
 end


### PR DESCRIPTION
Adding `no_assoc_constraint` stops this from blowing up, allowing us to show a nice message instead.

There is a question to be answered (outside of this PR) if we should loosen this restriction, but for now showing a message is better than errors that are going to Sentry and not being shown to users.