### PR TITLE
Add download endpoint to firmware api

### DIFF
--- a/lib/nerves_hub_web/controllers/api/firmware_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/firmware_controller.ex
@@ -58,4 +58,13 @@ defmodule NervesHubWeb.API.FirmwareController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  operation(:download, summary: "Download a Firmware")
+
+  def download(%{assigns: %{product: product}} = conn, %{"uuid" => uuid}) do
+    with {:ok, firmware} <- Firmwares.get_firmware_by_product_and_uuid(product, uuid),
+         {:ok, url} <- Application.get_env(:nerves_hub, :firmware_upload).download_file(firmware) do
+      redirect(conn, external: url)
+    end
+  end
 end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -168,6 +168,7 @@ defmodule NervesHubWeb.Router do
                 get("/:uuid", FirmwareController, :show)
                 post("/", FirmwareController, :create)
                 delete("/:uuid", FirmwareController, :delete)
+                get("/:uuid/download", FirmwareController, :download)
               end
 
               scope "/deployments" do

--- a/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
@@ -103,6 +103,20 @@ defmodule NervesHubWeb.API.FirmwareControllerTest do
     end
   end
 
+  describe "download firmware" do
+    setup [:create_firmware]
+
+    test "downloads chosen firmware", %{conn: conn, org: org, product: product, firmware: firmware} do
+      conn =
+        get(
+          conn,
+          Routes.api_firmware_path(conn, :download, org.name, product.name, firmware.uuid)
+        )
+
+      assert redirected_to(conn) =~ "#{firmware.uuid}.fw"
+    end
+  end
+
   defp create_firmware(%{user: user, org: org, product: product, tmp_dir: tmp_dir}) do
     org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})


### PR DESCRIPTION
Having this would be very nice for our automation tools.
Would be used to fetch the latest firmware from a deploy group when flashing new cards for instance.