### PR TITLE
Add `deployment_group_id` index to `deployment_releases`

### DIFF
--- a/priv/repo/migrations/20260223071531_add_deployment_group_id_index_to_deployment_releases.exs
+++ b/priv/repo/migrations/20260223071531_add_deployment_group_id_index_to_deployment_releases.exs
@@ -1,0 +1,16 @@
+defmodule NervesHub.Repo.Migrations.AddDeploymentGroupIdIndexToDeploymentReleases do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    execute(
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS deployment_releases_deployment_group_id_inserted_at_idx ON deployment_releases(deployment_group_id, inserted_at DESC);"
+    )
+  end
+
+  def down() do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS deployment_releases_deployment_group_id_inserted_at_idx;")
+  end
+end


### PR DESCRIPTION
And include `inserted_at` so that ordering is faster