### PR TITLE
Tweak the Device export to use HTTP streaming (chunks)

### DIFF
--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -14,12 +14,8 @@ defmodule NervesHub.Products do
   alias NervesHub.Products.Product
   alias NervesHub.Products.SharedSecretAuth
   alias NervesHub.Repo
-  alias NimbleCSV.RFC4180, as: CSV
 
-  @csv_certs_sep "\n\n"
-  @csv_header ["identifier", "description", "tags", "product", "org", "certificates"]
-
-  def __csv_header__(), do: @csv_header
+  @export_certs_sep "\n\n"
 
   def get_by_name!(%Scope{} = current_scope, product_name) do
     Product
@@ -281,28 +277,34 @@ defmodule NervesHub.Products do
     |> Repo.update()
   end
 
-  @spec devices_csv(Product.t()) :: binary()
-  def devices_csv(%Product{} = product) do
+  @spec devices_export_reducer(Product.t(), any(), fun()) :: any()
+  def devices_export_reducer(%Product{} = product, acc, callback) do
     product = Repo.preload(product, [:org])
 
-    {:ok, devices} =
-      Repo.transact(fn ->
-        devices =
-          Device
-          |> where([d], d.product_id == ^product.id)
-          |> Repo.exclude_deleted()
-          |> Repo.stream(max_rows: 100)
-          |> Stream.chunk_every(100)
-          |> Stream.flat_map(&Repo.preload(&1, :device_certificates))
-          |> Stream.map(&device_csv_line(&1, product))
-          |> Enum.to_list()
+    Repo.transact(
+      fn ->
+        Device
+        |> select([d, dc], [:id, :identifier, :description, :tags, :deleted_at, :product_id])
+        |> where([d], d.product_id == ^product.id)
+        |> Repo.exclude_deleted()
+        |> Repo.stream(max_rows: 500)
+        |> Stream.chunk_every(100)
+        |> Stream.flat_map(&Repo.preload(&1, :device_certificates))
+        |> Stream.map(&device_csv_line(&1, product))
+        |> Enum.reduce_while(acc, fn line, acc ->
+          callback.(acc, line)
+          |> case do
+            {:ok, acc} ->
+              {:cont, acc}
 
-        {:ok, devices}
-      end)
-
-    [@csv_header | devices]
-    |> CSV.dump_to_iodata()
-    |> IO.iodata_to_binary()
+            {:error, _} ->
+              {:halt, acc}
+          end
+        end)
+        |> then(fn res -> {:ok, res} end)
+      end,
+      timeout: 90_000
+    )
   end
 
   defp device_csv_line(device, product) do
@@ -331,7 +333,7 @@ defmodule NervesHub.Products do
           not_after: db_cert.not_after
         }
         |> Jason.encode!()
-        |> Kernel.<>(@csv_certs_sep)
+        |> Kernel.<>(@export_certs_sep)
       end
     end
   end

--- a/lib/nerves_hub_web/controllers/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/product_controller.ex
@@ -2,11 +2,26 @@ defmodule NervesHubWeb.ProductController do
   use NervesHubWeb, :controller
 
   alias NervesHub.Products
+  alias NimbleCSV.RFC4180, as: CSV
+
+  @csv_header ["identifier", "description", "tags", "product", "org", "certificates"]
 
   plug(:validate_role, [org: :view] when action in [:devices_export])
 
   def devices_export(%{assigns: %{current_scope: scope}} = conn, _params) do
-    filename = "#{scope.product.name}-devices.csv"
-    send_download(conn, {:binary, Products.devices_csv(scope.product)}, filename: filename)
+    conn =
+      conn
+      |> put_resp_content_type("text/csv")
+      |> put_resp_header("content-disposition", ~s[attachment; filename="#{scope.product.name}-devices.csv"])
+      |> send_chunked(:ok)
+
+    {:ok, conn} = chunk(conn, CSV.dump_to_iodata([@csv_header]))
+
+    {:ok, conn} =
+      Products.devices_export_reducer(scope.product, conn, fn conn, line ->
+        chunk(conn, CSV.dump_to_iodata([line]))
+      end)
+
+    conn
   end
 end

