### PR TITLE
Don't crash device join when firmware_metadata is nil

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -724,7 +724,9 @@ defmodule NervesHub.Devices do
           nil ->
             # Device joined without any known firmware metadata (e.g. its
             # uboot env had no `nerves_fw_uuid`). Nothing to report against,
-            # so just persist the device-level values.
+            # so just persist the device-level values. This is unexpected,
+            # so raise a product notification to surface it.
+            _ = ProductNotifications.create_missing_firmware_metadata_notification!(device)
             attrs
 
           current_metadata ->

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -719,18 +719,27 @@ defmodule NervesHub.Devices do
         firmware_auto_revert_detected: auto_revert_detected?
       }
 
-      firmware_metadata = Map.from_struct(device.firmware_metadata)
-
       attrs =
-        DeviceFirmwares.add_or_update_reported_firmware(
-          device,
-          firmware_metadata,
-          validation_status,
-          auto_revert_detected?
-        )
-        |> case do
-          :ok -> attrs
-          {:ok, df} -> Map.put(attrs, :current_device_firmware_id, df.id)
+        case device.firmware_metadata do
+          nil ->
+            # Device joined without any known firmware metadata (e.g. its
+            # uboot env had no `nerves_fw_uuid`). Nothing to report against,
+            # so just persist the device-level values.
+            attrs
+
+          current_metadata ->
+            firmware_metadata = Map.from_struct(current_metadata)
+
+            DeviceFirmwares.add_or_update_reported_firmware(
+              device,
+              firmware_metadata,
+              validation_status,
+              auto_revert_detected?
+            )
+            |> case do
+              :ok -> attrs
+              {:ok, df} -> Map.put(attrs, :current_device_firmware_id, df.id)
+            end
         end
 
       update_device(device, attrs)

--- a/lib/nerves_hub/firmware_updates.ex
+++ b/lib/nerves_hub/firmware_updates.ex
@@ -17,6 +17,12 @@ defmodule NervesHub.FirmwareUpdates do
 
   @spec firmware_update_successful(Device.t(), FirmwareMetadata.t() | nil) ::
           {:ok, Device.t()} | {:error, Changeset.t()}
+  def firmware_update_successful(%Device{firmware_metadata: nil} = device, _previous_metadata) do
+    # Nothing meaningful to record — the device joined without a usable
+    # firmware uuid (see update_firmware_metadata/4 with nil metadata).
+    {:ok, device}
+  end
+
   def firmware_update_successful(device, previous_metadata) do
     :telemetry.execute([:nerves_hub, :devices, :update, :successful], %{count: 1}, %{
       identifier: device.identifier,

--- a/lib/nerves_hub/product_notifications.ex
+++ b/lib/nerves_hub/product_notifications.ex
@@ -130,6 +130,20 @@ defmodule NervesHub.ProductNotifications do
     |> insert_and_notify!()
   end
 
+  @spec create_missing_firmware_metadata_notification!(device :: Device.t()) :: Notification.t()
+  def create_missing_firmware_metadata_notification!(device) do
+    %Product{id: device.product_id}
+    |> Notification.new_changeset(%{
+      title: "A device connected without any firmware metadata.",
+      message:
+        "The device with the identifier '#{device.identifier}' connected but reported no firmware metadata (e.g. its uboot env had no `nerves_fw_uuid`). This is unexpected — please check the device's firmware.",
+      level: :warning,
+      metadata: %{identifier: device.identifier},
+      event_key: "missing_firmware_metadata-#{device.identifier}"
+    })
+    |> insert_and_notify!()
+  end
+
   defp insert_and_notify!(changeset) do
     conflict_query =
       Notification

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -249,6 +249,60 @@ defmodule NervesHub.DevicesTest do
       assert df.firmware_validation_status == :validated
       assert df.firmware_auto_revert_detected
     end
+
+    # Regression for #2430: a device whose uboot env never wrote a
+    # `nerves_fw_uuid` ends up with `firmware_metadata == nil`. When it
+    # joined the device channel, `update_firmware_metadata/4` was called
+    # with `nil` for `updated_metadata`, which then crashed inside
+    # `Map.from_struct(nil)` and took the channel join down with it.
+    test "tolerates a nil updated_metadata on a device with no firmware_metadata", %{
+      org: org,
+      product: product
+    } do
+      {:ok, device} =
+        Devices.create_device(%{
+          org_id: org.id,
+          product_id: product.id,
+          identifier: "device-without-firmware-metadata-#{System.unique_integer([:positive])}"
+        })
+
+      assert is_nil(device.firmware_metadata)
+
+      assert {:ok, device} =
+               Devices.update_firmware_metadata(
+                 device,
+                 nil,
+                 :validated,
+                 true
+               )
+
+      assert is_nil(device.firmware_metadata)
+      assert is_nil(device.current_device_firmware_id)
+      assert device.firmware_validation_status == :validated
+      assert device.firmware_auto_revert_detected
+      assert Repo.all(DeviceFirmware) == []
+    end
+  end
+
+  describe "firmware_update_successful/2" do
+    # Regression for #2430: when the join flow reached this function
+    # with a device that still had `firmware_metadata == nil`, the
+    # telemetry payload dereferenced `device.firmware_metadata.uuid`
+    # and crashed.
+    test "tolerates a device with no firmware_metadata", %{
+      org: org,
+      product: product
+    } do
+      {:ok, device} =
+        Devices.create_device(%{
+          org_id: org.id,
+          product_id: product.id,
+          identifier: "device-without-firmware-metadata-#{System.unique_integer([:positive])}"
+        })
+
+      assert is_nil(device.firmware_metadata)
+      assert {:ok, ^device} = Devices.firmware_update_successful(device, nil)
+    end
   end
 
   test "delete_device", %{org: org, device: device} do

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -282,6 +282,53 @@ defmodule NervesHub.DevicesTest do
       assert device.firmware_auto_revert_detected
       assert Repo.all(DeviceFirmware) == []
     end
+
+    test "raises a product notification when a device connects with no firmware_metadata", %{
+      org: org,
+      product: product
+    } do
+      {:ok, device} =
+        Devices.create_device(%{
+          org_id: org.id,
+          product_id: product.id,
+          identifier: "device-without-firmware-metadata-#{System.unique_integer([:positive])}"
+        })
+
+      assert is_nil(device.firmware_metadata)
+      assert Repo.aggregate(Notification, :count) == 0
+
+      assert {:ok, _device} =
+               Devices.update_firmware_metadata(device, nil, :validated, true)
+
+      assert [notification] = Repo.all(Notification)
+      assert notification.product_id == product.id
+      assert notification.level == :warning
+      assert notification.title == "A device connected without any firmware metadata."
+      assert notification.metadata == %{"identifier" => device.identifier}
+      assert notification.event_key == "missing_firmware_metadata-#{device.identifier}"
+      assert notification.occurrence_count == 1
+    end
+
+    test "de-duplicates the missing firmware_metadata notification across repeated connections", %{
+      org: org,
+      product: product
+    } do
+      {:ok, device} =
+        Devices.create_device(%{
+          org_id: org.id,
+          product_id: product.id,
+          identifier: "device-without-firmware-metadata-#{System.unique_integer([:positive])}"
+        })
+
+      assert {:ok, device} =
+               Devices.update_firmware_metadata(device, nil, :validated, true)
+
+      assert {:ok, _device} =
+               Devices.update_firmware_metadata(device, nil, :validated, true)
+
+      assert [notification] = Repo.all(Notification)
+      assert notification.occurrence_count == 2
+    end
   end
 
   describe "firmware_update_successful/2" do
@@ -301,7 +348,7 @@ defmodule NervesHub.DevicesTest do
         })
 
       assert is_nil(device.firmware_metadata)
