### PR TITLE
Its better to unregister completed uploads vs cancelling

### DIFF
--- a/lib/nerves_hub_web/live/archives.ex
+++ b/lib/nerves_hub_web/live/archives.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Archives do
   alias NervesHub.Archives
   alias NervesHubWeb.Components.Pager
   alias NervesHubWeb.Components.Sorting
+  alias Phoenix.LiveView.Upload
 
   embed_templates("archive_templates/*")
 
@@ -157,7 +158,7 @@ defmodule NervesHubWeb.Live.Archives do
 
       socket
       |> create_archive(filepath)
-      |> cancel_upload(:archive, entry.ref)
+      |> clear_completed_upload(:archive, entry)
       |> noreply()
     else
       {:noreply, socket}
@@ -245,6 +246,10 @@ defmodule NervesHubWeb.Live.Archives do
 
   defp error_feedback(socket, message) do
     put_flash(socket, :error, message)
+  end
+
+  defp clear_completed_upload(socket, upload_name, entry) do
+    Upload.unregister_completed_entry_upload(socket, socket.assigns[:uploads][upload_name], entry.ref)
   end
 
   defp format_signed(%{org_key_id: org_key_id}, org_keys) do

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -195,7 +195,7 @@ defmodule NervesHubWeb.Live.Firmware do
 
       socket
       |> create_firmware(filepath)
-      |> cancel_upload(:firmware, entry.ref)
+      |> clear_completed_upload(:firmware, entry)
       |> noreply()
     else
       {:noreply, assign(socket, status: "uploading...")}
@@ -309,6 +309,10 @@ defmodule NervesHubWeb.Live.Firmware do
   defp error_feedback(socket, message, _opts) do
     socket
     |> put_flash(:error, message)
+  end
+
+  defp clear_completed_upload(socket, upload_name, entry) do
+    Phoenix.LiveView.Upload.unregister_completed_entry_upload(socket, socket.assigns[:uploads][upload_name], entry.ref)
   end
 
   defp format_file_size(size) do


### PR DESCRIPTION
Cancelling uploads didn't remove them from the stored upload entries, or at least it wasn't consistent on when they would be removed by Phoenix, and this would cause inconsistent errors in our test suite.

This looks to be cleaner and more consistent.