### PR TITLE
Filter out already running Orchestrators

### DIFF
--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_registration_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_registration_test.exs
@@ -21,6 +21,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorRegistrationTest 
 
     expect(ProcessHub, :start_children, fn _hub_id, _spec, _opts -> :ok end)
 
+    expect(ProcessHub, :process_list, fn _table_name, _node_context ->
+      []
+    end)
+
     expect(ProcessHub.Future, :await, fn _ ->
       %ProcessHub.StartResult{
         status: :ok,


### PR DESCRIPTION
We need to filter out already running Orchestrators, otherwise ProcessHub will fail with a list of `:already_started` Orchestrator ids.

I've also added `check_existing: false` to avoid starting already running orchestrators, as noted in the ProcessHub documentation.

This addresses a slight change in behaviour from upgrading to the latest ProcessHub, which also resolves some recent Sentry errors.