### PR TITLE
Support running bulk actions on all listed devices, including matching devices when using filters

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -14,7 +14,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.Certificate
   alias NervesHub.DeploymentOrchestratorEvents
   alias NervesHub.DeviceEvents
-  alias NervesHub.Devices.BulkImport
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
@@ -40,7 +39,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.Products
   alias NervesHub.Products.Product
   alias NervesHub.Repo
-  alias NervesHub.TaskSupervisor, as: Tasks
   alias Phoenix.Channel.Server, as: ChannelServer
 
   require Logger
@@ -140,6 +138,20 @@ defmodule NervesHub.Devices do
 
   @spec filter(Product.t(), User.t(), map()) :: {[Device.t()], Flop.Meta.t()}
   def filter(product, user, opts) do
+    common_filter_query(user)
+    |> preload([latest_connection: lc], latest_connection: lc)
+    |> preload([latest_health: lh], latest_health: lh)
+    |> preload([deployment_group: dg], deployment_group: dg)
+    |> CommonFiltering.filter(product, opts)
+  end
+
+  @spec filter_query(Product.t(), User.t(), map()) :: Ecto.Query.t()
+  def filter_query(product, user, opts) do
+    common_filter_query(user)
+    |> CommonFiltering.filter_query(product, opts)
+  end
+
+  defp common_filter_query(user) do
     Device
     |> join(:left, [d], dc in assoc(d, :latest_connection), as: :latest_connection)
     |> join(:left, [d, dc], dh in assoc(d, :latest_health), as: :latest_health)
@@ -148,13 +160,6 @@ defmodule NervesHub.Devices do
       as: :pinned
     )
     |> join(:left, [d], dg in assoc(d, :deployment_group), as: :deployment_group)
-    |> preload([latest_connection: lc], latest_connection: lc)
-    |> preload([latest_health: lh], latest_health: lh)
-    |> preload([deployment_group: dg], deployment_group: dg)
-    |> CommonFiltering.filter(
-      product,
-      opts
-    )
   end
 
   def get_minimal_device_location_by_product(product) do
@@ -385,64 +390,6 @@ defmodule NervesHub.Devices do
     |> Device.changeset(params)
     |> Repo.insert()
     |> Repo.maybe_preload(:product)
-  end
-
-  def async_bulk_create(org_id, product_id, import_list, format, tags \\ [])
-
-  def async_bulk_create(org_id, product_id, import_list, format, tags) when not is_binary(import_list) do
-    async_bulk_create(org_id, product_id, JSON.encode!(import_list), format, tags)
-  end
-
-  def async_bulk_create(org_id, product_id, import_list, format, tags) do
-    Task.Supervisor.start_child(NervesHub.TaskSupervisor, fn ->
-      {successful_count, unsuccessful_count} = bulk_create(org_id, product_id, import_list, format, tags)
-
-      _ =
-        ProductNotifications.create_device_async_bulk_create_notification!(
-          product_id,
-          successful_count,
-          unsuccessful_count,
-          format
-        )
-    end)
-    |> case do
-      :ignore -> {:error, :ignored}
-      {:error, _} = error -> error
-      {:ok, pid, _info} -> {:ok, pid}
-      ok -> ok
-    end
-  end
-
-  def bulk_create(org_id, product_id, import_list, format, tags \\ []) do
-    product =
-      Product
-      |> where(org_id: ^org_id, id: ^product_id)
-      |> Repo.exclude_deleted()
-      |> Repo.one!()
-
-    BulkImport.parse_file(format, import_list)
-    |> Enum.map(fn details ->
-      changeset =
-        Device.changeset(%Device{}, %{
-          org_id: product.org_id,
-          product_id: product.id,
-          identifier: details.device_identifier,
-          tags: tags
-        })
-
-      Repo.transact(fn ->
-        with {:ok, device} <- Repo.insert(changeset),
-             {:ok, pem} <- details.pem,
-             {:ok, otp_cert} <- Certificate.from_pem_or_der(pem),
-             {:ok, _db_cert} <- create_device_certificate(device, otp_cert) do
-          {:ok, device}
-        end
-      end)
-    end)
-    |> Enum.frequencies_by(fn result -> elem(result, 0) end)
-    |> then(fn res ->
-      {Map.get(res, :ok, 0), Map.get(res, :error, 0)}
-    end)
   end
 
   def set_as_provisioned!(device) do
@@ -1098,33 +1045,12 @@ defmodule NervesHub.Devices do
   def clear_deployment_group(device) do
     device =
       device
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_change(:deployment_id, nil)
+      |> Device.clear_deployment_group()
       |> Repo.update!()
 
     DeviceEvents.deployment_cleared(device)
 
     Map.put(device, :deployment_group, nil)
-  end
-
-  @doc """
-  Remove multiple devices from their deployment groups.
-
-  Returns `{:ok, count}` with the number of devices updated.
-  """
-  @spec remove_many_from_deployment_group(Scope.t(), [non_neg_integer()]) :: {:ok, non_neg_integer()}
-  def remove_many_from_deployment_group(%Scope{product: product}, device_ids) when is_list(device_ids) do
-    {count, _} =
-      Device
-      |> Repo.exclude_deleted()
-      |> where([d], d.id in ^device_ids)
-      |> where([d], d.product_id == ^product.id)
-      |> where([d], not is_nil(d.deployment_id))
-      |> Repo.update_all(set: [deployment_id: nil])
-
-    Enum.each(device_ids, &DeviceEvents.updated(%Device{id: &1}))
-
-    {:ok, count}
   end
 
   @spec failure_threshold_met?(Device.t(), DeploymentGroup.t()) :: boolean()
@@ -1500,80 +1426,6 @@ defmodule NervesHub.Devices do
   end
 
   @doc """
-  Move devices to a deployment group. A deployment group struct or id can
-  be given. Devices are fetched by their id and also filtered by the given
-  deployment group firmware's architecture and platform.
-
-  `Repo.update_all()` is used to update the rows. The return informs how
-  many rows were updated and how many were ignored because of a problem.
-
-  move_many_to_deployment_group([1, 2, 3], deployment_group)
-  > {:ok, %{updated: 3, ignored: 0}}
-  """
-  @spec move_many_to_deployment_group(
-          Scope.t(),
-          [non_neg_integer()],
-          DeploymentGroup.t() | non_neg_integer()
-        ) ::
-          {:ok, %{updated: non_neg_integer(), ignored: non_neg_integer()}}
-  def move_many_to_deployment_group(%Scope{} = scope, device_ids, %DeploymentGroup{id: deployment_id}) do
-    move_many_to_deployment_group(scope, device_ids, deployment_id)
-  end
-
-  def move_many_to_deployment_group(%Scope{} = scope, device_ids, deployment_id) when is_number(deployment_id) do
-    deployment_group =
-      DeploymentGroup
-      |> from(as: :deployment_group)
-      |> join(:inner, [deployment_group: dg], o in assoc(dg, :org), as: :org)
-      |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
-      |> ManagedDeployments.join_current_release()
-      |> join(:inner, [current_release: cr], f in assoc(cr, :firmware), as: :firmware)
-      |> where([deployment_group: dg], dg.id == ^deployment_id)
-      |> where([users: users], users.id == ^scope.user.id)
-      |> preload([firmware: f, current_release: cr],
-        current_release: {cr, firmware: f}
-      )
-      |> Repo.one!()
-
-    # Use a transaction to ensure devices are updated and deltas are queued atomically
-    # This minimizes the race condition window where the orchestrator could pick up devices
-    # before their firmware_delta rows are created
-    {:ok, {devices_updated_count, _}} =
-      Repo.transact(fn ->
-        {count, _} =
-          Device
-          |> join(:inner, [d], o in assoc(d, :org), as: :org)
-          |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
-          |> where([users: users], users.id == ^scope.user.id)
-          |> Repo.exclude_deleted()
-          |> where([d], d.id in ^device_ids)
-          |> where(
-            [d],
-            d.firmware_metadata["platform"] == ^deployment_group.current_release.firmware.platform
-          )
-          |> where(
-            [d],
-            d.firmware_metadata["architecture"] ==
-              ^deployment_group.current_release.firmware.architecture
-          )
-          |> Repo.update_all([set: [deployment_id: deployment_id]], timeout: to_timeout(minute: 2))
-
-        # Queue delta generation for any new device firmware combinations immediately
-        # after the device updates within the same transaction
-        _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
-
-        {:ok, {count, nil}}
-      end)
-
-    :ok = Enum.each(device_ids, &DeviceEvents.updated(%Device{id: &1}))
-
-    # let the orchestrator know that some devices have been added to the deployment group
-    DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
-
-    {:ok, %{updated: devices_updated_count, ignored: length(device_ids) - devices_updated_count}}
-  end
-
-  @doc """
   Removes unmatched devices from deployment group. The given device ids are
   assumed to be ids of devices that "match" a deployment group's conditions,
   e.g. devices from ManagedDeployments.matched_device_ids/2. Devices are
@@ -1604,69 +1456,6 @@ defmodule NervesHub.Devices do
        updated: devices_updated_count,
        ignored: length(matched_device_ids) - devices_updated_count
      }}
-  end
-
-  @spec move_many(Scope.t(), [Device.t()], Product.t()) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def move_many(%Scope{user: user}, devices, product) do
-    product = Repo.preload(product, :org)
-
-    Enum.map(devices, &Task.Supervisor.async(Tasks, __MODULE__, :move, [&1, product, user]))
-    |> Task.await_many(20_000)
-    |> Enum.reduce(%{ok: [], error: []}, fn
-      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
-      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
-    end)
-  end
-
-  @spec disable_updates([Device.t()], User.t()) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def disable_updates_for_devices(devices, user) do
-    Enum.map(devices, &Task.Supervisor.async(Tasks, __MODULE__, :disable_updates, [&1, user]))
-    |> Task.await_many(20_000)
-    |> Enum.reduce(%{ok: [], error: []}, fn
-      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
-      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
-    end)
-  end
-
-  @spec tag_devices([Device.t()], User.t(), list(String.t())) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def tag_devices(devices, user, tags) do
-    Enum.map(devices, &Task.Supervisor.async(Tasks, __MODULE__, :tag_device, [&1, user, tags]))
-    |> Task.await_many(20_000)
-    |> Enum.reduce(%{ok: [], error: []}, fn
-      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
-      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
-    end)
-  end
-
-  @spec enable_updates_for_devices([Device.t()], User.t()) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def enable_updates_for_devices(devices, user) do
-    Enum.map(devices, &Task.Supervisor.async(Tasks, __MODULE__, :enable_updates, [&1, user]))
-    |> Task.await_many(20_000)
-    |> Enum.reduce(%{ok: [], error: []}, fn
-      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
-      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
-    end)
-  end
-
-  def clear_penalty_box_for_devices(devices, user) do
-    Enum.map(devices, &Task.Supervisor.async(Tasks, __MODULE__, :clear_penalty_box, [&1, user]))
-    |> Task.await_many(20_000)
-    |> Enum.reduce(%{ok: [], error: []}, fn
-      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
-      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
-    end)
   end
 
   @spec get_devices_by_id(Scope.t(), [non_neg_integer()]) :: [Device.t()]

--- a/lib/nerves_hub/devices/bulk_actions.ex
+++ b/lib/nerves_hub/devices/bulk_actions.ex
@@ -1,7 +1,6 @@
 defmodule NervesHub.Devices.BulkActions do
   import Ecto.Query
 
-  alias NervesHub.Accounts.Scope
   alias NervesHub.Accounts.User
   alias NervesHub.Certificate
   alias NervesHub.DeploymentOrchestratorEvents
@@ -76,11 +75,10 @@ defmodule NervesHub.Devices.BulkActions do
     end)
   end
 
-  @spec tag_devices([Device.t()], User.t(), list(String.t())) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def tag_devices(devices, user, tags) do
+  @spec tag_devices([Device.t()] | Ecto.Query.t(), User.t(), list(String.t())) ::
+          %{ok: [Device.t()], error: [{Ecto.Multi.name(), any()}]}
+          | %{ok: non_neg_integer(), error: non_neg_integer()}
+  def tag_devices(devices, user, tags) when is_list(devices) do
     Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :tag_device, [&1, user, tags]))
     |> Task.await_many(20_000)
     |> Enum.reduce(%{ok: [], error: []}, fn
@@ -89,13 +87,18 @@ defmodule NervesHub.Devices.BulkActions do
     end)
   end
 
+  def tag_devices(%Ecto.Query{} = devices_query, user, tags) do
+    stream_processing(devices_query, {:tag_device, [user, tags]})
+  end
+
   @doc """
   Remove multiple devices from their deployment groups.
 
   Returns `{:ok, count}` with the number of devices updated.
   """
-  @spec remove_many_from_deployment_group(Scope.t(), [non_neg_integer()]) :: {:ok, non_neg_integer()}
-  def remove_many_from_deployment_group(%Scope{product: product}, device_ids) when is_list(device_ids) do
+  @spec remove_many_from_deployment_group({[non_neg_integer()], Product.t()} | Ecto.Query.t()) ::
+          %{ok: non_neg_integer(), error: non_neg_integer()} | %{ok: non_neg_integer()}
+  def remove_many_from_deployment_group({device_ids, product} = args) when is_tuple(args) do
     {count, _} =
       Device
       |> Repo.exclude_deleted()
@@ -106,7 +109,23 @@ defmodule NervesHub.Devices.BulkActions do
 
     Enum.each(device_ids, &DeviceEvents.updated(%Device{id: &1}))
 
-    {:ok, count}
+    %{ok: count}
+  end
+
+  def remove_many_from_deployment_group(%Ecto.Query{} = devices_query) do
+    stream_processing(devices_query, fn device ->
+      device
+      |> Device.clear_deployment_group()
+      |> Repo.update()
+      |> case do
+        {:ok, device} = res ->
+          DeviceEvents.deployment_cleared(device)
+          res
+
+        res ->
+          res
+      end
+    end)
   end
 
   @doc """
