### PR TITLE
Reduce the information stored by the `DeviceSocket` and related channel

### DIFF
--- a/lib/nerves_hub/audit_logs/templates/device_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/device_templates.ex
@@ -6,6 +6,7 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
   alias NervesHub.Accounts.User
   alias NervesHub.Archives.Archive
   alias NervesHub.AuditLogs
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
   alias NervesHub.Firmwares.Firmware
@@ -27,8 +28,13 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
 
   ## Firmware and upgrades
 
-  @spec audit_update_attempt(Device.t()) :: :ok
-  def audit_update_attempt(device) do
+  @spec audit_update_attempt(Device.t() | DeviceInfo.t()) :: :ok
+  def audit_update_attempt(%DeviceInfo{} = device_info) do
+    %Device{id: device_info.device_id, identifier: device_info.device_identifier, org_id: device_info.org_id}
+    |> audit_update_attempt()
+  end
+
+  def audit_update_attempt(%Device{} = device) do
     description = "Device #{device.identifier} is attempting to update"
     AuditLogs.audit(device, device, description)
   end
@@ -60,8 +66,13 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     AuditLogs.audit!(device, device, description)
   end
 
-  @spec audit_firmware_validated(Device.t()) :: :ok
-  def audit_firmware_validated(device) do
+  @spec audit_firmware_validated(Device.t() | DeviceInfo.t()) :: :ok
+  def audit_firmware_validated(%DeviceInfo{} = device_info) do
+    %Device{id: device_info.device_id, identifier: device_info.device_identifier, org_id: device_info.org_id}
+    |> audit_firmware_validated()
+  end
+
+  def audit_firmware_validated(%Device{} = device) do
     description = "Device #{device.identifier} has validated its firmware"
     AuditLogs.audit!(device, device, description)
   end

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -96,12 +96,9 @@ defmodule NervesHub.DeviceLink do
 
   @spec fetch_connecting_code(DeviceInfo.t()) :: list(binary()) | nil
   def fetch_connecting_code(device_info) do
-    device = Devices.get_device(device_info.device_id, [:deployment])
+    {device_connecting_code, deployment_connecting_code} = Devices.fetch_connecting_code(device_info.device_id)
 
