### PR TITLE
Add runtime setting to default deployment group queue management to LIFO

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,7 +66,8 @@ config :nerves_hub,
   devices_websocket_url:
     System.get_env("DEVICES_WEBSOCKET_HOST") || System.get_env("DEVICE_HOST") || System.get_env("WEB_HOST") ||
       System.get_env("HOST"),
-  clean_up_soft_deleted_devices: System.get_env("CLEAN_UP_SOFT_DELETED_DEVICES", "false") == "true"
+  clean_up_soft_deleted_devices: System.get_env("CLEAN_UP_SOFT_DELETED_DEVICES", "false") == "true",
+  default_lifo_deployment_queue: System.get_env("DEFAULT_LIFO_DEPLOYMENT_QUEUE", "false") == "true"
 
 # only set this in :prod as not to override the :dev config
 if config_env() == :prod do

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -113,6 +113,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     |> put_change(:firmware, firmware)
     |> maybe_add_platform()
     |> maybe_add_architecture()
+    |> maybe_set_queue_management()
     |> validate_required([:name, :delta_updatable, :product_id, :org_id, :firmware])
     |> validate_firmware(product)
     |> validate_platform()
@@ -200,6 +201,14 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
       is_nil(firmware) -> changeset
       is_nil(platform) -> put_change(changeset, :platform, firmware.platform)
       true -> changeset
+    end
+  end
+
+  defp maybe_set_queue_management(changeset) do
+    if Application.get_env(:nerves_hub, :default_lifo_deployment_queue) do
+      put_change(changeset, :queue_management, :LIFO)
+    else
+      changeset
     end
   end
 


### PR DESCRIPTION
For SR, we have no need for the `FIFO` queue management setting for deployment groups. This PR lets a runtime config default it to `LIFO`.

Tested locally.