### PR TITLE
Fix a pill overflow in deployment group firmware version

### DIFF
--- a/lib/nerves_hub_web/live/deployment_groups/index.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.html.heex
@@ -103,7 +103,7 @@
             </td>
 
             <td class="min-w-fit">
-              <span class="inline-block h-7 py-1 px-2 items-center rounded bg-zinc-800">
+              <span class="inline-block py-1 px-2 items-center rounded bg-zinc-800 whitespace-nowrap">
                 <.link navigate={~p"/org/#{@org}/#{@product}/firmware/#{deployment_group.current_release.firmware}"} class="flex items-center">
                   <span class="text-sm text-base-300 mr-1">{deployment_group.current_release.firmware.version} ({String.slice(deployment_group.current_release.firmware.uuid, 0..7)})</span>
                   <svg class="w-4 h-4" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
I didn't enjoy this:
<img width="1826" height="511" alt="Screenshot_20260303_080902" src="https://github.com/user-attachments/assets/33c4a3b2-dbfd-4209-a941-ea552c8bd316" />

I prefer this:
<img width="1832" height="503" alt="Screenshot_20260303_081111" src="https://github.com/user-attachments/assets/03ef38c3-ceaf-4e2f-9526-95ec9a10677a" />
