### PR TITLE
Remove the document event listener when the LiveHook is destroyed

### DIFF
--- a/assets/js/hooks/pageVisible.js
+++ b/assets/js/hooks/pageVisible.js
@@ -1,15 +1,27 @@
 export default {
   mounted() {
-    document.addEventListener("visibilitychange", () => {
-      try {
-        if (liveSocket.isConnected()) {
-          this.pushEvent("page_visibility_change", {
-            visible: document.visibilityState === "visible",
-          })
+    this.controller = new AbortController()
+
+    document.addEventListener(
+      "visibilitychange",
+      () => {
+        const visibility = document.visibilityState === "visible"
+        try {
+          if (liveSocket.isConnected()) {
+            this.pushEvent("page_visibility_change", { visible: visibility })
+          }
+        } catch (error) {
+          console.error(
+            "Error during visibilitychange event callback with visibilityState=${visibility} : ",
+            error,
+          )
+          this.controller.abort()
         }
-      } catch (error) {
-        console.error("Error during visibilitychange event callback:", error)
-      }
-    })
+      },
+      { signal: this.controller.signal },
+    )
+  },
+  destroyed() {
+    this.controller.abort()
   },
 }


### PR DESCRIPTION
This ACTUALLY fixes #2664

The issue is that when you view the device list, but then navigate away, the event listener wasn't being destroyed. So if you went back to the device list, now there are two event handlers firing but one of them has a reference to a closed socket connection. 

I haven't been able to replicate the issue once I started using this.