### PR TITLE
Use notice color for the delta-preparing pill (#2482)

### DIFF
--- a/lib/nerves_hub_web/live/deployment_groups/show.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.html.heex
@@ -41,7 +41,7 @@
         <div
           :if={@deployment_group.status == :preparing}
           phx-remove={JS.hide(transition: {"ease-in duration-1000", "opacity-100", "opacity-0"}, blocking: false)}
-          class="bg-warning border-base-700 pulsing-div flex items-center gap-1 rounded-full border py-0.5 pr-3 pl-2.5"
+          class="bg-notice border-base-700 pulsing-div flex items-center gap-1 rounded-full border py-0.5 pr-3 pl-2.5"
         >
           <span class="text-base-50 text-xs">Preparing: Generating Deltas</span>
         </div>


### PR DESCRIPTION
The "Preparing: Generating Deltas" pill used `bg-warning` (amber), which reads as a problem at a glance even though delta generation is just progress. Switch to `bg-notice` (indigo) so it reads as informational.