### PR TITLE
A revamp of the Device Metrics page

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -20,6 +20,7 @@
   ],
   "ignorePaths": [
     "**/*.csv",
+    "assets/js/hooks/chart.js",
     "docker/*",
     "Dockerfile",
     "config",

--- a/assets/js/hooks/chart.js
+++ b/assets/js/hooks/chart.js
@@ -1,42 +1,37 @@
 import Chart from "chart.js/auto"
+import zoomPlugin from "chartjs-plugin-zoom"
+import { format } from "date-fns"
 
 export default {
-  dataset() {
-    return JSON.parse(this.el.dataset.metrics)
-  },
-  unit() {
-    return JSON.parse(this.el.dataset.unit)
-  },
   mounted() {
+    let key = this.el.dataset.key
     let metrics = JSON.parse(this.el.dataset.metrics)
-    let type = JSON.parse(this.el.dataset.type)
-    let max = JSON.parse(this.el.dataset.max)
-    let min = JSON.parse(this.el.dataset.min)
+
+    let max = null
+    // let min = JSON.parse(this.el.dataset.min)
+
     let maxTime = JSON.parse(this.el.dataset.maxtime)
     let minTime = JSON.parse(this.el.dataset.mintime)
-    let title = JSON.parse(this.el.dataset.title)
 
-    const ctx = this.el
-    var data = []
-    for (let i = 0; i < metrics.length; i++) {
-      data.push(metrics[i])
+    let title = this.el.dataset.title
+    let unit = this.el.dataset.unit
+
+    if (this.el.dataset.max != "") {
+      max = this.el.dataset.max
     }
 
     const areaChartDataset = {
-      type: "line",
+      type: "scatter",
       data: {
         datasets: [
           {
-            backgroundColor: "rgba(99, 102, 241)",
-            fill: {
-              target: "start",
-              above: "rgba(99, 102, 241, 0.29)",
-              below: "rgba(99, 102, 241, 0.29)"
-            },
             radius: 2,
-            data: this.dataset()
-          }
-        ]
+            data: metrics,
+            pointBackgroundColor: "rgb(97, 95, 255)",
+            pointBorderColor: "rgb(97, 95, 255)",
+            parsing: false,
+          },
+        ],
       },
       options: {
         plugins: {
@@ -46,67 +41,158 @@ export default {
             text: title,
             font: {
               size: 16,
-              weight: "normal"
+              weight: "normal",
             },
-            color: "rgba(212, 212, 216)",
+            color: null,
             padding: {
-              bottom: 14
-            }
+              bottom: 14,
+            },
           },
           legend: {
-            display: false
-          }
+            display: false,
+          },
+          tooltip: {
+            displayColors: false,
+            callbacks: {
+              title: function (context) {
+                return format(
+                  new Date(context[0].parsed.x),
+                  "dd-MM-yyyy : HH:mm:ssaaa",
+                )
+              },
+              label: function (context) {
+                return `${context.parsed.y}`
+              },
+            },
+          },
+          zoom: {
+            zoom: {
+              drag: {
+                enabled: true,
+              },
+              mode: "x",
+              onZoomComplete: function (chartRef) {
+                const { min, max } = chartRef.chart.scales.x
+
+                const event = new CustomEvent("chartZoomed", {
+                  detail: { min: min, max: max },
+                })
+
+                window.dispatchEvent(event)
+
+                chart.options.scales.x.time.unit = false
+
+                chart.update()
+              },
+            },
+          },
         },
         scales: {
           x: {
             grid: {
-              color: "rgba(63, 63, 70)"
+              color: null,
             },
             type: "time",
             time: {
-              unit: this.unit(),
+              unit: unit,
               displayFormats: {
-                millisecond: "HH:mm:ss.SSS",
-                second: "HH:mm:ss",
-                minute: "HH:mm",
-                hour: "HH:mm"
-              }
+                millisecond: "HH:mm:ss.SSSaaa",
+                second: "HH:mm:ssaaa",
+                minute: "HH:mmaaa",
+                hour: "HH:mmaaa",
+              },
             },
             ticks: {
+              source: "auto",
               display: true,
-              autoSkip: false
+              autoSkip: false,
             },
             min: minTime,
-            max: maxTime
+            max: maxTime,
           },
           y: {
-            offset: true,
             grid: {
-              color: "rgba(63 63 70)"
+              color: null,
             },
             type: "linear",
-            min: min,
-            max: max
-          }
+            suggestedMin: 0,
+            suggestedMax: max,
+          },
         },
         responsive: true,
