### PR TITLE
Only fetch Org and Product if the user is logged in

### DIFF
--- a/lib/nerves_hub_web/auth.ex
+++ b/lib/nerves_hub_web/auth.ex
@@ -97,8 +97,8 @@ defmodule NervesHubWeb.Auth do
   def assign_org_to_scope(conn, _opts) do
     current_scope = conn.assigns.current_scope
 
-    if name = conn.params["org_name"] do
-      membership = NervesHub.Accounts.get_membership_by_org_name!(current_scope, name)
+    if current_scope && conn.params["org_name"] do
+      membership = NervesHub.Accounts.get_membership_by_org_name!(current_scope, conn.params["org_name"])
 
       current_scope
       |> Scope.put_org(membership.org)
@@ -114,8 +114,8 @@ defmodule NervesHubWeb.Auth do
   def assign_product_to_scope(conn, _opts) do
     current_scope = conn.assigns.current_scope
 
-    if name = conn.params["product_name"] do
-      product = NervesHub.Products.get_by_name!(current_scope, name)
+    if current_scope && conn.params["product_name"] do
+      product = NervesHub.Products.get_by_name!(current_scope, conn.params["product_name"])
 
       assign(conn, :current_scope, Scope.put_product(current_scope, product))
     else

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -11,6 +11,13 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
     Endpoint.subscribe("device:#{device.id}")
   end
 
+  test "user is redirected to login when trying to access a products device list, but the user isn't logged in" do
+    build_conn()
+    |> visit("/org/snoot/boop/devices")
+    |> assert_path("/login")
+    |> assert_has("div", text: "You must login to access this page.")
+  end
+
   test "shows a loading message (async loading)", %{conn: conn, fixture: fixture} do
     %{device: device, org: org, product: product} = fixture
 

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -27,6 +27,13 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     Endpoint.subscribe("device:#{device.id}")
   end
 
+  test "user is redirected to login when trying to view a device, but the user isn't logged in" do
+    build_conn()
+    |> visit("/org/snoot/boop/devices/toot")
+    |> assert_path("/login")
+    |> assert_has("div", text: "You must login to access this page.")
+  end
+
   describe "shows device" do
     test "when device has no firmware", %{
       conn: conn,

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -3,6 +3,13 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
 
   alias NervesHub.Fixtures
 
+  test "user is redirected to login when trying to access an org, but the user isn't logged in" do
+    build_conn()
+    |> visit("/org/snoot")
+    |> assert_path("/login")
+    |> assert_has("div", text: "You must login to access this page.")
+  end
+
   describe "onboarding" do
     test "shows a friendly onboarding page if no devices are registered" do
       user_name = "Waffles"

--- a/test/nerves_hub_web/live/orgs/index_test.exs
+++ b/test/nerves_hub_web/live/orgs/index_test.exs
@@ -3,6 +3,13 @@ defmodule NervesHubWeb.Live.Orgs.IndexTest do
 
   alias NervesHub.Fixtures
 
+  test "user is redirected to login when trying to list their orgs, but the user isn't logged in" do
+    build_conn()
+    |> visit("/orgs")
+    |> assert_path("/login")
+    |> assert_has("div", text: "You must login to access this page.")
+  end
+
   describe "onboarding" do
     test "provides a simple way for users to create their first organization and product" do
       user = Fixtures.user_fixture(%{name: "Waffles"})


### PR DESCRIPTION
Instead of throwing a 500 error, lets redirect the user, like they expect.