### PR TITLE
Exclude updates-disabled devices from deployment progress

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1289,6 +1289,7 @@ defmodule NervesHub.Devices do
   def up_to_date_count(%DeploymentGroup{} = deployment_group) do
     Device
     |> where([d], d.deployment_id == ^deployment_group.id)
+    |> where([d], d.updates_enabled == true)
     |> where([d], d.firmware_metadata["uuid"] == ^deployment_group.current_release.firmware.uuid)
     |> Repo.exclude_deleted()
     |> Repo.aggregate(:count)
@@ -1305,11 +1306,30 @@ defmodule NervesHub.Devices do
   def waiting_for_update_count(%DeploymentGroup{} = deployment_group) do
     Device
     |> where([d], d.deployment_id == ^deployment_group.id)
+    |> where([d], d.updates_enabled == true)
     |> where(
       [d],
       is_nil(d.firmware_metadata) or
         d.firmware_metadata["uuid"] != ^deployment_group.current_release.firmware.uuid
     )
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+
+  @spec updates_disabled_count(DeploymentGroup.t()) :: non_neg_integer()
+  def updates_disabled_count(%DeploymentGroup{id: id}) do
+    Device
+    |> where([d], d.deployment_id == ^id)
+    |> where([d], d.updates_enabled == false)
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+
+  @spec in_penalty_box_count(DeploymentGroup.t(), DateTime.t()) :: non_neg_integer()
+  def in_penalty_box_count(%DeploymentGroup{id: id}, now \\ DateTime.utc_now()) do
+    Device
+    |> where([d], d.deployment_id == ^id)
+    |> where([d], not is_nil(d.updates_blocked_until) and d.updates_blocked_until > ^now)
     |> Repo.exclude_deleted()
     |> Repo.aggregate(:count)
   end

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -27,6 +27,8 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     |> assign(:up_to_date_count, Devices.up_to_date_count(deployment_group))
     |> assign(:waiting_for_update_count, Devices.waiting_for_update_count(deployment_group))
     |> assign(:updating_count, Devices.updating_count(deployment_group))
+    |> assign(:updates_disabled_count, Devices.updates_disabled_count(deployment_group))
+    |> assign(:in_penalty_box_count, Devices.in_penalty_box_count(deployment_group))
     |> assign(:deltas, Firmwares.get_deltas_by_target_firmware(deployment_group.current_release.firmware))
     |> ok()
   end
@@ -72,6 +74,8 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     |> assign(:up_to_date_count, Devices.up_to_date_count(deployment_group))
     |> assign(:waiting_for_update_count, Devices.waiting_for_update_count(deployment_group))
     |> assign(:updating_count, updating_count)
+    |> assign(:updates_disabled_count, Devices.updates_disabled_count(deployment_group))
+    |> assign(:in_penalty_box_count, Devices.in_penalty_box_count(deployment_group))
     |> assign(:inflight_updates, inflight_updates)
     |> assign(:firmware, deployment_group.current_release.firmware)
     |> assign(:deltas, Firmwares.get_deltas_by_target_firmware(deployment_group.current_release.firmware))
@@ -145,23 +149,34 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     ~H"""
     <div class="flex h-full flex-col items-start gap-4 p-6">
       <div :if={@waiting_for_update_count == 0} class="bg-base-900 border-base-700 w-full items-center justify-center rounded border p-4">
-        <div class="text-base-50 flex h-10 items-center justify-center text-xl/6 font-medium">All devices are up to date!</div>
+        <div class="text-base-50 flex h-10 items-center justify-center text-xl/6 font-medium">
+          {if @updates_disabled_count > 0, do: "All eligible devices are up to date!", else: "All devices are up to date!"}
+        </div>
+        <div :if={@updates_disabled_count > 0} class="text-nerves-gray-500 flex items-center justify-center text-sm">
+          {@updates_disabled_count} device(s) have updates disabled and were not counted.
+        </div>
       </div>
 
-      <div :if={@waiting_for_update_count > 0} class="bg-base-900 border-base-700 box-content flex h-24 w-full items-center justify-center rounded border">
+      <div :if={@waiting_for_update_count > 0} class="bg-base-900 border-base-700 box-content flex w-full items-center justify-center rounded border">
         <div class="relative top-0 z-20 w-full items-center justify-center overflow-visible rounded">
           <div
             :if={@deployment_group.is_active}
             class="border-success absolute -top-px z-40 rounded-tl border-t"
             role="progressbar"
-            style={"width: #{deployment_group_percentage(@up_to_date_count, @deployment_group)}%"}
+            style={"width: #{deployment_group_percentage(@up_to_date_count, @waiting_for_update_count)}%"}
           >
             <div class="progress-glow h-16 w-full animate-pulse" />
           </div>
 
           <div class="bg-surface-muted/20 my-1 flex flex-col items-center justify-center gap-1 p-2 text-sm font-medium">
-            <div class="text-base">{deployment_group_percentage(@up_to_date_count, @deployment_group)}% of devices updated</div>
+            <div class="text-base">{deployment_group_percentage(@up_to_date_count, @waiting_for_update_count)}% of eligible devices updated</div>
             <div>{@updating_count} device(s) updating - {@waiting_for_update_count} device(s) waiting</div>
+            <div :if={@in_penalty_box_count > 0} class="text-nerves-gray-500">
+              {@in_penalty_box_count} device(s) currently in the penalty box.
+            </div>
+            <div :if={@updates_disabled_count > 0} class="text-nerves-gray-500">
+              {@updates_disabled_count} device(s) have updates disabled and were not counted.
+            </div>
           </div>
         </div>
       </div>
@@ -535,10 +550,10 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     """
   end
 
