### PR TITLE
Speed up Deployment Group queries which include device and release counts

### DIFF
--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -77,6 +77,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
 
     field(:release_tags, Tag, default: [])
 
+    field(:releases_count, :integer, virtual: true)
     field(:device_count, :integer, virtual: true)
 
     # TODO: (joshk) this column is unused, remove after 1st May

--- a/lib/nerves_hub/managed_deployments/deployment_group_filtering.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group_filtering.ex
@@ -22,15 +22,15 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupFiltering do
   end
 
   def filter(query, _filters, :name, value) do
-    where(query, [d], ilike(d.name, ^"%#{value}%"))
+    where(query, [deployment_group: dg], ilike(dg.name, ^"%#{value}%"))
   end
 
   def filter(query, _filters, :platform, value) do
-    where(query, [_d, _dev, f], f.platform == ^value)
+    where(query, [firmware: f], f.platform == ^value)
   end
 
   def filter(query, _filters, :architecture, value) do
-    where(query, [_d, _dev, f], f.architecture == ^value)
+    where(query, [firmware: f], f.architecture == ^value)
   end
 
   def filter(query, _filters, :search, value) when is_binary(value) and value != "" do
@@ -38,11 +38,11 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupFiltering do
 
     query
     |> where(
-      [d, _dev, f],
-      ilike(d.name, ^search_term) or
+      [deployment_group: dg, firmware: f],
+      ilike(dg.name, ^search_term) or
         ilike(f.platform, ^search_term) or
         ilike(f.architecture, ^search_term) or
-        ilike(fragment(" COALESCE(?->>'tags', '')", d.conditions), ^search_term)
+        ilike(fragment(" COALESCE(?->>'tags', '')", dg.conditions), ^search_term)
     )
   end
 
@@ -54,19 +54,19 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupFiltering do
 
   @spec sort(Ecto.Query.t(), {atom(), atom()}) :: Ecto.Query.t()
   def sort(query, {direction, :platform}) do
-    order_by(query, [_d, _dev, f], {^direction, f.platform})
+    order_by(query, [firmware: f], {^direction, f.platform})
   end
 
   def sort(query, {direction, :architecture}) do
-    order_by(query, [_d, _dev, f], {^direction, f.architecture})
+    order_by(query, [firmware: f], {^direction, f.architecture})
   end
 
   def sort(query, {direction, :device_count}) do
-    order_by(query, [_d, dev], {^direction, dev.device_count})
+    order_by(query, [device_count: dev], {^direction, dev.device_count})
   end
 
   def sort(query, {direction, :firmware_version}) do
-    order_by(query, [_d, _dev, f], {^direction, f.version})
+    order_by(query, [firmware: f], {^direction, f.version})
   end
 
   def sort(query, sort), do: order_by(query, ^sort)

--- a/lib/nerves_hub_web/live/deployment_groups/index.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.html.heex
@@ -58,6 +58,9 @@
             <th phx-click="sort" phx-value-sort="device_count" class="cursor-pointer">
               <Sorting.sort_icon text="Devices" field="device_count" selected_field={@current_sort} selected_direction={@sort_direction} />
             </th>
+            <th phx-click="sort" phx-value-sort="releases_count" class="cursor-pointer">
+              <Sorting.sort_icon text="Releases" field="releases_count" selected_field={@current_sort} selected_direction={@sort_direction} />
+            </th>
             <th phx-click="sort" phx-value-sort="firmware_version" class="cursor-pointer min-w-fit">
               <Sorting.sort_icon text="Firmware version" field="firmware_version" selected_field={@current_sort} selected_direction={@sort_direction} />
             </th>
@@ -93,6 +96,10 @@
 
             <td>
               {deployment_group.device_count || 0}
+            </td>
+
+            <td>
+              {deployment_group.releases_count || 0}
             </td>
 
             <td class="min-w-fit">


### PR DESCRIPTION
Thanks to https://www.pgexplain.dev, I was able to eliminate some sequential scans and reduce some of the query complexity.

Plus I've added release counts to the Deployment Groups list.