### PR TITLE
Allow for Sentry tracing to be enabled (disabled by default)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -3,6 +3,8 @@ import Config
 alias NervesHub.Firmwares.Upload
 alias NervesHub.Firmwares.Upload.S3
 alias NervesHub.Telemetry.FilteredSampler
+alias Sentry.OpenTelemetry.Sampler
+alias Sentry.OpenTelemetry.SpanProcessor
 alias Swoosh.Adapters.SMTP
 alias Ueberauth.Strategy.Google.OAuth
 
@@ -413,21 +415,30 @@ config :sentry,
     ]
   ]
 
-if otlp_endpoint = System.get_env("OTLP_ENDPOINT") do
-  otlp_sampler_ratio =
-    if ratio = System.get_env("OTLP_SAMPLER_RATIO") do
-      String.to_float(ratio)
-    end
+cond do
+  System.get_env("SENTRY_ENABLE_TRACING", "false") == "true" ->
+    config :opentelemetry, sampler: {Sampler, []}
+    config :opentelemetry, span_processor: {SpanProcessor, []}
 
-  config :opentelemetry,
-    sampler: {:parent_based, %{root: {FilteredSampler, otlp_sampler_ratio}}}
+    config :sentry,
+      traces_sample_rate: 0.1
 
-  config :opentelemetry_exporter,
-    otlp_protocol: :http_protobuf,
-    otlp_endpoint: otlp_endpoint,
-    otlp_headers: [{System.get_env("OTLP_AUTH_HEADER"), System.get_env("OTLP_AUTH_HEADER_VALUE")}]
-else
-  config :opentelemetry, traces_exporter: :none
+  otlp_endpoint = System.get_env("OTLP_ENDPOINT") ->
+    otlp_sampler_ratio =
+      if ratio = System.get_env("OTLP_SAMPLER_RATIO") do
+        String.to_float(ratio)
+      end
+
+    config :opentelemetry,
+      sampler: {:parent_based, %{root: {FilteredSampler, otlp_sampler_ratio}}}
+
+    config :opentelemetry_exporter,
+      otlp_protocol: :http_protobuf,
+      otlp_endpoint: otlp_endpoint,
+      otlp_headers: [{System.get_env("OTLP_AUTH_HEADER"), System.get_env("OTLP_AUTH_HEADER_VALUE")}]
+
+  true ->
+    config :opentelemetry, traces_exporter: :none
 end
 
 if host = System.get_env("STATSD_HOST") do

--- a/lib/nerves_hub_web/sentry_event_filter.ex
+++ b/lib/nerves_hub_web/sentry_event_filter.ex
@@ -12,4 +12,9 @@ defmodule NervesHubWeb.SentryEventFilter do
         event
     end
   end
+
+  # let traces through
+  def filter_non_500(%Sentry.Transaction{} = trace) do
+    trace
+  end
 end


### PR DESCRIPTION
A good first setup for Sentry tracing.

We have this working on NervesCloud. Still more tweaking to do, but its working well so far.