### PR TITLE
Simplify the Oban queues into three

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -80,7 +80,7 @@ config :nerves_hub, Oban,
   ],
   plugins: [
     # 1 week
-    {Oban.Plugins.Pruner, max_age: 604_800},
+    {Oban.Plugins.Pruner, max_age: 86_400},
     {Oban.Plugins.Cron,
      crontab: [
        {"0 * * * *", ScheduleOrgAuditLogTruncation},

--- a/config/config.exs
+++ b/config/config.exs
@@ -66,13 +66,16 @@ config :nerves_hub, Oban,
   log: false,
   queues: [
     default: 1,
+    firmware: 5,
+    delete_file: 3,
+    cleanup: 2,
+    # temporary, schedule for removal
     delete_archive: 1,
     delete_firmware: 1,
     device: 1,
     firmware_delta_builder: 2,
     firmware_delta_timeout: 1,
     truncate: 1,
-    # temporary, will remove in November
     truncation: 1
   ],
   plugins: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -80,7 +80,7 @@ config :nerves_hub, Oban,
   ],
   plugins: [
     # 1 week
-    {Oban.Plugins.Pruner, max_age: 86_400},
+    {Oban.Plugins.Pruner, max_age: 86_400, interval: 180_000},
     {Oban.Plugins.Cron,
      crontab: [
        {"0 * * * *", ScheduleOrgAuditLogTruncation},

--- a/lib/nerves_hub/workers/clean_stale_device_connections.ex
+++ b/lib/nerves_hub/workers/clean_stale_device_connections.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Workers.CleanStaleDeviceConnections do
   use Oban.Worker,
+    queue: :cleanup,
     max_attempts: 5,
-    queue: :device,
     unique: [states: [:available, :scheduled, :executing]]
 
   alias NervesHub.Devices.Connections

--- a/lib/nerves_hub/workers/clean_up_soft_deleted_devices.ex
+++ b/lib/nerves_hub/workers/clean_up_soft_deleted_devices.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Workers.CleanUpSoftDeletedDevices do
   use Oban.Worker,
-    max_attempts: 5,
-    queue: :device
+    queue: :cleanup,
+    max_attempts: 5
 
   alias NervesHub.Devices
 

--- a/lib/nerves_hub/workers/delete_archive.ex
+++ b/lib/nerves_hub/workers/delete_archive.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Workers.DeleteArchive do
   use Oban.Worker,
-    max_attempts: 5,
-    queue: :delete_archive
+    queue: :delete_file,
+    max_attempts: 5
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"archive_path" => path}}) do

--- a/lib/nerves_hub/workers/delete_firmware.ex
+++ b/lib/nerves_hub/workers/delete_firmware.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Workers.DeleteFirmware do
   use Oban.Worker,
-    max_attempts: 5,
-    queue: :delete_firmware
+    queue: :delete_file,
+    max_attempts: 5
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do

--- a/lib/nerves_hub/workers/device_health_truncation.ex
+++ b/lib/nerves_hub/workers/device_health_truncation.ex
@@ -7,8 +7,8 @@ defmodule NervesHub.Workers.DeviceHealthTruncation do
   """
 
   use Oban.Worker,
-    max_attempts: 1,
-    queue: :truncate
+    queue: :cleanup,
+    max_attempts: 1
 
   alias NervesHub.Devices
   alias NervesHub.Devices.Metrics

--- a/lib/nerves_hub/workers/expire_inflight_updates.ex
+++ b/lib/nerves_hub/workers/expire_inflight_updates.ex
@@ -6,8 +6,8 @@ defmodule NervesHub.Workers.ExpireInflightUpdates do
   """
 
   use Oban.Worker,
-    max_attempts: 1,
-    queue: :truncate
+    queue: :cleanup,
+    max_attempts: 1
 
   alias NervesHub.Devices
 

--- a/lib/nerves_hub/workers/firmware_delta_builder.ex
+++ b/lib/nerves_hub/workers/firmware_delta_builder.ex
@@ -1,9 +1,7 @@
-max_attempts = 3
-
 defmodule NervesHub.Workers.FirmwareDeltaBuilder do
   use Oban.Worker,
-    max_attempts: unquote(max_attempts),
-    queue: :firmware_delta_builder,
+    queue: :firmware,
+    max_attempts: 3,
     unique: [
       period: 60 * 10,
       states: [:available, :scheduled, :executing],
@@ -17,10 +15,8 @@ defmodule NervesHub.Workers.FirmwareDeltaBuilder do
 
   require Logger
 
-  @max_attempts max_attempts
-
   @impl Oban.Worker
-  def perform(%Oban.Job{id: id, attempt: attempt, args: %{"source_id" => source_id, "target_id" => target_id}}) do
+  def perform(%Oban.Job{id: id, args: %{"source_id" => source_id, "target_id" => target_id}} = job) do
     source = Firmwares.get_firmware!(source_id)
     target = Firmwares.get_firmware!(target_id)
 
@@ -36,7 +32,7 @@ defmodule NervesHub.Workers.FirmwareDeltaBuilder do
     case Firmwares.get_firmware_delta_by_source_and_target(source.id, target.id) do
       {:ok, %FirmwareDelta{status: :processing} = delta} ->
         Logger.info(
-          "Processing delta #{source.version} to #{target.version}; attempt number #{attempt}/#{@max_attempts}"
+          "Processing delta #{source.version} to #{target.version}; attempt number #{job.attempt}/#{job.max_attempts}"
         )
 
         # if on last attempt and delta hasn't been marked as failed, fail it
@@ -51,7 +47,7 @@ defmodule NervesHub.Workers.FirmwareDeltaBuilder do
             delta = Repo.reload(delta)
 
             _ =
-              if attempt >= @max_attempts and delta.status != :failed do
+              if job.attempt >= job.max_attempts and delta.status != :failed do
                 Logger.warning("Delta generation failed on final attempt, marking as failed")
                 {:ok, _} = Firmwares.fail_firmware_delta(delta)
               end

--- a/lib/nerves_hub/workers/firmware_delta_timeout.ex
+++ b/lib/nerves_hub/workers/firmware_delta_timeout.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Workers.FirmwareDeltaTimeout do
   use Oban.Worker,
-    max_attempts: 5,
-    queue: :firmware_delta_timeout
+    queue: :cleanup,
+    max_attempts: 5
 
   alias NervesHub.Firmwares
 

--- a/lib/nerves_hub/workers/org_audit_log_truncation.ex
+++ b/lib/nerves_hub/workers/org_audit_log_truncation.ex
@@ -1,7 +1,7 @@
 defmodule NervesHub.Workers.OrgAuditLogTruncation do
   use Oban.Worker,
-    max_attempts: 5,
-    queue: :truncate
+    queue: :cleanup,
+    max_attempts: 5
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"org_id" => id, "days_to_keep" => days_to_keep}}) do

