### PR TITLE
Modify the `device_id` FK constraint on the `device_firmwares` table

### DIFF
--- a/priv/repo/migrations/20260518053037_change_device_firmwares_devices_fk_constraint.exs
+++ b/priv/repo/migrations/20260518053037_change_device_firmwares_devices_fk_constraint.exs
@@ -1,0 +1,19 @@
+defmodule NervesHub.Repo.Migrations.ChangeDeviceFirmwaresDevicesFKConstraint do
+  use Ecto.Migration
+
+  def up() do
+    drop(constraint(:device_firmwares, "device_firmwares_device_id_fkey"))
+
+    alter table(:device_firmwares) do
+      modify(:device_id, references(:devices, on_delete: :delete_all))
+    end
+  end
+
+  def down() do
+    drop(constraint(:device_firmwares, "device_firmwares_device_id_fkey"))
+
+    alter table(:device_firmwares) do
+      modify(:device_id, references(:devices, on_delete: :nothing))
+    end
+  end
+end


### PR DESCRIPTION
This fixes an issue where devices couldn't be destroyed