### PR TITLE
Add a minimum delta version

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -983,6 +983,20 @@ defmodule NervesHub.Devices do
     Repo.exists?(query)
   end
 
+  defp meets_delta_minimum_version?(%Device{} = device, %DeploymentGroup{delta_minimum_version: min_version})
+       when not is_nil(min_version) do
+    case {Version.parse(device.firmware_metadata.version), Version.parse(min_version)} do
+      {{:ok, device_vsn}, {:ok, min_vsn}} ->
+        Version.compare(device_vsn, min_vsn) != :lt
+
+      _ ->
+        # If either version is invalid, fall back to full firmware
+        false
+    end
+  end
+
+  defp meets_delta_minimum_version?(_device, _deployment_group), do: true
+
   @doc """
   Returns true if Version.match? and all deployment tags are in device tags.
   """
@@ -1956,21 +1970,21 @@ defmodule NervesHub.Devices do
   """
   @spec get_delta_or_firmware(Device.t(), DeploymentGroup.t()) ::
           {:ok, Firmware.t()} | {:ok, FirmwareDelta.t()}
-  def get_delta_or_firmware(%Device{firmware_metadata: %{uuid: source_uuid}} = device, %DeploymentGroup{
-        delta_updatable: true,
-        current_release: %DeploymentRelease{firmware: %Firmware{delta_updatable: true} = target_firmware}
-      }) do
-    case Firmwares.get_firmware_by_product_id_and_uuid(device.product_id, source_uuid) do
-      {:ok, source_firmware} ->
-        case get_delta_if_ready(device, source_firmware, target_firmware) do
-          {:ok, delta} ->
-            {:ok, delta}
-
-          _ ->
-            {:ok, target_firmware}
-        end
-
-      {:error, :not_found} ->
+  def get_delta_or_firmware(
+        %Device{} = device,
+        %DeploymentGroup{
+          delta_updatable: true,
+          current_release: %DeploymentRelease{firmware: %Firmware{delta_updatable: true} = target_firmware}
+        } = deployment_group
+      ) do
+    with {:ok, source_firmware} <-
+           Firmwares.get_firmware_by_product_id_and_uuid(device.product_id, device.firmware_metadata.uuid),
+         true <- meets_delta_minimum_version?(device, deployment_group),
+         {:ok, delta} <- get_delta_if_ready(device, source_firmware, target_firmware) do
+      {:ok, delta}
+    else
+      # Device firmware version is below minimum or delta not ready, use full firmware
+      _ ->
         {:ok, target_firmware}
     end
   end

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -65,6 +65,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     field(:queue_management, Ecto.Enum, values: [:FIFO, :LIFO], default: :FIFO)
 
     field(:delta_updatable, :boolean, default: true)
+    field(:delta_minimum_version, :string)
 
     field(:status, Ecto.Enum, values: [:ready, :preparing, :deltas_failed, :unknown_error], default: :ready)
 
@@ -106,7 +107,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
   @spec create_changeset(map(), Product.t(), Firmware.t(), User.t()) :: Ecto.Changeset.t()
   def create_changeset(params, product, firmware, user) do
     %DeploymentGroup{}
-    |> cast(params, [:name, :delta_updatable, :platform, :architecture])
+    |> cast(params, [:name, :delta_updatable, :delta_minimum_version, :platform, :architecture])
     |> cast_embed(:conditions, required: true, with: &conditions_changeset/2)
     |> put_change(:product_id, product.id)
     |> put_change(:org_id, product.org_id)
@@ -117,6 +118,8 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     |> validate_firmware(product)
     |> validate_platform()
     |> validate_architecture()
+    |> normalize_delta_minimum_version()
+    |> validate_delta_minimum_version()
     |> unique_constraint(:name, name: :deployments_product_id_name_index)
     |> then(fn changeset ->
       first_release = first_release_changeset(product, get_field(changeset, :firmware), user)
@@ -210,6 +213,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
       :name,
       :is_active,
       :delta_updatable,
+      :delta_minimum_version,
       :connecting_code,
       :queue_management,
       :priority_queue_enabled,
@@ -221,6 +225,8 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     |> cast_embed(:conditions, required: true, with: &conditions_changeset/2)
     |> validate_required([:name, :delta_updatable, :is_active, :queue_management])
     |> unique_constraint(:name, name: :deployments_product_id_name_index)
+    |> normalize_delta_minimum_version()
+    |> validate_delta_minimum_version()
     |> prepare_current_updated_devices()
     |> prepare_device_count()
     |> prepare_status()
@@ -310,6 +316,34 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
           add_error(
             changeset,
             :priority_queue_firmware_version_threshold,
+            "must be a valid semantic version"
+          )
+      end
+    else
+      changeset
+    end
+  end
+
+  defp normalize_delta_minimum_version(changeset) do
+    if get_change(changeset, :delta_minimum_version) == "" do
+      put_change(changeset, :delta_minimum_version, nil)
+    else
+      changeset
+    end
+  end
+
+  defp validate_delta_minimum_version(changeset) do
+    min_version = get_field(changeset, :delta_minimum_version)
+
+    if min_version do
+      case Version.parse(min_version) do
+        {:ok, _} ->
+          changeset
+
+        :error ->
+          add_error(
+            changeset,
+            :delta_minimum_version,
             "must be a valid semantic version"
           )
       end

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -37,6 +37,12 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
                   for more information on delta updates.
                 </:rich_hint>
               </.input>
+              <.input
+                field={@form[:delta_minimum_version]}
+                label="Delta Minimum Version"
+                placeholder="eg. 1.0.0"
+                hint="Devices with firmware versions below this will receive full firmware updates instead of deltas. Leave empty to allow deltas for all versions."
+              />
             </div>
           </div>
         </div>

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -212,6 +212,11 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
               <div class="flex items-center gap-4">
                 <span class="text-nerves-gray-500 text-sm">Firmware deltas provide smaller update payloads by only sending the differences between firmware versions.</span>
               </div>
+              <div :if={@deployment_group.delta_minimum_version} class="flex items-center gap-4">
+                <span class="text-nerves-gray-500 w-32 text-sm">Minimum Version:</span>
+                <span class="text-base-300 text-sm">{@deployment_group.delta_minimum_version}</span>
+                <span class="text-nerves-gray-500 text-xs">(devices below this version receive full updates)</span>
+              </div>
             </div>
             <div :if={Enum.any?(@deltas)} class="bg-base-900 border-base-700 rounded-b border-t">
               <div class="flex flex-col">

--- a/lib/nerves_hub_web/controllers/api/deployment_group_json.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_group_json.ex
@@ -19,6 +19,7 @@ defmodule NervesHubWeb.API.DeploymentGroupJSON do
       archive_uuid: get_in(deployment_group.current_release.archive.uuid),
       conditions: conditions(deployment_group.conditions),
       delta_updatable: deployment_group.delta_updatable,
+      delta_minimum_version: deployment_group.delta_minimum_version,
       device_count: deployment_group.device_count,
       releases_count: deployment_group.releases_count
     }

--- a/lib/nerves_hub_web/controllers/api/schemas/deployment_group_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/deployment_group_schemas.ex
@@ -77,6 +77,7 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
         current_release: CurrentRelease,
         conditions: Conditions,
         delta_updatable: %Schema{type: :boolean},
+        delta_minimum_version: %Schema{type: :string, nullable: true},
         device_count: %Schema{type: :integer},
         releases_count: %Schema{type: :integer}
       },
@@ -101,6 +102,7 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
           "tags" => ["beta"]
         },
         "delta_updatable" => false,
+        "delta_minimum_version" => "1.0.0",
         "device_count" => 42,
         "releases_count" => 3
       }

--- a/lib/nerves_hub_web/live/deployment_groups/new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/new.html.heex
@@ -44,6 +44,12 @@
                   for more information on delta updates.
                 </:rich_hint>
               </.input>
+              <.input
+                field={@form[:delta_minimum_version]}
+                label="Delta Minimum Version"
+                placeholder="eg. 1.0.0"
+                hint="Devices with firmware versions below this will receive full firmware updates instead of deltas. Leave empty to allow deltas for all versions."
+              />
             </div>
           </div>
 

--- a/priv/repo/migrations/20260420111908_add_delta_minimum_version_to_deployment_groups.exs
+++ b/priv/repo/migrations/20260420111908_add_delta_minimum_version_to_deployment_groups.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddDeltaMinimumVersionToDeploymentGroups do
+  use Ecto.Migration
+
+  def change() do
+    alter table(:deployments) do
+      add(:delta_minimum_version, :string)
+    end
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -668,6 +668,136 @@ defmodule NervesHub.DevicesTest do
 
       assert String.starts_with?(firmware_url, "https://files.customer.com/download?firmware=")
     end
+
+    test "broadcasts delta url when device firmware version meets delta_minimum_version", %{
+      org: org,
+      user: user,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      new_org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      old_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "1.5.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      new_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "2.0.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      deployment_group =
+        Fixtures.deployment_group_fixture(new_firmware, %{
+          name: "Delta deployment with minimum version",
+          is_active: true,
+          delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          user: user
+        })
+
+      device =
+        Fixtures.device_fixture(org, product, old_firmware, %{
+          status: :provisioned,
+          deployment_id: deployment_group.id,
+          fwup_version: "1.13.0"
+        })
+
+      delta = Fixtures.firmware_delta_fixture(old_firmware, new_firmware)
+      {:ok, delta_url} = Firmwares.get_firmware_url(delta)
+
+      deployment_group = Repo.preload(deployment_group, :org)
+
+      topic = "device:#{device.id}"
+      Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
+
+      {:ok, _inflight_update} = Devices.told_to_update(device, deployment_group)
+
+      assert_receive %Broadcast{
+                       topic: ^topic,
+                       event: "update",
+                       payload: %{
+                         firmware_url: firmware_url
+                       }
+                     },
+                     500
+
+      assert delta_url == firmware_url
+    end
+
+    test "broadcasts full firmware url when device firmware version is below delta_minimum_version",
+         %{
+           org: org,
+           user: user,
+           product: product,
+           tmp_dir: tmp_dir
+         } do
+      new_org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      old_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "0.9.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      new_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "2.0.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      deployment_group =
+        Fixtures.deployment_group_fixture(new_firmware, %{
+          name: "Delta deployment with minimum version",
+          is_active: true,
+          delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          user: user
+        })
+
+      device =
+        Fixtures.device_fixture(org, product, old_firmware, %{
+          status: :provisioned,
+          deployment_id: deployment_group.id,
+          fwup_version: "1.13.0"
+        })
+
+      # Create delta but it should not be used
+      _delta = Fixtures.firmware_delta_fixture(old_firmware, new_firmware)
+
+      deployment_group = Repo.preload(deployment_group, :org)
+
+      topic = "device:#{device.id}"
+      Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
+
+      {:ok, _inflight_update} = Devices.told_to_update(device, deployment_group)
+
+      assert_receive %Broadcast{
+                       topic: ^topic,
+                       event: "update",
+                       payload: %{
+                         firmware_url: firmware_url
+                       }
+                     },
+                     500
+
+      # Should get full firmware, not delta
+      refute String.ends_with?(firmware_url, ".delta.fw")
+    end
   end
 
   describe "inflight updates" do
@@ -1783,6 +1913,113 @@ defmodule NervesHub.DevicesTest do
       # confirm that the firmware url is the delta firmware url
       assert delta_url == update_payload.firmware_url
     end
+
+    test "returns delta when device firmware version meets delta_minimum_version and deployment group is delta updatable",
+         %{
+           org: org,
+           user: user,
+           product: product,
+           tmp_dir: tmp_dir
+         } do
+      new_org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      old_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "1.5.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      new_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "2.0.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      deployment_group =
+        Fixtures.deployment_group_fixture(new_firmware, %{
+          name: "Delta deployment with minimum version",
+          is_active: true,
+          delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          user: user
+        })
+
+      device =
+        Fixtures.device_fixture(org, product, old_firmware, %{
+          status: :provisioned,
+          deployment_id: deployment_group.id,
+          fwup_version: "1.13.0"
+        })
+        |> Repo.preload(:deployment_group)
+
+      delta = Fixtures.firmware_delta_fixture(old_firmware, new_firmware)
+      {:ok, delta_url} = Firmwares.get_firmware_url(delta)
+
+      update_payload = Devices.resolve_update(device)
+
+      assert delta_url == update_payload.firmware_url
+    end
+
+    test "returns full firmware when device firmware version is below delta_minimum_version and deployment group is delta updatable",
+         %{
+           org: org,
+           user: user,
+           product: product,
+           tmp_dir: tmp_dir
+         } do
+      new_org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      old_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "0.9.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      new_firmware =
+        Fixtures.firmware_fixture(new_org_key, product, %{
+          fwup_version: "1.13.0",
+          version: "2.0.0",
+          dir: tmp_dir
+        })
+        |> Ecto.Changeset.change(delta_updatable: true)
+        |> Repo.update!()
+
+      deployment_group =
+        Fixtures.deployment_group_fixture(new_firmware, %{
+          name: "Delta deployment with minimum version",
+          is_active: true,
+          delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          user: user
+        })
+
+      device =
+        Fixtures.device_fixture(org, product, old_firmware, %{
+          status: :provisioned,
+          deployment_id: deployment_group.id,
+          fwup_version: "1.13.0"
+        })
+        |> Repo.preload(:deployment_group)
+
+      # Create delta but it should not be used
+      _delta = Fixtures.firmware_delta_fixture(old_firmware, new_firmware)
+      {:ok, firmware_url} = Firmwares.get_firmware_url(new_firmware)
+
+      update_payload = Devices.resolve_update(device)
+
+      # Should get full firmware, not delta
+      assert firmware_url == update_payload.firmware_url
+      refute String.ends_with?(update_payload.firmware_url, ".delta.fw")
+    end
   end
 
   describe "get_device_firmware_for_delta_generation_by_deployment_group/1" do
@@ -2032,6 +2269,177 @@ defmodule NervesHub.DevicesTest do
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 
       assert String.ends_with?(url, "#{target_firmware.uuid}.fw")
+    end
+
+    test "returns full firmware when device version is below delta minimum version", %{
+      device: device,
+      deployment_group: deployment_group,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir, version: "2.0.0"})
+      _ = Fixtures.firmware_delta_fixture(deployment_group.current_release.firmware, target_firmware)
+
+      # Device is on version 0.5.0, but minimum is 1.0.0
+      device = %{
+        device
+        | firmware_metadata: %{
+            device.firmware_metadata
+            | fwup_version: "1.13.0",
+              version: "0.5.0"
+          }
+      }
+
+      deployment_group = %{
+        deployment_group
+        | delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
+      }
+
+      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, url} = Firmwares.get_firmware_url(firmware)
+
+      # Should get full firmware, not delta
+      assert String.ends_with?(url, "#{target_firmware.uuid}.fw")
+      refute String.ends_with?(url, ".delta.fw")
+    end
+
+    test "returns delta when device version meets delta minimum version", %{
+      device: device,
+      deployment_group: deployment_group,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir, version: "2.0.0"})
+      _ = Fixtures.firmware_delta_fixture(deployment_group.current_release.firmware, target_firmware)
+
+      # Device is on version 1.5.0, minimum is 1.0.0 - should get delta
+      device = %{
+        device
+        | firmware_metadata: %{
+            device.firmware_metadata
+            | fwup_version: "1.13.0",
+              version: "1.5.0"
+          }
+      }
+
+      deployment_group = %{
+        deployment_group
+        | delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
+      }
+
+      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, url} = Firmwares.get_firmware_url(firmware)
+
+      # Should get delta firmware
+      assert String.ends_with?(url, ".delta.fw")
+    end
+
+    test "returns delta when device version equals delta minimum version", %{
+      device: device,
+      deployment_group: deployment_group,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir, version: "2.0.0"})
+      _ = Fixtures.firmware_delta_fixture(deployment_group.current_release.firmware, target_firmware)
+
+      # Device is on version 1.0.0, minimum is 1.0.0 - should get delta
+      device = %{
+        device
+        | firmware_metadata: %{
+            device.firmware_metadata
+            | fwup_version: "1.13.0",
+              version: "1.0.0"
+          }
+      }
+
+      deployment_group = %{
+        deployment_group
+        | delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
+      }
+
+      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, url} = Firmwares.get_firmware_url(firmware)
+
+      # Should get delta firmware
+      assert String.ends_with?(url, ".delta.fw")
+    end
+
+    test "returns delta when delta_minimum_version is nil", %{
+      device: device,
+      deployment_group: deployment_group,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir, version: "2.0.0"})
+      _ = Fixtures.firmware_delta_fixture(deployment_group.current_release.firmware, target_firmware)
+
+      device = %{
+        device
+        | firmware_metadata: %{
+            device.firmware_metadata
+            | fwup_version: "1.13.0",
+              version: "0.1.0"
+          }
+      }
+
+      deployment_group = %{
+        deployment_group
+        | delta_updatable: true,
+          delta_minimum_version: nil,
+          current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
+      }
+
+      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, url} = Firmwares.get_firmware_url(firmware)
+
+      # Should get delta firmware even for very old version when minimum is nil
+      assert String.ends_with?(url, ".delta.fw")
+    end
+
+    test "returns full firmware when device version is invalid and minimum version is set", %{
+      device: device,
+      deployment_group: deployment_group,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir, version: "2.0.0"})
+      _ = Fixtures.firmware_delta_fixture(deployment_group.current_release.firmware, target_firmware)
+
+      # Device has invalid version format
+      device = %{
+        device
+        | firmware_metadata: %{
+            device.firmware_metadata
+            | fwup_version: "1.13.0",
+              version: "invalid-version"
+          }
+      }
+
+      deployment_group = %{
+        deployment_group
+        | delta_updatable: true,
+          delta_minimum_version: "1.0.0",
+          current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
+      }
+
+      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, url} = Firmwares.get_firmware_url(firmware)
+
+      # Should get full firmware when version is invalid
+      assert String.ends_with?(url, "#{target_firmware.uuid}.fw")
+      refute String.ends_with?(url, ".delta.fw")
     end
   end
 

--- a/test/nerves_hub/managed_deployments/deployment_group_test.exs
+++ b/test/nerves_hub/managed_deployments/deployment_group_test.exs
@@ -276,4 +276,108 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
       assert changeset.changes.priority_queue_firmware_version_threshold == "2.0.0"
     end
   end
+
+  describe "delta_minimum_version validations" do
+    setup do
+      Fixtures.standard_fixture()
+    end
+
+    test "delta_minimum_version must be valid semantic version", %{
+      deployment_group: deployment_group
+    } do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          delta_minimum_version: "not-a-version"
+        })
+
+      refute changeset.valid?
+
+      assert errors_on(changeset).delta_minimum_version == [
+               "must be a valid semantic version"
+             ]
+    end
+
+    test "delta_minimum_version accepts valid semantic versions", %{
+      deployment_group: deployment_group
+    } do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          delta_minimum_version: "1.0.0"
+        })
+
+      assert changeset.valid?
+      assert changeset.changes.delta_minimum_version == "1.0.0"
+    end
+
+    test "delta_minimum_version accepts nil", %{
+      deployment_group: deployment_group
+    } do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          delta_minimum_version: nil
+        })
+
+      assert changeset.valid?
+    end
+
+    test "delta_minimum_version accepts empty string and normalizes to nil", %{
+      deployment_group: deployment_group
+    } do
+      # First set a value so we can verify normalization
+      deployment_group = %{deployment_group | delta_minimum_version: "1.0.0"}
+
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{
+          delta_minimum_version: ""
+        })
+
+      assert changeset.valid?
+      assert changeset.changes.delta_minimum_version == nil
+    end
+
+    test "delta_minimum_version can be set in create_changeset", %{
+      product: product,
+      user: user,
+      firmware: firmware
+    } do
+      changeset =
+        DeploymentGroup.create_changeset(
+          %{
+            name: "Test Deployment",
+            delta_minimum_version: "1.5.0",
+            conditions: %{"tags" => [], "version" => ""}
+          },
+          product,
+          firmware,
+          user
+        )
+
+      assert changeset.valid?
+      assert changeset.changes.delta_minimum_version == "1.5.0"
+    end
+
+    test "delta_minimum_version validates in create_changeset", %{
+      product: product,
+      user: user,
+      firmware: firmware
+    } do
+      changeset =
+        DeploymentGroup.create_changeset(
+          %{
+            name: "Test Deployment",
+            delta_minimum_version: "invalid",
+            conditions: %{"tags" => [], "version" => ""}
+          },
+          product,
+          firmware,
+          user
+        )
+
+      refute changeset.valid?
+
+      assert errors_on(changeset).delta_minimum_version == [
+               "must be a valid semantic version"
+             ]
+    end
+  end
 end


### PR DESCRIPTION
After all the work to fwup to improve delta performance, it's clear we cannot update some of our devices until they get a fully updated version of fwup. As such, this PR introduces a gate on deltas so you can specify a minimum version. This will allow us to constrain deltas to a firmware version that we know includes a fwup with all the perf improvements we need.

<img width="1019" height="726" alt="Screenshot 2026-04-20 at 1 26 56 PM" src="https://github.com/user-attachments/assets/528d1e41-ef1a-4971-8e21-43007dd1b6ff" />