### PR TITLE
Handle `UserSocket` auth token missing user cases

### DIFF
--- a/lib/nerves_hub_web/channels/user_socket.ex
+++ b/lib/nerves_hub_web/channels/user_socket.ex
@@ -23,6 +23,10 @@ defmodule NervesHubWeb.UserSocket do
     end
   end
 
+  def connect(_, _socket) do
+    :error
+  end
+
   def id(%{assigns: %{user: user}}) do
     "user_socket:#{user.id}"
   end


### PR DESCRIPTION
Came across this in the NervesCloud Sentry logs