-        maintainAspectRatio: false
-      }
+        maintainAspectRatio: false,
+      },
     }
 
-    const chart = new Chart(ctx, areaChartDataset)
+    setThemeColors(areaChartDataset)
+
+    Chart.register(zoomPlugin)
+
+    const chart = new Chart(this.el, areaChartDataset)
     this.el.chart = chart
 
-    this.handleEvent("update-charts", function(payload) {
-      if (payload.type == type) {
+    this.handleEvent("update-charts", function (payload) {
+      if (payload.key == key) {
+        chart.options.scales.x.time.unit = payload.unit
+        chart.options.scales.x.min = payload.from
+        chart.options.scales.x.max = payload.until
+        chart.options.scales.x.suggestedMin = payload.from
+        chart.options.scales.x.suggestedMax = payload.until
+
         chart.data.datasets[0].data = payload.data
+
         chart.update()
       }
     })
 
-    this.handleEvent("update-time-unit", function(payload) {
-      chart.options.scales.x.time.unit = payload.unit
+    this.handleEvent("update-time-frame", function (payload) {
+      chart.options.scales.x.min = payload.from
+      chart.options.scales.x.max = payload.until
+      chart.options.scales.x.suggestedMin = payload.from
+      chart.options.scales.x.suggestedMax = payload.until
+
       chart.update()
     })
-  }
+
+    this.handleEvent("add-data-point", function (payload) {
+      if (payload.key == key) {
+        let data = chart.data.datasets[0].data
+        data.push(payload.data)
+
+        chart.options.scales.x.min = payload.from
+        chart.options.scales.x.max = payload.until
+        chart.options.scales.x.suggestedMin = payload.from
+        chart.options.scales.x.suggestedMax = payload.until
+
+        chart.data.datasets[0].data = data
+
+        chart.update()
+      }
+    })
+
+    window.addEventListener("themeUpdated", function (payload) {
+      setThemeColors(chart)
+      chart.update()
+    })
+
+    window.addEventListener("chartZoomed", function (payload) {
+      chart.options.scales.x.min = payload.detail.min
+      chart.options.scales.x.max = payload.detail.max
+      chart.update()
+    })
+
+    function setThemeColors(chart) {
+      let theme = document.documentElement.getAttribute("data-theme")
+
+      if (theme == "dark") {
+        chart.options.plugins.title.color = "rgba(212, 212, 216)"
+        chart.options.scales.x.grid.color = "rgba(63, 63, 70)"
+        chart.options.scales.y.grid.color = "rgba(63, 63, 70)"
+      } else if (theme == "light") {
+        chart.options.plugins.title.color = "rgba(9, 9, 11)"
+        chart.options.scales.x.grid.color = "rgba(218, 218, 218)"
+        chart.options.scales.y.grid.color = "rgba(218, 218, 218)"
+      }
+    }
+  },
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -17,6 +17,7 @@
         "@xterm/xterm": "^6.0.0",
         "chart.js": "^4.5.1",
         "chartjs-adapter-date-fns": "^3.0.0",
+        "chartjs-plugin-zoom": "^2.2.0",
         "date-fns": "^4.1.0",
         "highlight.js": "^11.10.0",
         "javascript-time-ago": "^2.5.10",
@@ -59,7 +60,7 @@
       "version": "4.3.0"
     },
     "../deps/phoenix_live_view": {
-      "version": "1.1.26",
+      "version": "1.1.28",
       "license": "MIT",
       "dependencies": {
         "morphdom": "2.7.8"
@@ -495,6 +496,12 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -789,6 +796,19 @@
       "peerDependencies": {
         "chart.js": ">=2.8.0",
         "date-fns": ">=2.0.0"
+      }
+    },
+    "node_modules/chartjs-plugin-zoom": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz",
+      "integrity": "sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.45",
+        "hammerjs": "^2.0.8"
+      },
+      "peerDependencies": {
+        "chart.js": ">=3.2.0"
       }
     },
     "node_modules/cheap-ruler": {
@@ -1452,6 +1472,15 @@
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
       "license": "ISC"
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -14,6 +14,7 @@
     "@xterm/xterm": "^6.0.0",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-plugin-zoom": "^2.2.0",
     "date-fns": "^4.1.0",
     "highlight.js": "^11.10.0",
     "javascript-time-ago": "^2.5.10",

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -4,11 +4,11 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   alias NervesHub.Devices.Metrics
 
   @time_frame_opts [
-    {"hour", 1},
+    {"hour", 3},
     {"day", 1},
     {"day", 7}
   ]
-  @default_time_frame {"hour", 1}
+  @default_time_frame {"hour", 3}
 
   # Metric types with belonging titles to display as default.
   # Also sets order of charts.
@@ -41,15 +41,16 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     "disk_total_kb"
   ]
 
+  @tick_interval 55_000
+
   def tab_params(_params, _uri, socket) do
-    time_frame = Map.get(socket.assigns, :time_frame, @default_time_frame)
+    _ = if connected?(socket), do: Process.send_after(self(), :tick, @tick_interval)
 
     socket
-    |> assign(:time_frame, time_frame)
+    |> update_from_and_until_timestamps()
     |> assign(:time_frame_opts, @time_frame_opts)
     |> assign(:latest_metrics, Metrics.get_latest_metric_set(socket.assigns.device.id))
-    |> assign_charts()
-    |> update_charts()
+    |> async_assign_charts()
     |> cont()
   end
 
@@ -57,14 +58,39 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     [:time_frame, :time_frame_opts, :charts]
   end
 
+  def hooked_async("update_chart:" <> key, {:ok, results}, socket) do
+    {from, until} = fetch_from_and_until(socket)
+
+    socket
+    |> assign(has_chart_data_key(key), Enum.any?(results))
+    |> push_event("update-charts", %{
+      key: key,
+      data: results,
+      from: from,
+      until: until,
+      unit: get_time_unit(socket.assigns.time_frame)
+    })
+    |> halt()
+  end
+
+  def hooked_async("update_chart:" <> key, {:exit, reason}, socket) do
+    _ =
+      Sentry.capture_message("Unexpected error when updating device health charts",
+        extra: %{key: key, reason: reason},
+        result: :none
+      )
+
+    halt(socket)
+  end
+
   def hooked_async(_name, _async_fun_result, socket), do: {:cont, socket}
 
   def hooked_event("set-time-frame", %{"unit" => unit, "amount" => amount}, socket) do
-    payload = %{unit: get_time_unit({unit, String.to_integer(amount)})}
+    {parsed_amount, ""} = Integer.parse(amount)
 
     socket
-    |> assign(:time_frame, {unit, String.to_integer(amount)})
-    |> push_event("update-time-unit", payload)
+    |> assign(:time_frame, {unit, parsed_amount})
+    |> update_from_and_until_timestamps()
     |> update_charts()
     |> halt()
   end
@@ -74,10 +100,45 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   def hooked_info(%Broadcast{event: "health_check_report"}, %{assigns: %{device: device}} = socket) do
     latest_metrics = Metrics.get_latest_metric_set(device.id)
 
+    chart_keys = metrics_to_chart(socket.assigns.latest_metrics)
+
+    socket =
+      socket
+      |> update_from_and_until_timestamps()
+      |> assign(:latest_metrics, latest_metrics)
+      |> assign_metadata()
+
+    {from, until} = fetch_from_and_until(socket)
+
+    # if we previously didn't loaded any metric keys, now is the time to do it
+    if Enum.empty?(chart_keys) do
+      async_assign_charts(socket)
+    else
+      latest_metrics
+      |> metrics_to_chart()
+      |> Enum.reduce(socket, fn key, socket ->
+        data = %{
+          x: DateTime.to_unix(latest_metrics["timestamp"], :millisecond),
+          y: latest_metrics[key]
+        }
+
+        socket
+        |> push_event("add-data-point", %{key: key, data: data, from: from, until: until})
+        |> assign(has_chart_data_key(key), true)
+      end)
+    end
+    |> halt()
+  end
+
+  def hooked_info(:tick, socket) do
+    Process.send_after(self(), :tick, @tick_interval)
+
     socket
-    |> assign(:latest_metrics, latest_metrics)
-    |> assign_metadata()
-    |> update_charts()
+    |> update_from_and_until_timestamps()
+    |> then(fn socket ->
+      {from, until} = fetch_from_and_until(socket)
+      push_event(socket, "update-time-frame", %{from: from, until: until})
+    end)
     |> halt()
   end
 
@@ -92,7 +153,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     <div
       id="health-tab"
       phx-mounted={JS.remove_class("opacity-0")}
-      class="phx-click-loading:opacity-50 tab-content w-full p-6 opacity-0 transition-all duration-500"
+      class="phx-click-loading:opacity-50 tab-content size-full p-6 opacity-0 transition-all duration-500"
     >
       <div :if={Enum.any?(@latest_metrics) && @health_enabled?} class="bg-base-900 border-base-700 mb-6 flex w-full flex-col rounded border">
         <div class="shadow-device-details-content flex flex-col">
@@ -145,7 +206,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
         </div>
       </div>
 
-      <div class="bg-base-900 border-base-700 flex w-full flex-col rounded border">
+      <div :if={Enum.any?(Map.keys(@latest_metrics))} class="bg-base-900 border-base-700 flex w-full flex-col rounded border">
         <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
           <div class="flex items-end gap-3">
             <div class="text-base-50 text-base font-medium">Health over time</div>
@@ -161,7 +222,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
               :for={{unit, amount} <- @time_frame_opts}
               type="button"
               class={[
-                "border-base-600 hover:bg-base-700 hover:text-base-200 border px-4 py-2 text-sm font-medium first:rounded-s-lg last:rounded-e-lg focus:z-10 focus:ring-0",
+                "border-base-600 hover:bg-base-700 hover:text-base-200 cursor-pointer border px-4 py-2 text-sm font-medium first:rounded-s-lg last:rounded-e-lg focus:z-10 focus:ring-0",
                 {unit, amount} != @time_frame && "bg-base-800 text-base-300",
                 {unit, amount} == @time_frame && "bg-base-700 text-base-200"
               ]}
@@ -177,40 +238,116 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
         </div>
 
         <div class="flex flex-col gap-10 p-10">
-          <div :if={Enum.empty?(@charts)} class="flex items-center justify-center p-6">
-            <span class="text-base-500 font-extralight">No metrics for the selected period.</span>
-          </div>
-
-          <div :for={chart <- @charts} :if={Enum.any?(@charts)} class="flex flex-col gap-3">
-            <div class="h-[200px] w-full">
-              <canvas
-                id={chart.type}
-                phx-hook="Chart"
-                phx-update="ignore"
-                data-type={Jason.encode!(chart.type)}
-                data-unit={Jason.encode!(chart.unit)}
-                data-max={Jason.encode!(chart.max)}
-                data-min={Jason.encode!(chart.min)}
-                data-maxtime={Jason.encode!(chart.max_time)}
-                data-mintime={Jason.encode!(chart.min_time)}
-                data-metrics={Jason.encode!(chart.data)}
-                data-title={Jason.encode!(chart_title(chart))}
-              >
-              </canvas>
+          <div :for={key <- metrics_to_chart(@latest_metrics)} class="flex flex-col gap-3">
+            <div class="relative flex h-[200px] w-full">
+              <.async_result :let={chart_data} assign={assigns[chart_data_key(key)]}>
+                <:loading>
+                  <div class="bg-base-900/70 absolute inset-0 flex items-center justify-center">
+                    <span class="text-base-500 font-extralight">Loading history for {key}...</span>
+                  </div>
+                </:loading>
+                <:failed :let={_failure}>
+                  <div class="bg-base-900/70 absolute inset-0 flex items-center justify-center">
+                    <span class="text-base-500 font-extralight">Sorry, there was an error loading the history for {key}.</span>
+                  </div>
+                </:failed>
+                <canvas
+                  id={key <> "-chart"}
+                  phx-hook="Chart"
+                  phx-update="ignore"
+                  data-key={key}
+                  data-metrics={Jason.encode!(chart_data)}
+                  data-title={title(key)}
+                  data-max={suggested_max(key)}
+                  data-mintime={Jason.encode!(@charts_from_timestamp)}
+                  data-maxtime={Jason.encode!(@charts_until_timestamp)}
+                  data-unit="minute"
+                >
+                </canvas>
+                <div :if={not assigns[has_chart_data_key(key)] && Enum.empty?(chart_data)} class="bg-base-900/70 absolute inset-0 flex items-center justify-center">
+                  <span class="text-base-500 font-extralight">No metrics for {key} found for the selected period.</span>
+                </div>
+              </.async_result>
             </div>
           </div>
         </div>
       </div>
+
+      <div :if={Enum.empty?(Map.keys(@latest_metrics))} class="bg-base-900 border-base-700 flex size-full flex-col rounded border">
+        <div class="border-base-700 flex h-14 shrink-0 items-center justify-between border-b px-4">
+          <div class="flex items-end gap-3">
+            <div class="text-base-50 text-base font-medium">Health over time</div>
+          </div>
+          <div class="inline-flex rounded-md shadow-sm" role="group">
+            <button
+              :for={{unit, amount} <- @time_frame_opts}
+              type="button"
+              class={[
+                "border-base-600 border px-4 py-2 text-sm font-medium first:rounded-s-lg last:rounded-e-lg focus:z-10 focus:ring-0",
+                {unit, amount} != @time_frame && "bg-base-800 text-base-300",
+                {unit, amount} == @time_frame && "bg-base-700 text-base-200"
+              ]}
+              aria-label={Integer.to_string(amount) <> " " <> unit <> if amount > 1, do: "s", else: ""}
+              type="button"
+              disabled
+              phx-click="set-time-frame"
+              phx-value-unit={unit}
+              phx-value-amount={amount}
+            >
+              {Integer.to_string(amount) <> " " <> unit <> if amount > 1, do: "s", else: ""}
+            </button>
+          </div>
+        </div>
+
+        <div class="flex h-full flex-col items-center justify-center gap-10 p-10">
+          <div class="text-base-500 flex flex-col gap-3">
+            No health metrics have been received from the device
+          </div>
+        </div>
+      </div>
+
+      <div :if={Enum.any?(Map.keys(@latest_metrics))} class="h-6"></div>
     </div>
     """
   end
 
-  defp assign_charts(socket) do
-    %{device: device, time_frame: time_frame, latest_metrics: latest_metrics} = socket.assigns
+  defp update_from_and_until_timestamps(socket) do
+    {unit, unit_amount} = Map.get(socket.assigns, :time_frame, @default_time_frame)
 
-    charts = create_chart_data(device.id, time_frame, latest_metrics["mem_size_mb"])
+    from = DateTime.add(DateTime.utc_now(), -unit_amount, String.to_atom(unit))
+    until = DateTime.utc_now()
 
-    assign(socket, :charts, charts)
+    socket
+    |> assign(:time_frame, {unit, unit_amount})
+    |> assign(:charts_from_timestamp, from)
+    |> assign(:charts_until_timestamp, until)
+  end
+
+  defp update_charts(socket) do
+    %{device: %{id: device_id}, time_frame: time_frame, latest_metrics: latest_metrics} = socket.assigns
+
+    latest_metrics
+    |> metrics_to_chart()
+    |> Enum.reduce(socket, fn key, socket ->
+      start_async(socket, "update_chart:#{key}", fn ->
+        formatted_metrics(device_id, key, time_frame)
+      end)
+    end)
+  end
+
+  defp async_assign_charts(socket) do
+    device_id = socket.assigns.device.id
+    time_frame = socket.assigns.time_frame
+
+    socket.assigns.latest_metrics
+    |> metrics_to_chart()
+    |> Enum.reduce(socket, fn key, socket ->
+      socket
+      |> assign_async(chart_data_key(key), fn ->
+        {:ok, %{chart_data_key(key) => formatted_metrics(device_id, key, time_frame)}}
+      end)
+      |> assign(has_chart_data_key(key), false)
+    end)
   end
 
   defp assign_metadata(%{assigns: %{device: device}} = socket) do
@@ -220,111 +357,52 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     assign(socket, :metadata, Map.drop(metadata, standard_keys(device)))
   end
 
+  defp fetch_from_and_until(socket) do
+    {unit, amount} = socket.assigns.time_frame
+
+    from = DateTime.add(DateTime.utc_now(), -amount, String.to_atom(unit))
+    until = DateTime.utc_now()
+
+    {from, until}
+  end
+
   defp standard_keys(%{firmware_metadata: nil}), do: []
 
   defp standard_keys(%{firmware_metadata: firmware_metadata}),
     do: firmware_metadata |> Map.keys() |> Enum.map(&to_string/1)
 
-  # @doc """
-  # There are four cases for chart updates:
-  #   - Create hooks if data previously was empty.
-  #   - Clear hooks if there's no data for selected time frame.
-  #   - Do a push_patch to render more or less charts if custom types varies for time frames.
-  #   - Update existing hooks with new data via push_event (should happen most frequent).
-  # """
-  defp update_charts(%{charts: charts} = assigns) when charts == [], do: assign_charts(assigns)
-
-  defp update_charts(
-         %{
-           assigns: %{
-             device: device,
-             product: product,
-             org: org,
-             time_frame: time_frame,
-             latest_metrics: latest_metrics,
-             charts: charts
-           }
-         } = socket
-       ) do
-    data = create_chart_data(device.id, time_frame, latest_metrics["size_mb"])
-
-    cond do
-      data == [] ->
-        assign(socket, :charts, [])
-
-      types(charts) != types(data) ->
-        push_patch(socket,
-          to: ~p"/org/#{org}/#{product}/devices/#{device}/health"
-        )
-
-      true ->
-        Enum.reduce(data, socket, fn %{type: type, data: data}, socket ->
-          type = if is_binary(type), do: type, else: Atom.to_string(type)
-          push_event(socket, "update-charts", %{type: type, data: data})
-        end)
-    end
-  end
-
-  defp types(data) do
-    Enum.map(data, &Map.get(&1, :type))
-  end
-
-  defp create_chart_data(device_id, {unit, _} = time_frame, memory_size) do
-    metrics =
-      device_id
-      |> Metrics.get_device_metrics(time_frame)
-
-    %{inserted_at: max_time} =
-      Enum.max_by(metrics, & &1.inserted_at, DateTime, fn ->
-        %{inserted_at: DateTime.from_unix!(0)}
-      end)
-
-    %{inserted_at: min_time} =
-      Enum.min_by(metrics, & &1.inserted_at, DateTime, fn ->
-        %{inserted_at: DateTime.from_unix!(1)}
-      end)
-
-    metrics
-    |> Enum.group_by(& &1.key)
-    |> filter_and_sort()
-    |> Enum.map(fn {type, metrics} ->
-      data = organize_metrics_for_chart(metrics, unit)
-
-      # Build structure for rendering charts
-      %{
-        type: type,
-        title: title(type),
-        data: data,
-        max: get_max_value(type, data, memory_size),
-        min: get_min_value(type, data),
-        min_time: min_time,
-        max_time: max_time,
-        unit: get_time_unit(time_frame)
-      }
+  defp formatted_metrics(device_id, key, time_frame) do
+    Metrics.get_device_metrics_by_key(device_id, key, time_frame)
+    |> Enum.map(fn metric ->
+      %{x: DateTime.to_unix(metric.inserted_at, :millisecond), y: metric.value}
     end)
   end
 
-  defp filter_and_sort(metrics) do
-    metrics
-    |> Enum.reject(fn {type, _} -> type in @no_chart_metrics end)
-    |> Enum.sort_by(fn {type, _} ->
+  defp chart_title(key) do
+    String.replace(key, ~r/mb$/, "MB")
+  end
+
+  defp metrics_to_chart(latest_metrics) do
+    latest_metrics
+    |> Map.keys()
+    |> Enum.reject(fn k ->
+      k == "timestamp" or String.downcase(k) in @no_chart_metrics
+    end)
+    |> Enum.sort_by(fn key ->
       # Sorts list by @default_metrics order
       Enum.find_index(@default_metrics, fn {default_type, _} ->
-        default_type == type
+        default_type == key
       end)
     end)
   end
 
-  defp organize_metrics_for_chart(metrics, unit) do
-    metrics
-    |> get_max_per_hour(unit)
-    |> Enum.map(fn %{inserted_at: timestamp, value: value} ->
-      %{x: DateTime.to_string(timestamp), y: value}
-    end)
-  end
-
-  defp chart_title(chart) do
-    String.replace(chart.title, ~r/mb$/, "MB")
+  defp suggested_max(key) do
+    cond do
+      key == "cpu_temp" -> 100
+      String.starts_with?(key, "load_") -> 1
+      String.ends_with?(key, "_percent") or String.ends_with?(key, "_percentage") -> 100
+      true -> nil
+    end
   end
 
   defp title(type) do
@@ -337,78 +415,12 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
         |> String.replace("_", " ")
         |> String.capitalize()
     end
-  end
-
-  # Do nothing if time frame unit is hour
-  defp get_max_per_hour(metrics, "hour"), do: metrics
-
-  defp get_max_per_hour(metrics, _unit) do
-    metrics
-    |> Enum.group_by(& &1.inserted_at.hour)
-    |> Enum.map(fn {_key, val} ->
-      Enum.max_by(val, & &1.value)
-    end)
-    |> Enum.sort_by(& &1.inserted_at)
+    |> chart_title()
   end
 
   defp get_time_unit({"hour", _}), do: "minute"
   defp get_time_unit({"day", 1}), do: "hour"
   defp get_time_unit({"day", _}), do: "day"
-
-  defp get_max_value(_type, data, _memory_size) when data == [], do: 0
-
-  defp get_max_value(type, data, memory_size) do
-    case type do
-      "load_" <> _ ->
-        cpu_load_max_value(data)
-
-      "mem_used_mb" ->
-        memory_size
-
-      type
-      when type in ["mem_used_percent", "cpu_temp", "cpu_usage_percent", "disk_used_percentage"] ->
-        100
-
-      _ ->
-        data
-        |> Enum.max_by(& &1.y)
-        |> Map.get(:y)
-        # Space it out a little
-        |> Kernel.+(1.0)
-    end
-  end
-
-  defp cpu_load_max_value(data) do
-    data
-    |> Enum.max_by(& &1.y)
-    |> Map.get(:y)
-    |> ceil()
-    |> max(1)
-  end
-
-  defp get_min_value(type, data) do
-    case type do
-      "load_" <> _ ->
-        0
-
-      type
-      when type in [
-             "mem_used_mb",
-             "mem_used_percent",
-             "cpu_temp",
-             "cpu_usage_percent",
-             "disk_used_percentage"
-           ] ->
-        0
-
-      _ ->
-        data
-        |> Enum.min_by(& &1.y)
-        |> Map.get(:y)
-        # Space it out a little
-        |> Kernel.-(1.0)
-    end
-  end
 
   defp custom_metrics(metrics) do
     Enum.reject(metrics, &(elem(&1, 0) in @manual_metrics))
@@ -422,4 +434,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     |> String.replace("_", " ")
     |> String.capitalize()
   end
+
+  defp chart_data_key(key), do: String.to_atom("#{key}_chart_data")
+  defp has_chart_data_key(key), do: String.to_atom("#{key}_has_chart_data")
 end

--- a/test/nerves_hub_web/live/devices/show/health_tab_test.exs
+++ b/test/nerves_hub_web/live/devices/show/health_tab_test.exs
@@ -33,7 +33,7 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
     conn
     |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
     |> assert_has("div", text: "Health over time")
-    |> assert_has("span", text: "No metrics for the selected period.")
+    |> assert_has("div", text: "No health metrics have been received from the device")
   end
 
   test "graph sections are displayed when metrics data exists", %{
@@ -47,17 +47,17 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
     conn
     |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
     # Six of the default metric types are shown as charts
-    |> assert_has("canvas", count: 6)
+    |> assert_has("canvas", count: 6, timeout: 100)
     # Charts should be displayed for all time frames
     |> click_button("1 day")
-    |> assert_has("canvas", count: 6)
+    |> assert_has("canvas", count: 6, timeout: 100)
     |> click_button("7 days")
-    |> assert_has("canvas", count: 6)
+    |> assert_has("canvas", count: 6, timeout: 100)
     |> tap(fn session ->
       # Assert all default metrics except "size_mb" appears as element id:s
       for metric <- Map.keys(@metrics),
           metric != "mem_size_mb",
-          do: assert_has(session, "##{metric}")
+          do: assert_has(session, "##{metric}-chart")
     end)
   end
 
@@ -70,7 +70,7 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
     } do
       timestamp =
         DateTime.now!("Etc/UTC")
-        |> DateTime.add(-23, :hour)
+        |> DateTime.add(-4, :hour)
         |> DateTime.truncate(:millisecond)
 
       _ = save_metrics_with_timestamp(device.id, timestamp)
@@ -78,14 +78,38 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
       # Default time frame is 1 hour, so no charts are expected.
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
       |> click_button("1 day")
-      |> assert_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          refute_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
       |> click_button("7 days")
-      |> assert_has("canvas")
-      # Makes sure "1 hour" button is working
-      |> click_button("1 hour")
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          refute_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
+      # Makes sure "3 hours" button is working
+      |> click_button("3 hours")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
     end
 
     test "within 7 days", %{
@@ -104,11 +128,29 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
       |> click_button("1 day")
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
       |> click_button("7 days")
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
 
       timestamp =
         DateTime.now!("Etc/UTC")
@@ -120,11 +162,29 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
       |> click_button("1 day")
-      |> refute_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          assert_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
       |> click_button("7 days")
-      |> assert_has("canvas")
+      |> then(fn socket ->
+        @metrics
+        |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+        |> Enum.reduce(socket, fn {key, _}, socket ->
+          refute_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+        end)
+      end)
     end
   end
 
@@ -136,7 +196,7 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
   } do
     conn
     |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
-    |> refute_has("canvas")
+    |> assert_has("div", text: "No health metrics have been received from the device")
     |> unwrap(fn view ->
       assert {7, _} = save_metrics_with_timestamp(device.id, DateTime.now!("Etc/UTC"))
 
@@ -148,7 +208,13 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
 
       render(view)
     end)
-    |> assert_has("canvas")
+    |> then(fn socket ->
+      @metrics
+      |> Enum.reject(fn {key, _} -> key == "mem_size_mb" end)
+      |> Enum.reduce(socket, fn {key, _}, socket ->
+        refute_has(socket, "span", text: "No metrics for #{key} found for the selected period.", timeout: 100)
+      end)
+    end)
   end
 
   test "metrics data is correctly structured for js graphs", %{
@@ -170,15 +236,15 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
              |> DeviceMetric.save_with_timestamp()
              |> Repo.insert()
 
-    {:ok, _view, html} =
+    {:ok, lv, _html} =
       live(conn, "/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
 
     organized_metrics =
-      ~s([{"x":"#{now}","y":#{value}}])
+      ~s([{"x":#{DateTime.to_unix(now, :millisecond)},"y":#{value}}])
       |> html_escape()
       |> safe_to_string()
 
-    assert html =~ ~s(data-metrics="#{organized_metrics}")
+    assert render_async(lv, 1000) =~ ~s(data-metrics="#{organized_metrics}")
   end
 
   defp save_metrics_with_timestamp(device_id, timestamp) do


### PR DESCRIPTION
- better light theme support
- use `assign_async` for data loading
- show all data points fetched
- live updating of data, including updating the start and end dates of the graphs after each 'tick' (55 seconds)
- and support zooming in on a region


https://github.com/user-attachments/assets/58e081dc-bc3c-4ec5-943e-5c2b31d1d9d1

