### PR TITLE
Fix a UI bug related to the deployment group filter being reset

### DIFF
--- a/lib/nerves_hub_web/components/filter_sidebar.ex
+++ b/lib/nerves_hub_web/components/filter_sidebar.ex
@@ -56,7 +56,7 @@ defmodule NervesHubWeb.Components.FilterSidebar do
                     <input class="sidebar-text-input" type="text" name={filter.attr} id={"input_#{filter.attr}"} value={@current_filters[filter.attr]} phx-debounce="500" />
                   <% :select -> %>
                     <select class="sidebar-select" name={filter.attr} id={"input_#{filter.attr}"}>
-                      <option :for={{label, value} <- filter.values} value={value} selected={to_string(@current_filters[filter.attr]) == value}>
+                      <option :for={{label, value} <- filter.values} value={value} selected={to_string(@current_filters[filter.attr]) == to_string(value)}>
                         {label}
                       </option>
                     </select>

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -564,6 +564,32 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> select("Update status", option: "Updating")
       |> refute_has("a", text: device.identifier, timeout: 1000)
     end
+
+    test "using another select drop down filter doesn't reset the deployment group drop down filter", %{
+      conn: conn,
+      fixture: fixture
+    } do
+      %{device: device, firmware: firmware, org: org, product: product, deployment_group: deployment_group} = fixture
+
+      device2 = Fixtures.device_fixture(org, product, firmware)
+      device3 = Fixtures.device_fixture(org, product, firmware, %{tags: nil})
+
+      Repo.update!(Ecto.Changeset.change(device2, deployment_id: deployment_group.id))
+      Repo.update!(Ecto.Changeset.change(device3, deployment_id: deployment_group.id))
+
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("#device-count", text: "3", timeout: 1000)
+      |> assert_has("div a", text: device.identifier)
+      |> assert_has("div a", text: device2.identifier)
+      |> assert_has("div a", text: device3.identifier)
+      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> select("Deployment Group", option: deployment_group.name)
+      |> assert_has("#device-count", text: "2", timeout: 1_000)
+      |> select("Platform", option: "platform")
+      |> assert_has("#device-count", text: "2", timeout: 1_000)
+      |> assert_has("#input_deployment_id:has(> option[selected])")
+    end
   end
 
   describe "bulk actions" do


### PR DESCRIPTION
If a deployment group was selected in the devices list filtering, and then another select drop-down filter was used, the UI reset the deployment group filter even though it was still present.

This fixes the UI bug.