--- a/lib/nerves_hub/workers/schedule_org_audit_log_truncation.ex
+++ b/lib/nerves_hub/workers/schedule_org_audit_log_truncation.ex
@@ -1,6 +1,6 @@
 defmodule NervesHub.Workers.ScheduleOrgAuditLogTruncation do
   use Oban.Worker,
-    queue: :truncation,
+    queue: :cleanup,
     max_attempts: 1
 
   alias NervesHub.Accounts

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -502,7 +502,7 @@ defmodule NervesHub.FirmwaresTest do
       assert_enqueued(
         args: %{source_id: source_id, target_id: target_id},
         worker: FirmwareDeltaBuilder,
-        queue: :firmware_delta_builder
+        queue: :firmware
       )
 
       expect(UpdateToolDefault, :create_firmware_delta_file, fn _, _, _ ->

--- a/test/nerves_hub/workers/firmware_delta_builder_test.exs
+++ b/test/nerves_hub/workers/firmware_delta_builder_test.exs
@@ -119,6 +119,7 @@ defmodule NervesHub.Workers.FirmwareDeltaBuilderTest do
       job = %Oban.Job{
         id: Ecto.UUID.generate(),
         attempt: 3,
+        max_attempts: 3,
         args: %{
           "source_id" => source_firmware.id,
           "target_id" => target_firmware.id


### PR DESCRIPTION
This implements an Oban best practice of less queues is better.

Less queues, grouped based on function (and essentially priority).