@@ -121,16 +140,17 @@ defmodule NervesHub.Devices.BulkActions do
   > {:ok, %{updated: 3, ignored: 0}}
   """
   @spec move_many_to_deployment_group(
-          Scope.t(),
-          [non_neg_integer()],
-          DeploymentGroup.t() | non_neg_integer()
+          [non_neg_integer()] | Ecto.Query.t(),
+          DeploymentGroup.t() | non_neg_integer(),
+          User.t()
         ) ::
-          {:ok, %{updated: non_neg_integer(), ignored: non_neg_integer()}}
-  def move_many_to_deployment_group(%Scope{} = scope, device_ids, %DeploymentGroup{id: deployment_id}) do
-    move_many_to_deployment_group(scope, device_ids, deployment_id)
+          %{updated: non_neg_integer(), ignored: non_neg_integer()}
+          | %{ok: non_neg_integer(), error: non_neg_integer()}
+  def move_many_to_deployment_group(devices, %DeploymentGroup{id: deployment_id}, user) do
+    move_many_to_deployment_group(devices, deployment_id, user)
   end
 
-  def move_many_to_deployment_group(%Scope{} = scope, device_ids, deployment_id) when is_number(deployment_id) do
+  def move_many_to_deployment_group(device_ids, deployment_id, user) when is_list(device_ids) do
     deployment_group =
       DeploymentGroup
       |> from(as: :deployment_group)
@@ -139,7 +159,7 @@ defmodule NervesHub.Devices.BulkActions do
       |> ManagedDeployments.join_current_release()
       |> join(:inner, [current_release: cr], f in assoc(cr, :firmware), as: :firmware)
       |> where([deployment_group: dg], dg.id == ^deployment_id)
-      |> where([users: users], users.id == ^scope.user.id)
+      |> where([users: users], users.id == ^user.id)
       |> preload([firmware: f, current_release: cr],
         current_release: {cr, firmware: f}
       )
@@ -154,7 +174,7 @@ defmodule NervesHub.Devices.BulkActions do
           Device
           |> join(:inner, [d], o in assoc(d, :org), as: :org)
           |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
-          |> where([users: users], users.id == ^scope.user.id)
+          |> where([users: users], users.id == ^user.id)
           |> Repo.exclude_deleted()
           |> where([d], d.id in ^device_ids)
           |> where(
@@ -180,15 +200,61 @@ defmodule NervesHub.Devices.BulkActions do
     # let the orchestrator know that some devices have been added to the deployment group
     DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
 
-    {:ok, %{updated: devices_updated_count, ignored: length(device_ids) - devices_updated_count}}
+    %{updated: devices_updated_count, ignored: length(device_ids) - devices_updated_count}
   end
 
-  @spec move_many(Scope.t(), [Device.t()], Product.t()) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def move_many(%Scope{user: user}, devices, product) do
-    product = Repo.preload(product, :org)
+  def move_many_to_deployment_group(%Ecto.Query{} = devices_query, deployment_id, user) do
+    deployment_group =
+      DeploymentGroup
+      |> from(as: :deployment_group)
+      |> join(:inner, [deployment_group: dg], o in assoc(dg, :org), as: :org)
+      |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
+      |> ManagedDeployments.join_current_release()
+      |> join(:inner, [current_release: cr], f in assoc(cr, :firmware), as: :firmware)
+      |> where([deployment_group: dg], dg.id == ^deployment_id)
+      |> where([users: users], users.id == ^user.id)
+      |> preload([firmware: f, current_release: cr],
+        current_release: {cr, firmware: f}
+      )
+      |> Repo.one!()
+
+    devices_query
+    |> where(
+      [d],
+      d.firmware_metadata["platform"] == ^deployment_group.current_release.firmware.platform or
+        is_nil(d.firmware_metadata)
+    )
+    |> where(
+      [d],
+      d.firmware_metadata["architecture"] ==
+        ^deployment_group.current_release.firmware.architecture or is_nil(d.firmware_metadata)
+    )
+    |> stream_processing(
+      fn device ->
+        device
+        |> Device.update_deployment_group(deployment_group)
+        |> Repo.update()
+        |> case do
+          {:ok, device} ->
+            DeviceEvents.updated(device)
+            :ok
+
+          _ ->
+            :error
+        end
+      end,
+      before_commit: fn ->
+        _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
+        DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
+      end
+    )
+  end
+
+  @spec move_many([Device.t()] | Ecto.Query.t(), Product.t(), User.t()) ::
+          %{ok: [Device.t()], error: [{Ecto.Multi.name(), any()}]}
+          | %{ok: non_neg_integer(), error: non_neg_integer()}
+  def move_many(devices, target_product, user) when is_list(devices) do
+    product = Repo.preload(target_product, :org)
 
     Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :move, [&1, product, user]))
     |> Task.await_many(20_000)
@@ -198,11 +264,14 @@ defmodule NervesHub.Devices.BulkActions do
     end)
   end
 
-  @spec enable_updates_for_devices([Device.t()], User.t()) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def enable_updates_for_devices(devices, user) do
+  def move_many(%Ecto.Query{} = devices_query, target_product, user) do
+    stream_processing(devices_query, {:move, [target_product, user]})
+  end
+
+  @spec enable_updates_for_devices([Device.t()] | Ecto.Query.t(), User.t()) ::
+          %{ok: [Device.t()], error: [{Ecto.Multi.name(), any()}]}
+          | %{ok: non_neg_integer(), error: non_neg_integer()}
+  def enable_updates_for_devices(devices, user) when is_list(devices) do
     Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :enable_updates, [&1, user]))
     |> Task.await_many(20_000)
     |> Enum.reduce(%{ok: [], error: []}, fn
@@ -211,11 +280,14 @@ defmodule NervesHub.Devices.BulkActions do
     end)
   end
 
-  @spec disable_updates_for_devices([Device.t()], User.t()) :: %{
-          ok: [Device.t()],
-          error: [{Ecto.Multi.name(), any()}]
-        }
-  def disable_updates_for_devices(devices, user) do
+  def enable_updates_for_devices(%Ecto.Query{} = devices_query, user) do
+    stream_processing(devices_query, {:enable_updates, [user]})
+  end
+
+  @spec disable_updates_for_devices([Device.t()] | Ecto.Query.t(), User.t()) ::
+          %{ok: [Device.t()], error: [{Ecto.Multi.name(), any()}]}
+          | %{ok: non_neg_integer(), error: non_neg_integer()}
+  def disable_updates_for_devices(devices, user) when is_list(devices) do
     Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :disable_updates, [&1, user]))
     |> Task.await_many(20_000)
     |> Enum.reduce(%{ok: [], error: []}, fn
@@ -224,7 +296,14 @@ defmodule NervesHub.Devices.BulkActions do
     end)
   end
 
-  def clear_penalty_box_for_devices(devices, user) do
+  def disable_updates_for_devices(%Ecto.Query{} = devices_query, user) do
+    stream_processing(devices_query, {:disable_updates, [user]})
+  end
+
+  @spec clear_penalty_box_for_devices([Device.t()] | Ecto.Query.t(), User.t()) ::
+          %{ok: [Device.t()], error: [{Ecto.Multi.name(), any()}]}
+          | %{ok: non_neg_integer(), error: non_neg_integer()}
+  def clear_penalty_box_for_devices(devices, user) when is_list(devices) do
     Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :clear_penalty_box, [&1, user]))
     |> Task.await_many(20_000)
     |> Enum.reduce(%{ok: [], error: []}, fn
@@ -233,213 +312,8 @@ defmodule NervesHub.Devices.BulkActions do
     end)
   end
 
-  def async_remove_many_from_deployment_group(devices_query, callback_pid) do
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> stream_processing(fn device ->
-        device
-        |> Device.clear_deployment_group()
-        |> Repo.update()
-        |> case do
-          {:ok, device} = res ->
-            DeviceEvents.deployment_cleared(device)
-            res
-
-          res ->
-            res
-        end
-      end)
-      |> case do
-        {:ok, %{ok: successful_count, error: 0}} ->
-          send_async_msg(callback_pid, "All device(s) (#{successful_count}) removed from their deployment group.")
-
-        {:ok, %{ok: 0, error: _}} ->
-          send_async_msg(callback_pid, "No devices were successfully removed from their deployment group.", :error)
-
-        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
-          send_async_msg(
-            callback_pid,
-            "#{successful_count} devices were successfully from their deployment group, and #{unsuccessful_count} devices had errors and couldn't be removed",
-            :notice
-          )
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
-  end
-
-  def async_move_many_to_deployment_group(devices_query, deployment_id, scope, callback_pid) do
-    deployment_group =
-      DeploymentGroup
-      |> from(as: :deployment_group)
-      |> join(:inner, [deployment_group: dg], o in assoc(dg, :org), as: :org)
-      |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
-      |> ManagedDeployments.join_current_release()
-      |> join(:inner, [current_release: cr], f in assoc(cr, :firmware), as: :firmware)
-      |> where([deployment_group: dg], dg.id == ^deployment_id)
-      |> where([users: users], users.id == ^scope.user.id)
-      |> preload([firmware: f, current_release: cr],
-        current_release: {cr, firmware: f}
-      )
-      |> Repo.one!()
-
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> where(
-        [d],
-        d.firmware_metadata["platform"] == ^deployment_group.current_release.firmware.platform or
-          is_nil(d.firmware_metadata)
-      )
-      |> where(
-        [d],
-        d.firmware_metadata["architecture"] ==
-          ^deployment_group.current_release.firmware.architecture or is_nil(d.firmware_metadata)
-      )
-      |> stream_processing(
-        fn device ->
-          device
-          |> Device.update_deployment_group(deployment_group)
-          |> Repo.update()
-          |> case do
-            {:ok, device} ->
-              DeviceEvents.updated(device)
-              :ok
-
-            _ ->
-              :error
-          end
-        end,
-        before_commit: fn ->
-          _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
-          DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
-        end
-      )
-      |> case do
-        {:ok, %{ok: _, error: 0}} ->
-          send(
-            callback_pid,
-            {:async_update_complete, :info, "All selected devices successfully assigned to #{deployment_group.name}"}
-          )
-
-        {:ok, %{ok: 0, error: _}} ->
-          send(
-            callback_pid,
-            {:async_update_complete, :error, "No devices were successfully assigned to #{deployment_group.name}"}
-          )
-
-        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
-          send(
-            callback_pid,
-            {:async_update_complete, :notice,
-             "#{successful_count} devices were successfully assigned to #{deployment_group.name}, and #{unsuccessful_count} devices had errors and couldn't be assigned"}
-          )
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
-  end
-
-  def async_move_many(devices_query, target_product, user, callback_pid) do
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> stream_processing({:move, [target_product, user]})
-      |> case do
-        {:ok, %{ok: _, error: 0}} ->
-          send_async_msg(callback_pid, "All selected devices successfully moved to #{target_product.name}")
-
-        {:ok, %{ok: 0, error: _}} ->
-          send_async_msg(callback_pid, "No devices were successfully moved to #{target_product.name}", :error)
-
-        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
-          send_async_msg(
-            callback_pid,
-            "#{successful_count} devices were successfully moved to #{target_product.name}, and #{unsuccessful_count} devices had errors and couldn't be moved",
-            :notice
-          )
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
-  end
-
-  def async_disable_updates_for_devices(devices_query, user, callback_pid) do
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> stream_processing({:disable_updates, [user]})
-      |> case do
-        {:ok, res} ->
-          send_async_msg(callback_pid, "Disabled updates for #{res.ok} selected device(s).")
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
-  end
-
-  def async_tag_devices(devices_query, user, tags, callback_pid) do
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> stream_processing({:tag_device, [user, tags]})
-      |> case do
-        {:ok, %{ok: successful_count, error: 0}} ->
-          send_async_msg(callback_pid, "All selected devices (#{successful_count}) tagged successfully.")
-
-        {:ok, %{ok: 0, error: unsuccessful_count}} ->
-          send_async_msg(
-            callback_pid,
-            "All selected devices (#{unsuccessful_count}) failed updating with new tags.",
-            :error
-          )
-
-        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
-          send_async_msg(
-            callback_pid,
-            "#{successful_count} devices were successfully tagged and #{unsuccessful_count} devices had errors.",
-            :notice
-          )
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
-  end
-
-  def async_enable_updates_for_devices(devices_query, user, callback_pid) do
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> stream_processing({:enable_updates, [user]})
-      |> case do
-        {:ok, res} ->
-          send_async_msg(callback_pid, "Enabled updates for #{res.ok} selected device(s).")
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
-  end
-
-  def async_clear_penalty_box_for_devices(devices_query, user, callback_pid) do
-    Task.Supervisor.start_child(Tasks, fn ->
-      devices_query
-      |> stream_processing({:clear_penalty_box, [user]})
-      |> case do
-        {:ok, res} ->
-          send_async_msg(callback_pid, "#{res.ok} selected device(s) cleared from the penalty box.")
-      end
-    end)
-    |> case do
-      {:ok, _} -> :ok
-      {:ok, _, _} -> :ok
-    end
+  def clear_penalty_box_for_devices(%Ecto.Query{} = devices_query, user) do
+    stream_processing(devices_query, {:clear_penalty_box, [user]})
   end
 
   defp stream_processing(devices_query, fun, opts \\ []) do
@@ -471,9 +345,8 @@ defmodule NervesHub.Devices.BulkActions do
       end,
       timeout: 60_000
     )
-  end
-
-  defp send_async_msg(callback_pid, message, key \\ :info) do
-    send(callback_pid, {:async_update_complete, key, message})
+    |> case do
+      {:ok, res} -> res
+    end
   end
 end

--- a/lib/nerves_hub/devices/bulk_actions.ex
+++ b/lib/nerves_hub/devices/bulk_actions.ex
@@ -1,0 +1,479 @@
+defmodule NervesHub.Devices.BulkActions do
+  import Ecto.Query
+
+  alias NervesHub.Accounts.Scope
+  alias NervesHub.Accounts.User
+  alias NervesHub.Certificate
+  alias NervesHub.DeploymentOrchestratorEvents
+  alias NervesHub.DeviceEvents
+  alias NervesHub.Devices
+  alias NervesHub.Devices.BulkImport
+  alias NervesHub.Devices.Device
+  alias NervesHub.ManagedDeployments
+  alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.ProductNotifications
+  alias NervesHub.Products.Product
+  alias NervesHub.Repo
+  alias NervesHub.TaskSupervisor, as: Tasks
+
+  require Logger
+
+  def async_bulk_create(org_id, product_id, import_list, format, tags \\ [])
+
+  def async_bulk_create(org_id, product_id, import_list, format, tags) when not is_binary(import_list) do
+    async_bulk_create(org_id, product_id, JSON.encode!(import_list), format, tags)
+  end
+
+  def async_bulk_create(org_id, product_id, import_list, format, tags) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      {successful_count, unsuccessful_count} = bulk_create(org_id, product_id, import_list, format, tags)
+
+      _ =
+        ProductNotifications.create_device_async_bulk_create_notification!(
+          product_id,
+          successful_count,
+          unsuccessful_count,
+          format
+        )
+    end)
+    |> case do
+      :ignore -> {:error, :ignored}
+      {:error, _} = error -> error
+      {:ok, pid, _info} -> {:ok, pid}
+      ok -> ok
+    end
+  end
+
+  def bulk_create(org_id, product_id, import_list, format, tags \\ []) do
+    product =
+      Product
+      |> where(org_id: ^org_id, id: ^product_id)
+      |> Repo.exclude_deleted()
+      |> Repo.one!()
+
+    BulkImport.parse_file(format, import_list)
+    |> Enum.map(fn details ->
+      changeset =
+        Device.changeset(%Device{}, %{
+          org_id: product.org_id,
+          product_id: product.id,
+          identifier: details.device_identifier,
+          tags: tags
+        })
+
+      Repo.transact(fn ->
+        with {:ok, device} <- Repo.insert(changeset),
+             {:ok, pem} <- details.pem,
+             {:ok, otp_cert} <- Certificate.from_pem_or_der(pem),
+             {:ok, _db_cert} <- Devices.create_device_certificate(device, otp_cert) do
+          {:ok, device}
+        end
+      end)
+    end)
+    |> Enum.frequencies_by(fn result -> elem(result, 0) end)
+    |> then(fn res ->
+      {Map.get(res, :ok, 0), Map.get(res, :error, 0)}
+    end)
+  end
+
+  @spec tag_devices([Device.t()], User.t(), list(String.t())) :: %{
+          ok: [Device.t()],
+          error: [{Ecto.Multi.name(), any()}]
+        }
+  def tag_devices(devices, user, tags) do
+    Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :tag_device, [&1, user, tags]))
+    |> Task.await_many(20_000)
+    |> Enum.reduce(%{ok: [], error: []}, fn
+      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
+      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
+    end)
+  end
+
+  @doc """
+  Remove multiple devices from their deployment groups.
+
+  Returns `{:ok, count}` with the number of devices updated.
+  """
+  @spec remove_many_from_deployment_group(Scope.t(), [non_neg_integer()]) :: {:ok, non_neg_integer()}
+  def remove_many_from_deployment_group(%Scope{product: product}, device_ids) when is_list(device_ids) do
+    {count, _} =
+      Device
+      |> Repo.exclude_deleted()
+      |> where([d], d.id in ^device_ids)
+      |> where([d], d.product_id == ^product.id)
+      |> where([d], not is_nil(d.deployment_id))
+      |> Repo.update_all(set: [deployment_id: nil])
+
+    Enum.each(device_ids, &DeviceEvents.updated(%Device{id: &1}))
+
+    {:ok, count}
+  end
+
+  @doc """
+  Move devices to a deployment group. A deployment group struct or id can
+  be given. Devices are fetched by their id and also filtered by the given
+  deployment group firmware's architecture and platform.
+
+  `Repo.update_all()` is used to update the rows. The return informs how
+  many rows were updated and how many were ignored because of a problem.
+
+  move_many_to_deployment_group([1, 2, 3], deployment_group)
+  > {:ok, %{updated: 3, ignored: 0}}
+  """
+  @spec move_many_to_deployment_group(
+          Scope.t(),
+          [non_neg_integer()],
+          DeploymentGroup.t() | non_neg_integer()
+        ) ::
+          {:ok, %{updated: non_neg_integer(), ignored: non_neg_integer()}}
+  def move_many_to_deployment_group(%Scope{} = scope, device_ids, %DeploymentGroup{id: deployment_id}) do
+    move_many_to_deployment_group(scope, device_ids, deployment_id)
+  end
+
+  def move_many_to_deployment_group(%Scope{} = scope, device_ids, deployment_id) when is_number(deployment_id) do
+    deployment_group =
+      DeploymentGroup
+      |> from(as: :deployment_group)
+      |> join(:inner, [deployment_group: dg], o in assoc(dg, :org), as: :org)
+      |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
+      |> ManagedDeployments.join_current_release()
+      |> join(:inner, [current_release: cr], f in assoc(cr, :firmware), as: :firmware)
+      |> where([deployment_group: dg], dg.id == ^deployment_id)
+      |> where([users: users], users.id == ^scope.user.id)
+      |> preload([firmware: f, current_release: cr],
+        current_release: {cr, firmware: f}
+      )
+      |> Repo.one!()
+
+    # Use a transaction to ensure devices are updated and deltas are queued atomically
+    # This minimizes the race condition window where the orchestrator could pick up devices
+    # before their firmware_delta rows are created
+    {:ok, {devices_updated_count, _}} =
+      Repo.transact(fn ->
+        {count, _} =
+          Device
+          |> join(:inner, [d], o in assoc(d, :org), as: :org)
+          |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
+          |> where([users: users], users.id == ^scope.user.id)
+          |> Repo.exclude_deleted()
+          |> where([d], d.id in ^device_ids)
+          |> where(
+            [d],
+            d.firmware_metadata["platform"] == ^deployment_group.current_release.firmware.platform
+          )
+          |> where(
+            [d],
+            d.firmware_metadata["architecture"] ==
+              ^deployment_group.current_release.firmware.architecture
+          )
+          |> Repo.update_all([set: [deployment_id: deployment_id]], timeout: to_timeout(minute: 2))
+
+        # Queue delta generation for any new device firmware combinations immediately
+        # after the device updates within the same transaction
+        _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
+
+        {:ok, {count, nil}}
+      end)
+
+    :ok = Enum.each(device_ids, &DeviceEvents.updated(%Device{id: &1}))
+
+    # let the orchestrator know that some devices have been added to the deployment group
+    DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
+
+    {:ok, %{updated: devices_updated_count, ignored: length(device_ids) - devices_updated_count}}
+  end
+
+  @spec move_many(Scope.t(), [Device.t()], Product.t()) :: %{
+          ok: [Device.t()],
+          error: [{Ecto.Multi.name(), any()}]
+        }
+  def move_many(%Scope{user: user}, devices, product) do
+    product = Repo.preload(product, :org)
+
+    Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :move, [&1, product, user]))
+    |> Task.await_many(20_000)
+    |> Enum.reduce(%{ok: [], error: []}, fn
+      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
+      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
+    end)
+  end
+
+  @spec enable_updates_for_devices([Device.t()], User.t()) :: %{
+          ok: [Device.t()],
+          error: [{Ecto.Multi.name(), any()}]
+        }
+  def enable_updates_for_devices(devices, user) do
+    Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :enable_updates, [&1, user]))
+    |> Task.await_many(20_000)
+    |> Enum.reduce(%{ok: [], error: []}, fn
+      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
+      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
+    end)
+  end
+
+  @spec disable_updates_for_devices([Device.t()], User.t()) :: %{
+          ok: [Device.t()],
+          error: [{Ecto.Multi.name(), any()}]
+        }
+  def disable_updates_for_devices(devices, user) do
+    Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :disable_updates, [&1, user]))
+    |> Task.await_many(20_000)
+    |> Enum.reduce(%{ok: [], error: []}, fn
+      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
+      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
+    end)
+  end
+
+  def clear_penalty_box_for_devices(devices, user) do
+    Enum.map(devices, &Task.Supervisor.async(Tasks, Devices, :clear_penalty_box, [&1, user]))
+    |> Task.await_many(20_000)
+    |> Enum.reduce(%{ok: [], error: []}, fn
+      {:ok, updated}, acc -> %{acc | ok: [updated | acc.ok]}
+      {:error, name, changeset, _}, acc -> %{acc | error: [{name, changeset} | acc.error]}
+    end)
+  end
+
+  def async_remove_many_from_deployment_group(devices_query, callback_pid) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> stream_processing(fn device ->
+        device
+        |> Device.clear_deployment_group()
+        |> Repo.update()
+        |> case do
+          {:ok, device} = res ->
+            DeviceEvents.deployment_cleared(device)
+            res
+
+          res ->
+            res
+        end
+      end)
+      |> case do
+        {:ok, %{ok: successful_count, error: 0}} ->
+          send_async_msg(callback_pid, "All device(s) (#{successful_count}) removed from their deployment group.")
+
+        {:ok, %{ok: 0, error: _}} ->
+          send_async_msg(callback_pid, "No devices were successfully removed from their deployment group.", :error)
+
+        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
+          send_async_msg(
+            callback_pid,
+            "#{successful_count} devices were successfully from their deployment group, and #{unsuccessful_count} devices had errors and couldn't be removed",
+            :notice
+          )
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  def async_move_many_to_deployment_group(devices_query, deployment_id, scope, callback_pid) do
+    deployment_group =
+      DeploymentGroup
+      |> from(as: :deployment_group)
+      |> join(:inner, [deployment_group: dg], o in assoc(dg, :org), as: :org)
+      |> join(:inner, [org: o], u in assoc(o, :users), as: :users)
+      |> ManagedDeployments.join_current_release()
+      |> join(:inner, [current_release: cr], f in assoc(cr, :firmware), as: :firmware)
+      |> where([deployment_group: dg], dg.id == ^deployment_id)
+      |> where([users: users], users.id == ^scope.user.id)
+      |> preload([firmware: f, current_release: cr],
+        current_release: {cr, firmware: f}
+      )
+      |> Repo.one!()
+
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> where(
+        [d],
+        d.firmware_metadata["platform"] == ^deployment_group.current_release.firmware.platform or
+          is_nil(d.firmware_metadata)
+      )
+      |> where(
+        [d],
+        d.firmware_metadata["architecture"] ==
+          ^deployment_group.current_release.firmware.architecture or is_nil(d.firmware_metadata)
+      )
+      |> stream_processing(
+        fn device ->
+          device
+          |> Device.update_deployment_group(deployment_group)
+          |> Repo.update()
+          |> case do
+            {:ok, device} ->
+              DeviceEvents.updated(device)
+              :ok
+
+            _ ->
+              :error
+          end
+        end,
+        before_commit: fn ->
+          _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
+          DeploymentOrchestratorEvents.bulk_devices_added(deployment_group)
+        end
+      )
+      |> case do
+        {:ok, %{ok: _, error: 0}} ->
+          send(
+            callback_pid,
+            {:async_update_complete, :info, "All selected devices successfully assigned to #{deployment_group.name}"}
+          )
+
+        {:ok, %{ok: 0, error: _}} ->
+          send(
+            callback_pid,
+            {:async_update_complete, :error, "No devices were successfully assigned to #{deployment_group.name}"}
+          )
+
+        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
+          send(
+            callback_pid,
+            {:async_update_complete, :notice,
+             "#{successful_count} devices were successfully assigned to #{deployment_group.name}, and #{unsuccessful_count} devices had errors and couldn't be assigned"}
+          )
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  def async_move_many(devices_query, target_product, user, callback_pid) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> stream_processing({:move, [target_product, user]})
+      |> case do
+        {:ok, %{ok: _, error: 0}} ->
+          send_async_msg(callback_pid, "All selected devices successfully moved to #{target_product.name}")
+
+        {:ok, %{ok: 0, error: _}} ->
+          send_async_msg(callback_pid, "No devices were successfully moved to #{target_product.name}", :error)
+
+        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
+          send_async_msg(
+            callback_pid,
+            "#{successful_count} devices were successfully moved to #{target_product.name}, and #{unsuccessful_count} devices had errors and couldn't be moved",
+            :notice
+          )
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  def async_disable_updates_for_devices(devices_query, user, callback_pid) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> stream_processing({:disable_updates, [user]})
+      |> case do
+        {:ok, res} ->
+          send_async_msg(callback_pid, "Disabled updates for #{res.ok} selected device(s).")
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  def async_tag_devices(devices_query, user, tags, callback_pid) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> stream_processing({:tag_device, [user, tags]})
+      |> case do
+        {:ok, %{ok: successful_count, error: 0}} ->
+          send_async_msg(callback_pid, "All selected devices (#{successful_count}) tagged successfully.")
+
+        {:ok, %{ok: 0, error: unsuccessful_count}} ->
+          send_async_msg(
+            callback_pid,
+            "All selected devices (#{unsuccessful_count}) failed updating with new tags.",
+            :error
+          )
+
+        {:ok, %{ok: successful_count, error: unsuccessful_count}} ->
+          send_async_msg(
+            callback_pid,
+            "#{successful_count} devices were successfully tagged and #{unsuccessful_count} devices had errors.",
+            :notice
+          )
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  def async_enable_updates_for_devices(devices_query, user, callback_pid) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> stream_processing({:enable_updates, [user]})
+      |> case do
+        {:ok, res} ->
+          send_async_msg(callback_pid, "Enabled updates for #{res.ok} selected device(s).")
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  def async_clear_penalty_box_for_devices(devices_query, user, callback_pid) do
+    Task.Supervisor.start_child(Tasks, fn ->
+      devices_query
+      |> stream_processing({:clear_penalty_box, [user]})
+      |> case do
+        {:ok, res} ->
+          send_async_msg(callback_pid, "#{res.ok} selected device(s) cleared from the penalty box.")
+      end
+    end)
+    |> case do
+      {:ok, _} -> :ok
+      {:ok, _, _} -> :ok
+    end
+  end
+
+  defp stream_processing(devices_query, fun, opts \\ []) do
+    stream = Repo.stream(devices_query)
+
+    Repo.transact(
+      fn ->
+        stream
+        |> Stream.map(fn device ->
+          case fun do
+            {fun_name, args} ->
+              apply(NervesHub.Devices, fun_name, [device | args])
+
+            fun ->
+              fun.(device)
+          end
+        end)
+        |> Enum.reduce(%{ok: 0, error: 0}, fn
+          :ok, acc -> %{acc | ok: acc.ok + 1}
+          {:ok, _updated}, acc -> %{acc | ok: acc.ok + 1}
+          :error, acc -> %{acc | error: acc.error + 1}
+          {:error, _changeset}, acc -> %{acc | error: acc.error + 1}
+          {:error, _name, _changeset, _}, acc -> %{acc | error: acc.error + 1}
+        end)
+        |> then(fn res ->
+          if opts[:before_commit], do: opts[:before_commit].()
+          {:ok, res}
+        end)
+      end,
+      timeout: 60_000
+    )
+  end
+
+  defp send_async_msg(callback_pid, message, key \\ :info) do
+    send(callback_pid, {:async_update_complete, key, message})
+  end
+end

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -128,6 +128,12 @@ defmodule NervesHub.Devices.Device do
     |> put_change(:deployment_id, deployment_group.id)
   end
 
+  def clear_deployment_group(device) do
+    device
+    |> change()
+    |> put_change(:deployment_id, nil)
+  end
+
   def clear_updates_information_changeset(%Device{} = device) do
     device
     |> change()

--- a/lib/nerves_hub/filtering.ex
+++ b/lib/nerves_hub/filtering.ex
@@ -31,10 +31,6 @@ defmodule NervesHub.Filtering do
   @spec filter(Ecto.Query.t(), Product.t(), map()) ::
           {[Device.t()] | [DeploymentGroup.t()] | [Script.t()], Flop.Meta.t()}
   def filter(base_query, product, opts \\ %{}) do
-    opts = Map.reject(opts, fn {_key, val} -> is_nil(val) end)
-
-    sorting = Map.get(opts, :sort, {:asc, :name})
-    filters = Map.get(opts, :filters, %{})
     pagination = Map.get(opts, :pagination, %{})
 
     flop = %Flop{
@@ -42,10 +38,20 @@ defmodule NervesHub.Filtering do
       page_size: Map.get(pagination, :page_size, 25)
     }
 
+    filter_query(base_query, product, opts)
+    |> Flop.run(flop)
+  end
+
+  @spec filter_query(Ecto.Query.t(), Product.t(), map()) :: Ecto.Query.t()
+  def filter_query(base_query, product, opts \\ %{}) do
+    opts = Map.reject(opts, fn {_key, val} -> is_nil(val) end)
+
+    sorting = Map.get(opts, :sort, {:asc, :name})
+    filters = Map.get(opts, :filters, %{})
+
     base_query
     |> where([q], q.product_id == ^product.id)
     |> filter_and_sort(base_query.from, sorting, filters)
-    |> Flop.run(flop)
   end
 
   defp filter_and_sort(query, %{source: {_, Device}}, sorting_opts, filter_opts) do

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -609,6 +609,17 @@ defmodule NervesHub.Firmwares do
         {:ok, %FirmwareDelta{}} ->
           {:ok, :delta_already_exists}
 
+        {:delta_insert,
+         {:error,
+          [
+            {:unique_firmware_delta,
+             {"has already been taken", [constraint: :unique, constraint_name: "source_id_target_id_unique_index"]}}
+          ]}} ->
+          # a race condition exists where multiple devices connect, are added to a deployment group, and
+          # try to create a delta, only for one to 'start' but all others fail.
+          # This should be regarded as an `:ok` response.
+          {:ok, :delta_already_exists}
+
         {:delta_insert, {:error, changeset}} ->
           Logger.warning("Failed to insert firmware delta for #{source_id} -> #{target_id}")
 

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -7,6 +7,7 @@ defmodule NervesHubWeb.API.DeviceController do
   alias NervesHub.AuditLogs.DeviceTemplates
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
+  alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.UpdatePayload
@@ -75,7 +76,13 @@ defmodule NervesHubWeb.API.DeviceController do
     tags = get_req_header(conn, "tags") |> List.first()
 
     with {:ok, _task_pid} <-
-           Devices.async_bulk_create(org.id, product.id, import_list["_json"], format || "microchip_trust_and_go", tags) do
+           BulkActions.async_bulk_create(
+             org.id,
+             product.id,
+             import_list["_json"],
+             format || "microchip_trust_and_go",
+             tags
+           ) do
       send_resp(conn, 201, "")
     end
   end

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
 
   alias NervesHub.AuditLogs.DeploymentGroupTemplates
   alias NervesHub.Devices
+  alias NervesHub.Devices.BulkActions
   alias NervesHub.Helpers.Logging
   alias NervesHub.ManagedDeployments
   alias NervesHubWeb.Components.DeploymentGroupPage.Activity, as: ActivityTab
@@ -92,7 +93,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
     move_devices = fn ->
       devices = ManagedDeployments.matched_device_ids(deployment_group, in_deployment: false)
 
-      Devices.move_many_to_deployment_group(scope, devices, deployment_group)
+      BulkActions.move_many_to_deployment_group(scope, devices, deployment_group)
       |> then(fn {:ok, %{updated: updated_count, ignored: ignored_count}} ->
         if ignored_count > 0 do
           {:error, updated_count, ignored_count}

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -93,8 +93,8 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
     move_devices = fn ->
       devices = ManagedDeployments.matched_device_ids(deployment_group, in_deployment: false)
 
-      BulkActions.move_many_to_deployment_group(scope, devices, deployment_group)
-      |> then(fn {:ok, %{updated: updated_count, ignored: ignored_count}} ->
+      BulkActions.move_many_to_deployment_group(devices, deployment_group, scope.user)
+      |> then(fn %{updated: updated_count, ignored: ignored_count} ->
         if ignored_count > 0 do
           {:error, updated_count, ignored_count}
         else

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
+  alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.Metrics
   alias NervesHub.Firmwares
   alias NervesHub.ManagedDeployments
@@ -105,6 +106,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:current_filters, @default_filters)
     |> assign(:currently_filtering, false)
     |> assign(:selected_devices, [])
+    |> assign(:select_all_matching, false)
     |> assign(:target_product, nil)
     |> assign(:progress, %{})
     |> assign(:valid_tags, true)
@@ -225,6 +227,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
     socket
     |> assign(:selected_devices, [])
+    |> assign(:select_all_matching, false)
     |> push_patch(to: self_path(socket, Map.merge(params, page_params)))
     |> noreply()
   end
@@ -253,6 +256,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
       socket
       |> assign(:selected_devices, selected_devices)
+      |> assign(:select_all_matching, false)
       |> update_selected_device_info()
       |> noreply()
     else
@@ -288,7 +292,24 @@ defmodule NervesHubWeb.Live.Devices.Index do
   @decorate requires_permission(:"device:update")
   def handle_event("deselect-all", _, socket) do
     socket
-    |> assign(%{selected_devices: [], available_deployment_groups_for_filtered_platform: []})
+    |> assign(%{
+      selected_devices: [],
+      select_all_matching: false,
+      available_deployment_groups_for_filtered_platform: []
+    })
+    |> update_selected_device_info()
+    |> noreply()
+  end
+
+  @decorate requires_permission(:"device:update")
+  def handle_event("select-all-matching", _, socket) do
+    %{devices: devices} = socket.assigns
+
+    selected_devices = Enum.map(devices.result, & &1.id)
+
+    socket
+    |> assign(:selected_devices, selected_devices)
+    |> assign(:select_all_matching, true)
     |> update_selected_device_info()
     |> noreply()
   end
@@ -303,33 +324,42 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   @decorate requires_permission(:"device:update")
   def handle_event("tag-devices", %{"tags" => tags}, socket) do
-    %{selected_devices: selected_devices, current_scope: scope} = socket.assigns
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_tag_devices(socket.assigns.current_scope.user, tags, self())
 
-    with {:devices, devices} when is_list(devices) and devices != [] <-
-           {:devices, Devices.get_devices_by_id(scope, selected_devices)},
-         result = Devices.tag_devices(devices, scope.user, tags),
-         {:successful, true} <- {:successful, Enum.any?(result[:ok])},
-         {:has_errors, false, _result} <- {:has_errors, Enum.any?(result[:error]), result} do
       socket
-      |> put_flash(:info, "Tagged all selected device(s).")
-      |> assign_display_devices()
+      |> put_flash(:notice, "Updating devices...")
       |> noreply()
     else
-      {:devices, _} ->
-        {:noreply, put_flash(socket, :error, "You haven't selected any devices")}
+      %{selected_devices: selected_devices, current_scope: scope} = socket.assigns
 
-      {:successful, false} ->
-        {:noreply, put_flash(socket, :error, "No devices were successfully tagged")}
-
-      {:has_errors, true, result} ->
+      with {:devices, devices} when is_list(devices) and devices != [] <-
+             {:devices, Devices.get_devices_by_id(scope, selected_devices)},
+           result = BulkActions.tag_devices(devices, scope.user, tags),
+           {:successful, true} <- {:successful, Enum.any?(result[:ok])},
+           {:has_errors, false, _result} <- {:has_errors, Enum.any?(result[:error]), result} do
         socket
-        |> put_flash(
-          :info,
-          "#{Enum.count(result[:ok])} devices were successfully tagged and #{Enum.count(result[:error])} devices had errors."
-        )
-        |> assign(selected_devices: Enum.map(result[:ok], & &1.id))
+        |> put_flash(:info, "Tagged all selected device(s).")
         |> assign_display_devices()
         |> noreply()
+      else
+        {:devices, _} ->
+          {:noreply, put_flash(socket, :error, "You haven't selected any devices")}
+
+        {:successful, false} ->
+          {:noreply, put_flash(socket, :error, "No devices were successfully tagged")}
+
+        {:has_errors, true, result} ->
+          socket
+          |> put_flash(
+            :info,
+            "#{Enum.count(result[:ok])} devices were successfully tagged and #{Enum.count(result[:error])} devices had errors."
+          )
+          |> assign(selected_devices: Enum.map(result[:ok], & &1.id))
+          |> assign_display_devices()
+          |> noreply()
+      end
     end
   end
 
@@ -381,36 +411,45 @@ defmodule NervesHubWeb.Live.Devices.Index do
       current_scope: scope
     } = socket.assigns
 
-    with {:devices_selected, true} <- {:devices_selected, selected_devices != []},
-         {:product_selected, true} <- {:product_selected, target_product != nil},
-         devices when is_list(devices) and devices != [] <- Devices.get_devices_by_id(scope, selected_devices),
-         result = Devices.move_many(scope, devices, target_product),
-         {:successful, true} <- {:successful, Enum.any?(result[:ok])},
-         {:has_errors, false, _result} <- {:has_errors, Enum.any?(result[:error]), result} do
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_move_many(target_product, scope.user, self())
+
       socket
-      |> assign(:target_product, nil)
-      |> assign_display_devices()
-      |> put_flash(:info, "All selected devices successfully moved moved to #{target_product.name}")
+      |> put_flash(:notice, "Updating devices...")
       |> noreply()
     else
-      {:devices_selected, false} ->
-        {:noreply, put_flash(socket, :error, "You haven't selected any devices")}
-
-      {:product_selected, false} ->
-        {:noreply, put_flash(socket, :error, "You haven't selected a product")}
-
-      {:successful, false} ->
-        {:noreply, put_flash(socket, :error, "No devices were successfully moved to #{target_product.name}")}
-
-      {:has_errors, true, result} ->
+      with {:devices_selected, true} <- {:devices_selected, selected_devices != []},
+           {:product_selected, true} <- {:product_selected, target_product != nil},
+           devices when is_list(devices) and devices != [] <- Devices.get_devices_by_id(scope, selected_devices),
+           result = BulkActions.move_many(scope, devices, target_product),
+           {:successful, true} <- {:successful, Enum.any?(result[:ok])},
+           {:has_errors, false, _result} <- {:has_errors, Enum.any?(result[:error]), result} do
         socket
-        |> put_flash(
-          :info,
-          "#{Enum.count(result[:ok])} devices were successfully moved to #{target_product.name}, and #{Enum.count(result[:error])} devices had errors and couldn't be moved"
-        )
-        |> assign(selected_devices: Enum.map(result[:ok], & &1.id))
+        |> assign(:target_product, nil)
         |> assign_display_devices()
+        |> put_flash(:info, "All selected devices successfully moved to #{target_product.name}")
         |> noreply()
+      else
+        {:devices_selected, false} ->
+          {:noreply, put_flash(socket, :error, "You haven't selected any devices")}
+
+        {:product_selected, false} ->
+          {:noreply, put_flash(socket, :error, "You haven't selected a product")}
+
+        {:successful, false} ->
+          {:noreply, put_flash(socket, :error, "No devices were successfully moved to #{target_product.name}")}
+
+        {:has_errors, true, result} ->
+          socket
+          |> put_flash(
+            :info,
+            "#{Enum.count(result[:ok])} devices were successfully moved to #{target_product.name}, and #{Enum.count(result[:error])} devices had errors and couldn't be moved"
+          )
+          |> assign(selected_devices: Enum.map(result[:ok], & &1.id))
+          |> assign_display_devices()
+          |> noreply()
+      end
     end
   end
 
@@ -424,33 +463,42 @@ defmodule NervesHubWeb.Live.Devices.Index do
       }
     } = socket
 
-    with {:ok, %{updated: updated_count, ignored: ignored_count} = result} <-
-           Devices.move_many_to_deployment_group(scope, selected_devices, target_deployment_group.id),
-         {:successful, true} <- {:successful, updated_count > 0},
-         {:has_ignores, false, _result} <- {:has_ignores, ignored_count > 0, result} do
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_move_many_to_deployment_group(target_deployment_group.id, scope, self())
+
       socket
-      |> assign(:target_deployment_group, nil)
-      |> assign_display_devices()
-      |> put_flash(:info, "All selected devices were added to deployment #{target_deployment_group.name}")
+      |> put_flash(:notice, "Updating devices...")
       |> noreply()
     else
-      {:successful, false} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           "No devices selected could be added to deployment #{target_deployment_group.name} because of mismatched firmware"
-         )}
-
-      {:has_ignores, true, result} ->
+      with {:ok, %{updated: updated_count, ignored: ignored_count} = result} <-
+             BulkActions.move_many_to_deployment_group(scope, selected_devices, target_deployment_group.id),
+           {:successful, true} <- {:successful, updated_count > 0},
+           {:has_ignores, false, _result} <- {:has_ignores, ignored_count > 0, result} do
         socket
-        |> put_flash(
-          :info,
-          "#{result.updated} #{maybe_pluralize(result.updated, "device")} added to deployment #{target_deployment_group.name}. #{result.ignored} #{maybe_pluralize(result.ignored, "device")} could not be added to deployment because of mismatched firmware"
-        )
         |> assign(:target_deployment_group, nil)
         |> assign_display_devices()
+        |> put_flash(:info, "All selected devices were added to deployment #{target_deployment_group.name}")
         |> noreply()
+      else
+        {:successful, false} ->
+          {:noreply,
+           put_flash(
+             socket,
+             :error,
+             "No devices selected could be added to deployment #{target_deployment_group.name} because of mismatched firmware"
+           )}
+
+        {:has_ignores, true, result} ->
+          socket
+          |> put_flash(
+            :info,
+            "#{result.updated} #{maybe_pluralize(result.updated, "device")} added to deployment #{target_deployment_group.name}. #{result.ignored} #{maybe_pluralize(result.ignored, "device")} could not be added to deployment because of mismatched firmware"
+          )
+          |> assign(:target_deployment_group, nil)
+          |> assign_display_devices()
+          |> noreply()
+      end
     end
   end
 
@@ -503,60 +551,96 @@ defmodule NervesHubWeb.Live.Devices.Index do
   def handle_event("remove-devices-from-deployment-group", _, socket) do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
-    {:ok, count} = Devices.remove_many_from_deployment_group(scope, selected_devices)
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_remove_many_from_deployment_group(self())
 
-    socket
-    |> assign_display_devices()
-    |> put_flash(:info, "#{count} device(s) removed from their deployment group.")
-    |> noreply()
+      socket
+      |> put_flash(:notice, "Updating devices...")
+      |> noreply()
+    else
+      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, selected_devices)
+
+      socket
+      |> assign_display_devices()
+      |> put_flash(:info, "#{count} device(s) removed from their deployment group.")
+      |> noreply()
+    end
   end
 
   @decorate requires_permission(:"device:update")
   def handle_event("disable-updates-for-devices", _, socket) do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
-    %{ok: successfuls} =
-      Devices.get_devices_by_id(scope, selected_devices)
-      |> Devices.disable_updates_for_devices(scope.user)
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_disable_updates_for_devices(scope.user, self())
 
-    socket
-    |> assign(selected_devices: selected_devices)
-    |> put_flash(:info, "Disabled updates for #{Enum.count(successfuls)} selected device(s).")
-    |> assign_display_devices()
-    |> noreply()
+      socket
+      |> put_flash(:notice, "Updating devices...")
+      |> noreply()
+    else
+      %{ok: successfuls} =
+        Devices.get_devices_by_id(scope, selected_devices)
+        |> BulkActions.disable_updates_for_devices(scope.user)
+
+      socket
+      |> assign(selected_devices: selected_devices)
+      |> put_flash(:info, "Disabled updates for #{Enum.count(successfuls)} selected device(s).")
+      |> assign_display_devices()
+      |> noreply()
+    end
   end
 
   @decorate requires_permission(:"device:update")
   def handle_event("enable-updates-for-devices", _, socket) do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
-    %{ok: successfuls} =
-      Devices.get_devices_by_id(scope, selected_devices)
-      |> Devices.enable_updates_for_devices(scope.user)
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_enable_updates_for_devices(scope.user, self())
 
-    socket
-    |> assign(selected_devices: selected_devices)
-    |> put_flash(:info, "Enabled updates for #{Enum.count(successfuls)} selected device(s).")
-    |> assign_display_devices()
-    |> noreply()
+      socket
+      |> put_flash(:notice, "Updating devices...")
+      |> noreply()
+    else
+      %{ok: successfuls} =
+        Devices.get_devices_by_id(scope, selected_devices)
+        |> BulkActions.enable_updates_for_devices(scope.user)
+
+      socket
+      |> assign(selected_devices: selected_devices)
+      |> put_flash(:info, "Enabled updates for #{Enum.count(successfuls)} selected device(s).")
+      |> assign_display_devices()
+      |> noreply()
+    end
   end
 
   @decorate requires_permission(:"device:update")
   def handle_event("clear-penalty-box-for-devices", _, socket) do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
-    %{ok: successfuls} =
-      Devices.get_devices_by_id(scope, selected_devices)
-      |> Devices.clear_penalty_box_for_devices(scope.user)
+    if socket.assigns.select_all_matching do
+      filter_query(socket)
+      |> BulkActions.async_clear_penalty_box_for_devices(scope.user, self())
 
-    socket
-    |> assign(selected_devices: selected_devices)
-    |> put_flash(
-      :info,
-      "#{Enum.count(successfuls)} selected device(s) cleared from the penalty box."
-    )
-    |> assign_display_devices()
-    |> noreply()
+      socket
+      |> put_flash(:notice, "Updating devices...")
+      |> noreply()
+    else
+      %{ok: successfuls} =
+        Devices.get_devices_by_id(scope, selected_devices)
+        |> BulkActions.clear_penalty_box_for_devices(scope.user)
+
+      socket
+      |> assign(selected_devices: selected_devices)
+      |> put_flash(
+        :info,
+        "#{Enum.count(successfuls)} selected device(s) cleared from the penalty box."
+      )
+      |> assign_display_devices()
+      |> noreply()
+    end
   end
 
   def handle_event("page_visibility_change", %{"visible" => visible?}, socket) do
@@ -570,6 +654,13 @@ defmodule NervesHubWeb.Live.Devices.Index do
       end
     end)
     |> assign(visible?: visible?)
+    |> noreply()
+  end
+
+  def handle_info({:async_update_complete, key, message}, socket) do
+    socket
+    |> put_flash(key, message)
+    |> assign_display_devices()
     |> noreply()
   end
 
@@ -745,6 +836,18 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:total_entries, pager.total_count)
     |> assign(:paginate_opts, paginate_opts)
     |> assign(:pager_meta, pager)
+  end
+
+  defp filter_query(%{assigns: %{current_scope: scope}} = socket) do
+    opts = %{
+      sort: {
+        String.to_existing_atom(socket.assigns.sort_direction),
+        String.to_atom(socket.assigns.current_sort)
+      },
+      filters: transform_deployment_filter(socket.assigns.current_filters)
+    }
+
+    Devices.filter_query(scope.product, scope.user, opts)
   end
 
   defp transform_deployment_filter(%{deployment_id: ""} = filters), do: Map.delete(filters, :deployment_id)

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.Live.Devices.Index do
   use NervesHubWeb, :live_view
 
+  import Number.Delimit, only: [number_to_delimited: 2]
+
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
@@ -325,12 +327,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   @decorate requires_permission(:"device:update")
   def handle_event("tag-devices", %{"tags" => tags}, socket) do
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_tag_devices(socket.assigns.current_scope.user, tags, self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :tag_devices, [socket.assigns.current_scope.user, tags])
     else
       %{selected_devices: selected_devices, current_scope: scope} = socket.assigns
 
@@ -412,17 +409,12 @@ defmodule NervesHubWeb.Live.Devices.Index do
     } = socket.assigns
 
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_move_many(target_product, scope.user, self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :move_many, [target_product, scope.user])
     else
       with {:devices_selected, true} <- {:devices_selected, selected_devices != []},
            {:product_selected, true} <- {:product_selected, target_product != nil},
            devices when is_list(devices) and devices != [] <- Devices.get_devices_by_id(scope, selected_devices),
-           result = BulkActions.move_many(scope, devices, target_product),
+           result = BulkActions.move_many(devices, target_product, scope.user),
            {:successful, true} <- {:successful, Enum.any?(result[:ok])},
            {:has_errors, false, _result} <- {:has_errors, Enum.any?(result[:error]), result} do
         socket
@@ -464,15 +456,10 @@ defmodule NervesHubWeb.Live.Devices.Index do
     } = socket
 
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_move_many_to_deployment_group(target_deployment_group.id, scope, self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :move_many_to_deployment_group, [target_deployment_group.id, scope.user])
     else
-      with {:ok, %{updated: updated_count, ignored: ignored_count} = result} <-
-             BulkActions.move_many_to_deployment_group(scope, selected_devices, target_deployment_group.id),
+      with %{updated: updated_count, ignored: ignored_count} = result <-
+             BulkActions.move_many_to_deployment_group(selected_devices, target_deployment_group.id, scope.user),
            {:successful, true} <- {:successful, updated_count > 0},
            {:has_ignores, false, _result} <- {:has_ignores, ignored_count > 0, result} do
         socket
@@ -552,14 +539,9 @@ defmodule NervesHubWeb.Live.Devices.Index do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_remove_many_from_deployment_group(self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :remove_many_from_deployment_group, [])
     else
-      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, selected_devices)
+      %{ok: count} = BulkActions.remove_many_from_deployment_group({selected_devices, scope.product})
 
       socket
       |> assign_display_devices()
@@ -573,12 +555,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_disable_updates_for_devices(scope.user, self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :disable_updates_for_devices, [scope.user])
     else
       %{ok: successfuls} =
         Devices.get_devices_by_id(scope, selected_devices)
@@ -597,12 +574,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_enable_updates_for_devices(scope.user, self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :enable_updates_for_devices, [scope.user])
     else
       %{ok: successfuls} =
         Devices.get_devices_by_id(scope, selected_devices)
@@ -621,12 +593,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     %{assigns: %{current_scope: scope, selected_devices: selected_devices}} = socket
 
     if socket.assigns.select_all_matching do
-      filter_query(socket)
-      |> BulkActions.async_clear_penalty_box_for_devices(scope.user, self())
-
-      socket
-      |> put_flash(:notice, "Updating devices...")
-      |> noreply()
+      start_bulk_async(socket, :clear_penalty_box_for_devices, [scope.user])
     else
       %{ok: successfuls} =
         Devices.get_devices_by_id(scope, selected_devices)
@@ -822,6 +789,137 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
     socket
     |> assign(:filters_ready?, false)
+    |> noreply()
+  end
+
+  def handle_async(:enable_updates_for_devices, {:ok, results}, socket) do
+    socket
+    |> put_flash(
+      :info,
+      "Enabled updates for #{number_to_delimited(results.ok, precision: 0)} selected device(s)."
+    )
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  def handle_async(:disable_updates_for_devices, {:ok, results}, socket) do
+    socket
+    |> put_flash(
+      :info,
+      "Disabled updates for #{number_to_delimited(results.ok, precision: 0)} selected device(s)."
+    )
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  def handle_async(:clear_penalty_box_for_devices, {:ok, results}, socket) do
+    socket
+    |> put_flash(
+      :info,
+      "#{number_to_delimited(results.ok, precision: 0)} selected device(s) cleared from the penalty box."
+    )
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  def handle_async(:tag_devices, {:ok, results}, socket) do
+    case results do
+      %{ok: successful_count, error: 0} ->
+        put_flash(
+          socket,
+          :info,
+          "All selected devices (#{number_to_delimited(successful_count, precision: 0)}) tagged successfully."
+        )
+
+      %{ok: 0, error: unsuccessful_count} ->
+        put_flash(
+          socket,
+          :error,
+          "All selected devices (#{number_to_delimited(unsuccessful_count, precision: 0)}) failed updating with new tags."
+        )
+
+      %{ok: successful_count, error: unsuccessful_count} ->
+        put_flash(
+          socket,
+          :notice,
+          "#{number_to_delimited(successful_count, precision: 0)} devices were successfully tagged and #{number_to_delimited(unsuccessful_count, precision: 0)} devices had errors."
+        )
+    end
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  def handle_async(:remove_many_from_deployment_group, {:ok, results}, socket) do
+    case results do
+      %{ok: successful_count, error: 0} ->
+        put_flash(
+          socket,
+          :info,
+          "All devices (#{number_to_delimited(successful_count, precision: 0)}) were successfully removed from their deployment group."
+        )
+
+      %{ok: 0, error: _} ->
+        put_flash(
+          socket,
+          :error,
+          "No devices were successfully removed from their deployment group."
+        )
+
+      %{ok: successful_count, error: unsuccessful_count} ->
+        put_flash(
+          socket,
+          :notice,
+          "#{number_to_delimited(successful_count, precision: 0)} devices were successfully from their deployment group, and #{number_to_delimited(unsuccessful_count, precision: 0)} devices had errors and couldn't be removed"
+        )
+    end
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  def handle_async(:move_many_to_deployment_group, {:ok, results}, socket) do
+    case results do
+      %{ok: _, error: 0} ->
+        put_flash(socket, :info, "All selected devices were successfully assigned to the selected deployment group.")
+
+      %{ok: 0, error: _} ->
+        put_flash(socket, :error, "No devices were successfully assigned to the selected deployment group.")
+
+      %{ok: successful_count, error: unsuccessful_count} ->
+        put_flash(
+          socket,
+          :notice,
+          "#{number_to_delimited(successful_count, precision: 0)} devices were successfully assigned to the selected deployment group, and #{number_to_delimited(unsuccessful_count, precision: 0)} devices encountered errors and couldn't be assigned."
+        )
+    end
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  def handle_async(:move_many, {:ok, results}, socket) do
+    case results do
+      %{ok: _, error: 0} ->
+        put_flash(socket, :info, "All selected devices successfully moved to the selected product.")
+
+      %{ok: 0, error: _} ->
+        put_flash(socket, :error, "No devices were successfully moved to the selected product.")
+
+      %{ok: successful_count, error: unsuccessful_count} ->
+        put_flash(
+          socket,
+          :error,
+          "#{number_to_delimited(successful_count, precision: 0)} devices were successfully moved to the selected product, and #{number_to_delimited(unsuccessful_count, precision: 0)} devices had errors and couldn't be moved"
+        )
+    end
+    |> assign_display_devices()
+    |> noreply()
+  end
+
+  defp start_bulk_async(socket, name, args) do
+    ecto_query = filter_query(socket)
+
+    socket
+    |> start_async(name, fn -> apply(BulkActions, name, [ecto_query | args]) end)
+    |> put_flash(:notice, "Updating devices, please wait...")
     |> noreply()
   end
 

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -498,6 +498,7 @@
                 <span class="text-base-300 text-xs tracking-tight italic">All deployment groups</span>
               </span>
               <button
+                id="remove-devices-from-deployment-group"
                 class="bg-base-800 cursor-pointer rounded-full border border-red-500 p-1"
                 data-confirm="This will remove all selected devices from their deployment groups. Would you like to continue?"
                 aria-label="Remove selected devices from deployment group"
@@ -622,7 +623,7 @@
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
                     <path d="M4.1665 10.8333L7.49984 14.1667L16.6665 5" stroke="#A1A1AA" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
                   </svg>
-                  <span class="">Enable</span>
+                  Enable
                 </button>
               </form>
             </div>

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -434,8 +434,11 @@
     ]}>
       <div class="h-0 flex-1 overflow-y-auto">
         <div class="border-base-700 flex h-14 items-center border-b px-4 py-3">
-          <h4 :if={length(@selected_devices) == 1} class="text-base font-semibold">{length(@selected_devices)} device selected</h4>
-          <h4 :if={length(@selected_devices) > 1} class="text-base font-semibold">{length(@selected_devices)} devices selected</h4>
+          <h4 :if={length(@selected_devices) == 1 and not @select_all_matching} class="text-base font-semibold">1 device selected</h4>
+          <h4 :if={length(@selected_devices) > 1 and not @select_all_matching} class="text-base font-semibold">
+            {length(@selected_devices) |> Number.Delimit.number_to_delimited(precision: 0)} devices selected
+          </h4>
+          <h4 :if={@select_all_matching} class="text-base font-semibold">All devices selected</h4>
 
           <button class="ml-auto cursor-pointer p-1.5" type="button" phx-click="deselect-all">
             <svg xmlns="http://www.w3.org/2000/svg" class="size-5" viewBox="0 0 20 20" fill="none">
@@ -448,6 +451,16 @@
               />
             </svg>
           </button>
+        </div>
+
+        <div class="flex flex-1 flex-col gap-6 px-4 pt-6">
+          <span :if={length(@selected_devices) == @total_entries or @select_all_matching}>All available devices matching the filters have been selected.</span>
+          <div :if={length(@selected_devices) != @total_entries and not @select_all_matching}>
+            <span>{Number.Delimit.number_to_delimited(@total_entries - length(@selected_devices), precision: 0)} additional devices match the filters but haven't been selected.</span>
+            <button class="sidebar-button" type="button" phx-click="select-all-matching">
+              Select all
+            </button>
+          </div>
         </div>
 
         <div class="flex flex-1 flex-col gap-6 px-4 py-6">
@@ -472,14 +485,17 @@
             </div>
           </form>
 
-          <div :if={@selected_have_deployment_groups} class="flex flex-col gap-2">
+          <div :if={@selected_have_deployment_groups or @select_all_matching} class="flex flex-col gap-2">
             <label class="sidebar-label">Remove from deployment group</label>
             <div class="flex items-center gap-2">
-              <span :if={@selected_shared_deployment_group} class="bg-base-800 border-base-700 flex items-center gap-1 rounded-full border py-0.5 pr-2.5 pl-1.5">
+              <span :if={@selected_shared_deployment_group && not @select_all_matching} class="bg-base-800 border-base-700 flex items-center gap-1 rounded-full border py-0.5 pr-2.5 pl-1.5">
                 <svg class="size-1.5" viewBox="0 0 6 6" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <circle cx="3" cy="3" r="3" fill="#10B981" />
                 </svg>
                 <span class="text-base-300 text-xs tracking-tight">{@selected_shared_deployment_group.name}</span>
+              </span>
+              <span :if={is_nil(@selected_shared_deployment_group) or @select_all_matching} class="bg-base-800 border-base-700 flex items-center gap-1 rounded-full border py-0.5 pr-2.5 pl-1.5">
+                <span class="text-base-300 text-xs tracking-tight italic">All deployment groups</span>
               </span>
               <button
                 class="bg-base-800 cursor-pointer rounded-full border border-red-500 p-1"
@@ -550,7 +566,7 @@
           </form>
 
           <form
-            :if={Enum.any?(@available_firmwares_for_filtered_platform)}
+            :if={Enum.any?(@available_firmwares_for_filtered_platform) and not @select_all_matching}
             id="push-firmware"
             class="flex flex-col gap-2"
             phx-change="target-firmware"

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -207,31 +207,82 @@ defmodule NervesHub.DevicesTest do
     refute Repo.exists?(where(DeviceHealth, device_id: ^device.id))
   end
 
-  test "can tag multiple devices", %{
-    user: user,
-    device: device,
-    device2: device2,
-    device3: device3
-  } do
-    devices = [device, device2, device3]
-    tags = "New,Tags"
+  describe "tag_devices/3" do
+    test "can tag multiple devices", %{
+      user: user,
+      device: device,
+      device2: device2,
+      device3: device3
+    } do
+      devices = [device, device2, device3]
+      tags = "New,Tags"
 
-    %{ok: devices} = BulkActions.tag_devices(devices, user, tags)
+      %{ok: devices} = BulkActions.tag_devices(devices, user, tags)
 
-    assert Enum.all?(devices, fn device -> device.tags == ["New", "Tags"] end)
+      assert Enum.all?(devices, fn device -> device.tags == ["New", "Tags"] end)
+    end
+
+    test "supports an Ecto.Query for the first argument", %{
+      user: user,
+      device: device,
+      device2: device2,
+      device3: device3
+    } do
+      devices = [device, device2, device3]
+      device_ids = Enum.map(devices, & &1.id)
+
+      tags = "New,Tags"
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in ^device_ids)
+        |> BulkActions.tag_devices(user, tags)
+
+      assert count == 3
+
+      assert Enum.all?(devices, fn device ->
+               Repo.reload(device).tags == ["New", "Tags"]
+             end)
+    end
   end
 
-  test "can disable updates for multiple devices", %{
-    user: user,
-    device: device,
-    device2: device2,
-    device3: device3
-  } do
-    devices = [device, device2, device3]
+  describe "disable_updates_for_devices/2" do
+    test "can disable updates for multiple devices", %{
+      user: user,
+      device: device,
+      device2: device2,
+      device3: device3
+    } do
+      devices = [device, device2, device3]
 
-    %{ok: devices} = BulkActions.disable_updates_for_devices(devices, user)
+      %{ok: devices} = BulkActions.disable_updates_for_devices(devices, user)
 
-    assert Enum.all?(devices, fn device -> device.updates_enabled == false end)
+      assert Enum.all?(devices, fn device -> device.updates_enabled == false end)
+    end
+
+    test "accepts an Ecto.Query for the first argument", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+      device = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+      device2 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+      device3 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+
+      devices = [device, device2, device3]
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in ^Enum.map(devices, & &1.id))
+        |> BulkActions.disable_updates_for_devices(user)
+
+      assert count == 3
+
+      assert Enum.all?(devices, fn device ->
+               Repo.reload(device).updates_enabled == false
+             end)
+    end
   end
 
   test "can enable updates for a devices", %{tmp_dir: tmp_dir} do
@@ -249,44 +300,102 @@ defmodule NervesHub.DevicesTest do
     assert device.update_attempts == []
   end
 
-  test "can enable updates for multiple devices", %{tmp_dir: tmp_dir} do
-    user = Fixtures.user_fixture()
-    org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
-    product = Fixtures.product_fixture(user, org)
-    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
-    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
-    device = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
-    device2 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
-    device3 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+  describe "enable_updates_for_devices/2" do
+    test "can enable updates for multiple devices", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+      device = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+      device2 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+      device3 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
 
-    devices = [device, device2, device3]
+      devices = [device, device2, device3]
 
-    %{ok: devices} = BulkActions.enable_updates_for_devices(devices, user)
+      %{ok: devices} = BulkActions.enable_updates_for_devices(devices, user)
 
-    assert Enum.all?(devices, fn device -> device.updates_enabled == true end)
+      assert Enum.all?(devices, fn device -> device.updates_enabled == true end)
+    end
+
+    test "accepts an Ecto.Query for the first argument", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+      device = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+      device2 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+      device3 = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
+
+      devices = [device, device2, device3]
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in ^Enum.map(devices, & &1.id))
+        |> BulkActions.enable_updates_for_devices(user)
+
+      assert count == 3
+
+      assert Enum.all?(devices, fn device ->
+               Repo.reload(device).updates_enabled == true
+             end)
+    end
   end
 
-  test "can clear penalty box for multiple devices", %{tmp_dir: tmp_dir} do
-    user = Fixtures.user_fixture()
-    org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
-    product = Fixtures.product_fixture(user, org)
-    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
-    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+  describe "clear_penalty_box_for_devices/2" do
+    test "can clear penalty box for multiple devices", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
-    device =
-      Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+      device =
+        Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
 
-    device2 =
-      Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+      device2 =
+        Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
 
-    device3 =
-      Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+      device3 =
+        Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
 
-    devices = [device, device2, device3]
+      devices = [device, device2, device3]
 
-    %{ok: devices} = BulkActions.clear_penalty_box_for_devices(devices, user)
+      %{ok: devices} = BulkActions.clear_penalty_box_for_devices(devices, user)
 
-    assert Enum.all?(devices, fn device -> is_nil(device.updates_blocked_until) end)
+      assert Enum.all?(devices, fn device -> is_nil(device.updates_blocked_until) end)
+    end
+
+    test "accepts an Ecto.Query for the first argument", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user, %{name: "Test-Org-2"})
+      product = Fixtures.product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      device =
+        Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+
+      device2 =
+        Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+
+      device3 =
+        Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+
+      devices = [device, device2, device3]
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in ^Enum.map(devices, & &1.id))
+        |> BulkActions.clear_penalty_box_for_devices(user)
+
+      assert count == 3
+
+      assert Enum.all?(devices, fn device ->
+               Repo.reload(device).updates_blocked_until |> is_nil()
+             end)
+    end
   end
 
   test "delete_device deletes its certificates", %{device: device} do
@@ -905,6 +1014,43 @@ defmodule NervesHub.DevicesTest do
         args: %{"source_id" => device_firmware.id, "target_id" => target_firmware.id}
       )
     end
+  end
+
+  describe "move_many_to_deployment_group/3" do
+    test "many devices can be moved to a deployment group", %{
+      deployment_group: deployment_group,
+      device: device1,
+      device2: device2,
+      user: user
+    } do
+      refute Repo.exists?(where(Device, [d], d.deployment_id == ^deployment_group.id))
+
+      %{updated: count} = BulkActions.move_many_to_deployment_group([device1.id, device2.id], deployment_group, user)
+
+      assert count == 2
+
+      assert Repo.aggregate(where(Device, [d], d.deployment_id == ^deployment_group.id), :count) == 2
+    end
+
+    test "accepts an Ecto.Query for the first argument", %{
+      deployment_group: deployment_group,
+      device: device1,
+      device2: device2,
+      user: user
+    } do
+      refute Repo.exists?(where(Device, [d], d.deployment_id == ^deployment_group.id))
+
+      device_ids = [device1.id, device2.id]
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in ^device_ids)
+        |> BulkActions.move_many_to_deployment_group(deployment_group, user)
+
+      assert count == 2
+
+      assert Repo.aggregate(where(Device, [d], d.deployment_id == ^deployment_group.id), :count) == 2
+    end
 
     test "broadcasts bulk-devices-added when a group (bulk) of devices are added to a deployment group", %{
       deployment_group: deployment_group,
@@ -939,7 +1085,7 @@ defmodule NervesHub.DevicesTest do
       deployment_topic = "orchestrator:deployment:#{deployment_group.id}"
       Phoenix.PubSub.subscribe(NervesHub.PubSub, deployment_topic)
 
-      BulkActions.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
+      BulkActions.move_many_to_deployment_group([device1.id, device2.id], deployment_group, user)
 
       # Assert that the bulk-devices-added event was broadcast
       assert_receive %Broadcast{topic: ^deployment_topic, event: "bulk-devices-added"}, 500
@@ -975,7 +1121,7 @@ defmodule NervesHub.DevicesTest do
       {:ok, {_release, deployment_group}} =
         ManagedDeployments.create_deployment_release(deployment_group, target_firmware, nil, user, %{})
 
-      BulkActions.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
+      BulkActions.move_many_to_deployment_group([device1.id, device2.id], deployment_group, user)
 
       # Delta generation happens inline in the transaction
       # Assert that delta generation job was enqueued for the new firmware pair
@@ -983,6 +1129,45 @@ defmodule NervesHub.DevicesTest do
         worker: FirmwareDeltaBuilder,
         args: %{"source_id" => device_firmware.id, "target_id" => target_firmware.id}
       )
+    end
+  end
+
+  describe "move_many/3" do
+    test "many devices can be moved to a product", %{
+      org: org,
+      device: device1,
+      device2: device2,
+      user: user
+    } do
+      target_product = Fixtures.product_fixture(user, org)
+
+      refute Repo.exists?(where(Device, [d], d.product_id == ^target_product.id))
+
+      %{ok: moved_list} = BulkActions.move_many([device1, device2], target_product, user)
+
+      assert length(moved_list) == 2
+
+      assert Repo.aggregate(where(Device, [d], d.product_id == ^target_product.id), :count) == 2
+    end
+
+    test "accepts an Ecto.Query for the first argument", %{
+      org: org,
+      device: device1,
+      device2: device2,
+      user: user
+    } do
+      target_product = Fixtures.product_fixture(user, org)
+
+      refute Repo.exists?(where(Device, [d], d.product_id == ^target_product.id))
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in [^device1.id, ^device2.id])
+        |> BulkActions.move_many(target_product, user)
+
+      assert count == 2
+
+      assert Repo.aggregate(where(Device, [d], d.product_id == ^target_product.id), :count) == 2
     end
   end
 
@@ -2171,18 +2356,34 @@ defmodule NervesHub.DevicesTest do
 
   describe "remove_many_from_deployment_group/2" do
     test "removes deployment group from devices that have one", %{
-      user: user,
-      org: org,
       product: product,
       device: device,
       device2: device2,
       deployment_group: deployment_group
     } do
-      scope = Scope.for_user(user) |> Scope.put_org(org) |> Scope.put_product(product)
       Repo.update!(Changeset.change(device, deployment_id: deployment_group.id))
       Repo.update!(Changeset.change(device2, deployment_id: deployment_group.id))
 
-      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, [device.id, device2.id])
+      %{ok: count} = BulkActions.remove_many_from_deployment_group({[device.id, device2.id], product})
+
+      assert count == 2
+
+      assert Repo.get!(Device, device.id).deployment_id == nil
+      assert Repo.get!(Device, device2.id).deployment_id == nil
+    end
+
+    test "supports an Ecto.Query for the first argument", %{
+      device: device,
+      device2: device2,
+      deployment_group: deployment_group
+    } do
+      Repo.update!(Changeset.change(device, deployment_id: deployment_group.id))
+      Repo.update!(Changeset.change(device2, deployment_id: deployment_group.id))
+
+      %{ok: count} =
+        Device
+        |> where([d], d.id in [^device.id, ^device2.id])
+        |> BulkActions.remove_many_from_deployment_group()
 
       assert count == 2
 
@@ -2191,32 +2392,26 @@ defmodule NervesHub.DevicesTest do
     end
 
     test "only counts devices that had a deployment group", %{
-      user: user,
-      org: org,
       product: product,
       device: device,
       device2: device2,
       deployment_group: deployment_group
     } do
-      scope = Scope.for_user(user) |> Scope.put_org(org) |> Scope.put_product(product)
       Repo.update!(Changeset.change(device, deployment_id: deployment_group.id))
       # device2 has no deployment group
 
-      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, [device.id, device2.id])
+      %{ok: count} = BulkActions.remove_many_from_deployment_group({[device.id, device2.id], product})
 
       assert count == 1
     end
 
     test "returns zero when no devices have a deployment group", %{
-      user: user,
-      org: org,
       product: product,
       device: device
     } do
-      scope = Scope.for_user(user) |> Scope.put_org(org) |> Scope.put_product(product)
       refute device.deployment_id
 
-      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, [device.id])
+      %{ok: count} = BulkActions.remove_many_from_deployment_group({[device.id], product})
 
       assert count == 0
     end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Accounts.Scope
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
+  alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
@@ -89,7 +90,7 @@ defmodule NervesHub.DevicesTest do
 
       json_import_data = File.read!("test/fixtures/devices_bulk_create/microchip_trust_and_go_manifest.json")
 
-      assert {5, 0} == Devices.bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
+      assert {5, 0} == BulkActions.bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
 
       assert Repo.aggregate(Device, :count) == 5
     end
@@ -101,7 +102,8 @@ defmodule NervesHub.DevicesTest do
 
       json_import_data = File.read!("test/fixtures/devices_bulk_create/microchip_trust_and_go_manifest.json")
 
-      assert {5, 0} == Devices.bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go", "snoot-boop")
+      assert {5, 0} ==
+               BulkActions.bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go", "snoot-boop")
 
       assert Repo.aggregate(Device, :count) == 5
 
@@ -116,7 +118,7 @@ defmodule NervesHub.DevicesTest do
       json_import_data =
         File.read!("test/fixtures/devices_bulk_create/microchip_trust_and_go_manifest_two_failures.json")
 
-      assert {5, 2} == Devices.bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
+      assert {5, 2} == BulkActions.bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
 
       assert Repo.aggregate(Device, :count) == 5
     end
@@ -130,7 +132,8 @@ defmodule NervesHub.DevicesTest do
 
       json_import_data = File.read!("test/fixtures/devices_bulk_create/microchip_trust_and_go_manifest.json")
 
-      assert {:ok, task_pid} = Devices.async_bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
+      assert {:ok, task_pid} =
+               BulkActions.async_bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
 
       ref = Process.monitor(task_pid)
       assert_receive {:DOWN, ^ref, _, _, :normal}
@@ -147,7 +150,13 @@ defmodule NervesHub.DevicesTest do
       json_import_data = File.read!("test/fixtures/devices_bulk_create/microchip_trust_and_go_manifest.json")
 
       assert {:ok, task_pid} =
-               Devices.async_bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go", "snoot-boop")
+               BulkActions.async_bulk_create(
+                 org.id,
+                 product.id,
+                 json_import_data,
+                 "microchip_trust_and_go",
+                 "snoot-boop"
+               )
 
       ref = Process.monitor(task_pid)
       assert_receive {:DOWN, ^ref, _, _, :normal}
@@ -166,7 +175,8 @@ defmodule NervesHub.DevicesTest do
       json_import_data =
         File.read!("test/fixtures/devices_bulk_create/microchip_trust_and_go_manifest_two_failures.json")
 
-      assert {:ok, task_pid} = Devices.async_bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
+      assert {:ok, task_pid} =
+               BulkActions.async_bulk_create(org.id, product.id, json_import_data, "microchip_trust_and_go")
 
       ref = Process.monitor(task_pid)
       assert_receive {:DOWN, ^ref, _, _, :normal}
@@ -206,7 +216,7 @@ defmodule NervesHub.DevicesTest do
     devices = [device, device2, device3]
     tags = "New,Tags"
 
-    %{ok: devices} = Devices.tag_devices(devices, user, tags)
+    %{ok: devices} = BulkActions.tag_devices(devices, user, tags)
 
     assert Enum.all?(devices, fn device -> device.tags == ["New", "Tags"] end)
   end
@@ -219,7 +229,7 @@ defmodule NervesHub.DevicesTest do
   } do
     devices = [device, device2, device3]
 
-    %{ok: devices} = Devices.disable_updates_for_devices(devices, user)
+    %{ok: devices} = BulkActions.disable_updates_for_devices(devices, user)
 
     assert Enum.all?(devices, fn device -> device.updates_enabled == false end)
   end
@@ -251,7 +261,7 @@ defmodule NervesHub.DevicesTest do
 
     devices = [device, device2, device3]
 
-    %{ok: devices} = Devices.enable_updates_for_devices(devices, user)
+    %{ok: devices} = BulkActions.enable_updates_for_devices(devices, user)
 
     assert Enum.all?(devices, fn device -> device.updates_enabled == true end)
   end
@@ -274,7 +284,7 @@ defmodule NervesHub.DevicesTest do
 
     devices = [device, device2, device3]
 
-    %{ok: devices} = Devices.clear_penalty_box_for_devices(devices, user)
+    %{ok: devices} = BulkActions.clear_penalty_box_for_devices(devices, user)
 
     assert Enum.all?(devices, fn device -> is_nil(device.updates_blocked_until) end)
   end
@@ -929,7 +939,7 @@ defmodule NervesHub.DevicesTest do
       deployment_topic = "orchestrator:deployment:#{deployment_group.id}"
       Phoenix.PubSub.subscribe(NervesHub.PubSub, deployment_topic)
 
-      Devices.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
+      BulkActions.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
 
       # Assert that the bulk-devices-added event was broadcast
       assert_receive %Broadcast{topic: ^deployment_topic, event: "bulk-devices-added"}, 500
@@ -965,7 +975,7 @@ defmodule NervesHub.DevicesTest do
       {:ok, {_release, deployment_group}} =
         ManagedDeployments.create_deployment_release(deployment_group, target_firmware, nil, user, %{})
 
-      Devices.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
+      BulkActions.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
 
       # Delta generation happens inline in the transaction
       # Assert that delta generation job was enqueued for the new firmware pair
@@ -2172,7 +2182,7 @@ defmodule NervesHub.DevicesTest do
       Repo.update!(Changeset.change(device, deployment_id: deployment_group.id))
       Repo.update!(Changeset.change(device2, deployment_id: deployment_group.id))
 
-      {:ok, count} = Devices.remove_many_from_deployment_group(scope, [device.id, device2.id])
+      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, [device.id, device2.id])
 
       assert count == 2
 
@@ -2192,7 +2202,7 @@ defmodule NervesHub.DevicesTest do
       Repo.update!(Changeset.change(device, deployment_id: deployment_group.id))
       # device2 has no deployment group
 
-      {:ok, count} = Devices.remove_many_from_deployment_group(scope, [device.id, device2.id])
+      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, [device.id, device2.id])
 
       assert count == 1
     end
@@ -2206,7 +2216,7 @@ defmodule NervesHub.DevicesTest do
       scope = Scope.for_user(user) |> Scope.put_org(org) |> Scope.put_product(product)
       refute device.deployment_id
 
-      {:ok, count} = Devices.remove_many_from_deployment_group(scope, [device.id])
+      {:ok, count} = BulkActions.remove_many_from_deployment_group(scope, [device.id])
 
       assert count == 0
     end

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
   alias NervesHub.Accounts.Scope
   alias NervesHub.Devices
+  alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Firmwares
@@ -368,7 +369,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     allow(Devices, self(), pid)
 
-    Devices.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
+    BulkActions.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "bulk-devices-added"}, 500
 

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -3,7 +3,6 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
   use Mimic
   use AssertEventually, timeout: 500, interval: 50
 
-  alias NervesHub.Accounts.Scope
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.Connections
@@ -369,7 +368,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     allow(Devices, self(), pid)
 
-    BulkActions.move_many_to_deployment_group(Scope.for_user(user), [device1.id, device2.id], deployment_group)
+    BulkActions.move_many_to_deployment_group([device1.id, device2.id], deployment_group, user)
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "bulk-devices-added"}, 500
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -867,7 +867,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         )
         |> submit()
       end)
-      |> assert_has("div", text: "All selected devices successfully moved moved to #{other_product.name}")
+      |> assert_has("div", text: "All selected devices successfully moved to #{other_product.name}")
       |> visit("/org/#{org.name}/#{other_product.name}/devices")
       |> assert_has("div", text: "2", timeout: 1000)
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -940,6 +940,202 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
     end
   end
 
+  describe "bulk actions after selecting all devices" do
+    test "move devices to a different product", %{conn: conn, fixture: fixture} do
+      %{user: user, org: org, product: product, firmware: firmware} = fixture
+
+      Repo.delete_all(Device)
+
+      devices = Enum.map(1..75, fn _ -> Fixtures.device_fixture(org, product, firmware) end)
+
+      other_product = Fixtures.product_fixture(user, org)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> within("form#product-move", fn session ->
+        session
+        |> select("Move device(s) to product:",
+          option: other_product.name,
+          exact_option: false
+        )
+        |> submit()
+      end)
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div", text: "All selected devices successfully moved to the selected product.", timeout: 3_000)
+      |> visit("/org/#{org.name}/#{other_product.name}/devices")
+      |> assert_has("div", text: "75", timeout: 1000)
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> device.product_id == other_product.id end)
+    end
+
+    test "remove devices from assigned deployment groups", %{conn: conn, fixture: fixture} do
+      %{org: org, product: product, firmware: firmware, deployment_group: deployment_group} = fixture
+
+      Repo.delete_all(Device)
+
+      devices =
+        Enum.map(1..75, fn _ ->
+          Fixtures.device_fixture(org, product, firmware, %{deployment_id: deployment_group.id})
+        end)
+
+      assert Enum.all?(devices, fn device -> device.deployment_id == deployment_group.id end)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> click_button("#remove-devices-from-deployment-group", "")
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div",
+        text: "All devices (75) were successfully removed from their deployment group.",
+        timeout: 3_000
+      )
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> is_nil(device.deployment_id) end)
+    end
+
+    test "move devices to a different deployment group", %{conn: conn, fixture: fixture} do
+      %{org: org, product: product, firmware: firmware, deployment_group: deployment_group} = fixture
+
+      Repo.delete_all(Device)
+
+      devices = Enum.map(1..75, fn _ -> Fixtures.device_fixture(org, product, firmware) end)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> within("form#deployment-set", fn session ->
+        session
+        |> select("Set deployment group",
+          option: deployment_group.name,
+          exact_option: false
+        )
+        |> submit()
+      end)
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div",
+        text: "All selected devices were successfully assigned to the selected deployment group.",
+        timeout: 3_000
+      )
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> device.deployment_id == deployment_group.id end)
+    end
+
+    test "changes tags", %{conn: conn, fixture: fixture} do
+      %{org: org, product: product, firmware: firmware} = fixture
+
+      Repo.delete_all(Device)
+
+      devices = Enum.map(1..75, fn _ -> Fixtures.device_fixture(org, product, firmware) end)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> unwrap(fn view ->
+        render_submit(view, "tag-devices", %{"tags" => "moussaka"})
+      end)
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div", text: "All selected devices (75) tagged successfully.", timeout: 3_000)
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> device.tags == ["moussaka"] end)
+    end
+
+    test "enables updates", %{conn: conn, fixture: fixture} do
+      %{org: org, product: product, firmware: firmware} = fixture
+
+      Repo.delete_all(Device)
+
+      devices = Enum.map(1..75, fn _ -> Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false}) end)
+
+      assert Enum.all?(devices, fn device -> not device.updates_enabled end)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> click_button("Enable")
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div", text: "Enabled updates for #{75} selected device(s).", timeout: 3_000)
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> device.updates_enabled end)
+    end
+
+    test "disable updates", %{conn: conn, fixture: fixture} do
+      %{org: org, product: product, firmware: firmware} = fixture
+
+      Repo.delete_all(Device)
+
+      devices = Enum.map(1..75, fn _ -> Fixtures.device_fixture(org, product, firmware, %{updates_enabled: true}) end)
+
+      assert Enum.all?(devices, fn device -> device.updates_enabled end)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> click_button("Disable")
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div", text: "Disabled updates for 75 selected device(s).", timeout: 3_000)
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> not device.updates_enabled end)
+    end
+
+    test "clear penalty boxes", %{conn: conn, fixture: fixture} do
+      %{org: org, product: product, firmware: firmware} = fixture
+
+      Repo.delete_all(Device)
+
+      devices =
+        Enum.map(1..75, fn _ ->
+          Fixtures.device_fixture(org, product, firmware, %{updates_blocked_until: DateTime.utc_now()})
+        end)
+
+      assert Enum.all?(devices, fn device -> not is_nil(device.updates_blocked_until) end)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices")
+      |> assert_has("h1", text: "Devices", timeout: 1_000)
+      |> assert_has("#device-count", text: "75", timeout: 1_000)
+      |> check("Select all devices", exact: false)
+      |> click_button("Select all")
+      |> assert_has("h4", "All devices selected")
+      |> assert_has("span", "All available devices matching the filters have been selected.")
+      |> click_button("Clear penalty box")
+      |> assert_has("div", text: "Updating devices, please wait...", timeout: 1_000)
+      |> assert_has("div", text: "75 selected device(s) cleared from the penalty box.", timeout: 3_000)
+
+      assert Repo.reload(devices) |> Enum.all?(fn device -> is_nil(device.updates_blocked_until) end)
+    end
+  end
+
   describe "pagination" do
     test "no pagination when less than 25 devices", %{conn: conn, fixture: fixture} do
       %{


### PR DESCRIPTION
I've added a way to 'select all' devices, including when using filters.

And then I've added support for bulk actions to accept an Ecto query.

And I've used LiveView `start_async` for background processing.

More thought and love needs to be applied to the various 'edge' cases when selecting all devices, then maybe paginating, or removing a device. But I'm going to leave that for another PR.


https://github.com/user-attachments/assets/98f05878-5b76-4a72-8a94-a8b4f2cd5b1b