--- a/test/nerves_hub/products/products_test.exs
+++ b/test/nerves_hub/products/products_test.exs
@@ -73,7 +73,7 @@ defmodule NervesHub.ProductsTest do
       assert [^product] = Products.get_products_by_user_and_org(user, org)
     end
 
-    test "create devices CSV IO", %{
+    test "stream and reduce devices from a product", %{
       user: user,
       product: product,
       org: org,
@@ -98,10 +98,9 @@ defmodule NervesHub.ProductsTest do
         Fixtures.device_certificate_fixture_without_der(device, otp_cert)
 
       # Generate CSV
-      csv_io = Products.devices_csv(product)
+      {:ok, csv_io} = Products.devices_export_reducer(product, [], fn res, line -> {:ok, [line | res]} end)
 
-      [[id, desc, tags, product_name, org_name, cert_io] | _] =
-        NimbleCSV.RFC4180.parse_string(csv_io)
+      [[id, desc, tags, product_name, org_name, cert_io] | _] = csv_io
 
       assert id == device.identifier
       assert desc == device.description || ""

--- a/test/nerves_hub_web/controllers/product_controller_test.exs
+++ b/test/nerves_hub_web/controllers/product_controller_test.exs
@@ -1,0 +1,76 @@
+defmodule NervesHubWeb.ProductControllerTest do
+  use NervesHubWeb.ConnCase.Browser, async: true
+
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.DeviceCertificate
+  alias NervesHub.Fixtures
+  alias NervesHub.Repo
+
+  setup %{user: user, org: org} do
+    [product: Fixtures.product_fixture(user, org)]
+  end
+
+  test "download device list csv", %{
+    conn: conn,
+    org: org,
+    product: product,
+    user: user,
+    tmp_dir: tmp_dir
+  } do
+    Repo.delete_all(Device)
+    Repo.delete_all(DeviceCertificate)
+
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    %{db_cert: db_cert} = Fixtures.device_certificate_fixture(device)
+
+    ##
+    # Need to create a second certificate without a DER saved to test JSON
+    # TODO: Remove when DERs are saved
+    %{cert: ca1, key: ca1_key} = Fixtures.ca_certificate_fixture(org)
+
+    otp_cert =
+      X509.PrivateKey.new_ec(:secp256r1)
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("CN=#{device.identifier}", ca1, ca1_key)
+
+    %{db_cert: db_cert_no_der} =
+      Fixtures.device_certificate_fixture_without_der(device, otp_cert)
+
+    conn = get(conn, ~p"/org/#{org}/#{product}/devices/export")
+
+    [str] = Plug.Conn.get_resp_header(conn, "content-disposition")
+
+    assert str =~ "attachment; filename"
+
+    [[id, desc, tags, product_name, org_name, cert_io] | _] =
+      NimbleCSV.RFC4180.parse_string(conn.resp_body)
+
+    assert id == device.identifier
+    assert desc == device.description || ""
+    assert String.split(tags, ",") == device.tags
+    assert product_name == product.name
+    assert org_name == org.name
+
+    String.split(cert_io, "\n\n")
+    |> Enum.each(fn
+      "{" <> _ = cert_json ->
+        # TODO: Remove testing JSON when DERs saved
+        parsed_cert = Jason.decode!(cert_json)
+
+        assert parsed_cert["serial"] == db_cert_no_der.serial
+        assert parsed_cert["not_before"] == DateTime.to_iso8601(db_cert_no_der.not_before)
+        assert parsed_cert["not_after"] == DateTime.to_iso8601(db_cert_no_der.not_after)
+        assert Base.decode16!(parsed_cert["aki"]) == db_cert_no_der.aki
+        assert Base.decode16!(parsed_cert["ski"]) == db_cert_no_der.ski
+
+      "---" <> _ = cert_pem ->
+        assert X509.Certificate.from_pem!(cert_pem) == X509.Certificate.from_der!(db_cert.der)
+
+      _ ->
+        :ignore
+    end)
+  end
+end


### PR DESCRIPTION
The core change is generalising `devices_csv/1` to instead act as a reducer so we can pass in a custom function which allows us to stream the response to the user.

I've also tweaked the function to select less information from the database, fetch more rows, and use a 90 second timeout for the transaction.

Oh, and I added a test for the HTTP part of this.

Side note: This is way more memory efficient as we aren't creating a 500k row CSV and then sending it to the client, instead we are sending rows as they become available.
