### PR TITLE
Ignore messages to Extensions if they aren't attached

### DIFF
--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -113,7 +113,12 @@ defmodule NervesHubWeb.ExtensionsChannel do
 
   @decorate with_span("Channels.ExtensionsChannel.handle_info[Broadcast]")
   def handle_info({mod, msg}, socket) do
-    mod.handle_info(msg, socket)
+    socket.assigns.extensions
+    |> Enum.find(fn {_, v} -> v[:module] == mod && v[:status] == :attached end)
+    |> case do
+      nil -> {:noreply, socket}
+      _ -> mod.handle_info(msg, socket)
+    end
   rescue
     error ->
       Logger.warning("#{inspect(mod)} failed handle_info - #{inspect(error)}")


### PR DESCRIPTION
I've been hunting down this issue for ages, and I finally found it!

Its possible for Extensions to be forwarded `handle_info` messages when they aren't attached.

This ignores messages, and finally fixing the Sentry error that keeps popping up under a race condition.