-      assert {:ok, ^device} = Devices.firmware_update_successful(device, nil)
+      assert {:ok, ^device} = FirmwareUpdates.firmware_update_successful(device, nil)
     end
   end
 

--- a/test/nerves_hub/product_notifications_test.exs
+++ b/test/nerves_hub/product_notifications_test.exs
@@ -2,6 +2,7 @@ defmodule NervesHub.ProductNotificationsTest do
   use NervesHub.DataCase, async: true
 
   alias NervesHub.Accounts.Scope
+  alias NervesHub.Devices.Device
   alias NervesHub.Fixtures
   alias NervesHub.Products.Notification
   alias Phoenix.Socket.Broadcast
@@ -88,5 +89,19 @@ defmodule NervesHub.ProductNotificationsTest do
     NervesHub.ProductNotifications.subscribe(product.id)
     NervesHub.ProductNotifications.create_duplicate_device_identifier_notification!(product.id, "abc", :shared_secrets)
     assert_receive %Broadcast{event: "created"}
+  end
+
+  test "creates a notification when a device connects with no firmware metadata",
+       %{product: product} do
+    device = %Device{product_id: product.id, identifier: "no-firmware-metadata"}
+
+    notification = NervesHub.ProductNotifications.create_missing_firmware_metadata_notification!(device)
+
+    assert notification.product_id == product.id
+    assert notification.level == :warning
+    assert notification.title == "A device connected without any firmware metadata."
+    assert notification.metadata == %{identifier: device.identifier}
+    assert notification.event_key == "missing_firmware_metadata-#{device.identifier}"
+    assert notification.occurrence_count == 1
   end
 end


### PR DESCRIPTION
A device whose `firmware_metadata` is nil — e.g. a fresh row whose uboot env never reported a `nerves_fw_uuid` — would crash the device channel on join. `update_firmware_metadata/4` called `Map.from_struct(nil)` and, in older code paths, `firmware_update_successful/2` dereferenced `device.firmware_metadata.uuid`.

Skip the DeviceFirmwares report when there's no firmware metadata to attach to, and short-circuit `firmware_update_successful/2` for the same case — without metadata there's no real update to record.

Closes #2430.