### PR TITLE
Fix a very hidden race condition related to finding devices to be updated

### DIFF
--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -711,7 +711,7 @@ defmodule NervesHubWeb.WebsocketTest do
         )
 
       # This is what the orchestrator process will do
-      Orchestrator.trigger_update(deployment_group)
+      Orchestrator.trigger_update(Map.put(deployment_group, :firmware, new_firmware))
 
       message = SocketClient.wait_update(socket)
 


### PR DESCRIPTION
This race condition was likely the source of devices getting stuck in update limbo.

It is possible for Deployments to be updated, but the Orchestrator hears about the updated Deployment Group after already starting a check for devices to update. 

The query would then return 1 or more devices to update, but it would use the old Deployment information when using `Devices.verify_update_eligibility`, which would return `{:error, :up_to_date, device}`, which would then return `%UpdatePayload{update_available: false}`, which would be sent to the device.

This fixes the issue with the query, which will fix the overall problem, but further work should be undertaken so that `%UpdatePayload{update_available: false}` payloads can't be sent to devices.