### PR TITLE
Oban doesn't need its own Repo

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -57,7 +57,7 @@ config :nerves_hub, NervesHubWeb.Endpoint,
 config :nerves_hub, NervesHubWeb.Gettext, default_locale: "en"
 
 config :nerves_hub, Oban,
-  repo: NervesHub.ObanRepo,
+  repo: NervesHub.Repo,
   notifier: Oban.Notifiers.PG,
   log: false,
   queues: [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,12 +11,6 @@ web_port = String.to_integer(System.get_env("WEB_PORT", "4000"))
 
 config :logger, :console, format: "[$level] $message\n"
 
-config :nerves_hub, NervesHub.ObanRepo,
-  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_dev"),
-  show_sensitive_data_on_connection_error: true,
-  pool_size: 10,
-  ssl: false
-
 config :nerves_hub, NervesHub.Repo,
   url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_dev"),
   show_sensitive_data_on_connection_error: true,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,7 +3,6 @@ import Config
 # Do not print debug messages in production
 config :logger, level: :info, backends: [:console, Sentry.LoggerBackend]
 
-config :nerves_hub, NervesHub.ObanRepo, pool_size: 10
 config :nerves_hub, NervesHub.Repo, pool_size: 20
 config :nerves_hub, NervesHubWeb.DeviceEndpoint, server: true
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,12 +15,6 @@ config :nerves_hub, NervesHub.Firmwares.Upload.File,
   local_path: System.tmp_dir(),
   public_path: "/firmware"
 
-config :nerves_hub, NervesHub.ObanRepo,
-  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/nerves_hub_test"),
-  ssl: false,
-  pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 10
-
 config :nerves_hub, NervesHub.RateLimit, limit: 100
 
 config :nerves_hub, NervesHub.Repo,

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -123,7 +123,7 @@ defmodule NervesHub.Application do
   end
 
   defp ecto_repos() do
-    [NervesHub.Repo, NervesHub.ObanRepo] ++
+    [NervesHub.Repo] ++
       if Application.get_env(:nerves_hub, :analytics_enabled) do
         [NervesHub.AnalyticsRepo]
       else

--- a/lib/nerves_hub/repo.ex
+++ b/lib/nerves_hub/repo.ex
@@ -51,9 +51,3 @@ defmodule NervesHub.Repo do
 
   def destroy(struct_or_changeset), do: delete(struct_or_changeset)
 end
-
-defmodule NervesHub.ObanRepo do
-  use Ecto.Repo,
-    otp_app: :nerves_hub,
-    adapter: Ecto.Adapters.Postgres
-end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.ChannelCase do
   using do
     quote do
       use DefaultMocks
-      use Oban.Testing, repo: NervesHub.ObanRepo
+      use Oban.Testing, repo: NervesHub.Repo
       use AssertEventually, timeout: 500, interval: 50
 
       import Ecto.Query
@@ -59,16 +59,13 @@ defmodule NervesHubWeb.ChannelCase do
   setup do
     # Explicitly get a connection before each test
     :ok = SQLSandbox.checkout(NervesHub.Repo)
-    :ok = SQLSandbox.checkout(NervesHub.ObanRepo)
   end
 
   setup tags do
     pid = SQLSandbox.start_owner!(NervesHub.Repo, shared: not tags[:async])
-    pid2 = SQLSandbox.start_owner!(NervesHub.ObanRepo, shared: not tags[:async])
 
     on_exit(fn ->
       SQLSandbox.stop_owner(pid)
-      SQLSandbox.stop_owner(pid2)
     end)
 
     :ok

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -19,7 +19,7 @@ defmodule NervesHub.DataCase do
   using do
     quote do
       use DefaultMocks
-      use Oban.Testing, repo: NervesHub.ObanRepo
+      use Oban.Testing, repo: NervesHub.Repo
 
       import Ecto
       import Ecto.Changeset
@@ -34,11 +34,9 @@ defmodule NervesHub.DataCase do
 
   setup tags do
     :ok = SQLSandbox.checkout(NervesHub.Repo)
-    :ok = SQLSandbox.checkout(NervesHub.ObanRepo)
 
     if !tags[:async] do
       SQLSandbox.mode(NervesHub.Repo, {:shared, self()})
-      SQLSandbox.mode(NervesHub.ObanRepo, {:shared, self()})
     end
 
     :ok


### PR DESCRIPTION
By removing `NervesHub.ObanRepo` and having Oban use `NervesHub.Repo`, we can now safely use Oban in transactions.