### PR TITLE
Improve the PubSub topic used for internal device notifications

### DIFF
--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -161,7 +161,7 @@ defmodule NervesHub.DeviceLink do
 
   @spec firmware_update_progress(device_info :: DeviceInfo.t(), percent :: integer()) :: :ok
   def firmware_update_progress(device_info, percent) do
-    topic = "device:#{device_info.device_identifier}:internal"
+    topic = "internal:device:#{device_info.device_id}"
 
     :ok =
       ChannelServer.broadcast_from!(NervesHub.PubSub, self(), topic, "fwup_progress", %{
@@ -212,7 +212,7 @@ defmodule NervesHub.DeviceLink do
 
   defp announce_online(device_info) do
     # Update the connection to say that we are fully up and running
-    Connections.device_connected(device_info.device_identifier, device_info.connection_ref)
+    Connections.device_connected(device_info.connection_ref)
     # tell the orchestrator that we are online
     Devices.deployment_device_online(device_info)
   end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -782,7 +782,7 @@ defmodule NervesHub.Devices do
     ChannelServer.broadcast_from!(
       NervesHub.PubSub,
       self(),
-      "device:#{device_info.device_identifier}:internal",
+      "internal:device:#{device_info.device_id}",
       "firmware:validated",
       %{}
     )

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -21,9 +21,9 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connecting(pos_integer(), String.t()) ::
+  @spec device_connecting(pos_integer()) ::
           {:ok, DeviceConnection.t()} | {:error, Ecto.Changeset.t()}
-  def device_connecting(device_id, device_identifier) do
+  def device_connecting(device_id) do
     conflict_query =
       DeviceConnection
       |> update([ldc],
@@ -42,7 +42,7 @@ defmodule NervesHub.Devices.Connections do
     |> Repo.insert(on_conflict: conflict_query, conflict_target: [:device_id])
     |> case do
       {:ok, device_connection} ->
-        Tracker.connecting(device_identifier)
+        Tracker.connecting(device_id)
 
         {:ok, device_connection}
 
@@ -54,11 +54,12 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connected(String.t(), connection_id :: binary()) :: :ok | :error
-  def device_connected(device_identifier, connection_id) do
+  @spec device_connected(connection_id :: binary()) :: :ok | :error
+  def device_connected(connection_id) do
     DeviceConnection
     |> where(id: ^connection_id)
     |> where([dc], not (dc.status == :disconnected))
+    |> select([dc], %{device_id: dc.device_id})
     |> Repo.update_all(
       set: [
         last_seen_at: DateTime.utc_now(),
@@ -66,8 +67,8 @@ defmodule NervesHub.Devices.Connections do
       ]
     )
     |> case do
-      {1, _} ->
-        Tracker.online(device_identifier)
+      {1, [%{device_id: device_id}]} ->
+        Tracker.online(device_id)
         :ok
 
       _ ->
@@ -78,11 +79,12 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Updates the `last_seen_at`field for a device connection with current timestamp
   """
-  @spec device_heartbeat(String.t(), UUIDv7.t()) :: :ok | :error
-  def device_heartbeat(device_identifier, id) do
+  @spec device_heartbeat(UUIDv7.t()) :: :ok | :error
+  def device_heartbeat(id) do
     DeviceConnection
     |> where([dc], dc.id == ^id)
     |> where([dc], not (dc.status == :disconnected))
+    |> select([dc], %{device_id: dc.device_id})
     |> Repo.update_all(
       set: [
         status: :connected,
@@ -90,8 +92,8 @@ defmodule NervesHub.Devices.Connections do
       ]
     )
     |> case do
-      {1, _} ->
-        Tracker.heartbeat(device_identifier)
+      {1, [%{device_id: device_id}]} ->
+        Tracker.heartbeat(device_id)
         :ok
 
       _ ->
@@ -103,12 +105,13 @@ defmodule NervesHub.Devices.Connections do
   Updates `status` and relevant timestamps for a device connection record,
   and stores the reason for disconnection if provided.
   """
-  @spec device_disconnected(String.t(), UUIDv7.t(), String.t() | nil) :: :ok | {:error, any()}
-  def device_disconnected(device_identifier, ref_id, reason \\ nil) do
+  @spec device_disconnected(UUIDv7.t(), String.t() | nil) :: :ok | {:error, any()}
+  def device_disconnected(ref_id, reason \\ nil) do
     now = DateTime.utc_now()
 
     DeviceConnection
     |> where(id: ^ref_id)
+    |> select([dc], %{device_id: dc.device_id})
     |> Repo.update_all(
       set: [
         last_seen_at: now,
@@ -118,8 +121,8 @@ defmodule NervesHub.Devices.Connections do
       ]
     )
     |> case do
-      {1, _} ->
-        Tracker.offline(device_identifier)
+      {1, [%{device_id: device_id}]} ->
+        Tracker.offline(device_id)
         :ok
 
       res ->

--- a/lib/nerves_hub/devices/log_lines.ex
+++ b/lib/nerves_hub/devices/log_lines.ex
@@ -58,7 +58,7 @@ defmodule NervesHub.Devices.LogLines do
         _ =
           ChannelServer.broadcast(
             NervesHub.PubSub,
-            "device:#{device_info.device_identifier}:internal",
+            "internal:device:#{device_info.device_id}",
             "logs:received",
             log_line
           )

--- a/lib/nerves_hub/extensions/geo.ex
+++ b/lib/nerves_hub/extensions/geo.ex
@@ -54,7 +54,7 @@ defmodule NervesHub.Extensions.Geo do
     _ =
       ChannelServer.broadcast(
         NervesHub.PubSub,
-        "device:#{socket.assigns.device_info.device_identifier}:internal",
+        "internal:device:#{socket.assigns.device_info.device_id}",
         "location:updated",
         location
       )

--- a/lib/nerves_hub/tracker.ex
+++ b/lib/nerves_hub/tracker.ex
@@ -8,14 +8,14 @@ defmodule NervesHub.Tracker do
   """
 
   def heartbeat(%Device{} = device) do
-    heartbeat(device.identifier)
+    heartbeat(device.id)
   end
 
-  def heartbeat(device_identifier) when is_binary(device_identifier) do
+  def heartbeat(device_id) when is_integer(device_id) do
     _ =
       ChannelServer.broadcast(
         NervesHub.PubSub,
-        "device:#{device_identifier}:internal",
+        "internal:device:#{device_id}",
         "connection:heartbeat",
         %{}
       )
@@ -24,55 +24,39 @@ defmodule NervesHub.Tracker do
   end
 
   def connecting(%Device{} = device) do
-    connecting(device.identifier)
+    connecting(device.id)
   end
 
-  def connecting(device_identifier) when is_binary(device_identifier) do
-    publish(device_identifier, "connecting")
+  def connecting(device_id) when is_integer(device_id) do
+    publish(device_id, "connecting")
   end
 
-  def online(%{} = device) do
-    online(device.identifier)
+  def online(%Device{} = device) do
+    online(device.id)
   end
 
-  def online(identifier) when is_binary(identifier) do
-    publish(identifier, "online")
-  end
-
-  def confirm_online(%Device{identifier: identifier}) do
-    _ =
-      ChannelServer.broadcast(
-        NervesHub.PubSub,
-        "device:#{identifier}:internal",
-        "connection:status",
-        %{
-          device_id: identifier,
-          status: "online"
-        }
-      )
-
-    :ok
+  def online(device_id) when is_integer(device_id) do
+    publish(device_id, "online")
   end
 
   @doc """
   Tell internal listeners that the device is offline, via a connection change
   """
-  def offline(%Device{identifier: identifier}) do
-    offline(identifier)
+  def offline(%Device{} = device) do
+    offline(device.id)
   end
 
-  def offline(identifier) when is_binary(identifier) do
-    publish(identifier, "offline")
+  def offline(device_id) when is_integer(device_id) do
+    publish(device_id, "offline")
   end
 
-  defp publish(identifier, status) do
+  defp publish(device_id, status) do
     _ =
       ChannelServer.broadcast(
         NervesHub.PubSub,
-        "device:#{identifier}:internal",
+        "internal:device:#{device_id}",
         "connection:change",
         %{
-          device_id: identifier,
           status: status
         }
       )

--- a/lib/nerves_hub_web/channels/device_events_stream_channel.ex
+++ b/lib/nerves_hub_web/channels/device_events_stream_channel.ex
@@ -9,6 +9,7 @@ defmodule NervesHubWeb.DeviceEventsStreamChannel do
   use Phoenix.Channel
 
   alias NervesHub.Accounts
+  alias NervesHub.Devices
   alias NervesHubWeb.Helpers.Authorization
   alias Phoenix.Socket.Broadcast
 
@@ -18,7 +19,8 @@ defmodule NervesHubWeb.DeviceEventsStreamChannel do
   def join("device:" <> device_identifier, _params, socket) do
     # Socket already has authenticated user, just validate device access
     if authorized?(socket.assigns.user, device_identifier) do
-      :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device_identifier}:internal")
+      device = Devices.get_by_identifier!(device_identifier)
+      :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "internal:device:#{device.id}")
 
       {:ok, socket}
     else

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -75,7 +75,7 @@ defmodule NervesHubWeb.DeviceSocket do
   @decorate with_span("Channels.DeviceSocket.heartbeat")
   defp heartbeat(%{assigns: %{device_info: device_info}} = socket) do
     if update_heartbeat?(socket) do
-      Connections.device_heartbeat(device_info.device_identifier, device_info.connection_ref)
+      Connections.device_heartbeat(device_info.connection_ref)
       update_last_heartbeat(socket)
     else
       socket
@@ -283,8 +283,7 @@ defmodule NervesHubWeb.DeviceSocket do
   @decorate with_span("Channels.DeviceSocket.on_connect")
   defp on_connect(%{assigns: %{device_info: device_info}} = socket) do
     # Report connection and use connection id as reference
-    {:ok, %DeviceConnection{id: connection_id}} =
-      Connections.device_connecting(device_info.device_id, device_info.device_identifier)
+    {:ok, %DeviceConnection{id: connection_id}} = Connections.device_connecting(device_info.device_id)
 
     :telemetry.execute([:nerves_hub, :devices, :connect], %{count: 1}, %{
       ref_id: connection_id,
@@ -329,7 +328,7 @@ defmodule NervesHubWeb.DeviceSocket do
 
     # its possible that this is a stale connection and the device has already reconnected,
     # which means the following call might return :error, but we can ignore it
-    _ = Connections.device_disconnected(device_info.device_identifier, device_info.connection_ref)
+    _ = Connections.device_disconnected(device_info.connection_ref)
 
     assign(socket, :disconnection_handled?, true)
   end

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -631,24 +631,18 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> noreply()
   end
 
-  def handle_info(%Broadcast{event: "connection:status", payload: payload}, socket) do
-    socket
-    |> assign(
-      :received_connection_change_identifiers,
-      Map.put(socket.assigns.received_connection_change_identifiers, payload.device_id, payload)
-    )
-    |> safe_refresh()
-    |> update_device_statuses(payload)
-  end
+  def handle_info(
+        %Broadcast{topic: "internal:device:" <> device_id, event: "connection:change", payload: payload},
+        socket
+      ) do
+    device_id = String.to_integer(device_id)
 
-  def handle_info(%Broadcast{event: "connection:change", payload: payload}, socket) do
     socket
-    |> assign(
-      :received_connection_change_identifiers,
-      Map.put(socket.assigns.received_connection_change_identifiers, payload.device_id, payload)
-    )
+    |> update(:received_connection_change_identifiers, fn identifiers ->
+      Map.put(identifiers, device_id, payload)
+    end)
     |> safe_refresh()
-    |> update_device_statuses(payload)
+    |> update_device_statuses(device_id, payload.status)
   end
 
   def handle_info(%Broadcast{event: "fwup_progress", payload: %{device_id: device_id, percent: percent}}, socket)
@@ -666,7 +660,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> noreply()
   end
 
-  # Unknown broadcasts get ignored, likely from the device:id:internal channel
+  # Unknown broadcasts get ignored, likely from the internal:device:id channel
   def handle_info(%Broadcast{}, socket) do
     socket
     |> safe_refresh()
@@ -690,8 +684,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   def handle_info(:live_refresh, socket) do
     if socket.assigns.visible? and socket.assigns.live_refresh_pending? do
       Tracer.with_span "NervesHubWeb.Live.Devices.Index.live_refresh_device_list" do
-        socket
-        |> assign_display_devices()
+        assign_display_devices(socket)
       end
     else
       socket
@@ -737,19 +730,19 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
     Enum.each(
       old_devices.result || [],
-      fn device -> socket.endpoint.unsubscribe("device:#{device.identifier}:internal") end
+      fn device -> socket.endpoint.unsubscribe("internal:device:#{device.id}") end
     )
 
     updated_device_statuses =
       Map.new(updated_devices, fn device ->
-        socket.endpoint.subscribe("device:#{device.identifier}:internal")
+        socket.endpoint.subscribe("internal:device:#{device.id}")
 
-        payload = socket.assigns.received_connection_change_identifiers[device.identifier]
+        payload = socket.assigns.received_connection_change_identifiers[device.id]
 
         if payload do
-          {payload.device_id, payload.status}
+          {device.id, payload.status}
         else
-          {device.identifier, Tracker.connection_status(device)}
+          {device.id, Tracker.connection_status(device)}
         end
       end)
 
@@ -955,9 +948,9 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   defp transform_deployment_filter(filters), do: %{filters | deployment_id: String.to_integer(filters.deployment_id)}
 
-  defp update_device_statuses(socket, payload) do
+  defp update_device_statuses(socket, device_id, status) do
     updated_device_statuses =
-      Map.replace(socket.assigns.device_statuses.result, payload.device_id, payload.status)
+      Map.replace(socket.assigns.device_statuses.result, device_id, status)
 
     {:noreply,
      assign(

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -237,7 +237,7 @@
                   <td>
                     <div class="flex items-center gap-2">
                       <span title={connection_established_at_status(device.latest_connection)}>
-                        <%= if @device_statuses.result[device.identifier] == "online" do %>
+                        <%= if @device_statuses.result[device.id] == "online" do %>
                           <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6" fill="none">
                             <circle cx="3" cy="3" r="3" fill="#10B981" />
                           </svg>

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -41,7 +41,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
     if connected?(socket) do
       Logger.metadata(device_id: device.id, user_id: user.id, product_id: product.id)
-      socket.endpoint.subscribe("device:#{device.identifier}:internal")
+      socket.endpoint.subscribe("internal:device:#{device.id}")
       socket.endpoint.subscribe("device:console:#{device.id}:internal")
       socket.endpoint.subscribe("device:console:#{device.id}")
       socket.endpoint.subscribe("device:#{device.id}:extensions")
@@ -93,25 +93,6 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def handle_info(%Broadcast{event: "connection:heartbeat"}, socket) do
     %{device: device} = socket.assigns
 
-    {:noreply, assign(socket, :device_connection, Connections.get_latest_for_device(device.id))}
-  end
-
-  def handle_info(
-        %Broadcast{event: "connection:status", payload: %{status: "online"}},
-        %{assigns: %{device: device, current_scope: scope}} = socket
-      ) do
-    device = load_device(scope, device.identifier)
-
-    socket
-    |> general_assigns(device)
-    |> assign(:update_information, Devices.resolve_update(device))
-    |> noreply()
-  end
-
-  def handle_info(
-        %Broadcast{event: "connection:status", payload: %{status: "offline"}},
-        %{assigns: %{device: device}} = socket
-      ) do
     {:noreply, assign(socket, :device_connection, Connections.get_latest_for_device(device.id))}
   end
 

--- a/lib/nerves_hub_web/live/orgs/index.ex
+++ b/lib/nerves_hub_web/live/orgs/index.ex
@@ -60,10 +60,6 @@ defmodule NervesHubWeb.Live.Orgs.Index do
   end
 
   @impl Phoenix.LiveView
-  def handle_info(%Broadcast{event: "connection:status", payload: payload}, socket) do
-    update_device_statuses(socket, payload)
-  end
-
   def handle_info(%Broadcast{event: "connection:change", payload: payload}, socket) do
     update_device_statuses(socket, payload)
   end
@@ -74,7 +70,7 @@ defmodule NervesHubWeb.Live.Orgs.Index do
   def subscribe(%{assigns: %{pinned_devices: devices}} = socket) do
     if connected?(socket) do
       Enum.each(devices, fn device ->
-        socket.endpoint.subscribe("device:#{device.identifier}:internal")
+        socket.endpoint.subscribe("internal:device:#{device.id}")
       end)
     end
 

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -23,20 +23,20 @@ defmodule NervesHub.Devices.ConnectionsTest do
     end
 
     test "transitions through connecting -> connected -> disconnected states", %{device: device} do
-      topic = "device:#{device.identifier}:internal"
+      topic = "internal:device:#{device.id}"
       Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
 
       assert {:ok, %DeviceConnection{id: ref, status: :connecting}} =
-               Connections.device_connecting(device.id, device.identifier)
+               Connections.device_connecting(device.id)
 
       assert %DeviceConnection{status: :connecting} = Connections.get_latest_for_device(device.id)
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "connecting"}}, 500
 
-      assert :ok = Connections.device_connected(device, ref)
+      assert :ok = Connections.device_connected(ref)
       assert %DeviceConnection{status: :connected} = Connections.get_latest_for_device(device.id)
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "online"}}, 500
 
-      assert :ok = Connections.device_disconnected(device, ref)
+      assert :ok = Connections.device_disconnected(ref)
 
       assert %DeviceConnection{status: :disconnected, disconnected_at: disconnected_at} =
                Connections.get_latest_for_device(device.id)
@@ -48,19 +48,19 @@ defmodule NervesHub.Devices.ConnectionsTest do
 
   describe "device_heartbeat/2" do
     test "updates last_seen_at and broadcasts heartbeat event", %{device: device} do
-      topic = "device:#{device.identifier}:internal"
+      topic = "internal:device:#{device.id}"
       Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
 
       assert {:ok, %DeviceConnection{id: connection_id, last_seen_at: first_seen_at} = connection} =
-               Connections.device_connecting(device.id, device.identifier)
+               Connections.device_connecting(device.id)
 
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "connecting"}}, 500
 
-      assert :ok = Connections.device_connected(device, connection_id)
+      assert :ok = Connections.device_connected(connection_id)
 
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "online"}}, 500
 
-      Connections.device_heartbeat(device, connection_id)
+      Connections.device_heartbeat(connection_id)
 
       assert_receive %Broadcast{topic: ^topic, event: "connection:heartbeat"}, 500
 
@@ -74,8 +74,8 @@ defmodule NervesHub.Devices.ConnectionsTest do
 
   describe "clean_stale_connections/0" do
     test "marks stale connected connections as disconnected", %{device: device} do
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
 
       # Get the configured interval and jitter
       interval = Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
@@ -98,8 +98,8 @@ defmodule NervesHub.Devices.ConnectionsTest do
     end
 
     test "does not mark recent connections as stale", %{device: device} do
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
 
       # Set last_seen_at to recent time
       recent_time = DateTime.utc_now() |> DateTime.add(-5, :minute)

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -77,8 +77,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device1.id, device1.identifier)
-    :ok = Connections.device_connected(device1.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device1.id)
+    :ok = Connections.device_connected(connection.id)
     to_device_info(device1) |> Devices.deployment_device_online()
 
     # sent when a device is a assigned a deployment group
@@ -92,8 +92,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic2)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.identifier)
-    :ok = Connections.device_connected(device2.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device2.id)
+    :ok = Connections.device_connected(connection.id)
     to_device_info(device2) |> Devices.deployment_device_online()
 
     # and check that device2 was told to update
@@ -104,8 +104,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic3)
 
     device3 = Devices.update_deployment_group(device3, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device3.id, device3.identifier)
-    :ok = Connections.device_connected(device3.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device3.id)
+    :ok = Connections.device_connected(connection.id)
     to_device_info(device3) |> Devices.deployment_device_online()
 
     # and check that device3 isn't told to update as the concurrent limit has been reached
@@ -128,12 +128,12 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     deployment_group = Repo.preload(deployment_group, current_release: :firmware)
 
     device = Devices.update_deployment_group(device, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-    :ok = Connections.device_connected(device.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device.id)
+    :ok = Connections.device_connected(connection.id)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.identifier)
-    :ok = Connections.device_connected(device2.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device2.id)
+    :ok = Connections.device_connected(connection.id)
 
     topic1 = "device:#{device.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
@@ -193,8 +193,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     device = Devices.update_deployment_group(device, deployment_group)
     {:ok, device} = Devices.update_device(device, %{firmware_validation_status: "not_validated"})
-    {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-    :ok = Connections.device_connected(device.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device.id)
+    :ok = Connections.device_connected(connection.id)
 
     topic1 = "device:#{device.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
@@ -281,8 +281,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-added"}, 500
 
-    {:ok, connection} = Connections.device_connecting(device1.id, device1.identifier)
-    :ok = Connections.device_connected(device1.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device1.id)
+    :ok = Connections.device_connected(connection.id)
 
     to_device_info(device1) |> Devices.deployment_device_online()
 
@@ -311,8 +311,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     Mimic.reject(&Devices.available_for_update/2)
 
-    {:ok, connection} = Connections.device_connecting(device2.id, device2.identifier)
-    :ok = Connections.device_connected(device2.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device2.id)
+    :ok = Connections.device_connected(connection.id)
 
     to_device_info(device2) |> Devices.deployment_device_online()
 
@@ -414,8 +414,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     device1 = Devices.update_deployment_group(device1, deployment_group)
     {:ok, device1} = Devices.update_device(device1, %{updates_enabled: false})
 
-    {:ok, connection} = Connections.device_connecting(device1.id, device1.identifier)
-    :ok = Connections.device_connected(device1.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device1.id)
+    :ok = Connections.device_connected(connection.id)
 
     to_device_info(device1) |> Devices.deployment_device_online()
 
@@ -591,8 +591,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       Fixtures.device_fixture(org, product, other_firmware)
       |> Devices.update_deployment_group(deployment_group)
 
-    {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-    :ok = Connections.device_connected(device.identifier, connection.id)
+    {:ok, connection} = Connections.device_connecting(device.id)
+    :ok = Connections.device_connected(connection.id)
 
     deployment_group =
       Ecto.Changeset.change(deployment_group, %{is_active: false, delta_updatable: true}) |> Repo.update!()
@@ -707,13 +707,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
-      {:ok, conn3} = Connections.device_connecting(new_device.id, new_device.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id)
+      {:ok, conn3} = Connections.device_connecting(new_device.id)
 
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
-      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
-      :ok = Connections.device_connected(new_device.identifier, conn3.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
+      :ok = Connections.device_connected(conn3.id)
 
       # Test logic
       old_device1_topic = "device:#{old_device1.id}"
@@ -774,8 +774,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      :ok = Connections.device_connected(conn1.id)
       assert Orchestrator.available_priority_slots(deployment_group) == 2
 
       # Add one device to priority queue
@@ -828,11 +828,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      {:ok, conn2} = Connections.device_connecting(new_device.id, new_device.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(new_device.id)
 
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
-      :ok = Connections.device_connected(new_device.identifier, conn2.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
       # Fill priority queue
       {:ok, _} = Devices.told_to_update(old_device1, deployment_group, priority_queue: true)
 
@@ -865,8 +865,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       device = Devices.update_deployment_group(device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, conn.id)
+      {:ok, conn} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(conn.id)
 
       # Should return empty list since priority queue is disabled
       assert Devices.available_for_priority_update(deployment_group, 10) == []
@@ -904,8 +904,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(new_device.id, new_device.identifier)
-      :ok = Connections.device_connected(new_device.identifier, conn.id)
+      {:ok, conn} = Connections.device_connecting(new_device.id)
+      :ok = Connections.device_connected(conn.id)
       # new_device has version 1.5.0, threshold is 1.0.0
       available = Devices.available_for_priority_update(deployment_group, 10)
       refute Enum.any?(available, &(&1.id == new_device.id))
@@ -953,11 +953,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id)
 
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
-      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
       # old devices have versions 0.9.0 and 0.8.0, threshold is 1.0.0
       available = Devices.available_for_priority_update(deployment_group, 10)
       device_ids = Enum.map(available, & &1.id)
@@ -1020,13 +1020,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
-      {:ok, conn3} = Connections.device_connecting(new_device.id, new_device.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id)
+      {:ok, conn3} = Connections.device_connecting(new_device.id)
 
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
-      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
-      :ok = Connections.device_connected(new_device.identifier, conn3.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
+      :ok = Connections.device_connected(conn3.id)
       assert Devices.count_inflight_priority_updates_for(deployment_group) == 0
 
       {:ok, _} = Devices.told_to_update(old_device1, deployment_group, priority_queue: true)
@@ -1084,11 +1084,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      {:ok, conn2} = Connections.device_connecting(new_device.id, new_device.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(new_device.id)
 
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
-      :ok = Connections.device_connected(new_device.identifier, conn2.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
       assert Devices.count_inflight_updates_for(deployment_group) == 0
 
       {:ok, _} = Devices.told_to_update(new_device, deployment_group, priority_queue: false)
@@ -1122,8 +1122,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       device = Devices.update_deployment_group(device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, conn.id)
+      {:ok, conn} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(conn.id)
 
       assert Devices.available_for_priority_update(deployment_group, 10) == []
     end
@@ -1199,15 +1199,15 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       device_2_0 = Devices.update_deployment_group(device_2_0, deployment_group)
       device_1_1 = Devices.update_deployment_group(device_1_1, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(device_1_10.id, device_1_10.identifier)
-      {:ok, conn2} = Connections.device_connecting(device_1_9.id, device_1_9.identifier)
-      {:ok, conn3} = Connections.device_connecting(device_2_0.id, device_2_0.identifier)
-      {:ok, conn4} = Connections.device_connecting(device_1_1.id, device_1_1.identifier)
+      {:ok, conn1} = Connections.device_connecting(device_1_10.id)
+      {:ok, conn2} = Connections.device_connecting(device_1_9.id)
+      {:ok, conn3} = Connections.device_connecting(device_2_0.id)
+      {:ok, conn4} = Connections.device_connecting(device_1_1.id)
 
-      :ok = Connections.device_connected(device_1_10.identifier, conn1.id)
-      :ok = Connections.device_connected(device_1_9.identifier, conn2.id)
-      :ok = Connections.device_connected(device_2_0.identifier, conn3.id)
-      :ok = Connections.device_connected(device_1_1.identifier, conn4.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
+      :ok = Connections.device_connected(conn3.id)
+      :ok = Connections.device_connected(conn4.id)
 
       available = Devices.available_for_priority_update(deployment_group, 10)
       device_ids = Enum.map(available, & &1.id)
@@ -1279,13 +1279,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
-      {:ok, conn3} = Connections.device_connecting(new_device.id, new_device.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id)
+      {:ok, conn3} = Connections.device_connecting(new_device.id)
 
-      :ok = Connections.device_connected(old_device1.identifier, conn1.id)
-      :ok = Connections.device_connected(old_device2.identifier, conn2.id)
-      :ok = Connections.device_connected(new_device.identifier, conn3.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
+      :ok = Connections.device_connected(conn3.id)
 
       # Fill both the priority queue slot and normal queue slot
       {:ok, _} = Devices.told_to_update(old_device1.id, deployment_group, priority_queue: true)
@@ -1382,19 +1382,19 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       # Device 3 should be third (2 minutes ago)
       # Device 4 should be last (newest connection - 1 minute ago)
       now = DateTime.utc_now()
-      {:ok, conn1} = Connections.device_connecting(old_device1.id, old_device1.identifier)
+      {:ok, conn1} = Connections.device_connecting(old_device1.id)
       conn1 = Ecto.Changeset.change(conn1, established_at: DateTime.add(now, -240, :second)) |> Repo.update!()
-      {:ok, conn2} = Connections.device_connecting(old_device2.id, old_device2.identifier)
+      {:ok, conn2} = Connections.device_connecting(old_device2.id)
       conn2 = Ecto.Changeset.change(conn2, established_at: DateTime.add(now, -180, :second)) |> Repo.update!()
-      {:ok, conn3} = Connections.device_connecting(old_device3.id, old_device3.identifier)
+      {:ok, conn3} = Connections.device_connecting(old_device3.id)
       conn3 = Ecto.Changeset.change(conn3, established_at: DateTime.add(now, -120, :second)) |> Repo.update!()
-      {:ok, conn4} = Connections.device_connecting(old_device4.id, old_device4.identifier)
+      {:ok, conn4} = Connections.device_connecting(old_device4.id)
       conn4 = Ecto.Changeset.change(conn4, established_at: DateTime.add(now, -60, :second)) |> Repo.update!()
 
-      :ok = Connections.device_connected(old_device1, conn1.id)
-      :ok = Connections.device_connected(old_device2, conn2.id)
-      :ok = Connections.device_connected(old_device3, conn3.id)
-      :ok = Connections.device_connected(old_device4, conn4.id)
+      :ok = Connections.device_connected(conn1.id)
+      :ok = Connections.device_connected(conn2.id)
+      :ok = Connections.device_connected(conn3.id)
+      :ok = Connections.device_connected(conn4.id)
 
       # Give device1 enough failed update attempts to meet the failure threshold
       # The default device_failure_threshold is 3, so we'll add 3 attempts

--- a/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
@@ -19,7 +19,7 @@ defmodule NervesHubWeb.DeviceEventsStreamChannelTest do
       {:ok, _join_reply, _channel} =
         subscribe_and_join(socket, DeviceEventsStreamChannel, "device:#{device.identifier}")
 
-      NervesHubWeb.Endpoint.broadcast("device:#{device.identifier}:internal", "fwup_progress", %{
+      NervesHubWeb.Endpoint.broadcast("internal:device:#{device.id}", "fwup_progress", %{
         percent: 50
       })
 

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -340,16 +340,14 @@ defmodule NervesHubWeb.WebsocketTest do
         "nerves_fw_platform" => "test_host"
       }
 
-      subscribe_for_updates(%Device{identifier: identifier})
-
       {:ok, socket} = SocketClient.start_link(opts)
       SocketClient.join_and_wait(socket, params)
 
       assert device = Repo.get_by(Device, identifier: identifier)
 
-      assert_connection_change()
       assert_online_and_available(device)
 
+      subscribe_for_updates(device)
       close_socket_cleanly(socket)
     end
 
@@ -375,16 +373,14 @@ defmodule NervesHubWeb.WebsocketTest do
         "nerves_fw_platform" => "test_host"
       }
 
-      subscribe_for_updates(%Device{identifier: identifier})
-
       {:ok, socket} = SocketClient.start_link(opts)
       SocketClient.join_and_wait(socket, params)
 
       assert device = Repo.get_by(Device, identifier: identifier)
 
-      assert_connection_change()
       assert_online_and_available(device)
 
+      subscribe_for_updates(device)
       close_socket_cleanly(socket)
     end
 
@@ -564,14 +560,12 @@ defmodule NervesHubWeb.WebsocketTest do
         "nerves_fw_platform" => "test_host"
       }
 
-      subscribe_for_updates(%Device{identifier: identifier})
-
       {:ok, socket} = SocketClient.start_link(opts)
       SocketClient.join_and_wait(socket, params)
 
-      assert_connection_change()
-
       assert device = Repo.get_by(Device, identifier: identifier)
+
+      subscribe_for_updates(device)
 
       assert_online_and_available(device)
 
@@ -619,13 +613,9 @@ defmodule NervesHubWeb.WebsocketTest do
         "nerves_fw_platform" => "test_host"
       }
 
-      subscribe_for_updates(%Device{identifier: identifier})
-
       {:ok, socket} = SocketClient.start_link(opts)
 
       SocketClient.join_and_wait(socket, params)
-
-      assert_connection_change()
 
       assert device = Repo.get_by(Device, identifier: identifier)
       assert device_connection = Connections.get_latest_for_device(device.id)

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -80,32 +80,9 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("circle[fill='#{offline_indicator_color}']", timeout: 1000)
       |> unwrap(fn view ->
         send(view.pid, %Broadcast{
-          topic: "device:#{device.identifier}:internal",
+          topic: "internal:device:#{device.id}",
           event: "connection:change",
-          payload: %{device_id: device.identifier, status: "online"}
-        })
-
-        render(view)
-      end)
-      |> assert_has("circle[fill='#{online_indicator_color}']")
-    end
-
-    test "connection:status", %{
-      conn: conn,
-      fixture: fixture,
-      offline_indicator_color: offline_indicator_color,
-      online_indicator_color: online_indicator_color
-    } do
-      %{device: device, org: org, product: product} = fixture
-
-      conn
-      |> visit(~p"/org/#{org}/#{product}/devices")
-      |> assert_has("circle[fill='#{offline_indicator_color}']", timeout: 1000)
-      |> unwrap(fn view ->
-        send(view.pid, %Broadcast{
-          topic: "device:#{device.identifier}:internal",
-          event: "connection:status",
-          payload: %{device_id: device.identifier, status: "online"}
+          payload: %{status: "online"}
         })
 
         render(view)

--- a/test/nerves_hub_web/live/devices/show/health_tab_test.exs
+++ b/test/nerves_hub_web/live/devices/show/health_tab_test.exs
@@ -201,7 +201,7 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
       assert {7, _} = save_metrics_with_timestamp(device.id, DateTime.now!("Etc/UTC"))
 
       send(view.pid, %Broadcast{
-        topic: "device:#{device.identifier}:internal",
+        topic: "internal:device:#{device.id}",
         event: "health_check_report",
         payload: %{}
       })

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -197,8 +197,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit(device_show_path(fixture))
       |> assert_has("svg[data-connection-status=unknown]")
       |> unwrap(fn view ->
-        {:ok, connection} = Connections.device_connecting(fixture.device.id, fixture.device.identifier)
-        :ok = Connections.device_connected(fixture.device.identifier, connection.id)
+        {:ok, connection} = Connections.device_connecting(fixture.device.id)
+        :ok = Connections.device_connected(connection.id)
         render(view)
       end)
       |> assert_has("svg[data-connection-status=connected]")
@@ -220,8 +220,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       # Set device status to :provisioned for deployment group eligibility
       %{status: :provisioned} = device = Devices.set_as_provisioned!(device)
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
 
       # mismatch device and deployment group firmware so "Send Update" form doesn't display
       original_firmware_platform = device.firmware_metadata.platform
@@ -243,7 +243,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "No device health information has been received.")
       |> refute_has("div", text: "CPU use")
       |> unwrap(fn view ->
-        :ok = Connections.device_disconnected(device, connection.id)
+        :ok = Connections.device_disconnected(connection.id)
         render(view)
       end)
       |> assert_has("svg[data-connection-status=disconnected]")
@@ -261,8 +261,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
         {:ok, _} = Metrics.save_metrics(device.id, %{"cpu_usage_percent" => 22})
 
-        {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-        :ok = Connections.device_connected(device.identifier, connection.id)
+        {:ok, connection} = Connections.device_connecting(device.id)
+        :ok = Connections.device_connected(connection.id)
 
         topic = "device:#{device.id}:extensions"
         ChannelServer.broadcast!(NervesHub.PubSub, topic, "health_check_report", %{})
@@ -332,7 +332,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "Update complete: The device will reboot shortly.")
       |> unwrap(fn view ->
         send(view.pid, %Broadcast{
-          topic: "device:#{device.identifier}:internal",
+          topic: "internal:device:#{device.id}",
           event: "connection:change",
           payload: %{status: "offline"}
         })
@@ -342,7 +342,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "Update complete: The device will reboot shortly.")
       |> unwrap(fn view ->
         send(view.pid, %Broadcast{
-          topic: "device:#{device.identifier}:internal",
+          topic: "internal:device:#{device.id}",
           event: "connection:change",
           payload: %{status: "online"}
         })
@@ -374,8 +374,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{}})
 
       conn
@@ -391,8 +391,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{"latitude" => nil, "longitude" => nil}})
 
       conn
@@ -408,8 +408,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{"latitude" => "", "longitude" => ""}})
 
       conn
@@ -424,8 +424,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "location" => %{"error_code" => "BOOP", "error_description" => "BEEP"}
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
@@ -446,8 +446,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         }
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
       conn
@@ -671,8 +671,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
 
       {:ok, {_release, deployment_group}} =
         ManagedDeployments.create_deployment_release(deployment_group, firmware, nil, user, %{})
@@ -714,8 +714,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         |> Ecto.Changeset.change(%{deployment_id: deployment_group.id})
         |> Repo.update!()
 
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
 
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
@@ -942,8 +942,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
       conn
@@ -976,8 +976,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -1029,8 +1029,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -1079,8 +1079,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       Devices.update_device(device, %{firmware_metadata: metadata})
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id, device.identifier)
-      :ok = Connections.device_connected(device.identifier, connection.id)
+      {:ok, connection} = Connections.device_connecting(device.id)
+      :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
       new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -67,32 +67,9 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       |> assert_has("circle[fill='#{offline_indicator_color}']", timeout: 1000)
       |> unwrap(fn view ->
         send(view.pid, %Broadcast{
-          topic: "device:#{device.identifier}:internal",
+          topic: "internal:device:#{device.id}",
           event: "connection:change",
-          payload: %{device_id: device.identifier, status: "online"}
-        })
-
-        render(view)
-      end)
-      |> assert_has("circle[fill='#{online_indicator_color}']")
-    end
-
-    test "connection:status", %{
-      conn: conn,
-      fixture: fixture,
-      offline_indicator_color: offline_indicator_color,
-      online_indicator_color: online_indicator_color
-    } do
-      %{device: device, org: org, product: product} = fixture
-
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/devices")
-      |> assert_has("circle[fill='#{offline_indicator_color}']", timeout: 1000)
-      |> unwrap(fn view ->
-        send(view.pid, %Broadcast{
-          topic: "device:#{device.identifier}:internal",
-          event: "connection:status",
-          payload: %{device_id: device.identifier, status: "online"}
+          payload: %{status: "online"}
         })
 
         render(view)

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -74,8 +74,8 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       _ = Fixtures.device_fixture(org, product, firmware)
 
       device = Fixtures.device_fixture(org, product, firmware)
-      {:ok, device_connection} = Connections.device_connecting(device.id, device.identifier)
-      Connections.device_connected(device.identifier, device_connection.id)
+      {:ok, device_connection} = Connections.device_connecting(device.id)
+      Connections.device_connected(device_connection.id)
 
       conn
       |> visit("/org/#{org.name}")

--- a/test/nerves_hub_web/live/orgs/index_test.exs
+++ b/test/nerves_hub_web/live/orgs/index_test.exs
@@ -59,9 +59,9 @@ defmodule NervesHubWeb.Live.Orgs.IndexTest do
       _ = Fixtures.device_fixture(org, product, firmware)
 
       device = Fixtures.device_fixture(org, product, firmware)
-      {:ok, device_connection} = Connections.device_connecting(device.id, device.identifier)
+      {:ok, device_connection} = Connections.device_connecting(device.id)
 
-      Connections.device_connected(device, device_connection.id)
+      Connections.device_connected(device_connection.id)
 
       conn
       |> visit("/orgs")

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -36,7 +36,7 @@ defmodule NervesHubWeb.ChannelCase do
       @endpoint NervesHubWeb.DeviceEndpoint
 
       def subscribe_device_internal(device) do
-        Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.identifier}:internal")
+        Phoenix.PubSub.subscribe(NervesHub.PubSub, "internal:device:#{device.id}")
       end
 
       def subscribe_extensions(device) do

--- a/test/support/tracker_helper.ex
+++ b/test/support/tracker_helper.ex
@@ -3,7 +3,7 @@ defmodule TrackerHelper do
 
   defmacro subscribe_for_updates(device) do
     quote do
-      Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{unquote(device).identifier}:internal")
+      Phoenix.PubSub.subscribe(NervesHub.PubSub, "internal:device:#{unquote(device).id}")
     end
   end
 
@@ -15,9 +15,9 @@ defmodule TrackerHelper do
 
   defmacro refute_online(device) do
     quote do
-      Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{unquote(device).identifier}:internal")
+      Phoenix.PubSub.subscribe(NervesHub.PubSub, "internal:device:#{unquote(device).id}")
       NervesHub.Tracker.online?(unquote(device))
-      refute_receive %{event: "connection:status"}
+      refute_receive %{event: "connection:change"}
     end
   end
 end


### PR DESCRIPTION
- `internal:device:[device_id]` allows for pattern matching based on topic, eg. `"internal:device:" <> device_id`
- remove an unused `Tracker.confirm_online/1`, and any `handle_info`s which listened for `connection:status`
- switch to using `device.id` instead of `device.identifier` in the topics