### PR TITLE
Set Oban `peer` to false for the device nodes

### DIFF
--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -107,7 +107,9 @@ defmodule NervesHub.Application do
 
     case Application.get_env(:nerves_hub, :app) do
       "device" ->
-        Keyword.put(config, :queues, [])
+        config
+        |> Keyword.put(:queues, [])
+        |> Keyword.put(:peer, false)
 
       _ ->
         config


### PR DESCRIPTION
This stops device nodes from checking if they are the 'leader' when we have already disabled them from processing queues.