### PR TITLE
Use a try/catch when using `pushEvent` for page visibility changes

### DIFF
--- a/assets/js/hooks/pageVisible.js
+++ b/assets/js/hooks/pageVisible.js
@@ -1,13 +1,14 @@
 export default {
   mounted() {
-    this.init()
-  },
-  init() {
     document.addEventListener("visibilitychange", () => {
-      if (this.liveSocket.isConnected()) {
-        this.pushEvent("page_visibility_change", {
-          visible: document.visibilityState === "visible",
-        })
+      try {
+        if (liveSocket.isConnected()) {
+          this.pushEvent("page_visibility_change", {
+            visible: document.visibilityState === "visible",
+          })
+        }
+      } catch (error) {
+        console.error("Error during visibilitychange event callback:", error)
       }
     })
   },


### PR DESCRIPTION
If a LiveView has a disconnection and then reconnection, a little race condition exists where the `liveSocket` is disconnected when `pushEvent` is called. This adds a little try/catch goodness so not to crash anything.