### PR TITLE
Only show Firmware flashes when viewing the Firmware list page

### DIFF
--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -152,7 +152,8 @@ defmodule NervesHubWeb.Live.Firmware do
   def handle_info(
         %Broadcast{topic: "product:" <> _product_id, event: "firmware/created", payload: %{firmware: firmware}},
         %{assigns: assigns} = socket
-      ) do
+      )
+      when assigns.live_action == :index do
     if viewing_first_page?(assigns) do
       socket
       |> assign_firmware_with_pagination()
@@ -174,7 +175,8 @@ defmodule NervesHubWeb.Live.Firmware do
   def handle_info(
         %Broadcast{topic: "product:" <> _product_id, event: "firmware/deleted", payload: %{firmware: firmware}},
         socket
-      ) do
+      )
+      when socket.assigns.live_action == :index do
     socket
     |> assign_firmware_with_pagination()
     |> put_flash(
@@ -182,6 +184,11 @@ defmodule NervesHubWeb.Live.Firmware do
       "Firmware #{firmware.version} (#{String.slice(firmware.uuid, 0..7)}) has been deleted by another user."
     )
     |> noreply()
+  end
+
+  # Ignore all other broadcasts
+  def handle_info(_broadcast, socket) do
+    {:noreply, socket}
   end
 
   def handle_progress(:firmware, entry, socket) do
@@ -246,7 +253,10 @@ defmodule NervesHubWeb.Live.Firmware do
   end
 
   defp viewing_first_page?(assigns) do
-    !(assigns.params && assigns.params["page_number"] && assigns.params["page_number"] > 1)
+    case get_in(assigns, [:params, "page_number"]) do
+      nil -> true
+      page_number -> String.to_integer(page_number) == 1
+    end
   end
 
   defp create_firmware(socket, filepath) do

--- a/test/nerves_hub_web/live/firmware_test.exs
+++ b/test/nerves_hub_web/live/firmware_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.Live.FirmwareTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
+  alias NervesHub.Firmwares
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
   alias NervesHub.Repo
@@ -189,6 +190,64 @@ defmodule NervesHubWeb.Live.FirmwareTest do
       |> assert_has("p",
         text: "Error deleting firmware: Firmware has associated deployment releases"
       )
+    end
+
+    test "no flash is shown when new firmware is uploaded",
+         %{
+           conn: conn,
+           user: user,
+           org: org,
+           tmp_dir: tmp_dir
+         } do
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      conn =
+        conn
+        |> visit("/org/#{org.name}/#{product.name}/firmware/#{firmware.uuid}")
+        |> assert_has("h1", text: firmware.uuid)
+        |> refute_has("p",
+          text: "New firmware (#{firmware.version} - #{String.slice(firmware.uuid, 0..7)}) available for selection."
+        )
+        |> refute_has("p",
+          text:
+            "New firmware (#{firmware.version} - #{String.slice(firmware.uuid, 0..7)}) available for selection. Please go back to page 1 to view it."
+        )
+
+      new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      conn
+      |> refute_has("p",
+        text:
+          "New firmware (#{new_firmware.version} - #{String.slice(new_firmware.uuid, 0..7)}) available for selection."
+      )
+      |> refute_has("p",
+        text:
+          "New firmware (#{new_firmware.version} - #{String.slice(new_firmware.uuid, 0..7)}) available for selection. Please go back to page 1 to view it."
+      )
+    end
+
+    test "no flash is show when other firmware is deleted",
+         %{
+           conn: conn,
+           user: user,
+           org: org,
+           tmp_dir: tmp_dir
+         } do
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+      other_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/firmware/#{firmware.uuid}")
+      |> assert_has("h1", text: firmware.uuid)
+      |> refute_has("p", text: "has been deleted by another user.")
+      |> tap(fn _ -> Firmwares.delete_firmware(other_firmware) end)
+      |> refute_has("p", text: "has been deleted by another user.")
     end
   end
 


### PR DESCRIPTION
This bug was found in our Sentry error reporting