### PR TITLE
Start a health check endpoint when running a Device node

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -211,6 +211,17 @@ if config_env() == :prod do
       ]
   end
 
+  if nerves_hub_app == "device" do
+    host = System.get_env("DEVICE_HOST") || System.get_env("WEB_HOST") || System.get_env("HOST")
+    port = String.to_integer(System.get_env("DEVICE_HOST_STATUS_PORT", "4040"))
+
+    config :nerves_hub, NervesHubWeb.HealthCheckEndpoint,
+      url: [host: host],
+      http: [port: port],
+      adapter: Bandit.PhoenixAdapter,
+      server: true
+  end
+
   config :nerves_hub, NervesHubWeb.DeviceSocket,
     shared_secrets: [
       enabled: System.get_env("DEVICE_SHARED_SECRETS_ENABLED", "false") == "true"

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -172,7 +172,10 @@ defmodule NervesHub.Application do
         ]
 
       "device" ->
-        [NervesHubWeb.DeviceEndpoint]
+        [
+          NervesHubWeb.DeviceEndpoint,
+          NervesHubWeb.HealthCheckEndpoint
+        ]
 
       "web" ->
         [NervesHubWeb.Endpoint]

--- a/lib/nerves_hub_web/health_check_endpoint.ex
+++ b/lib/nerves_hub_web/health_check_endpoint.ex
@@ -1,0 +1,13 @@
+defmodule NervesHubWeb.HealthCheckEndpoint do
+  use Sentry.PlugCapture
+  use Phoenix.Endpoint, otp_app: :nerves_hub
+
+  alias NervesHubWeb.Plugs.DeviceEndpointRedirect
+  alias NervesHubWeb.Plugs.ImAlive
+
+  plug(ImAlive)
+
+  plug(Sentry.PlugContext)
+
+  plug(DeviceEndpointRedirect)
+end


### PR DESCRIPTION
This is useful for containerized deployments, like k8s or fly.io, where the health check can't use the full hostname, causing SSL to fail.