### PR TITLE
Use `Phoenix.Channel.Server` over `Endpoint` for deltas pubsub

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -19,6 +19,7 @@ defmodule NervesHub.Firmwares do
   alias NervesHub.Repo
   alias NervesHub.Workers.DeleteFirmware
   alias NervesHub.Workers.FirmwareDeltaBuilder
+  alias Phoenix.Channel.Server, as: ChannelServer
 
   require Logger
 
@@ -699,16 +700,12 @@ defmodule NervesHub.Firmwares do
   end
 
   defp notify_firmware_delta_target({:ok, %FirmwareDelta{} = firmware_delta}) do
-    _ =
-      NervesHubWeb.Endpoint.broadcast(
-        "firmware:#{firmware_delta.target_id}",
-        "delta/status_update",
-        %{
-          delta_id: firmware_delta.id,
-          source_firmware_id: firmware_delta.source_id,
-          status: firmware_delta.status
-        }
-      )
+    :ok =
+      ChannelServer.broadcast(NervesHub.PubSub, "firmware:#{firmware_delta.target_id}", "delta/status_update", %{
+        delta_id: firmware_delta.id,
+        source_firmware_id: firmware_delta.source_id,
+        status: firmware_delta.status
+      })
 
     {:ok, firmware_delta}
   end


### PR DESCRIPTION
If a device is added to a deployment during its connection dance, and a delta needs to be created, we need to send pubsub messages using `Phoenix.Channel.Server` as it works for both Web and Device endpoints.