### PR TITLE
The Devices endpoint doesn't have access to verified routes

### DIFF
--- a/lib/nerves_hub_web/controllers/error_html/400.html.heex
+++ b/lib/nerves_hub_web/controllers/error_html/400.html.heex
@@ -13,9 +13,9 @@
     <meta name="description" content="" />
     <meta name="author" content="" />
 
-    <link rel="icon" type="image/png" href={~p"/images/favicon-96x96.png"} sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href={~p"/images/favicon.svg"} />
-    <link rel="shortcut icon" href={~p"/images/favicon.ico"} />
+    <link rel="icon" type="image/png" href="/images/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
+    <link rel="shortcut icon" href="/images/favicon.ico" />
 
     <title>Invalid request · #{Application.get_env(:nerves_hub, :web_title_suffix)}"}</title>
     <link rel="stylesheet" href={static_path("/assets/css/app.css")} />

--- a/lib/nerves_hub_web/controllers/error_html/404.html.heex
+++ b/lib/nerves_hub_web/controllers/error_html/404.html.heex
@@ -13,9 +13,9 @@
     <meta name="description" content="" />
     <meta name="author" content="" />
 
-    <link rel="icon" type="image/png" href={~p"/images/favicon-96x96.png"} sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href={~p"/images/favicon.svg"} />
-    <link rel="shortcut icon" href={~p"/images/favicon.ico"} />
+    <link rel="icon" type="image/png" href="/images/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
+    <link rel="shortcut icon" href="/images/favicon.ico" />
 
     <title>Page not found · #{Application.get_env(:nerves_hub, :web_title_suffix)}"}</title>
     <link rel="stylesheet" href={static_path("/assets/css/app.css")} />

--- a/lib/nerves_hub_web/controllers/error_html/500.html.heex
+++ b/lib/nerves_hub_web/controllers/error_html/500.html.heex
@@ -13,9 +13,9 @@
     <meta name="description" content="" />
     <meta name="author" content="" />
 
-    <link rel="icon" type="image/png" href={~p"/images/favicon-96x96.png"} sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href={~p"/images/favicon.svg"} />
-    <link rel="shortcut icon" href={~p"/images/favicon.ico"} />
+    <link rel="icon" type="image/png" href="/images/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
+    <link rel="shortcut icon" href="/images/favicon.ico" />
 
     <title>Unexpected error · #{Application.get_env(:nerves_hub, :web_title_suffix)}"}</title>
     <link rel="stylesheet" href={static_path("/assets/css/app.css")} />


### PR DESCRIPTION
so lets not use them in our error pages (fixing a Sentry error)