### PR TITLE
Fix health info backgrounds

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -136,7 +136,7 @@
   background-image: linear-gradient(
     180deg,
     rgba(16, 185, 129, 0) 18.75%,
-    rgba(16, 185, 129, 0.04) 81.25%
+    rgba(16, 185, 129, 0.06) 81.25%
   );
 }
 @utility health-warning {
@@ -150,7 +150,7 @@
   background-image: linear-gradient(
     180deg,
     rgba(99, 102, 241, 0) 18.75%,
-    rgba(99, 102, 241, 0.08) 81.25%
+    rgba(99, 102, 241, 0.06) 81.25%
   );
 }
 @utility health-plain {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -140,43 +140,25 @@
   );
 }
 @utility health-warning {
-  background-image:
-    linear-gradient(
-      180deg,
-      rgba(245, 158, 11, 0) 18.75%,
-      rgba(245, 158, 11, 0.04) 81.25%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(63, 63, 70, 0.16) 0%,
-      rgba(63, 63, 70, 0.24) 100%
-    );
+  background-image: linear-gradient(
+    180deg,
+    rgba(245, 158, 11, 0) 18.75%,
+    rgba(245, 158, 11, 0.04) 81.25%
+  );
 }
 @utility health-neutral {
-  background-image:
-    linear-gradient(
-      180deg,
-      rgba(99, 102, 241, 0) 18.75%,
-      rgba(99, 102, 241, 0.04) 81.25%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(63, 63, 70, 0.16) 0%,
-      rgba(63, 63, 70, 0.24) 100%
-    );
+  background-image: linear-gradient(
+    180deg,
+    rgba(99, 102, 241, 0) 18.75%,
+    rgba(99, 102, 241, 0.08) 81.25%
+  );
 }
 @utility health-plain {
-  background-image:
-    linear-gradient(
-      180deg,
-      rgba(99, 99, 99, 0) 18.75%,
-      rgba(99, 99, 99, 0.04) 81.25%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(63, 63, 63, 0.16) 0%,
-      rgba(63, 63, 63, 0.24) 100%
-    );
+  background-image: linear-gradient(
+    180deg,
+    rgba(99, 99, 99, 0) 18.75%,
+    rgba(99, 99, 99, 0.04) 81.25%
+  );
 }
 @utility progress-glow {
   background-image:

--- a/lib/mix/tasks/gen.metrics.ex
+++ b/lib/mix/tasks/gen.metrics.ex
@@ -11,6 +11,7 @@ defmodule Mix.Tasks.NervesHub.Gen.Metrics do
 
   use Mix.Task
 
+  alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceMetric
   alias NervesHub.Repo
 

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -132,7 +132,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
             </div>
           </div>
           <div class="flex flex-wrap items-center justify-items-stretch gap-2 px-4 pt-2 pb-4">
-            <div class="bg-health-good border-success flex h-16 grow flex-col rounded border-b px-3 py-2">
+            <div class="border-success health-good flex h-16 grow flex-col rounded border-b px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">CPU</span>
               <div :if={@latest_metrics["cpu_usage_percent"] && @latest_metrics["cpu_temp"]} class="flex items-end justify-between">
                 <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_usage_percent"])}%</span>
@@ -146,7 +146,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
               </div>
               <span :if={!@latest_metrics["cpu_usage_percent"] && !@latest_metrics["cpu_temp"]} class="text-nerves-gray-500 text-xl leading-[30px]">NA</span>
             </div>
-            <div class="bg-health-warning border-warning flex h-16 grow flex-col rounded border-b px-3 py-2">
+            <div class="border-warning health-warning flex h-16 grow flex-col rounded border-b px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">Memory used</span>
               <div :if={@latest_metrics["mem_used_mb"]} class="flex items-end justify-between">
                 <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["mem_used_mb"])}MB</span>
@@ -156,7 +156,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
                 <span class="text-nerves-gray-500 text-xl leading-[30px]">Not reported</span>
               </div>
             </div>
-            <div class="bg-health-neutral flex h-16 grow flex-col rounded border-b border-indigo-500 px-3 py-2">
+            <div class="border-notice health-neutral flex h-16 grow flex-col rounded border-b px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">Load avg</span>
               <div :if={@latest_metrics["load_1min"] || @latest_metrics["load_5min"] || @latest_metrics["load_15min"]} class="flex items-center justify-between">
                 <span :if={@latest_metrics["load_1min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_1min"]}</span>

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -97,7 +97,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
       <div :if={Enum.any?(@latest_metrics) && @health_enabled?} class="bg-base-900 border-base-700 mb-6 flex w-full flex-col rounded border">
         <div class="shadow-device-details-content flex flex-col">
           <div class="flex flex-wrap items-center justify-items-stretch gap-2 px-4 pt-2 pb-4">
-            <div class="bg-health-good border-success flex h-16 grow flex-col rounded border-b px-3 py-2">
+            <div class="border-success health-good flex h-16 grow flex-col rounded border-b px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">CPU</span>
               <div :if={@latest_metrics["cpu_usage_percent"] && @latest_metrics["cpu_temp"]} class="flex items-end justify-between">
                 <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_usage_percent"])}%</span>
@@ -111,7 +111,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
               </div>
               <span :if={!@latest_metrics["cpu_usage_percent"] && !@latest_metrics["cpu_temp"]} class="text-nerves-gray-500 text-xl leading-[30px]">NA</span>
             </div>
-            <div class="bg-health-warning border-warning flex h-16 grow flex-col rounded border-b px-3 py-2">
+            <div class="border-warning health-warning flex h-16 grow flex-col rounded border-b px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">Memory used</span>
               <div :if={@latest_metrics["mem_used_mb"]} class="flex items-end justify-between">
                 <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["mem_used_mb"])}MB</span>
@@ -121,7 +121,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
                 <span class="text-nerves-gray-500 text-xl leading-[30px]">Not reported</span>
               </div>
             </div>
-            <div class="bg-health-neutral flex h-16 grow flex-col rounded border-b border-indigo-500 px-3 py-2">
+            <div class="health-neutral flex h-16 grow flex-col rounded border-b border-indigo-500 px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">Load avg</span>
               <div :if={@latest_metrics["load_1min"] || @latest_metrics["load_5min"] || @latest_metrics["load_15min"]} class="flex items-center justify-between">
                 <span :if={@latest_metrics["load_1min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_1min"]}</span>
@@ -137,7 +137,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
                 <span class="text-nerves-gray-500 text-xl leading-[30px]">Not reported</span>
               </div>
             </div>
-            <div :for={{key, value} <- custom_metrics(@latest_metrics)} class="bg-health-plain flex h-16 grow flex-col rounded border-b border-neutral-500 px-3 py-2">
+            <div :for={{key, value} <- custom_metrics(@latest_metrics)} class="health-plain flex h-16 grow flex-col rounded border-b border-neutral-500 px-3 py-2">
               <span class="text-base-400 text-xs tracking-wide">{key_label(key)}</span>
               <span class="text-base-50 text-xl leading-[30px]">{nice_round(value)}</span>
             </div>


### PR DESCRIPTION
Bring the health info box backgrounds back.

**Before:**
<img width="608" height="197" alt="Screenshot 2026-04-17 at 9 27 34 AM" src="https://github.com/user-attachments/assets/e6b6b859-045d-4863-8337-81f7f14564d1" />

**After:**
<img width="606" height="194" alt="Screenshot 2026-04-17 at 9 32 28 AM" src="https://github.com/user-attachments/assets/c3d3eefc-f828-4111-80de-1d29a90d36e7" />