-  defp deployment_group_percentage(_up_to_date_count, %{device_count: 0}), do: 0.0
+  defp deployment_group_percentage(0, 0), do: 0.0
 
-  defp deployment_group_percentage(up_to_date_count, deployment_group) do
-    floor(up_to_date_count / deployment_group.device_count * 100)
+  defp deployment_group_percentage(up_to_date_count, waiting_for_update_count) do
+    floor(up_to_date_count / (up_to_date_count + waiting_for_update_count) * 100)
   end
 
   defp assign_update_stats(socket, deployment_group) do

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -460,6 +460,94 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
+  describe "deployment progress counts" do
+    setup %{product: product, org_key: org_key, deployment_group: deployment_group, tmp_dir: tmp_dir} do
+      deployment_group = ManagedDeployments.load_current_release(deployment_group)
+      current_firmware = deployment_group.current_release.firmware
+      other_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      %{
+        deployment_group: deployment_group,
+        current_firmware: current_firmware,
+        other_firmware: other_firmware
+      }
+    end
+
+    test "up_to_date_count/1 only counts eligible devices on the current firmware",
+         %{
+           org: org,
+           product: product,
+           deployment_group: dg,
+           current_firmware: current,
+           other_firmware: other
+         } do
+      _on_current = Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id})
+      _on_other = Fixtures.device_fixture(org, product, other, %{deployment_id: dg.id})
+
+      _disabled_on_current =
+        Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id, updates_enabled: false})
+
+      _no_deployment = Fixtures.device_fixture(org, product, current, %{})
+
+      assert Devices.up_to_date_count(dg) == 1
+    end
+
+    test "waiting_for_update_count/1 only counts eligible devices not on the current firmware",
+         %{
+           org: org,
+           product: product,
+           deployment_group: dg,
+           current_firmware: current,
+           other_firmware: other
+         } do
+      _on_current = Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id})
+      _on_other = Fixtures.device_fixture(org, product, other, %{deployment_id: dg.id})
+
+      _disabled_on_other =
+        Fixtures.device_fixture(org, product, other, %{deployment_id: dg.id, updates_enabled: false})
+
+      _no_deployment = Fixtures.device_fixture(org, product, other, %{})
+
+      assert Devices.waiting_for_update_count(dg) == 1
+    end
+
+    test "updates_disabled_count/1 counts deployment devices with updates_enabled = false",
+         %{org: org, product: product, deployment_group: dg, current_firmware: current} do
+      _enabled = Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id})
+
+      _disabled_a =
+        Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id, updates_enabled: false})
+
+      _disabled_b =
+        Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id, updates_enabled: false})
+
+      _disabled_no_deployment =
+        Fixtures.device_fixture(org, product, current, %{updates_enabled: false})
+
+      assert Devices.updates_disabled_count(dg) == 2
+    end
+
+    test "in_penalty_box_count/2 only counts deployment devices with a future block timestamp",
+         %{org: org, product: product, deployment_group: dg, current_firmware: current} do
+      now = DateTime.utc_now()
+      future = DateTime.add(now, 60, :second)
+      past = DateTime.add(now, -60, :second)
+
+      _blocked_future =
+        Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id, updates_blocked_until: future})
+
+      _blocked_past =
+        Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id, updates_blocked_until: past})
+
+      _not_blocked = Fixtures.device_fixture(org, product, current, %{deployment_id: dg.id})
+
+      _blocked_no_deployment =
+        Fixtures.device_fixture(org, product, current, %{updates_blocked_until: future})
+
+      assert Devices.in_penalty_box_count(dg, now) == 1
+    end
+  end
+
   test "delete_device deletes its certificates", %{device: device} do
     [_cert] = Devices.get_device_certificates(device)
 


### PR DESCRIPTION
Devices with `updates_enabled = false` were counted as "waiting" in the deployment progress panel, so a deployment with a single user-disabled device could never reach 100%. The progress now reflects only eligible devices, and the panel surfaces how many devices are disabled or currently in the penalty box so the gap is explained.

Closes #2641