-    [
-      get_in(device, [Access.key(:deployment_group), Access.key(:connecting_code)]),
-      device.connecting_code
-    ]
+    [deployment_connecting_code, device_connecting_code]
     |> Enum.filter(&(not is_nil(&1) and byte_size(&1) > 0))
     |> case do
       list when list == [] -> nil

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -16,6 +16,7 @@ defmodule NervesHub.DeviceLink do
 
   defmodule DeviceInfo do
     defstruct [
+      :allowed_extensions,
       :connection_ref,
       :deployment_id,
       :device_id,
@@ -29,6 +30,7 @@ defmodule NervesHub.DeviceLink do
     ]
 
     @type t :: %__MODULE__{
+            allowed_extensions: list(atom()) | nil,
             connection_ref: String.t() | nil,
             deployment_id: pos_integer() | nil,
             device_id: pos_integer() | nil,

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -14,33 +14,97 @@ defmodule NervesHub.DeviceLink do
 
   require Logger
 
-  @spec join(Device.t(), connection_reference :: String.t(), params :: map()) ::
-          {:ok, Device.t()} | {:error, any()}
-  def join(device, ref_id, params) do
+  defmodule DeviceInfo do
+    defstruct [
+      :connection_ref,
+      :deployment_id,
+      :device_id,
+      :device_identifier,
+      :device_network_interface,
+      :device_updates_blocked_until,
+      :device_updates_enabled,
+      :firmware_metadata,
+      :org_id,
+      :product_id
+    ]
+
+    @type t :: %__MODULE__{
+            connection_ref: String.t() | nil,
+            deployment_id: pos_integer() | nil,
+            device_id: pos_integer() | nil,
+            device_updates_enabled: boolean() | nil,
+            device_updates_blocked_until: DateTime.t() | nil,
+            device_identifier: String.t() | nil,
+            device_network_interface: String.t() | nil,
+            firmware_metadata: map() | nil,
+            org_id: pos_integer() | nil,
+            product_id: pos_integer() | nil
+          }
+  end
+
+  @public_key_types ["fwup_public_keys", "archive_public_keys"]
+
+  @spec join(DeviceInfo.t(), params :: map()) :: {:ok, DeviceInfo.t()} | {:error, any()}
+  def join(device_info, params) do
     updated_metadata = %{
       "device_api_version" => params["device_api_version"]
     }
 
+    device = Devices.get_device(device_info.device_id)
+
     with {:ok, device} <- update_firmware_metadata(device, params),
-         :ok <- update_connection_metadata(ref_id, updated_metadata),
+         :ok <- update_connection_metadata(device_info.connection_ref, updated_metadata),
          :ok <- maybe_clear_inflight_update(device, params) do
       device = refresh_deployment_group(device)
-      {:ok, device}
+
+      {:ok, %{device_info | deployment_id: device.deployment_id, firmware_metadata: device.firmware_metadata}}
     else
       err -> {:error, err}
     end
   end
 
-  @spec after_join(Device.t(), connection_reference :: String.t(), params :: map()) ::
-          :ok | {:error, any()}
-  def after_join(device, reference_id, params) do
-    with :ok <- maybe_send_public_keys(device, params),
-         :ok <- maybe_send_archive(device, params["device_api_version"], reference_id),
-         :ok <- maybe_request_extensions(device, params["device_api_version"]) do
-      announce_online(device, reference_id)
+  @spec after_join(DeviceInfo.t(), params :: map()) :: :ok | {:error, any()}
+  def after_join(device_info, params) do
+    with :ok <- maybe_send_public_keys(device_info, params),
+         :ok <- maybe_send_archive(device_info, params["device_api_version"]),
+         :ok <- maybe_request_extensions(device_info, params["device_api_version"]) do
+      announce_online(device_info)
     end
   rescue
     err -> {:error, err}
+  end
+
+  @spec refresh_device_info(DeviceInfo.t()) :: DeviceInfo.t()
+  def refresh_device_info(device_info) do
+    device = Devices.get_device(device_info.device_id)
+
+    %{
+      device_info
+      | org_id: device.org_id,
+        product_id: device.product_id,
+        device_id: device.id,
+        device_identifier: device.identifier,
+        deployment_id: device.deployment_id,
+        firmware_metadata: device.firmware_metadata,
+        device_updates_enabled: device.updates_enabled,
+        device_updates_blocked_until: device.updates_blocked_until,
+        device_network_interface: device.network_interface
+    }
+  end
+
+  @spec fetch_connecting_code(DeviceInfo.t()) :: list(binary()) | nil
+  def fetch_connecting_code(device_info) do
+    device = Devices.get_device(device_info.device_id, [:deployment])
+
+    [
+      get_in(device, [Access.key(:deployment_group), Access.key(:connecting_code)]),
+      device.connecting_code
+    ]
+    |> Enum.filter(&(not is_nil(&1) and byte_size(&1) > 0))
+    |> case do
+      list when list == [] -> nil
+      list -> list
+    end
   end
 
   @spec update_connection_metadata(reference_id :: String.t(), metadata :: map()) :: :ok | {:error, any()}
@@ -48,47 +112,47 @@ defmodule NervesHub.DeviceLink do
     Connections.merge_update_metadata(reference_id, metadata)
   end
 
-  @spec status_update(device :: Device.t(), status :: map(), update_started? :: boolean()) ::
+  @spec status_update(device_info :: DeviceInfo.t(), status :: map(), update_started? :: boolean()) ::
           :ok
-  def status_update(device, %{"status" => "started", "downloader_network_interface" => nil}, _update_started?) do
+  def status_update(device_info, %{"status" => "started", "downloader_network_interface" => nil}, _update_started?) do
     :telemetry.execute([:nerves_hub, :devices, :downloader_network_interface_nil], %{count: 1}, %{
-      identifier: device.identifier
+      identifier: device_info.device_identifier
     })
 
     :ok
   end
 
   def status_update(
-        device,
+        %{device_network_interface: device_network_interface} = device_info,
         %{"status" => "started", "downloader_network_interface" => downloader_network_interface},
         _update_started?
       ) do
-    if is_nil(device.network_interface) or
-         device.network_interface == Device.humanized_network_interface_name(downloader_network_interface) do
+    if is_nil(device_network_interface) or
+         device_network_interface == Device.humanized_network_interface_name(downloader_network_interface) do
       :ok
     else
       :telemetry.execute([:nerves_hub, :devices, :network_interface_mismatch], %{count: 1}, %{
         downloader_network_interface: downloader_network_interface,
-        device_network_interface: device.network_interface,
-        identifier: device.identifier
+        device_network_interface: device_info.device_network_interface,
+        identifier: device_info.device_identifier
       })
 
       :ok
     end
   end
 
-  def status_update(device, %{"status" => status}, update_started?) do
+  def status_update(device_info, %{"status" => status}, update_started?) do
     # a temporary hook into failed updates
     if String.contains?(String.downcase(status), "fwup error") do
       # if there was an error during updating
       # mark the attempt
       _ =
         if update_started? do
-          Devices.update_attempted(device)
+          Devices.update_attempted(device_info)
         end
 
       # clear the inflight update
-      Devices.clear_inflight_update(device)
+      Devices.clear_inflight_update(device_info)
       :ok
     else
       # if there was no error during updating, do nothing
@@ -96,43 +160,42 @@ defmodule NervesHub.DeviceLink do
     end
   end
 
-  @spec firmware_update_progress(device :: Device.t(), percent :: integer()) :: :ok
-  def firmware_update_progress(device, percent) do
-    topic = "device:#{device.identifier}:internal"
+  @spec firmware_update_progress(device_info :: DeviceInfo.t(), percent :: integer()) :: :ok
+  def firmware_update_progress(device_info, percent) do
+    topic = "device:#{device_info.device_identifier}:internal"
 
     :ok =
       ChannelServer.broadcast_from!(NervesHub.PubSub, self(), topic, "fwup_progress", %{
-        device_id: device.id,
+        device_id: device_info.device_id,
         percent: percent
       })
   end
 
   @spec maybe_send_archive(
-          device :: Device.t(),
+          device_info :: DeviceInfo.t(),
           device_api_version :: String.t(),
-          reference_id :: String.t(),
           opts :: Keyword.t()
         ) :: :ok
-  def maybe_send_archive(device, device_api_version, reference_id, opts \\ [])
+  def maybe_send_archive(device_info, device_api_version, opts \\ [])
 
-  def maybe_send_archive(%{deployment_id: nil}, _device_api_version, _reference_id, _opts), do: :ok
+  def maybe_send_archive(%{deployment_id: nil}, _device_api_version, _opts), do: :ok
 
-  def maybe_send_archive(device, device_api_version, reference_id, opts) do
+  def maybe_send_archive(device_info, device_api_version, opts) do
     opts = Keyword.validate!(opts, audit_log: false)
-    updates_enabled = device.updates_enabled && !Devices.device_in_penalty_box?(device)
+    updates_enabled = device_info.device_updates_enabled && !Devices.device_in_penalty_box?(device_info)
     version_match = Version.match?(device_api_version, ">= 2.0.0")
 
     if updates_enabled && version_match do
-      if archive = Archives.archive_for_deployment_group(device.deployment_id) do
+      if archive = Archives.archive_for_deployment_group(device_info.deployment_id) do
         if opts[:audit_log],
           do:
             DeviceTemplates.audit_device_archive_update_triggered(
-              device,
+              %Device{id: device_info.device_id, identifier: device_info.device_identifier, org_id: device_info.org_id},
               archive,
-              reference_id
+              device_info.connection_ref
             )
 
-        broadcast(device, "archive", %{
+        broadcast(device_info, "archive", %{
           size: archive.size,
           uuid: archive.uuid,
           version: archive.version,
@@ -148,11 +211,11 @@ defmodule NervesHub.DeviceLink do
     :ok
   end
 
-  defp announce_online(device, reference_id) do
+  defp announce_online(device_info) do
     # Update the connection to say that we are fully up and running
-    Connections.device_connected(device, reference_id)
+    Connections.device_connected(device_info.device_identifier, device_info.connection_ref)
     # tell the orchestrator that we are online
-    Devices.deployment_device_online(device)
+    Devices.deployment_device_online(device_info)
   end
 
   defp refresh_deployment_group(device) do
@@ -162,12 +225,20 @@ defmodule NervesHub.DeviceLink do
     |> Map.put(:deployment_group, nil)
   end
 
-  defp maybe_send_public_keys(device, params) do
-    Enum.each(["fwup_public_keys", "archive_public_keys"], fn key_type ->
-      if params[key_type] == "on_connect" do
-        org_keys = NervesHub.Accounts.list_org_keys(device.org_id, false)
+  defp maybe_send_public_keys(device_info, params) do
+    signing_keys =
+      if Enum.any?(@public_key_types, fn type -> params[type] == "on_connect" end) do
+        Devices.fetch_firmware_signing_keys(device_info.device_id)
+      else
+        []
+      end
 
-        broadcast(device, key_type, %{keys: Enum.map(org_keys, & &1.key)})
+    Enum.each(["fwup_public_keys", "archive_public_keys"], fn key_type ->
+      with "on_connect" <- params[key_type],
+           org_keys when is_list(org_keys) and org_keys != [] <- signing_keys do
+        broadcast(device_info, key_type, %{keys: Enum.map(org_keys, & &1.key)})
+      else
+        _ -> :ok
       end
     end)
 
@@ -182,9 +253,9 @@ defmodule NervesHub.DeviceLink do
     :ok
   end
 
-  defp maybe_request_extensions(device, device_api_version) do
+  defp maybe_request_extensions(device_info, device_api_version) do
     if Version.match?(device_api_version, ">= 2.2.0"),
-      do: broadcast(device, "extensions:get", %{})
+      do: broadcast(device_info, "extensions:get", %{})
 
     :ok
   end
@@ -233,11 +304,11 @@ defmodule NervesHub.DeviceLink do
     |> Map.get("firmware_auto_revert_detected", false)
   end
 
-  defp topic(%Device{id: id}) do
+  defp topic(%DeviceInfo{device_id: id}) do
     "device:#{id}"
   end
 
-  defp broadcast(device, event, payload) do
-    :ok = ChannelServer.broadcast(NervesHub.PubSub, topic(device), event, payload)
+  defp broadcast(device_info, event, payload) do
+    :ok = ChannelServer.broadcast(NervesHub.PubSub, topic(device_info), event, payload)
   end
 end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -343,7 +343,7 @@ defmodule NervesHub.Devices do
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}
-      certificate -> {:ok, certificate}
+      device -> {:ok, device}
     end
   end
 
@@ -1725,21 +1725,6 @@ defmodule NervesHub.Devices do
     |> where([iu], iu.deployment_id == ^deployment_group.id)
     |> where([iu], iu.priority_queue == true)
     |> Repo.aggregate(:count)
-  end
-
-  @spec fetch_allowed_extensions(pos_integer()) :: allowed_extensions :: list(atom())
-  def fetch_allowed_extensions(device_id) do
-    {device_extensions, product_extensions} =
-      Device
-      |> join(:left, [d], p in assoc(d, :product))
-      |> select([d, p], {d.extensions, p.extensions})
-      |> where(id: ^device_id)
-      |> Repo.one!()
-
-    for {extension, true} <- Map.from_struct(product_extensions),
-        {^extension, device_enabled?} <- Map.from_struct(device_extensions),
-        device_enabled? != false,
-        do: extension
   end
 
   def enable_extension_setting(%Device{} = device, extension_string) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -14,6 +14,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.Certificate
   alias NervesHub.DeploymentOrchestratorEvents
   alias NervesHub.DeviceEvents
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
@@ -45,6 +46,13 @@ defmodule NervesHub.Devices do
 
   def get_device(device_id) when is_integer(device_id) do
     Repo.get(Device, device_id)
+  end
+
+  def get_device(device_id, preloads \\ []) do
+    Device
+    |> where(id: ^device_id)
+    |> join_and_preload(preloads)
+    |> Repo.one!()
   end
 
   def get_complete_device(device_id) do
@@ -295,6 +303,10 @@ defmodule NervesHub.Devices do
   end
 
   defp join_and_preload(query, nil), do: query
+
+  defp join_and_preload(query, :deployment) do
+    join_and_preload_deployment_group_and_current_release(query)
+  end
 
   defp join_and_preload(query, :device_certificates) do
     query
@@ -709,20 +721,22 @@ defmodule NervesHub.Devices do
     })
   end
 
-  def firmware_validated(device) do
-    DeviceTemplates.audit_firmware_validated(device)
+  def firmware_validated(device_info) do
+    %Device{id: device_info.device_id}
+    |> Device.firmware_validated()
+    |> Repo.update!()
 
-    {:ok, device} = update_device(device, %{firmware_validation_status: "validated"})
+    DeviceTemplates.audit_firmware_validated(device_info)
 
     ChannelServer.broadcast_from!(
       NervesHub.PubSub,
       self(),
-      "device:#{device.identifier}:internal",
+      "device:#{device_info.device_identifier}:internal",
       "firmware:validated",
       %{}
     )
 
-    {:ok, device}
+    :ok
   end
 
   @spec update_device(Device.t(), map(), broadcast: boolean()) ::
@@ -741,9 +755,9 @@ defmodule NervesHub.Devices do
     end
   end
 
-  @spec update_network_interface(Device.t(), binary()) :: {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
-  def update_network_interface(device, network_interface) do
-    device
+  @spec update_network_interface(pos_integer(), binary()) :: {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
+  def update_network_interface(device_id, network_interface) do
+    %Device{id: device_id}
     |> Device.update_network_interface_changeset(network_interface)
     |> Repo.update()
   end
@@ -1075,11 +1089,18 @@ defmodule NervesHub.Devices do
   Devices that haven't been automatically blocked are not in the penalty window.
   Devices that have a time greater than now are in the penalty window.
   """
-  def device_in_penalty_box?(device, now \\ DateTime.utc_now())
+  @spec device_in_penalty_box?(device_or_device_info :: Device.t() | DeviceInfo.t(), now :: DateTime.t()) :: boolean()
+  def device_in_penalty_box?(device_or_device_info, now \\ DateTime.utc_now())
 
-  def device_in_penalty_box?(%{updates_blocked_until: nil}, _now), do: false
+  def device_in_penalty_box?(%DeviceInfo{device_updates_blocked_until: nil}, _now), do: false
 
-  def device_in_penalty_box?(device, now) do
+  def device_in_penalty_box?(%Device{updates_blocked_until: nil}, _now), do: false
+
+  def device_in_penalty_box?(%DeviceInfo{} = device_info, now) do
+    DateTime.after?(device_info.device_updates_blocked_until, now)
+  end
+
+  def device_in_penalty_box?(%Device{} = device, now) do
     DateTime.after?(device.updates_blocked_until, now)
   end
 
@@ -1133,8 +1154,8 @@ defmodule NervesHub.Devices do
     update_device(device, %{updates_blocked_until: blocked_until, update_attempts: []})
   end
 
-  @spec update_attempted(Device.t(), DateTime.t()) :: :ok | {:error, Changeset.t()}
-  def update_attempted(device, now \\ DateTime.utc_now()) do
+  @spec update_attempted(DeviceInfo.t(), DateTime.t()) :: :ok | {:error, Changeset.t()}
+  def update_attempted(device_info, now \\ DateTime.utc_now()) do
     now = DateTime.truncate(now, :second)
 
     Multi.new()
@@ -1142,13 +1163,13 @@ defmodule NervesHub.Devices do
       :device,
       fn _ ->
         Device
-        |> where(id: ^device.id)
+        |> where(id: ^device_info.device_id)
         |> update(set: [update_attempts: fragment("update_attempts || ?::timestamp", ^now)])
       end,
       []
     )
     |> Multi.run(:audit_device, fn _, _ ->
-      DeviceTemplates.audit_update_attempt(device)
+      DeviceTemplates.audit_update_attempt(device_info)
     end)
     |> Repo.transact()
     |> case do
@@ -1196,20 +1217,20 @@ defmodule NervesHub.Devices do
     |> Repo.update()
   end
 
-  def deployment_device_online(%Device{deployment_id: nil}) do
+  def deployment_device_online(%DeviceInfo{deployment_id: nil}) do
     :ok
   end
 
-  def deployment_device_online(device) do
-    firmware_uuid = if(device.firmware_metadata, do: device.firmware_metadata.uuid)
+  def deployment_device_online(device_info) do
+    firmware_uuid = if(device_info.firmware_metadata, do: device_info.firmware_metadata.uuid)
 
     payload = %{
-      updates_enabled: device.updates_enabled,
-      updates_blocked_until: device.updates_blocked_until,
+      updates_enabled: device_info.device_updates_enabled,
+      updates_blocked_until: device_info.device_updates_blocked_until,
       firmware_uuid: firmware_uuid
     }
 
-    DeploymentOrchestratorEvents.device_online(device, payload)
+    DeploymentOrchestratorEvents.device_online(device_info, payload)
 
     :ok
   end
@@ -1540,6 +1561,14 @@ defmodule NervesHub.Devices do
     Enum.all?(deployment_group_tags, fn tag -> tag in device_tags end)
   end
 
+  def fetch_firmware_signing_keys(device_id) do
+    OrgKey
+    |> join(:left, [ok], d in assoc(ok, :org))
+    |> join(:left, [ok, o], d in assoc(o, :devices))
+    |> where([ok, o, d], d.id == ^device_id)
+    |> Repo.all()
+  end
+
   def maybe_copy_firmware_keys(%{firmware_metadata: %{uuid: uuid}, org_id: source}, %Org{id: target}) do
     existing_target_keys = from(k in OrgKey, where: [org_id: ^target], select: k.key)
 
@@ -1635,9 +1664,17 @@ defmodule NervesHub.Devices do
     end
   end
 
-  def clear_inflight_update(device) do
+  def clear_inflight_update(%DeviceInfo{device_id: id}) do
+    clear_inflight_update(id)
+  end
+
+  def clear_inflight_update(%Device{id: id}) do
+    clear_inflight_update(id)
+  end
+
+  def clear_inflight_update(device_id) do
     InflightUpdate
-    |> where([iu], iu.device_id == ^device.id)
+    |> where([iu], iu.device_id == ^device_id)
     |> Repo.delete_all()
   end
 
@@ -1688,6 +1725,21 @@ defmodule NervesHub.Devices do
     |> where([iu], iu.deployment_id == ^deployment_group.id)
     |> where([iu], iu.priority_queue == true)
     |> Repo.aggregate(:count)
+  end
+
+  @spec fetch_allowed_extensions(pos_integer()) :: allowed_extensions :: list(atom())
+  def fetch_allowed_extensions(device_id) do
+    device =
+      Device
+      |> join(:left, [d], p in assoc(d, :product))
+      |> preload([d, p], product: p)
+      |> where(id: ^device_id)
+      |> Repo.one!()
+
+    for {extension, true} <- Map.from_struct(device.product.extensions),
+        {^extension, device_enabled?} <- Map.from_struct(device.extensions),
+        device_enabled? != false,
+        do: extension
   end
 
   def enable_extension_setting(%Device{} = device, extension_string) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -352,10 +352,11 @@ defmodule NervesHub.Devices do
   def get_shared_secret_auth(key) do
     SharedSecretAuth
     |> join(:inner, [ssa], d in assoc(ssa, :device))
+    |> join(:inner, [ssa, d], p in assoc(d, :product))
     |> where([ssa], ssa.key == ^key)
     |> where([ssa], is_nil(ssa.deactivated_at))
     |> where([_, d], is_nil(d.deleted_at))
-    |> preload([:device, :product_shared_secret_auth])
+    |> preload([ssa, d, p], [:product_shared_secret_auth, device: {d, product: p}])
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1729,15 +1729,15 @@ defmodule NervesHub.Devices do
 
   @spec fetch_allowed_extensions(pos_integer()) :: allowed_extensions :: list(atom())
   def fetch_allowed_extensions(device_id) do
-    device =
+    {device_extensions, product_extensions} =
       Device
       |> join(:left, [d], p in assoc(d, :product))
-      |> preload([d, p], product: p)
+      |> select([d, p], {d.extensions, p.extensions})
       |> where(id: ^device_id)
       |> Repo.one!()
 
-    for {extension, true} <- Map.from_struct(device.product.extensions),
-        {^extension, device_enabled?} <- Map.from_struct(device.extensions),
+    for {extension, true} <- Map.from_struct(product_extensions),
+        {^extension, device_enabled?} <- Map.from_struct(device_extensions),
         device_enabled? != false,
         do: extension
   end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1564,8 +1564,8 @@ defmodule NervesHub.Devices do
 
   def fetch_firmware_signing_keys(device_id) do
     OrgKey
-    |> join(:left, [ok], d in assoc(ok, :org))
-    |> join(:left, [ok, o], d in assoc(o, :devices))
+    |> join(:inner, [ok], d in assoc(ok, :org))
+    |> join(:inner, [ok, o], d in assoc(o, :devices))
     |> where([ok, o, d], d.id == ^device_id)
     |> Repo.all()
   end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1727,6 +1727,14 @@ defmodule NervesHub.Devices do
     |> Repo.aggregate(:count)
   end
 
+  def fetch_connecting_code(device_id) do
+    Device
+    |> join(:left, [d], dp in assoc(d, :deployment_group))
+    |> select([d, dp], {d.connecting_code, dp.connecting_code})
+    |> where(id: ^device_id)
+    |> Repo.one!()
+  end
+
   def enable_extension_setting(%Device{} = device, extension_string) do
     device = get_device(device.id)
 

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -4,7 +4,6 @@ defmodule NervesHub.Devices.Connections do
   """
   import Ecto.Query
 
-  alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Repo
   alias NervesHub.Tracker
@@ -22,9 +21,9 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connecting(Device.t()) ::
+  @spec device_connecting(pos_integer(), String.t()) ::
           {:ok, DeviceConnection.t()} | {:error, Ecto.Changeset.t()}
-  def device_connecting(device) do
+  def device_connecting(device_id, device_identifier) do
     conflict_query =
       DeviceConnection
       |> update([ldc],
@@ -39,11 +38,11 @@ defmodule NervesHub.Devices.Connections do
         ]
       )
 
-    DeviceConnection.connecting_changeset(device)
+    DeviceConnection.connecting_changeset(device_id)
     |> Repo.insert(on_conflict: conflict_query, conflict_target: [:device_id])
     |> case do
       {:ok, device_connection} ->
-        Tracker.connecting(device)
+        Tracker.connecting(device_identifier)
 
         {:ok, device_connection}
 
@@ -55,8 +54,8 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connected(Device.t(), connection_id :: binary()) :: :ok | :error
-  def device_connected(device, connection_id) do
+  @spec device_connected(String.t(), connection_id :: binary()) :: :ok | :error
+  def device_connected(device_identifier, connection_id) do
     DeviceConnection
     |> where(id: ^connection_id)
     |> where([dc], not (dc.status == :disconnected))
@@ -68,7 +67,7 @@ defmodule NervesHub.Devices.Connections do
     )
     |> case do
       {1, _} ->
-        Tracker.online(device)
+        Tracker.online(device_identifier)
         :ok
 
       _ ->
@@ -79,8 +78,8 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Updates the `last_seen_at`field for a device connection with current timestamp
   """
-  @spec device_heartbeat(Device.t(), UUIDv7.t()) :: :ok | :error
-  def device_heartbeat(device, id) do
+  @spec device_heartbeat(String.t(), UUIDv7.t()) :: :ok | :error
+  def device_heartbeat(device_identifier, id) do
     DeviceConnection
     |> where([dc], dc.id == ^id)
     |> where([dc], not (dc.status == :disconnected))
@@ -92,7 +91,7 @@ defmodule NervesHub.Devices.Connections do
     )
     |> case do
       {1, _} ->
-        Tracker.heartbeat(device)
+        Tracker.heartbeat(device_identifier)
         :ok
 
       _ ->
@@ -104,8 +103,8 @@ defmodule NervesHub.Devices.Connections do
   Updates `status` and relevant timestamps for a device connection record,
   and stores the reason for disconnection if provided.
   """
-  @spec device_disconnected(Device.t(), UUIDv7.t(), String.t() | nil) :: :ok | {:error, any()}
-  def device_disconnected(device, ref_id, reason \\ nil) do
+  @spec device_disconnected(String.t(), UUIDv7.t(), String.t() | nil) :: :ok | {:error, any()}
+  def device_disconnected(device_identifier, ref_id, reason \\ nil) do
     now = DateTime.utc_now()
 
     DeviceConnection
@@ -120,7 +119,7 @@ defmodule NervesHub.Devices.Connections do
     )
     |> case do
       {1, _} ->
-        Tracker.offline(device)
+        Tracker.offline(device_identifier)
         :ok
 
       res ->

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -141,6 +141,12 @@ defmodule NervesHub.Devices.Device do
     |> put_change(:updates_blocked_until, nil)
   end
 
+  def firmware_validated(%Device{} = device) do
+    device
+    |> change()
+    |> put_change(:firmware_validation_status, :validated)
+  end
+
   def update_network_interface_changeset(%Device{} = device, nil) do
     add_error(
       change(device),

--- a/lib/nerves_hub/devices/device_connection.ex
+++ b/lib/nerves_hub/devices/device_connection.ex
@@ -23,12 +23,12 @@ defmodule NervesHub.Devices.DeviceConnection do
     )
   end
 
-  def connecting_changeset(device) do
+  def connecting_changeset(device_id) do
     now = DateTime.utc_now()
 
     %__MODULE__{}
     |> change()
-    |> put_assoc(:device, device)
+    |> put_change(:device_id, device_id)
     |> put_change(:established_at, now)
     |> put_change(:last_seen_at, now)
     |> put_change(:status, :connecting)

--- a/lib/nerves_hub/devices/log_line.ex
+++ b/lib/nerves_hub/devices/log_line.ex
@@ -18,11 +18,11 @@ defmodule NervesHub.Devices.LogLine do
     field(:meta, Ch, type: "Map(LowCardinality(String), String)", default: %{})
   end
 
-  def create_changeset(device, params \\ %{}) do
+  def create_changeset(device_id, product_id, params \\ %{}) do
     params =
       params
-      |> Map.put("device_id", device.id)
-      |> Map.put("product_id", device.product_id)
+      |> Map.put("device_id", device_id)
+      |> Map.put("product_id", product_id)
       |> maybe_set_timestamp()
       |> format_message()
 

--- a/lib/nerves_hub/devices/log_lines.ex
+++ b/lib/nerves_hub/devices/log_lines.ex
@@ -6,6 +6,7 @@ defmodule NervesHub.Devices.LogLines do
   import Ecto.Query
 
   alias NervesHub.AnalyticsRepo
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.LogLine
   alias Phoenix.Channel.Server, as: ChannelServer
@@ -45,10 +46,10 @@ defmodule NervesHub.Devices.LogLines do
       %LogLine{}
 
   """
-  @spec async_create(Device.t(), log_line_payload) ::
+  @spec async_create(DeviceInfo.t(), log_line_payload) ::
           {:ok, LogLine.t()} | {:error, Ecto.Changeset.t()}
-  def async_create(%Device{} = device, attrs) do
-    changeset = LogLine.create_changeset(device, attrs)
+  def async_create(%DeviceInfo{} = device_info, attrs) do
+    changeset = LogLine.create_changeset(device_info.device_id, device_info.product_id, attrs)
 
     case Ecto.Changeset.apply_action(changeset, :create) do
       {:ok, log_line} ->
@@ -57,7 +58,7 @@ defmodule NervesHub.Devices.LogLines do
         _ =
           ChannelServer.broadcast(
             NervesHub.PubSub,
-            "device:#{device.identifier}:internal",
+            "device:#{device_info.device_identifier}:internal",
             "logs:received",
             log_line
           )

--- a/lib/nerves_hub/events/deployment_orchestrator_events.ex
+++ b/lib/nerves_hub/events/deployment_orchestrator_events.ex
@@ -3,6 +3,7 @@ defmodule NervesHub.DeploymentOrchestratorEvents do
   Encapsulation of events to be sent to the Deployment Orchestrator
   """
 
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.Device
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias Phoenix.Channel.Server, as: ChannelServer
@@ -32,6 +33,10 @@ defmodule NervesHub.DeploymentOrchestratorEvents do
   end
 
   def topic(%Device{deployment_id: id}) do
+    "orchestrator:deployment:#{id}"
+  end
+
+  def topic(%DeviceInfo{deployment_id: id}) do
     "orchestrator:deployment:#{id}"
   end
 

--- a/lib/nerves_hub/extensions/geo.ex
+++ b/lib/nerves_hub/extensions/geo.ex
@@ -49,12 +49,12 @@ defmodule NervesHub.Extensions.Geo do
 
   @impl NervesHub.Extensions
   def handle_in("location:update", location, socket) do
-    :ok = Connections.merge_update_metadata(socket.assigns.reference_id, %{location: location})
+    :ok = Connections.merge_update_metadata(socket.assigns.device_info.connection_ref, %{location: location})
 
     _ =
       ChannelServer.broadcast(
         NervesHub.PubSub,
-        "device:#{socket.assigns.device.identifier}:internal",
+        "device:#{socket.assigns.device_info.device_identifier}:internal",
         "location:updated",
         location
       )

--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -1,6 +1,7 @@
 defmodule NervesHub.Extensions.Health do
   @behaviour NervesHub.Extensions
 
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.HealthStatus
   alias NervesHub.Devices.Metrics
@@ -65,7 +66,7 @@ defmodule NervesHub.Extensions.Health do
       end
 
     device_health = %{
-      "device_id" => socket.assigns.device.id,
+      "device_id" => socket.assigns.device_info.device_id,
       "data" => device_report,
       "status" => status,
       "status_reasons" => reasons
@@ -74,14 +75,14 @@ defmodule NervesHub.Extensions.Health do
     with {:health_report, {:ok, _}} <-
            {:health_report, Devices.save_device_health(device_health)},
          {:metrics_report, {:ok, _}} <-
-           {:metrics_report, Metrics.save_metrics(socket.assigns.device.id, metrics)} do
-      :ok = device_internal_broadcast!(socket.assigns.device, "health_check_report", %{})
+           {:metrics_report, Metrics.save_metrics(socket.assigns.device_info.device_id, metrics)} do
+      :ok = device_internal_broadcast!(socket.assigns.device_info, "health_check_report", %{})
     else
       {:health_report, {:error, err}} ->
         Logger.warning("Failed to save health check data: #{inspect(err)}")
 
         Logging.log_to_sentry(
-          socket.assigns.device,
+          socket.assigns.device_info,
           "[DeviceChannel] Failed to save health check data."
         )
 
@@ -89,7 +90,7 @@ defmodule NervesHub.Extensions.Health do
         Logger.warning("Failed to save metrics report")
 
         Logging.log_to_sentry(
-          socket.assigns.device,
+          socket.assigns.device_info,
           "[DeviceChannel] Failed to save metrics report."
         )
     end
@@ -104,11 +105,15 @@ defmodule NervesHub.Extensions.Health do
   end
 
   def request_health_check(device) do
-    :ok = device_internal_broadcast!(device, "health:check", %{})
+    :ok = device_internal_broadcast!(device.id, "health:check", %{})
   end
 
-  defp device_internal_broadcast!(device, event, payload) do
-    topic = "device:#{device.id}:extensions"
+  defp device_internal_broadcast!(%DeviceInfo{} = device_info, event, payload) do
+    device_internal_broadcast!(device_info.device_id, event, payload)
+  end
+
+  defp device_internal_broadcast!(device_id, event, payload) do
+    topic = "device:#{device_id}:extensions"
 
     ChannelServer.broadcast_from!(NervesHub.PubSub, self(), topic, event, payload)
   end

--- a/lib/nerves_hub/extensions/local_shell.ex
+++ b/lib/nerves_hub/extensions/local_shell.ex
@@ -55,7 +55,7 @@ defmodule NervesHub.Extensions.LocalShell do
       |> assign(:current_line, current_line)
       |> assign(:buffer, buffer)
 
-    topic = "user:local_shell:#{socket.assigns.device.id}"
+    topic = "user:local_shell:#{socket.assigns.device_info.device_id}"
 
     socket.endpoint.broadcast!(topic, "output", %{data: data})
 
@@ -64,7 +64,7 @@ defmodule NervesHub.Extensions.LocalShell do
 
   def handle_in(event, params, socket) do
     Logger.warning(
-      "[Extensions.LocalShell] unknown message received for device: #{inspect(socket.assigns.device.id)} / #{inspect(event)} / #{inspect(params)}"
+      "[Extensions.LocalShell] unknown message received for device: #{inspect(socket.assigns.device_info.device_id)} / #{inspect(event)} / #{inspect(params)}"
     )
 
     {:noreply, socket}

--- a/lib/nerves_hub/extensions/logging.ex
+++ b/lib/nerves_hub/extensions/logging.ex
@@ -31,15 +31,15 @@ defmodule NervesHub.Extensions.Logging do
   end
 
   @impl NervesHub.Extensions
-  def handle_in("send", log_line, %{assigns: %{device: device}} = socket) do
+  def handle_in("send", log_line, %{assigns: %{device_info: device_info}} = socket) do
     case RateLimit.hit(
-           "device_#{device.id}",
+           "device_#{device_info.device_id}",
            @rate_limit_tokens_per_sec,
            @rate_limit_max_capacity,
            @rate_limit_token_cost
          ) do
       {:allow, _} ->
-        schedule_create(device, log_line)
+        schedule_create(device_info, log_line)
 
       {:deny, _} ->
         :noop
@@ -53,11 +53,11 @@ defmodule NervesHub.Extensions.Logging do
     {:noreply, socket}
   end
 
-  defp schedule_create(device, log_line) do
+  defp schedule_create(device_info, log_line) do
     _ =
       Task.Supervisor.start_child(
         {:via, PartitionSupervisor, {NervesHub.AnalyticsEventsProcessing, self()}},
-        fn -> {:ok, _} = LogLines.async_create(device, log_line) end
+        fn -> {:ok, _} = LogLines.async_create(device_info, log_line) end
       )
 
     :noop

--- a/lib/nerves_hub/helpers/logging.ex
+++ b/lib/nerves_hub/helpers/logging.ex
@@ -1,4 +1,5 @@
 defmodule NervesHub.Helpers.Logging do
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.Device
   alias NervesHub.ManagedDeployments.DeploymentGroup
 
@@ -31,6 +32,14 @@ defmodule NervesHub.Helpers.Logging do
 
     :ok
   end
+
+  defp set_sentry_tags(%DeviceInfo{} = device_info),
+    do:
+      Sentry.Context.set_tags_context(%{
+        device_identifier: device_info.device_identifier,
+        device_id: device_info.device_id,
+        product_id: device_info.product_id
+      })
 
   defp set_sentry_tags(%Device{} = device),
     do:

--- a/lib/nerves_hub/logger.ex
+++ b/lib/nerves_hub/logger.ex
@@ -109,7 +109,8 @@ defmodule NervesHub.Logger do
     Logger.info("Device duplicate connection detected",
       event: "nerves_hub.devices.duplicate_connection",
       ref_id: metadata[:ref_id],
-      identifier: metadata[:device].identifier
+      device_id: metadata[:device_id],
+      device_identifier: metadata[:device_identifier]
     )
   end
 
@@ -124,7 +125,8 @@ defmodule NervesHub.Logger do
     Logger.info("Device disconnected",
       event: "nerves_hub.devices.disconnect",
       ref_id: metadata[:ref_id],
-      identifier: metadata[:identifier]
+      device_id: metadata[:device_id],
+      device_identifier: metadata[:device_identifier]
     )
   end
 

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -640,10 +640,9 @@ defmodule NervesHub.ManagedDeployments do
       when not is_nil(deployment_id) do
     deployment_group =
       DeploymentGroup
-      |> from(as: :deployment_group)
+      |> select([:id, :org_id, :name, :conditions, :platform, :architecture])
       |> where([d], d.id == ^deployment_id)
-      |> join_current_release(true)
-      |> Repo.one()
+      |> Repo.one!()
 
     bad_version =
       if deployment_group.conditions.version == "" do
@@ -657,10 +656,10 @@ defmodule NervesHub.ManagedDeployments do
         end
       end
 
-    bad_platform = device.firmware_metadata.platform != deployment_group.current_release.firmware.platform
+    bad_platform = device.firmware_metadata.platform != deployment_group.platform
 
     bad_architecture =
-      device.firmware_metadata.architecture != deployment_group.current_release.firmware.architecture
+      device.firmware_metadata.architecture != deployment_group.architecture
 
     reason =
       cond do

--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -8,10 +8,14 @@ defmodule NervesHub.Tracker do
   """
 
   def heartbeat(%Device{} = device) do
+    heartbeat(device.identifier)
+  end
+
+  def heartbeat(device_identifier) when is_binary(device_identifier) do
     _ =
       ChannelServer.broadcast(
         NervesHub.PubSub,
-        "device:#{device.identifier}:internal",
+        "device:#{device_identifier}:internal",
         "connection:heartbeat",
         %{}
       )
@@ -20,7 +24,11 @@ defmodule NervesHub.Tracker do
   end
 
   def connecting(%Device{} = device) do
-    publish(device.identifier, "connecting")
+    connecting(device.identifier)
+  end
+
+  def connecting(device_identifier) when is_binary(device_identifier) do
+    publish(device_identifier, "connecting")
   end
 
   def online(%{} = device) do
@@ -49,7 +57,11 @@ defmodule NervesHub.Tracker do
   @doc """
   Tell internal listeners that the device is offline, via a connection change
   """
-  def offline(%Device{identifier: identifier}) when is_binary(identifier) do
+  def offline(%Device{identifier: identifier}) do
+    offline(identifier)
+  end
+
+  def offline(identifier) when is_binary(identifier) do
     publish(identifier, "offline")
   end
 

--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -4,16 +4,10 @@ defmodule NervesHubWeb.ConsoleChannel do
 
   alias Phoenix.Socket.Broadcast
 
-  def join("console", payload, %{assigns: %{device: device}} = socket) do
+  def join("console", payload, socket) do
     send(self(), {:after_join, payload})
 
-    socket =
-      socket
-      |> assign(:device, device)
-      |> assign(:current_line, "")
-      |> assign(:buffer, CircularBuffer.new(1024))
-
-    {:ok, socket}
+    {:ok, assign(socket, %{current_line: "", buffer: CircularBuffer.new(1024)})}
   end
 
   def terminate(_, _socket) do
@@ -34,27 +28,30 @@ defmodule NervesHubWeb.ConsoleChannel do
       |> assign(:current_line, current_line)
       |> assign(:buffer, buffer)
 
-    topic = "user:console:#{socket.assigns.device.id}"
-    socket.endpoint.broadcast!(topic, "up", payload)
+    user_topic(socket)
+    |> socket.endpoint.broadcast!("up", payload)
 
     {:noreply, socket}
   end
 
   def handle_in("file-data/start", payload, socket) do
-    topic = "user:console:#{socket.assigns.device.id}"
-    socket.endpoint.broadcast!(topic, "file-data/start", payload)
+    user_topic(socket)
+    |> socket.endpoint.broadcast!("file-data/start", payload)
+
     {:noreply, socket}
   end
 
   def handle_in("file-data", payload, socket) do
-    topic = "user:console:#{socket.assigns.device.id}"
-    socket.endpoint.broadcast!(topic, "file-data", payload)
+    user_topic(socket)
+    |> socket.endpoint.broadcast!("file-data", payload)
+
     {:noreply, socket}
   end
 
   def handle_in("file-data/stop", payload, socket) do
-    topic = "user:console:#{socket.assigns.device.id}"
-    socket.endpoint.broadcast!(topic, "file-data/stop", payload)
+    user_topic(socket)
+    |> socket.endpoint.broadcast!("file-data/stop", payload)
+
     {:noreply, socket}
   end
 
@@ -66,10 +63,10 @@ defmodule NervesHubWeb.ConsoleChannel do
     # additionally, this topic isn't needed or used, so we can unsubscribe from it
     socket.endpoint.unsubscribe("console")
 
-    socket.endpoint.subscribe("device:console:#{socket.assigns.device.id}")
+    socket.endpoint.subscribe(device_topic(socket))
 
     socket.endpoint.broadcast!(
-      "device:console:#{socket.assigns.device.id}:internal",
+      device_internal_topic(socket),
       "console_joined",
       %{}
     )
@@ -96,4 +93,10 @@ defmodule NervesHubWeb.ConsoleChannel do
     push(socket, event, payload)
     {:noreply, socket}
   end
+
+  defp device_topic(socket), do: "device:console:#{socket.assigns.device_info.device_id}"
+
+  defp device_internal_topic(socket), do: "device:console:#{socket.assigns.device_info.device_id}:internal"
+
+  defp user_topic(socket), do: "user:console:#{socket.assigns.device_info.device_id}"
 end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -25,7 +25,6 @@ defmodule NervesHubWeb.DeviceChannel do
   alias NervesHub.DeviceLink
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
-  alias NervesHub.Repo
   alias Phoenix.Socket.Broadcast
 
   require Logger
@@ -33,19 +32,19 @@ defmodule NervesHubWeb.DeviceChannel do
   intercept(["updated", "deployment_updated"])
 
   @decorate with_span("Channels.DeviceChannel.join")
-  def join("device:" <> _device_id, params, %{assigns: %{device: device, reference_id: reference_id}} = socket) do
-    Logger.metadata(device_id: device.id, device_identifier: device.identifier)
+  def join("device:" <> _device_id, params, %{assigns: %{device_info: device_info}} = socket) do
+    Logger.metadata(device_id: device_info.device_id, device_identifier: device_info.device_identifier)
 
     params = maybe_sanitize_device_api_version(params)
 
-    case DeviceLink.join(device, reference_id, params) do
-      {:ok, device} ->
+    case DeviceLink.join(device_info, params) do
+      {:ok, device_info} ->
         socket =
           socket
           |> assign(:currently_downloading_uuid, params["currently_downloading_uuid"])
           |> assign(:update_started?, !!params["currently_downloading_uuid"])
           |> assign(:device_api_version, params["device_api_version"])
-          |> update_device(device)
+          |> update_device_info(device_info)
 
         send(self(), {:after_join, params})
 
@@ -53,7 +52,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
       err ->
         :telemetry.execute([:nerves_hub, :devices, :join_failure], %{count: 1}, %{
-          identifier: device.identifier,
+          identifier: device_info.device_identifier,
           channel: "device",
           error: err
         })
@@ -64,36 +63,11 @@ defmodule NervesHubWeb.DeviceChannel do
 
   @decorate with_span("Channels.DeviceChannel.handle_info:after_join")
   def handle_info({:after_join, params}, socket) do
-    %{device: device, reference_id: reference_id} = socket.assigns
+    :ok = DeviceLink.after_join(socket.assigns.device_info, params)
 
-    # :deployment_group is manually set to nil in DeviceLink, need to force reload here
-    device = NervesHub.Repo.preload(device, :deployment_group, force: true)
-
-    connecting_codes =
-      [
-        get_in(device, [Access.key(:deployment_group), Access.key(:connecting_code)]),
-        device.connecting_code
-      ]
-      |> Enum.filter(&(not is_nil(&1) and byte_size(&1) > 0))
-
-    case [safe_to_run_scripts?(socket), Enum.empty?(connecting_codes)] do
-      [true, false] ->
-        connecting_code = Enum.join(connecting_codes, "\n")
-        # connecting code first in the case it attempts to change things before the other messages
-        push(socket, "scripts/run", %{"text" => connecting_code, "ref" => "connecting_code"})
-
-      [false, false] ->
-        connecting_code = Enum.join(connecting_codes, "\n")
-        text = ~s/#{connecting_code}\n\r/
-        topic = "device:console:#{device.id}"
-
-        socket.endpoint.broadcast_from!(self(), topic, "dn", %{"data" => text})
-
-      _ ->
-        :ok
-    end
-
-    :ok = DeviceLink.after_join(device, reference_id, params)
+    socket.assigns.device_info
+    |> DeviceLink.fetch_connecting_code()
+    |> send_connecting_code(safe_to_run_scripts?(socket), socket)
 
     {:noreply, socket}
   end
@@ -105,10 +79,11 @@ defmodule NervesHubWeb.DeviceChannel do
 
   # listen for notifications about archive updates for deployments
   def handle_info(%Broadcast{event: "archives/updated"}, socket) do
-    %{device: device, device_api_version: device_api_version, reference_id: reference_id} =
+    %{device_info: device_info, device_api_version: device_api_version} =
       socket.assigns
 
-    DeviceLink.maybe_send_archive(device, device_api_version, reference_id, audit_log: true)
+    DeviceLink.maybe_send_archive(device_info, device_api_version, audit_log: true)
+
     {:noreply, socket}
   end
 
@@ -150,7 +125,7 @@ defmodule NervesHubWeb.DeviceChannel do
   # Ignore unhandled messages, and send some telemetry
   def handle_info(msg, socket) do
     :telemetry.execute([:nerves_hub, :devices, :unhandled_info], %{count: 1}, %{
-      identifier: socket.assigns.device.identifier,
+      identifier: socket.assigns.device_info.device_identifier,
       msg: msg
     })
 
@@ -159,35 +134,35 @@ defmodule NervesHubWeb.DeviceChannel do
 
   # Update local state and tell the various servers of the new information
   @decorate with_span("Channels.DeviceChannel.handle_out:updated")
-  def handle_out("updated", _, %{assigns: %{device: device}} = socket) do
-    device = Repo.reload(device)
+  def handle_out("updated", _, %{assigns: %{device_info: device_info}} = socket) do
+    device_info = DeviceLink.refresh_device_info(device_info)
 
-    %{device_api_version: device_api_version, reference_id: reference_id} = socket.assigns
-    DeviceLink.maybe_send_archive(device, device_api_version, reference_id, audit_log: true)
+    %{device_api_version: device_api_version} = socket.assigns
+    DeviceLink.maybe_send_archive(device_info, device_api_version, audit_log: true)
 
-    {:noreply, update_device(socket, device)}
+    {:noreply, update_device_info(socket, device_info)}
   end
 
   @decorate with_span("Channels.DeviceChannel.handle_out:deployment_updated")
   def handle_out("deployment_updated", payload, socket) do
-    device = %{socket.assigns.device | deployment_id: payload.deployment_id}
+    device_info = %{socket.assigns.device_info | deployment_id: payload.deployment_id}
 
-    %{device_api_version: device_api_version, reference_id: reference_id} = socket.assigns
-    DeviceLink.maybe_send_archive(device, device_api_version, reference_id, audit_log: true)
+    %{device_api_version: device_api_version} = socket.assigns
+    DeviceLink.maybe_send_archive(device_info, device_api_version, audit_log: true)
 
-    {:noreply, update_device(socket, device)}
+    {:noreply, update_device_info(socket, device_info)}
   end
 
   @decorate with_span("Channels.DeviceChannel.handle_in:firmware_validated")
-  def handle_in("firmware_validated", _, %{assigns: %{device: device}} = socket) do
-    {:ok, device} = Devices.firmware_validated(device)
+  def handle_in("firmware_validated", _, %{assigns: %{device_info: device_info}} = socket) do
+    Devices.firmware_validated(device_info)
 
-    {:noreply, assign(socket, :device, device)}
+    {:noreply, socket}
   end
 
   @decorate with_span("Channels.DeviceChannel.handle_in:fwup_progress")
-  def handle_in("fwup_progress", %{"value" => percent}, %{assigns: %{device: device}} = socket) do
-    DeviceLink.firmware_update_progress(device, percent)
+  def handle_in("fwup_progress", %{"value" => percent}, %{assigns: %{device_info: device_info}} = socket) do
+    DeviceLink.firmware_update_progress(device_info, percent)
 
     {:noreply, maybe_update_update_attempts(socket)}
   end
@@ -195,7 +170,7 @@ defmodule NervesHubWeb.DeviceChannel do
   @decorate with_span("Channels.DeviceChannel.handle_in:connection_types")
   def handle_in("connection_types", %{"values" => types}, socket) do
     :ok =
-      DeviceLink.update_connection_metadata(socket.assigns.reference_id, %{
+      DeviceLink.update_connection_metadata(socket.assigns.device_info.connection_ref, %{
         "connection_types" => types
       })
 
@@ -204,7 +179,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
   @decorate with_span("Channels.DeviceChannel.handle_in:status_update")
   def handle_in("status_update", params, socket) do
-    DeviceLink.status_update(socket.assigns.device, params, socket.assigns.update_started?)
+    DeviceLink.status_update(socket.assigns.device_info, params, socket.assigns.update_started?)
 
     {:noreply, socket}
   end
@@ -222,7 +197,7 @@ defmodule NervesHubWeb.DeviceChannel do
       when result == "error" or return == "nil" do
     :telemetry.execute([:nerves_hub, :devices, :connecting_code_failure], %{
       output: output,
-      identifier: socket.assigns.device.identifier
+      identifier: socket.assigns.device_info.device_identifier
     })
 
     {:noreply, socket}
@@ -245,13 +220,17 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   @decorate with_span("Channels.DeviceChannel.handle_in:report_network_interface")
-  def handle_in("report_network_interface", %{"interface" => interface}, %{assigns: %{device: device}} = socket) do
-    if Device.humanized_network_interface_name(interface) == device.network_interface do
+  def handle_in(
+        "report_network_interface",
+        %{"interface" => interface},
+        %{assigns: %{device_info: device_info}} = socket
+      ) do
+    if Device.humanized_network_interface_name(interface) == device_info.device_network_interface do
       {:noreply, socket}
     else
-      case Devices.update_network_interface(device, interface) do
+      case Devices.update_network_interface(device_info.device_id, interface) do
         {:ok, device} ->
-          {:noreply, assign(socket, :device, device)}
+          {:noreply, assign(socket, :device_info, %{device_info | device_network_interface: device.network_interface})}
 
         {:error, changeset} ->
           Logger.warning(
@@ -263,11 +242,11 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  def handle_in(msg, params, %{assigns: %{device: device}} = socket) do
+  def handle_in(msg, params, %{assigns: %{device_info: device_info}} = socket) do
     # Ignore unhandled messages so that it doesn't crash the link process
     # preventing cascading problems.
     :telemetry.execute([:nerves_hub, :devices, :unhandled_in], %{count: 1}, %{
-      identifier: device.identifier,
+      identifier: device_info.device_identifier,
       msg: msg,
       params: params
     })
@@ -300,9 +279,25 @@ defmodule NervesHubWeb.DeviceChannel do
   #
   # we don't need to store the result as this information isn't used anywhere else
   def maybe_update_update_attempts(socket) do
-    :ok = Devices.update_attempted(socket.assigns.device)
+    :ok = Devices.update_attempted(socket.assigns.device_info)
 
     assign(socket, :update_started?, true)
+  end
+
+  defp send_connecting_code(nil, _, _), do: :ok
+
+  defp send_connecting_code(connecting_code, true, socket) when is_list(connecting_code) do
+    connecting_code = Enum.join(connecting_code, "\n")
+    # connecting code first in the case it attempts to change things before the other messages
+    push(socket, "scripts/run", %{"text" => connecting_code, "ref" => "connecting_code"})
+  end
+
+  defp send_connecting_code(connecting_code, false, socket) when is_list(connecting_code) do
+    connecting_code = Enum.join(connecting_code, "\n")
+    text = ~s/#{connecting_code}\n\r/
+    topic = "device:console:#{socket.assigns.device_info.device_id}"
+
+    socket.endpoint.broadcast_from!(self(), topic, "dn", %{"data" => text})
   end
 
   defp subscribe(topic) when not is_nil(topic) do
@@ -318,14 +313,14 @@ defmodule NervesHubWeb.DeviceChannel do
 
   defp unsubscribe(nil), do: :ok
 
-  defp update_device(socket, device) do
+  defp update_device_info(socket, device_info) do
     socket
-    |> assign(:device, device)
-    |> update_deployment_group_subscription(device)
+    |> assign(:device_info, device_info)
+    |> update_deployment_group_subscription(device_info)
   end
 
-  defp update_deployment_group_subscription(socket, device) do
-    deployment_channel = deployment_channel(device)
+  defp update_deployment_group_subscription(socket, device_info) do
+    deployment_channel = deployment_channel(device_info)
 
     if deployment_channel == socket.assigns[:deployment_channel] do
       socket
@@ -337,9 +332,9 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  defp deployment_channel(device) do
-    if device.deployment_id do
-      "deployment:#{device.deployment_id}"
+  defp deployment_channel(device_info) do
+    if device_info.deployment_id do
+      "deployment:#{device_info.deployment_id}"
     end
   end
 

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -73,9 +73,9 @@ defmodule NervesHubWeb.DeviceSocket do
   end
 
   @decorate with_span("Channels.DeviceSocket.heartbeat")
-  defp heartbeat(%{assigns: %{device: device, reference_id: ref_id}} = socket) do
+  defp heartbeat(%{assigns: %{device_info: device_info, reference_id: ref_id}} = socket) do
     if update_heartbeat?(socket) do
-      Connections.device_heartbeat(device, ref_id)
+      Connections.device_heartbeat(device_info.device_identifier, ref_id)
       update_last_heartbeat(socket)
     else
       socket

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -2,6 +2,7 @@ defmodule NervesHubWeb.DeviceSocket do
   use Phoenix.Socket
   use OpenTelemetryDecorator
 
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.DeviceConnection
@@ -189,7 +190,7 @@ defmodule NervesHubWeb.DeviceSocket do
   end
 
   @impl Phoenix.Socket
-  def id(%{assigns: %{device: device}}), do: "device_socket:#{device.id}"
+  def id(%{assigns: %{device_info: device_info}}), do: "device_socket:#{device_info.device_id}"
   def id(_socket), do: nil
 
   def drainer_configuration() do
@@ -260,29 +261,34 @@ defmodule NervesHubWeb.DeviceSocket do
     # disconnect devices using the same identifier
     _ = socket.endpoint.broadcast_from(self(), "device_socket:#{device.id}", "disconnect", %{})
 
-    socket =
-      socket
-      |> assign(:device, device)
+    if device.status == :registered do
+      Devices.set_as_provisioned!(device)
+    end
 
-    {:ok, socket}
+    device_info = %DeviceInfo{
+      org_id: device.org_id,
+      product_id: device.product_id,
+      device_id: device.id,
+      device_identifier: device.identifier,
+      deployment_id: device.deployment_id,
+      firmware_metadata: device.firmware_metadata,
+      device_updates_enabled: device.updates_enabled,
+      device_updates_blocked_until: device.updates_blocked_until
+    }
+
+    {:ok, assign(socket, :device_info, device_info)}
   end
 
-  @decorate with_span("Channels.DeviceSocket.on_connect#registered")
-  defp on_connect(%{assigns: %{device: %{status: :registered} = device}} = socket) do
-    socket
-    |> assign(device: Devices.set_as_provisioned!(device))
-    |> on_connect()
-  end
-
-  @decorate with_span("Channels.DeviceSocket.on_connect#provisioned")
-  defp on_connect(%{assigns: %{device: device}} = socket) do
+  @decorate with_span("Channels.DeviceSocket.on_connect")
+  defp on_connect(%{assigns: %{device_info: device_info}} = socket) do
     # Report connection and use connection id as reference
-    {:ok, %DeviceConnection{id: connection_id}} = Connections.device_connecting(device)
+    {:ok, %DeviceConnection{id: connection_id}} =
+      Connections.device_connecting(device_info.device_id, device_info.device_identifier)
 
     :telemetry.execute([:nerves_hub, :devices, :connect], %{count: 1}, %{
       ref_id: connection_id,
-      identifier: socket.assigns.device.identifier,
-      firmware_uuid: get_in(socket.assigns.device, [Access.key(:firmware_metadata), Access.key(:uuid)])
+      identifier: device_info.device_identifier,
+      firmware_uuid: get_in(device_info, [Access.key(:firmware_metadata), Access.key(:uuid)])
     })
 
     # this is required by `DeviceJSONSerializer` which needs to update the message topic,
@@ -291,11 +297,10 @@ defmodule NervesHubWeb.DeviceSocket do
     # we could remove this and instead modify the payload in `handle_in`, but I favoured
     # this approach as it simplifies the logic in `handle_in` and keeps the topic remapping
     # logic in one place, the serializer
-    Process.put(:device_id, device.id)
+    Process.put(:device_id, device_info.device_id)
 
     socket
-    |> assign(:device, device)
-    |> assign(:reference_id, connection_id)
+    |> assign(device_info: %{device_info | connection_ref: connection_id})
     |> update_last_heartbeat()
   end
 
@@ -305,23 +310,25 @@ defmodule NervesHubWeb.DeviceSocket do
 
   @decorate with_span("Channels.DeviceSocket.on_disconnect")
   defp on_disconnect(reason, socket) do
-    %{assigns: %{device: device, reference_id: reference_id}} = socket
+    %{assigns: %{device_info: device_info}} = socket
 
     if reason == {:error, {:shutdown, :disconnected}} do
       :telemetry.execute([:nerves_hub, :devices, :duplicate_connection], %{count: 1}, %{
-        ref_id: reference_id,
-        device: device
+        ref_id: device_info.connection_ref,
+        device_id: device_info.device_id,
+        device_identifier: device_info.device_identifier
       })
     end
 
     :telemetry.execute([:nerves_hub, :devices, :disconnect], %{count: 1}, %{
-      ref_id: reference_id,
-      identifier: device.identifier
+      ref_id: device_info.connection_ref,
+      device_id: device_info.device_id,
+      device_identifier: device_info.device_identifier
     })
 
     # its possible that this is a stale connection and the device has already reconnected,
     # which means the following call might return :error, but we can ignore it
-    _ = Connections.device_disconnected(device, reference_id)
+    _ = Connections.device_disconnected(device_info.device_identifier, device_info.connection_ref)
 
     assign(socket, :disconnection_handled?, true)
   end

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -273,7 +273,8 @@ defmodule NervesHubWeb.DeviceSocket do
       deployment_id: device.deployment_id,
       firmware_metadata: device.firmware_metadata,
       device_updates_enabled: device.updates_enabled,
-      device_updates_blocked_until: device.updates_blocked_until
+      device_updates_blocked_until: device.updates_blocked_until,
+      allowed_extensions: calculate_allowed_extensions(device)
     }
 
     {:ok, assign(socket, :device_info, device_info)}
@@ -331,6 +332,13 @@ defmodule NervesHubWeb.DeviceSocket do
     _ = Connections.device_disconnected(device_info.device_identifier, device_info.connection_ref)
 
     assign(socket, :disconnection_handled?, true)
+  end
+
+  defp calculate_allowed_extensions(device) do
+    for {extension, true} <- Map.from_struct(device.product.extensions),
+        {^extension, device_enabled?} <- Map.from_struct(device.extensions),
+        device_enabled? != false,
+        do: extension
   end
 
   defp last_seen_update_interval() do

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -2,7 +2,6 @@ defmodule NervesHubWeb.ExtensionsChannel do
   use Phoenix.Channel
   use OpenTelemetryDecorator
 
-  alias NervesHub.Devices
   alias NervesHub.Extensions
   alias NervesHub.Helpers.Logging
   alias Phoenix.PubSub
@@ -35,13 +34,11 @@ defmodule NervesHubWeb.ExtensionsChannel do
   end
 
   defp load_and_parse_extensions(device_info, extension_versions) do
-    allowed_extensions = Devices.fetch_allowed_extensions(device_info.device_id)
-
     for {key_str, version} <- extension_versions, into: %{} do
       meta =
         case Version.parse(version) do
           {:ok, ver} ->
-            extension = Enum.find(allowed_extensions, &(to_string(&1) == key_str))
+            extension = Enum.find(device_info.allowed_extensions, &(to_string(&1) == key_str))
 
             if extension do
               mod = Extensions.module(extension, ver)

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -2,9 +2,9 @@ defmodule NervesHubWeb.ExtensionsChannel do
   use Phoenix.Channel
   use OpenTelemetryDecorator
 
+  alias NervesHub.Devices
   alias NervesHub.Extensions
   alias NervesHub.Helpers.Logging
-  alias NervesHub.Repo
   alias Phoenix.PubSub
   alias Phoenix.Socket.Broadcast
 
@@ -12,13 +12,9 @@ defmodule NervesHubWeb.ExtensionsChannel do
 
   @impl Phoenix.Channel
   @decorate with_span("Channels.ExtensionsChannel.join")
-  def join("extensions", extension_versions, socket) do
-    # the assigns are not shared between channels, so if we don't
-    # reload the device we are likely to have incorrect data, especially
-    # after the first connect event
-    socket = reload_device(socket)
+  def join("extensions", extension_versions, %{assigns: %{device_info: device_info}} = socket) do
+    extensions = load_and_parse_extensions(device_info, extension_versions)
 
-    extensions = parse_extensions(socket.assigns.device, extension_versions)
     socket = assign(socket, :extensions, extensions)
 
     attach_list = for {key, %{attach?: true}} <- extensions, do: key
@@ -32,21 +28,14 @@ defmodule NervesHubWeb.ExtensionsChannel do
     # additionally, this topic isn't needed or used, so we can unsubscribe from it
     :ok = socket.endpoint.unsubscribe("extensions")
 
-    topic = "device:#{socket.assigns.device.id}:extensions"
+    topic = "device:#{device_info.device_id}:extensions"
     :ok = socket.endpoint.subscribe(topic)
 
     {:ok, attach_list, socket}
   end
 
-  defp parse_extensions(
-         %{extensions: device_extensions, product: %{extensions: product_extensions}},
-         extension_versions
-       ) do
-    allowed_extensions =
-      for {extension, true} <- Map.from_struct(product_extensions),
-          {^extension, device_enabled?} <- Map.from_struct(device_extensions),
-          device_enabled? != false,
-          do: extension
+  defp load_and_parse_extensions(device_info, extension_versions) do
+    allowed_extensions = Devices.fetch_allowed_extensions(device_info.device_id)
 
     for {key_str, version} <- extension_versions, into: %{} do
       meta =
@@ -107,13 +96,13 @@ defmodule NervesHubWeb.ExtensionsChannel do
     error ->
       Logger.warning("#{inspect(mod)} failed to handle extension message [#{event}] - #{inspect(error)}")
 
-      Logging.log_to_sentry(socket.assigns.device, error)
+      Logging.log_to_sentry(socket.assigns.device_info, error)
       {:noreply, socket}
   end
 
   @impl Phoenix.Channel
   def handle_info(:init_extensions, socket) do
-    topic = "product:#{socket.assigns.device.product.id}:extensions"
+    topic = "product:#{socket.assigns.device_info.product_id}:extensions"
     :ok = PubSub.subscribe(NervesHub.PubSub, topic)
 
     {:noreply, socket}
@@ -131,18 +120,9 @@ defmodule NervesHubWeb.ExtensionsChannel do
   rescue
     error ->
       Logger.warning("#{inspect(mod)} failed handle_info - #{inspect(error)}")
-      Logging.log_to_sentry(socket.assigns.device, error)
+      Logging.log_to_sentry(socket.assigns.device_info, error)
       {:noreply, socket}
   end
 
   def handle_info(_msg, socket), do: {:noreply, socket}
-
-  defp reload_device(%{assigns: %{device: device}} = socket) do
-    device =
-      device
-      |> Repo.reload()
-      |> Repo.preload(:product)
-
-    assign(socket, :device, device)
-  end
 end

--- a/test/nerves_hub/device_link_test.exs
+++ b/test/nerves_hub/device_link_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHub.DeviceLinkTest do
   use Mimic
 
   alias NervesHub.DeviceLink
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Fixtures
@@ -45,7 +46,8 @@ defmodule NervesHub.DeviceLinkTest do
                |> Enum.filter(&(&1.device_id == device.id))
 
       # Call status_update with a status containing "encountered fwup error"
-      :ok = DeviceLink.status_update(device, %{"status" => "Update failed: encountered fwup error"}, true)
+      :ok =
+        DeviceLink.status_update(to_device_info(device), %{"status" => "Update failed: encountered fwup error"}, true)
 
       # Verify the inflight update was cleared
       assert [] =
@@ -70,7 +72,7 @@ defmodule NervesHub.DeviceLinkTest do
                |> Enum.filter(&(&1.device_id == device.id))
 
       # Call status_update with a status containing "FWUP error: failure of some sort"
-      :ok = DeviceLink.status_update(device, %{"status" => "FWUP error: failure of some sort"}, true)
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "FWUP error: failure of some sort"}, true)
 
       # Verify the inflight update was cleared
       assert [] =
@@ -95,7 +97,12 @@ defmodule NervesHub.DeviceLinkTest do
                |> Enum.filter(&(&1.device_id == device.id))
 
       # Call status_update with a status that does not contain "fwup error"
-      :ok = DeviceLink.status_update(device, %{"status" => "Update in progress: downloading firmware"}, true)
+      :ok =
+        DeviceLink.status_update(
+          to_device_info(device),
+          %{"status" => "Update in progress: downloading firmware"},
+          true
+        )
 
       # Verify the inflight update still exists
       assert [%InflightUpdate{}] =
@@ -106,14 +113,21 @@ defmodule NervesHub.DeviceLinkTest do
     end
 
     test "'started' messages from device execute telemetry when there's a network interface mismatch", %{device: device} do
-      {:ok, device} = Devices.update_network_interface(device, "wlan0")
+      {:ok, _device} = Devices.update_network_interface(device.id, "wlan0")
 
       expect(:telemetry, :execute, fn _event, _measurements, metadata ->
         assert metadata.downloader_network_interface == "eth0"
         assert metadata.device_network_interface == :wifi
       end)
 
-      :ok = DeviceLink.status_update(device, %{"status" => "started", "downloader_network_interface" => "eth0"}, false)
+      device_info = Repo.reload(device) |> to_device_info()
+
+      :ok =
+        DeviceLink.status_update(
+          device_info,
+          %{"status" => "started", "downloader_network_interface" => "eth0"},
+          false
+        )
     end
 
     test "'started' messages from device do not blow up if downloader network interface is nil", %{device: device} do
@@ -121,7 +135,16 @@ defmodule NervesHub.DeviceLinkTest do
         assert metadata.identifier == device.identifier
       end)
 
-      :ok = DeviceLink.status_update(device, %{"status" => "started", "downloader_network_interface" => nil}, false)
+      :ok =
+        DeviceLink.status_update(
+          to_device_info(device),
+          %{"status" => "started", "downloader_network_interface" => nil},
+          false
+        )
     end
+  end
+
+  def to_device_info(device) do
+    %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
   end
 end

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -26,7 +26,8 @@ defmodule NervesHub.Devices.ConnectionsTest do
       topic = "device:#{device.identifier}:internal"
       Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
 
-      assert {:ok, %DeviceConnection{id: ref, status: :connecting}} = Connections.device_connecting(device)
+      assert {:ok, %DeviceConnection{id: ref, status: :connecting}} =
+               Connections.device_connecting(device.id, device.identifier)
 
       assert %DeviceConnection{status: :connecting} = Connections.get_latest_for_device(device.id)
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "connecting"}}, 500
@@ -51,7 +52,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
       Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
 
       assert {:ok, %DeviceConnection{id: connection_id, last_seen_at: first_seen_at} = connection} =
-               Connections.device_connecting(device)
+               Connections.device_connecting(device.id, device.identifier)
 
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "connecting"}}, 500
 
@@ -73,7 +74,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
 
   describe "clean_stale_connections/0" do
     test "marks stale connected connections as disconnected", %{device: device} do
-      {:ok, connection} = Connections.device_connecting(device)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
       :ok = Connections.device_connected(device, connection.id)
 
       # Get the configured interval and jitter
@@ -97,7 +98,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
     end
 
     test "does not mark recent connections as stale", %{device: device} do
-      {:ok, connection} = Connections.device_connecting(device)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
       :ok = Connections.device_connected(device, connection.id)
 
       # Set last_seen_at to recent time

--- a/test/nerves_hub/devices/log_lines_test.exs
+++ b/test/nerves_hub/devices/log_lines_test.exs
@@ -4,6 +4,7 @@ defmodule NervesHub.Devices.LogLinesTest do
   use NervesHub.DataCase, async: false
 
   alias NervesHub.AnalyticsRepo
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.LogLine
   alias NervesHub.Devices.LogLines
   alias NervesHub.Fixtures
@@ -36,7 +37,8 @@ defmodule NervesHub.Devices.LogLinesTest do
     product_id = device.product_id
 
     {:ok, log} =
-      LogLines.async_create(device, %{
+      to_device_info(device)
+      |> LogLines.async_create(%{
         "timestamp" => logged_at,
         "level" => level,
         "message" => message
@@ -71,7 +73,8 @@ defmodule NervesHub.Devices.LogLinesTest do
     product_id = device.product_id
 
     {:ok, log} =
-      LogLines.async_create(device, %{
+      to_device_info(device)
+      |> LogLines.async_create(%{
         "level" => level,
         "message" => message,
         "meta" => %{"time" => logged_at |> DateTime.to_unix(:microsecond) |> to_string()}
@@ -119,8 +122,17 @@ defmodule NervesHub.Devices.LogLinesTest do
       "message" => random_word()
     }
 
-    {:ok, log_line} = LogLines.async_create(device, attrs)
+    {:ok, log_line} = LogLines.async_create(to_device_info(device), attrs)
 
     log_line
+  end
+
+  def to_device_info(device) do
+    %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id
+    }
   end
 end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -7,6 +7,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Accounts.Org
   alias NervesHub.Accounts.Scope
   alias NervesHub.AuditLogs
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.CACertificate
@@ -293,7 +294,7 @@ defmodule NervesHub.DevicesTest do
     firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
     device = Fixtures.device_fixture(org, product, firmware, %{updates_enabled: false})
 
-    :ok = Devices.update_attempted(device)
+    :ok = Devices.update_attempted(to_device_info(device))
     {:ok, device} = Devices.enable_updates(device, user)
 
     assert device.updates_enabled
@@ -631,11 +632,11 @@ defmodule NervesHub.DevicesTest do
 
   describe "tracking update attempts and verifying eligibility" do
     test "records the timestamp of an attempt", %{device: device} do
-      :ok = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(to_device_info(device))
       device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 1
 
-      :ok = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(to_device_info(device))
       device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 2
     end
@@ -643,7 +644,7 @@ defmodule NervesHub.DevicesTest do
     test "records and audit log for updating", %{device: device} do
       assert [] = AuditLogs.logs_for(device)
 
-      :ok = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(to_device_info(device))
 
       [audit_log] = AuditLogs.logs_for(device)
 
@@ -651,7 +652,7 @@ defmodule NervesHub.DevicesTest do
     end
 
     test "resets update attempts on successful update", %{device: device} do
-      :ok = Devices.update_attempted(device)
+      :ok = to_device_info(device) |> Devices.update_attempted()
       device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 1
 
@@ -692,7 +693,7 @@ defmodule NervesHub.DevicesTest do
     test "device updates successfully", %{device: device, deployment_group: deployment_group} do
       {:ok, device} = update_firmware_uuid(device, Ecto.UUID.generate())
 
-      :ok = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(to_device_info(device))
 
       {:ok, device} = Devices.verify_update_eligibility(device, deployment_group)
 
@@ -706,8 +707,8 @@ defmodule NervesHub.DevicesTest do
     } do
       {:ok, device} = update_firmware_uuid(device, Ecto.UUID.generate())
 
-      :ok = Devices.update_attempted(device)
-      :ok = Devices.update_attempted(device)
+      :ok = Devices.update_attempted(to_device_info(device))
+      :ok = Devices.update_attempted(to_device_info(device))
 
       device = Repo.reload(device)
 
@@ -730,9 +731,9 @@ defmodule NervesHub.DevicesTest do
 
       now = DateTime.utc_now()
 
-      :ok = Devices.update_attempted(device, DateTime.add(now, -3600, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -1200, :second))
-      :ok = Devices.update_attempted(device, now)
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -3600, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -1200, :second))
+      :ok = Devices.update_attempted(to_device_info(device), now)
 
       device = Repo.reload(device)
 
@@ -759,12 +760,12 @@ defmodule NervesHub.DevicesTest do
 
       now = DateTime.utc_now()
 
-      :ok = Devices.update_attempted(device, DateTime.add(now, -3600, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -1200, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -500, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -500, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -500, :second))
-      :ok = Devices.update_attempted(device, now)
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -3600, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -1200, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -500, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -500, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -500, :second))
+      :ok = Devices.update_attempted(to_device_info(device), now)
 
       device = Repo.reload(device)
 
@@ -786,11 +787,11 @@ defmodule NervesHub.DevicesTest do
 
       now = DateTime.utc_now()
 
-      :ok = Devices.update_attempted(device, DateTime.add(now, -13, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -10, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -5, :second))
-      :ok = Devices.update_attempted(device, DateTime.add(now, -2, :second))
-      :ok = Devices.update_attempted(device, now)
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -13, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -10, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -5, :second))
+      :ok = Devices.update_attempted(to_device_info(device), DateTime.add(now, -2, :second))
+      :ok = Devices.update_attempted(to_device_info(device), now)
 
       device = Repo.reload(device)
 
@@ -1319,10 +1320,14 @@ defmodule NervesHub.DevicesTest do
       device_unknown = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
 
       # Set network interfaces and prepare for updates
-      {:ok, device_wifi} = Devices.update_network_interface(device_wifi, "wlan0")
-      {:ok, device_ethernet} = Devices.update_network_interface(device_ethernet, "eth0")
-      {:ok, device_cellular} = Devices.update_network_interface(device_cellular, "wwan0")
-      {:ok, device_unknown} = Devices.update_network_interface(device_unknown, "hmmmmmmm")
+      {:ok, device_wifi} = Devices.update_network_interface(device_wifi.id, "wlan0")
+      device_wifi = Repo.reload(device_wifi)
+      {:ok, device_ethernet} = Devices.update_network_interface(device_ethernet.id, "eth0")
+      device_ethernet = Repo.reload(device_ethernet)
+      {:ok, device_cellular} = Devices.update_network_interface(device_cellular.id, "wwan0")
+      device_cellular = Repo.reload(device_cellular)
+      {:ok, device_unknown} = Devices.update_network_interface(device_unknown.id, "hmmmmmmm")
+      device_unknown = Repo.reload(device_unknown)
 
       # Set up connections and different firmware versions for all devices
       for device <- [device_wifi, device_ethernet, device_cellular, device_unknown] do
@@ -1371,8 +1376,11 @@ defmodule NervesHub.DevicesTest do
       device_wifi = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
       device_cellular = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
 
-      {:ok, device_wifi} = Devices.update_network_interface(device_wifi, "wlan0")
-      {:ok, device_cellular} = Devices.update_network_interface(device_cellular, "wwan0")
+      {:ok, device_wifi} = Devices.update_network_interface(device_wifi.id, "wlan0")
+      device_wifi = Repo.reload(device_wifi)
+
+      {:ok, device_cellular} = Devices.update_network_interface(device_cellular.id, "wwan0")
+      device_cellular = Repo.reload(device_cellular)
 
       # Set up connections and different firmware versions
       for device <- [device_wifi, device_cellular] do
@@ -1537,17 +1545,21 @@ defmodule NervesHub.DevicesTest do
       device_cellular_prod = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
       device_ethernet_prod = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
 
-      {:ok, device_wifi_prod} = Devices.update_network_interface(device_wifi_prod, "wlan0")
       {:ok, device_wifi_prod} = Devices.update_device(device_wifi_prod, %{tags: ["production"]})
+      {:ok, device_wifi_prod} = Devices.update_network_interface(device_wifi_prod.id, "wlan0")
+      device_wifi_prod = Repo.reload(device_wifi_prod)
 
-      {:ok, device_wifi_prod} = Devices.update_network_interface(device_wifi_prod, "wlan0")
       {:ok, device_wifi_dev} = Devices.update_device(device_wifi_dev, %{tags: ["development"]})
+      {:ok, device_wifi_dev} = Devices.update_network_interface(device_wifi_dev.id, "wlan0")
+      device_wifi_dev = Repo.reload(device_wifi_dev)
 
-      {:ok, device_cellular_prod} = Devices.update_network_interface(device_cellular_prod, "wwan0")
       {:ok, device_cellular_prod} = Devices.update_device(device_cellular_prod, %{tags: ["production"]})
+      {:ok, device_cellular_prod} = Devices.update_network_interface(device_cellular_prod.id, "wwan0")
+      device_cellular_prod = Repo.reload(device_cellular_prod)
 
-      {:ok, device_ethernet_prod} = Devices.update_network_interface(device_ethernet_prod, "eth0")
       {:ok, device_ethernet_prod} = Devices.update_device(device_ethernet_prod, %{tags: ["production"]})
+      {:ok, device_ethernet_prod} = Devices.update_network_interface(device_ethernet_prod.id, "eth0")
+      device_ethernet_prod = Repo.reload(device_ethernet_prod)
 
       # Set up connections and different firmware versions for all devices
       for device <- [device_wifi_prod, device_wifi_dev, device_cellular_prod, device_ethernet_prod] do
@@ -2330,26 +2342,26 @@ defmodule NervesHub.DevicesTest do
     test "updates device.network_interface", %{device: device} do
       refute device.network_interface
 
-      {:ok, device} = Devices.update_network_interface(device, "eth0")
+      {:ok, device} = Devices.update_network_interface(device.id, "eth0")
       assert device.network_interface == :ethernet
 
-      {:ok, device} = Devices.update_network_interface(device, "en0")
+      {:ok, device} = Devices.update_network_interface(device.id, "en0")
       assert device.network_interface == :ethernet
 
-      {:ok, device} = Devices.update_network_interface(device, "wlan0")
+      {:ok, device} = Devices.update_network_interface(device.id, "wlan0")
       assert device.network_interface == :wifi
 
-      {:ok, device} = Devices.update_network_interface(device, "wwan0")
+      {:ok, device} = Devices.update_network_interface(device.id, "wwan0")
       assert device.network_interface == :cellular
     end
 
     test "sets to 'unknown' for invalid values", %{device: device} do
-      {:ok, device} = Devices.update_network_interface(device, "foobarbaz")
+      {:ok, device} = Devices.update_network_interface(device.id, "foobarbaz")
       assert device.network_interface == :unknown
     end
 
     test "cannot be explicitly set to nil", %{device: device} do
-      {:error, changeset} = Devices.update_network_interface(device, nil)
+      {:error, changeset} = Devices.update_network_interface(device.id, nil)
       {"cannot be set to nil", []} = changeset.errors[:network_interface]
     end
   end
@@ -2415,5 +2427,14 @@ defmodule NervesHub.DevicesTest do
 
       assert count == 0
     end
+  end
+
+  def to_device_info(device) do
+    %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id
+    }
   end
 end

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
   use Mimic
   use AssertEventually, timeout: 500, interval: 50
 
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.Connections
@@ -76,9 +77,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device1)
-    :ok = Connections.device_connected(device1, connection.id)
-    Devices.deployment_device_online(device1)
+    {:ok, connection} = Connections.device_connecting(device1.id, device1.identifier)
+    :ok = Connections.device_connected(device1.identifier, connection.id)
+    to_device_info(device1) |> Devices.deployment_device_online()
 
     # sent when a device is a assigned a deployment group
     assert_receive %Broadcast{topic: ^topic1, event: "deployment_updated"}, 500
@@ -91,9 +92,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic2)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2)
-    :ok = Connections.device_connected(device2, connection.id)
-    Devices.deployment_device_online(device2)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.identifier)
+    :ok = Connections.device_connected(device2.identifier, connection.id)
+    to_device_info(device2) |> Devices.deployment_device_online()
 
     # and check that device2 was told to update
     assert_receive %Broadcast{topic: ^topic2, event: "update"}, 500
@@ -103,9 +104,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic3)
 
     device3 = Devices.update_deployment_group(device3, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device3)
-    :ok = Connections.device_connected(device3, connection.id)
-    Devices.deployment_device_online(device3)
+    {:ok, connection} = Connections.device_connecting(device3.id, device3.identifier)
+    :ok = Connections.device_connected(device3.identifier, connection.id)
+    to_device_info(device3) |> Devices.deployment_device_online()
 
     # and check that device3 isn't told to update as the concurrent limit has been reached
     refute_receive %Broadcast{topic: ^topic3, event: "update"}, 500
@@ -127,12 +128,12 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     deployment_group = Repo.preload(deployment_group, current_release: :firmware)
 
     device = Devices.update_deployment_group(device, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device)
-    :ok = Connections.device_connected(device, connection.id)
+    {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+    :ok = Connections.device_connected(device.identifier, connection.id)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2)
-    :ok = Connections.device_connected(device2, connection.id)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.identifier)
+    :ok = Connections.device_connected(device2.identifier, connection.id)
 
     topic1 = "device:#{device.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
@@ -192,8 +193,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     device = Devices.update_deployment_group(device, deployment_group)
     {:ok, device} = Devices.update_device(device, %{firmware_validation_status: "not_validated"})
-    {:ok, connection} = Connections.device_connecting(device)
-    :ok = Connections.device_connected(device, connection.id)
+    {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+    :ok = Connections.device_connected(device.identifier, connection.id)
 
     topic1 = "device:#{device.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
@@ -280,10 +281,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-added"}, 500
 
-    {:ok, connection} = Connections.device_connecting(device1)
-    :ok = Connections.device_connected(device1, connection.id)
+    {:ok, connection} = Connections.device_connecting(device1.id, device1.identifier)
+    :ok = Connections.device_connected(device1.identifier, connection.id)
 
-    Devices.deployment_device_online(device1)
+    to_device_info(device1) |> Devices.deployment_device_online()
 
     # sent when a device is assigned a deployment group
     assert_receive %Broadcast{topic: ^device1_topic, event: "deployment_updated"},
@@ -310,9 +311,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     Mimic.reject(&Devices.available_for_update/2)
 
-    {:ok, connection} = Connections.device_connecting(device2)
-    :ok = Connections.device_connected(device2, connection.id)
-    Devices.deployment_device_online(device2)
+    {:ok, connection} = Connections.device_connecting(device2.id, device2.identifier)
+    :ok = Connections.device_connected(device2.identifier, connection.id)
+
+    to_device_info(device2) |> Devices.deployment_device_online()
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-online"}, 500
     refute_receive %Broadcast{topic: ^device2_topic, event: "update"}, 500
@@ -412,10 +414,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     device1 = Devices.update_deployment_group(device1, deployment_group)
     {:ok, device1} = Devices.update_device(device1, %{updates_enabled: false})
 
-    {:ok, connection} = Connections.device_connecting(device1)
-    :ok = Connections.device_connected(device1, connection.id)
+    {:ok, connection} = Connections.device_connecting(device1.id, device1.identifier)
+    :ok = Connections.device_connected(device1.identifier, connection.id)
 
-    Devices.deployment_device_online(device1)
+    to_device_info(device1) |> Devices.deployment_device_online()
 
     # sent when a device is assigned a deployment group
     assert_receive %Broadcast{topic: ^device1_topic, event: "deployment_updated"},
@@ -589,8 +591,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       Fixtures.device_fixture(org, product, other_firmware)
       |> Devices.update_deployment_group(deployment_group)
 
-    {:ok, connection} = Connections.device_connecting(device)
-    :ok = Connections.device_connected(device, connection.id)
+    {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+    :ok = Connections.device_connected(device.identifier, connection.id)
 
     deployment_group =
       Ecto.Changeset.change(deployment_group, %{is_active: false, delta_updatable: true}) |> Repo.update!()
@@ -705,13 +707,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      {:ok, conn2} = Connections.device_connecting(old_device2)
-      {:ok, conn3} = Connections.device_connecting(new_device)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
+      {:ok, conn3} = Connections.device_connecting(new_device.id, new_device.identifier)
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(old_device2, conn2.id)
-      :ok = Connections.device_connected(new_device, conn3.id)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
+      :ok = Connections.device_connected(new_device.identifier, conn3.id)
 
       # Test logic
       old_device1_topic = "device:#{old_device1.id}"
@@ -772,8 +774,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      :ok = Connections.device_connected(old_device1, conn1.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
       assert Orchestrator.available_priority_slots(deployment_group) == 2
 
       # Add one device to priority queue
@@ -826,11 +828,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      {:ok, conn2} = Connections.device_connecting(new_device)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn2} = Connections.device_connecting(new_device.id, new_device.identifier)
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(new_device, conn2.id)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      :ok = Connections.device_connected(new_device.identifier, conn2.id)
       # Fill priority queue
       {:ok, _} = Devices.told_to_update(old_device1, deployment_group, priority_queue: true)
 
@@ -863,8 +865,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       device = Devices.update_deployment_group(device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, conn.id)
+      {:ok, conn} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, conn.id)
 
       # Should return empty list since priority queue is disabled
       assert Devices.available_for_priority_update(deployment_group, 10) == []
@@ -902,8 +904,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(new_device)
-      :ok = Connections.device_connected(new_device, conn.id)
+      {:ok, conn} = Connections.device_connecting(new_device.id, new_device.identifier)
+      :ok = Connections.device_connected(new_device.identifier, conn.id)
       # new_device has version 1.5.0, threshold is 1.0.0
       available = Devices.available_for_priority_update(deployment_group, 10)
       refute Enum.any?(available, &(&1.id == new_device.id))
@@ -951,11 +953,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      {:ok, conn2} = Connections.device_connecting(old_device2)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(old_device2, conn2.id)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
       # old devices have versions 0.9.0 and 0.8.0, threshold is 1.0.0
       available = Devices.available_for_priority_update(deployment_group, 10)
       device_ids = Enum.map(available, & &1.id)
@@ -1018,13 +1020,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      {:ok, conn2} = Connections.device_connecting(old_device2)
-      {:ok, conn3} = Connections.device_connecting(new_device)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
+      {:ok, conn3} = Connections.device_connecting(new_device.id, new_device.identifier)
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(old_device2, conn2.id)
-      :ok = Connections.device_connected(new_device, conn3.id)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
+      :ok = Connections.device_connected(new_device.identifier, conn3.id)
       assert Devices.count_inflight_priority_updates_for(deployment_group) == 0
 
       {:ok, _} = Devices.told_to_update(old_device1, deployment_group, priority_queue: true)
@@ -1082,11 +1084,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      {:ok, conn2} = Connections.device_connecting(new_device)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn2} = Connections.device_connecting(new_device.id, new_device.identifier)
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(new_device, conn2.id)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      :ok = Connections.device_connected(new_device.identifier, conn2.id)
       assert Devices.count_inflight_updates_for(deployment_group) == 0
 
       {:ok, _} = Devices.told_to_update(new_device, deployment_group, priority_queue: false)
@@ -1120,8 +1122,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       device = Devices.update_deployment_group(device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, conn.id)
+      {:ok, conn} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, conn.id)
 
       assert Devices.available_for_priority_update(deployment_group, 10) == []
     end
@@ -1197,15 +1199,15 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       device_2_0 = Devices.update_deployment_group(device_2_0, deployment_group)
       device_1_1 = Devices.update_deployment_group(device_1_1, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(device_1_10)
-      {:ok, conn2} = Connections.device_connecting(device_1_9)
-      {:ok, conn3} = Connections.device_connecting(device_2_0)
-      {:ok, conn4} = Connections.device_connecting(device_1_1)
+      {:ok, conn1} = Connections.device_connecting(device_1_10.id, device_1_10.identifier)
+      {:ok, conn2} = Connections.device_connecting(device_1_9.id, device_1_9.identifier)
+      {:ok, conn3} = Connections.device_connecting(device_2_0.id, device_2_0.identifier)
+      {:ok, conn4} = Connections.device_connecting(device_1_1.id, device_1_1.identifier)
 
-      :ok = Connections.device_connected(device_1_10, conn1.id)
-      :ok = Connections.device_connected(device_1_9, conn2.id)
-      :ok = Connections.device_connected(device_2_0, conn3.id)
-      :ok = Connections.device_connected(device_1_1, conn4.id)
+      :ok = Connections.device_connected(device_1_10.identifier, conn1.id)
+      :ok = Connections.device_connected(device_1_9.identifier, conn2.id)
+      :ok = Connections.device_connected(device_2_0.identifier, conn3.id)
+      :ok = Connections.device_connected(device_1_1.identifier, conn4.id)
 
       available = Devices.available_for_priority_update(deployment_group, 10)
       device_ids = Enum.map(available, & &1.id)
@@ -1277,13 +1279,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1)
-      {:ok, conn2} = Connections.device_connecting(old_device2)
-      {:ok, conn3} = Connections.device_connecting(new_device)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
+      {:ok, conn3} = Connections.device_connecting(new_device.id, new_device.identifier)
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(old_device2, conn2.id)
-      :ok = Connections.device_connected(new_device, conn3.id)
+      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
+      :ok = Connections.device_connected(new_device.identifier, conn3.id)
 
       # Fill both the priority queue slot and normal queue slot
       {:ok, _} = Devices.told_to_update(old_device1.id, deployment_group, priority_queue: true)
@@ -1380,13 +1382,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       # Device 3 should be third (2 minutes ago)
       # Device 4 should be last (newest connection - 1 minute ago)
       now = DateTime.utc_now()
-      {:ok, conn1} = Connections.device_connecting(old_device1)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
       conn1 = Ecto.Changeset.change(conn1, established_at: DateTime.add(now, -240, :second)) |> Repo.update!()
-      {:ok, conn2} = Connections.device_connecting(old_device2)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
       conn2 = Ecto.Changeset.change(conn2, established_at: DateTime.add(now, -180, :second)) |> Repo.update!()
-      {:ok, conn3} = Connections.device_connecting(old_device3)
+      {:ok, conn3} = Connections.device_connecting(old_device3.id, old_device3.identifier)
       conn3 = Ecto.Changeset.change(conn3, established_at: DateTime.add(now, -120, :second)) |> Repo.update!()
-      {:ok, conn4} = Connections.device_connecting(old_device4)
+      {:ok, conn4} = Connections.device_connecting(old_device4.id, old_device4.identifier)
       conn4 = Ecto.Changeset.change(conn4, established_at: DateTime.add(now, -60, :second)) |> Repo.update!()
 
       :ok = Connections.device_connected(old_device1, conn1.id)
@@ -1397,9 +1399,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       # Give device1 enough failed update attempts to meet the failure threshold
       # The default device_failure_threshold is 3, so we'll add 3 attempts
       # This will cause it to fail can_device_update? and be skipped
-      :ok = Devices.update_attempted(old_device1)
-      :ok = Devices.update_attempted(old_device1)
-      :ok = Devices.update_attempted(old_device1)
+      :ok = to_device_info(old_device1) |> Devices.update_attempted()
+      :ok = to_device_info(old_device1) |> Devices.update_attempted()
+      :ok = to_device_info(old_device1) |> Devices.update_attempted()
 
       # Start orchestrator
       {:ok, pid} =
@@ -1444,5 +1446,18 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       # Verify device1 does not have an inflight update
       refute Enum.any?(inflight_updates, &(&1.device_id == old_device1.id))
     end
+  end
+
+  def to_device_info(device) do
+    %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id,
+      deployment_id: device.deployment_id,
+      device_updates_enabled: device.updates_enabled,
+      device_updates_blocked_until: device.updates_blocked_until,
+      firmware_metadata: device.firmware_metadata
+    }
   end
 end

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -436,7 +436,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
     assert_online_and_available(device)
 
-    refute is_nil(device_channel.assigns.device.deployment_id)
+    refute is_nil(device_channel.assigns.device_info.deployment_id)
     refute is_nil(device_channel.assigns.deployment_channel)
 
     Devices.clear_deployment_group(device)
@@ -445,7 +445,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     # check the state of the device's connection types
     state = :sys.get_state(device_channel.channel_pid)
 
-    assert is_nil(state.assigns.device.deployment_id)
+    assert is_nil(state.assigns.device_info.deployment_id)
     assert is_nil(state.assigns.deployment_channel)
 
     close_cleanly(device_channel)
@@ -464,7 +464,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     {:ok, _join_reply, device_channel} =
       subscribe_and_join(socket, DeviceChannel, "device:#{device.id}")
 
-    assert device_channel.assigns.device.deployment_id == deployment_group.id
+    assert device_channel.assigns.device_info.deployment_id == deployment_group.id
     refute is_nil(device_channel.assigns.deployment_channel)
 
     device = NervesHub.Repo.preload(device, :org)
@@ -478,7 +478,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     # check the state of the device's connection types
     state = :sys.get_state(device_channel.channel_pid)
 
-    assert state.assigns.device.deployment_id == new_deployment_group.id
+    assert state.assigns.device_info.deployment_id == new_deployment_group.id
     refute is_nil(state.assigns.deployment_channel)
 
     close_cleanly(device_channel)
@@ -500,7 +500,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     {:ok, _join_reply, device_channel} =
       subscribe_and_join(socket, DeviceChannel, "device:#{device.id}")
 
-    assert device_channel.assigns.device.deployment_id == deployment_group.id
+    assert device_channel.assigns.device_info.deployment_id == deployment_group.id
 
     close_cleanly(device_channel)
   end
@@ -527,7 +527,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     {:ok, _join_reply, device_channel} =
       subscribe_and_join(socket, DeviceChannel, "device:#{device.id}")
 
-    refute device_channel.assigns.device.deployment_id
+    refute device_channel.assigns.device_info.deployment_id
 
     close_cleanly(device_channel)
   end
@@ -546,7 +546,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     {:ok, _join_reply, device_channel} =
       subscribe_and_join(socket, DeviceChannel, "device:#{device.id}")
 
-    assert device_channel.assigns.device.deployment_id == deployment_group.id
+    assert device_channel.assigns.device_info.deployment_id == deployment_group.id
 
     close_cleanly(device_channel)
   end
@@ -587,7 +587,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
       user = Fixtures.user_fixture()
       {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
       %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
-      {:ok, device} = Devices.update_network_interface(device, "wlan0")
+      {:ok, device} = Devices.update_network_interface(device.id, "wlan0")
+      device = Repo.reload(device)
 
       subscribe_for_updates(device)
 

--- a/test/nerves_hub_web/live/devices/show/logs_tab_test.exs
+++ b/test/nerves_hub_web/live/devices/show/logs_tab_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.LogLines
   alias NervesHub.Products.Product
@@ -81,6 +82,8 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
     Product.changeset(product, %{"extensions" => %{"logging" => true}})
     |> Repo.update()
 
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
     for n <- 1..5 do
       attrs = %{
         "level" => "info",
@@ -88,7 +91,7 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
         "message" => "something wicked this way comes : #{n}"
       }
 
-      {:ok, _} = LogLines.async_create(device, attrs)
+      {:ok, _} = LogLines.async_create(device_info, attrs)
     end
 
     conn
@@ -116,7 +119,9 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
       "message" => "something wicked this way comes"
     }
 
-    {:ok, _} = LogLines.async_create(device, attrs)
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
+    {:ok, _} = LogLines.async_create(device_info, attrs)
 
     session =
       conn
@@ -124,13 +129,15 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
       |> assert_has("div", text: "Showing the last 25 log lines.")
       |> assert_has("div", text: "something wicked this way comes")
 
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
     attrs = %{
       "level" => "info",
       "timestamp" => DateTime.utc_now(),
       "message" => "something wicked this way comes, again"
     }
 
-    {:ok, _} = LogLines.async_create(device, attrs)
+    {:ok, _} = LogLines.async_create(device_info, attrs)
 
     assert_has(session, "div", text: "something wicked this way comes, again")
   end
@@ -145,13 +152,15 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
     Product.changeset(product, %{"extensions" => %{"logging" => true}})
     |> Repo.update()
 
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
     attrs = %{
       "level" => "info",
       "timestamp" => DateTime.utc_now(),
       "message" => "something wicked this way comes"
     }
 
-    {:ok, _} = LogLines.async_create(device, attrs)
+    {:ok, _} = LogLines.async_create(device_info, attrs)
 
     session =
       conn
@@ -166,7 +175,9 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
       "message" => "something wicked this way comes, again"
     }
 
-    {:ok, _} = LogLines.async_create(device, attrs)
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
+    {:ok, _} = LogLines.async_create(device_info, attrs)
 
     refute_has(session, "div", text: "something wicked this way comes, again", timeout: 500)
   end
@@ -180,6 +191,8 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
     Product.changeset(product, %{"extensions" => %{"logging" => true}})
     |> Repo.update()
 
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
     for n <- 1..26 do
       attrs = %{
         "level" => "info",
@@ -187,7 +200,7 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
         "message" => "something wicked this way comes : #{n}"
       }
 
-      {:ok, _} = LogLines.async_create(device, attrs)
+      {:ok, _} = LogLines.async_create(device_info, attrs)
 
       Process.sleep(5)
     end
@@ -200,13 +213,15 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
       |> assert_has("div", text: "something wicked this way comes : 2")
       |> refute_has("div", text: "something wicked this way comes : 1", exact: true)
 
+    device_info = %DeviceInfo{device_id: device.id, device_identifier: device.identifier, product_id: device.product_id}
+
     attrs = %{
       "level" => "info",
       "timestamp" => DateTime.utc_now(),
       "message" => "something wicked this way comes, again"
     }
 
-    {:ok, _} = LogLines.async_create(device, attrs)
+    {:ok, _} = LogLines.async_create(device_info, attrs)
 
     session
     |> assert_has("div", text: "something wicked this way comes, again")

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   alias NervesHub.Accounts
   alias NervesHub.Accounts.Org
   alias NervesHub.AuditLogs
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
@@ -196,8 +197,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit(device_show_path(fixture))
       |> assert_has("svg[data-connection-status=unknown]")
       |> unwrap(fn view ->
-        {:ok, connection} = Connections.device_connecting(fixture.device)
-        :ok = Connections.device_connected(fixture.device, connection.id)
+        {:ok, connection} = Connections.device_connecting(fixture.device.id, fixture.device.identifier)
+        :ok = Connections.device_connected(fixture.device.identifier, connection.id)
         render(view)
       end)
       |> assert_has("svg[data-connection-status=connected]")
@@ -219,8 +220,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       # Set device status to :provisioned for deployment group eligibility
       %{status: :provisioned} = device = Devices.set_as_provisioned!(device)
 
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
 
       # mismatch device and deployment group firmware so "Send Update" form doesn't display
       original_firmware_platform = device.firmware_metadata.platform
@@ -260,8 +261,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
         {:ok, _} = Metrics.save_metrics(device.id, %{"cpu_usage_percent" => 22})
 
-        {:ok, connection} = Connections.device_connecting(device)
-        :ok = Connections.device_connected(device, connection.id)
+        {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+        :ok = Connections.device_connected(device.identifier, connection.id)
 
         topic = "device:#{device.id}:extensions"
         ChannelServer.broadcast!(NervesHub.PubSub, topic, "health_check_report", %{})
@@ -373,8 +374,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{}})
 
       conn
@@ -390,8 +391,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{"latitude" => nil, "longitude" => nil}})
 
       conn
@@ -407,8 +408,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{"latitude" => "", "longitude" => ""}})
 
       conn
@@ -423,8 +424,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "location" => %{"error_code" => "BOOP", "error_description" => "BEEP"}
       }
 
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
@@ -445,8 +446,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         }
       }
 
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
@@ -670,8 +671,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
 
       {:ok, {_release, deployment_group}} =
         ManagedDeployments.create_deployment_release(deployment_group, firmware, nil, user, %{})
@@ -713,8 +714,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         |> Ecto.Changeset.change(%{deployment_id: deployment_group.id})
         |> Repo.update!()
 
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
 
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
@@ -941,8 +942,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       device = Devices.set_as_provisioned!(device)
 
       conn
@@ -975,8 +976,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       device = Devices.set_as_provisioned!(device)
 
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -1028,8 +1029,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       device = Devices.set_as_provisioned!(device)
 
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -1078,8 +1079,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       Devices.update_device(device, %{firmware_metadata: metadata})
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
+      :ok = Connections.device_connected(device.identifier, connection.id)
       device = Devices.set_as_provisioned!(device)
 
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -1409,7 +1410,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
         |> assert_has("span", text: "Not validated")
 
-      Devices.firmware_validated(device)
+      to_device_info(device)
+      |> Devices.firmware_validated()
 
       assert_has(conn, "span", text: "Validated")
     end
@@ -1464,5 +1466,14 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
   def device_show_path(%{device: device, org: org, product: product}) do
     ~p"/org/#{org}/#{product}/devices/#{device}"
+  end
+
+  def to_device_info(device) do
+    %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id
+    }
   end
 end

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -74,8 +74,8 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       _ = Fixtures.device_fixture(org, product, firmware)
 
       device = Fixtures.device_fixture(org, product, firmware)
-      {:ok, device_connection} = Connections.device_connecting(device)
-      Connections.device_connected(device, device_connection.id)
+      {:ok, device_connection} = Connections.device_connecting(device.id, device.identifier)
+      Connections.device_connected(device.identifier, device_connection.id)
 
       conn
       |> visit("/org/#{org.name}")

--- a/test/nerves_hub_web/live/orgs/index_test.exs
+++ b/test/nerves_hub_web/live/orgs/index_test.exs
@@ -59,7 +59,8 @@ defmodule NervesHubWeb.Live.Orgs.IndexTest do
       _ = Fixtures.device_fixture(org, product, firmware)
 
       device = Fixtures.device_fixture(org, product, firmware)
-      {:ok, device_connection} = Connections.device_connecting(device)
+      {:ok, device_connection} = Connections.device_connecting(device.id, device.identifier)
+
       Connections.device_connected(device, device_connection.id)
 
       conn


### PR DESCRIPTION
_This PR is part experiment, part ready for review_

This PR adds a struct to store minimal data used by `DeviceSocket`, `DeviceChannel`, `ExtensionsChannel` and `ConsoleChannel`.

The goal is to reduce what is stored between the channels, and where possible, reduce memory.

Currently NervesCloud has the following memory usage:

`DeviceSocket`: 22KB - 38KB (50KB spikes seen, before reducing)
`DeviceChannel`: 4.8KB - 5.6KB (200KB spikes seen, before reducing)
`ConsoleChannel`: 4.2KB - 7.1KB (50KB - 200KB spikes seen, before reducing)
`ExtensionsChannel`: 5.1KB - 5.9KB (many processes grow to 40KB - 140KB, likely due to a higher message load, before reducing)

I'll look at deploying this PR to NC for a short period over the weekend to gather updated memory stats for comparison.