### PR TITLE
Switch `env.sh.eex` to be shell compliant

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -11,7 +11,7 @@
 #     ;;
 # esac
 
-if [ "$APP_NAME" = "" ] || [[ "$PRIVATE_IP" = "" && "$POD_IP" = "" ]]
+if [ "$APP_NAME" = "" ] || { [ "$PRIVATE_IP" = "" ] && [ "$POD_IP" = "" ]; }
 then
   echo "APP_NAME and PRIVATE_IP (or POD_IP) environment variables must be set for distributed erlang"
 else


### PR DESCRIPTION
`[[ ... ]]` is supported in bash but not shell