### PR TITLE
Full integration of all firmware update statuses

### DIFF
--- a/lib/nerves_hub/audit_logs/templates/device_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/device_templates.ex
@@ -77,11 +77,76 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     AuditLogs.audit!(device, device, description)
   end
 
+  @spec audit_firmware_upgrade_ignored(Device.t(), DeploymentGroup.t() | nil, String.t() | nil) :: :ok
+  def audit_firmware_upgrade_ignored(device, nil, reason) do
+    description = """
+    Device #{device.identifier} ignored the manual firmware upgrade request#{reason && " because of \"#{reason}\""}.
+    """
+
+    AuditLogs.audit!(device, device, description)
+  end
+
+  def audit_firmware_upgrade_ignored(device, deployment_group, reason) do
+    description = """
+    Device #{device.identifier} ignored the scheduled firmware upgrade request#{reason && " because of \"#{reason}\""}.
+    Firmware upgrades are blocked for #{deployment_group.penalty_timeout_minutes} minutes.
+    """
+
+    AuditLogs.audit!(deployment_group, device, description)
+  end
+
   @spec audit_firmware_upgrade_blocked(DeploymentGroup.t(), Device.t()) :: :ok
   def audit_firmware_upgrade_blocked(deployment_group, device) do
     description = """
     Device #{device.identifier} automatically blocked firmware upgrades for #{deployment_group.penalty_timeout_minutes} minutes.
     Device failure rate met for firmware #{deployment_group.current_release.firmware.uuid} in deployment group #{deployment_group.name}.
+    """
+
+    AuditLogs.audit!(deployment_group, device, description)
+  end
+
+  @spec audit_firmware_upgrade_rescheduled(Device.t(), NaiveDateTime.t(), String.t() | nil) :: :ok
+  def audit_firmware_upgrade_rescheduled(
+        %{inflight_update: %{deployment_group: deployment_group}} = device,
+        blocked_until,
+        reason
+      )
+      when is_nil(deployment_group) do
+    description = """
+    During a manual firmware update request, device #{device.identifier} requested firmware upgrades be rescheduled #{Timex.from_now(blocked_until)} time #{reason && "because \"#{reason}\""}.
+    The update will not be automatically retried.
+    """
+
+    AuditLogs.audit!(device, device, description)
+  end
+
+  def audit_firmware_upgrade_rescheduled(
+        %{inflight_update: %{deployment_group: deployment_group}} = device,
+        blocked_until,
+        reason
+      ) do
+    description = """
+    During an update request from \"#{deployment_group.name}\", device #{device.identifier} requested firmware upgrades be rescheduled #{Timex.from_now(blocked_until)} time #{reason && "because \"#{reason}\""}.
+    """
+
+    AuditLogs.audit!(deployment_group, device, description)
+  end
+
+  @spec audit_firmware_upgrade_failed(Device.t(), String.t() | nil, Keyword.t()) :: :ok
+  def audit_firmware_upgrade_failed(device, reason, opts \\ [])
+
+  def audit_firmware_upgrade_failed(%{inflight_update: %{deployment_group: deployment_group}} = device, reason, _)
+      when is_nil(deployment_group) do
+    description = """
+    Device #{device.identifier} reported an error #{reason && "(\"#{reason}\") "}while trying to update its firmware.
+    """
+
+    AuditLogs.audit!(device, device, description)
+  end
+
+  def audit_firmware_upgrade_failed(%{inflight_update: %{deployment_group: deployment_group}} = device, reason, opts) do
+    description = """
+    Device #{device.identifier} reported an error #{reason && "(\"#{reason}\") "}while trying to update its firmware during a deployment release. Updates will be blocked for #{opts[:penalty_timeout_minutes]} minutes.
     """
 
     AuditLogs.audit!(deployment_group, device, description)

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -9,10 +9,9 @@ defmodule NervesHub.DeviceLink do
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
   alias NervesHub.Firmwares
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias Phoenix.Channel.Server, as: ChannelServer
-
-  require Logger
 
   defmodule DeviceInfo do
     defstruct [
@@ -111,58 +110,29 @@ defmodule NervesHub.DeviceLink do
     Connections.merge_update_metadata(reference_id, metadata)
   end
 
-  @spec status_update(device_info :: DeviceInfo.t(), status :: map(), update_started? :: boolean()) ::
-          :ok
-  def status_update(device_info, %{"status" => "started", "downloader_network_interface" => nil}, _update_started?) do
-    :telemetry.execute([:nerves_hub, :devices, :downloader_network_interface_nil], %{count: 1}, %{
-      identifier: device_info.device_identifier
-    })
+  @spec status_update(device_info :: DeviceInfo.t(), status :: map()) :: :ok
+  def status_update(device_info, %{"status" => "started"} = status_info) do
+    firmware_update_start_telemetry(device_info, status_info)
 
-    Devices.update_inflight_update(device_info.device_id, "started")
+    :ok = FirmwareUpdates.status_update("started", device_info.device_id)
 
     :ok
   end
 
-  def status_update(
-        %{device_network_interface: device_network_interface} = device_info,
-        %{"status" => "started", "downloader_network_interface" => downloader_network_interface},
-        _update_started?
-      ) do
-    Devices.update_inflight_update(device_info.device_id, "started")
+  def status_update(device_info, %{"status" => status} = status_info) do
+    cond do
+      String.contains?(String.downcase(status), "fwup error") ->
+        # a temporary hook into failed updates
+        :ok = FirmwareUpdates.status_update("failed", device_info.device_id, %{"reason" => "fwup error"})
 
-    if is_nil(device_network_interface) or
-         device_network_interface == Device.humanized_network_interface_name(downloader_network_interface) do
-      :ok
-    else
-      :telemetry.execute([:nerves_hub, :devices, :network_interface_mismatch], %{count: 1}, %{
-        downloader_network_interface: downloader_network_interface,
-        device_network_interface: device_info.device_network_interface,
-        identifier: device_info.device_identifier
-      })
+      status in ["ignored", "rescheduled", "failed"] ->
+        :ok = FirmwareUpdates.status_update(status, device_info.device_id, status_info)
 
-      :ok
+      true ->
+        :ok = FirmwareUpdates.status_update(status, device_info.device_id, status_info)
     end
-  end
 
-  def status_update(device_info, %{"status" => status}, update_started?) do
-    # a temporary hook into failed updates
-    if String.contains?(String.downcase(status), "fwup error") do
-      # if there was an error during updating
-      # mark the attempt
-      _ =
-        if update_started? do
-          Devices.update_attempted(device_info)
-        end
-
-      Devices.update_inflight_update(device_info.device_id, "failed", nil, false)
-
-      # clear the inflight update
-      Devices.clear_inflight_update(device_info)
-      :ok
-    else
-      Devices.update_inflight_update(device_info.device_id, status)
-      :ok
-    end
+    :ok
   end
 
   @spec firmware_update_progress(
@@ -172,7 +142,7 @@ defmodule NervesHub.DeviceLink do
           persist_progress :: boolean()
         ) :: :ok
   def firmware_update_progress(device_info, stage, percent, persist_progress? \\ true) do
-    Devices.update_inflight_update(device_info.device_id, stage, percent, persist_progress?)
+    FirmwareUpdates.update_inflight_update(device_info.device_id, stage, percent, persist_progress?)
   end
 
   @spec maybe_send_archive(
@@ -253,7 +223,7 @@ defmodule NervesHub.DeviceLink do
        when is_binary(uuid) and byte_size(uuid) > 0, do: :ok
 
   defp maybe_clear_inflight_update(device, _) do
-    Devices.clear_inflight_update(device)
+    FirmwareUpdates.clear_inflight_update(device)
     :ok
   end
 
@@ -287,7 +257,7 @@ defmodule NervesHub.DeviceLink do
              validation_status,
              auto_revert_detected?
            ) do
-      Devices.firmware_update_successful(device, previous_metadata)
+      FirmwareUpdates.firmware_update_successful(device, previous_metadata)
     end
   end
 
@@ -306,6 +276,33 @@ defmodule NervesHub.DeviceLink do
     params
     |> Map.get("meta", %{})
     |> Map.get("firmware_auto_revert_detected", false)
+  end
+
+  defp firmware_update_start_telemetry(%{device_identifier: identifier}, interface_info)
+       when not is_map_key(interface_info, "downloader_network_interface") do
+    :telemetry.execute([:nerves_hub, :devices, :downloader_network_interface_nil], %{count: 1}, %{
+      identifier: identifier
+    })
+  end
+
+  defp firmware_update_start_telemetry(%{device_identifier: identifier}, %{"downloader_network_interface" => nil}) do
+    :telemetry.execute([:nerves_hub, :devices, :downloader_network_interface_nil], %{count: 1}, %{
+      identifier: identifier
+    })
+  end
+
+  defp firmware_update_start_telemetry(%{device_identifier: identifier, device_network_interface: device_interface}, %{
+         "downloader_network_interface" => downloader_interface
+       }) do
+    if is_nil(device_interface) or device_interface == Device.humanized_network_interface_name(downloader_interface) do
+      :ok
+    else
+      :telemetry.execute([:nerves_hub, :devices, :network_interface_mismatch], %{count: 1}, %{
+        downloader_network_interface: downloader_interface,
+        device_network_interface: device_interface,
+        identifier: identifier
+      })
+    end
   end
 
   defp topic(%DeviceInfo{device_id: id}) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -27,7 +27,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.Devices.PinnedDevice
   alias NervesHub.Devices.SharedSecretAuth
   alias NervesHub.Devices.UpdatePayload
-  alias NervesHub.Devices.UpdateStats
   alias NervesHub.Extensions
   alias NervesHub.Filtering, as: CommonFiltering
   alias NervesHub.Firmwares
@@ -35,6 +34,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.Firmwares.FirmwareDelta
   alias NervesHub.Firmwares.FirmwareMetadata
   alias NervesHub.Firmwares.UpdateTool.Fwup
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias NervesHub.ManagedDeployments.DeploymentRelease
@@ -703,10 +703,10 @@ defmodule NervesHub.Devices do
   end
 
   @spec update_firmware_metadata(
-          Device.t(),
-          FirmwareMetadata.t() | nil,
-          Device.firmware_validation_statuses(),
-          boolean()
+          device :: Device.t(),
+          connecting_metadata :: FirmwareMetadata.t() | nil,
+          validation_status :: Device.firmware_validation_statuses(),
+          auto_revert_detected? :: boolean()
         ) ::
           {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
   def update_firmware_metadata(device, nil, validation_status, auto_revert_detected?) do
@@ -1176,7 +1176,7 @@ defmodule NervesHub.Devices do
         {:error, :up_to_date, device}
 
       updates_blocked?(device, now) ->
-        clear_inflight_update(device)
+        FirmwareUpdates.clear_inflight_update(device)
 
         {:error, :updates_blocked, device}
 
@@ -1202,7 +1202,7 @@ defmodule NervesHub.Devices do
       |> DateTime.add(deployment_group.penalty_timeout_minutes * 60, :second)
 
     :ok = DeviceTemplates.audit_firmware_upgrade_blocked(deployment_group, device)
-    _ = clear_inflight_update(device)
+    _ = FirmwareUpdates.clear_inflight_update(device)
 
     Logger.info("Device #{device.identifier} put in penalty box until #{blocked_until}")
 
@@ -1234,44 +1234,6 @@ defmodule NervesHub.Devices do
       err ->
         err
     end
-  end
-
-  @spec firmware_update_successful(Device.t(), FirmwareMetadata.t() | nil) ::
-          {:ok, Device.t()} | {:error, Changeset.t()}
-  def firmware_update_successful(device, previous_metadata) do
-    :telemetry.execute([:nerves_hub, :devices, :update, :successful], %{count: 1}, %{
-      identifier: device.identifier,
-      firmware_uuid: device.firmware_metadata.uuid
-    })
-
-    DeviceTemplates.audit_firmware_updated(device)
-
-    # Clear the inflight update, no longer inflight!
-    inflight_update =
-      Repo.get_by(InflightUpdate,
-        device_id: device.id,
-        firmware_uuid: device.firmware_metadata.uuid
-      )
-
-    _ =
-      if inflight_update do
-        if inflight_update.deployment_id do
-          DeploymentGroup
-          |> where([d], d.id == ^inflight_update.deployment_id)
-          |> Repo.update_all(inc: [current_updated_devices: 1])
-        end
-
-        Repo.delete(inflight_update)
-
-        # let the orchestrator know that an inflight update completed
-        DeploymentOrchestratorEvents.device_updated(device)
-      end
-
-    _ = UpdateStats.log_update(device, previous_metadata)
-
-    device
-    |> Device.clear_updates_information_changeset()
-    |> Repo.update()
   end
 
   def deployment_device_online(%DeviceInfo{deployment_id: nil}) do
@@ -1676,98 +1638,6 @@ defmodule NervesHub.Devices do
     |> where([d], d.product_id == ^product_id)
     |> order_by([d], fragment("?->>'platform'", d.firmware_metadata))
     |> Repo.all()
-  end
-
-  def update_inflight_update(device_id, status, progress \\ nil, persist_update? \\ true)
-
-  def update_inflight_update(device_id, status, progress, true) do
-    updated_at = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    InflightUpdate
-    |> where(device_id: ^device_id)
-    |> Repo.update_all(set: [status: status, progress: progress, updated_at: updated_at])
-    |> case do
-      {1, _} -> broadcast_inflight_update(device_id, status, progress)
-      _ -> true
-    end
-
-    :ok
-  end
-
-  def update_inflight_update(device_id, status, progress, false) do
-    broadcast_inflight_update(device_id, status, progress)
-    :ok
-  end
-
-  defp broadcast_inflight_update(device_id, status, progress) do
-    topic = "internal:device:#{device_id}"
-    payload = %{stage: status, percent: progress}
-    :ok = ChannelServer.broadcast_from!(NervesHub.PubSub, self(), topic, "firmware_update_progress", payload)
-  end
-
-  def clear_inflight_update(%DeviceInfo{device_id: id}) do
-    clear_inflight_update(id)
-  end
-
-  def clear_inflight_update(%Device{id: id}) do
-    clear_inflight_update(id)
-  end
-
-  def clear_inflight_update(device_id) do
-    InflightUpdate
-    |> where([iu], iu.device_id == ^device_id)
-    |> Repo.delete_all()
-  end
-
-  @spec delete_expired_inflight_updates() :: integer
-  def delete_expired_inflight_updates() do
-    {counts, results} =
-      InflightUpdate
-      |> join(:inner, [iu], d in assoc(iu, :device))
-      |> where([iu], iu.updated_at < fragment("NOW() - INTERVAL '30 minutes'"))
-      |> select([iu, d], %{device_id: d.id})
-      |> Repo.delete_all()
-
-    Enum.each(results, fn result ->
-      update_inflight_update(result.device_id, "expired", nil, false)
-    end)
-
-    counts
-  end
-
-  def inflight_update_for(%Device{id: device_id}) when not is_nil(device_id) do
-    InflightUpdate
-    |> where([iu], iu.device_id == ^device_id)
-    |> Repo.one()
-  end
-
-  def inflight_updates_for(%DeploymentGroup{} = deployment_group) do
-    InflightUpdate
-    |> where([iu], iu.deployment_id == ^deployment_group.id)
-    |> preload([:device])
-    |> Repo.all()
-  end
-
-  @doc """
-  Count inflight updates for a deployment group, excluding priority queue updates.
-  This ensures normal queue capacity is calculated independently.
-  """
-  def count_inflight_updates_for(%DeploymentGroup{} = deployment_group) do
-    InflightUpdate
-    |> where([iu], iu.deployment_id == ^deployment_group.id)
-    |> where([iu], iu.priority_queue == false)
-    |> Repo.aggregate(:count)
-  end
-
-  @doc """
-  Count inflight updates that are in the priority queue for a deployment group.
-  """
-  @spec count_inflight_priority_updates_for(DeploymentGroup.t()) :: non_neg_integer()
-  def count_inflight_priority_updates_for(%DeploymentGroup{} = deployment_group) do
-    InflightUpdate
-    |> where([iu], iu.deployment_id == ^deployment_group.id)
-    |> where([iu], iu.priority_queue == true)
-    |> Repo.aggregate(:count)
   end
 
   def fetch_connecting_code(device_id) do

--- a/lib/nerves_hub/devices/inflight_update.ex
+++ b/lib/nerves_hub/devices/inflight_update.ex
@@ -19,13 +19,31 @@ defmodule NervesHub.Devices.InflightUpdate do
     field(:priority_queue, :boolean, default: false)
 
     field(:status, Ecto.Enum,
-      values: [:requested, :received, :started, :downloading, :updating, :completed, :expired],
+      values: [
+        :requested,
+        :rescheduled,
+        :ignored,
+        :received,
+        :started,
+        :downloading,
+        :updating,
+        :completed,
+        :failed,
+        :expired
+      ],
       default: :requested
     )
 
     field(:progress, :integer)
 
     timestamps()
+  end
+
+  def empty_requested_changeset(device_id) do
+    %InflightUpdate{}
+    |> change(%{device_id: device_id})
+    |> validate_required([:device_id])
+    |> unique_constraint(:device_id, name: :inflight_updates_device_id_index)
   end
 
   def manual_requested_changeset(device_id, firmware) do
@@ -50,5 +68,9 @@ defmodule NervesHub.Devices.InflightUpdate do
     })
     |> validate_required([:device_id, :deployment_id, :firmware_id, :firmware_uuid])
     |> unique_constraint(:device_id, name: :inflight_updates_device_id_index)
+  end
+
+  def update_status_changeset(inflight_update, status, progress) do
+    cast(inflight_update, %{status: status, progress: progress}, [:status, :progress])
   end
 end

--- a/lib/nerves_hub/events/device_events.ex
+++ b/lib/nerves_hub/events/device_events.ex
@@ -131,12 +131,18 @@ defmodule NervesHub.DeviceEvents do
         firmware_meta: meta
       }
 
-      broadcast(device, "update", payload)
-
       :telemetry.execute([:nerves_hub, :devices, :update, :manual], %{count: 1})
 
-      {:ok, device}
+      {:ok, {device, payload}}
     end)
+    |> case do
+      {:ok, {device, payload}} ->
+        broadcast(device, "update", payload)
+        {:ok, device}
+
+      res ->
+        res
+    end
   end
 
   def topic(%Device{id: id}) do

--- a/lib/nerves_hub/firmware_updates.ex
+++ b/lib/nerves_hub/firmware_updates.ex
@@ -1,0 +1,302 @@
+defmodule NervesHub.FirmwareUpdates do
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias NervesHub.AuditLogs.DeviceTemplates
+  alias NervesHub.DeploymentOrchestratorEvents
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.Devices.UpdateStats
+  alias NervesHub.Firmwares.FirmwareMetadata
+  alias NervesHub.Helpers.Logging
+  alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.Repo
+  alias Phoenix.Channel.Server, as: ChannelServer
+
+  @spec firmware_update_successful(Device.t(), FirmwareMetadata.t() | nil) ::
+          {:ok, Device.t()} | {:error, Changeset.t()}
+  def firmware_update_successful(device, previous_metadata) do
+    :telemetry.execute([:nerves_hub, :devices, :update, :successful], %{count: 1}, %{
+      identifier: device.identifier,
+      firmware_uuid: device.firmware_metadata.uuid
+    })
+
+    Repo.transact(fn ->
+      DeviceTemplates.audit_firmware_updated(device)
+
+      device = Repo.preload(device, :inflight_update)
+
+      _ =
+        if device.inflight_update do
+          if device.inflight_update.deployment_id do
+            DeploymentGroup
+            |> where([d], d.id == ^device.inflight_update.deployment_id)
+            |> Repo.update_all(inc: [current_updated_devices: 1])
+
+            # let the orchestrator know that an inflight update completed
+            DeploymentOrchestratorEvents.device_updated(device)
+          end
+
+          # Clear the inflight update, no longer inflight!
+          Repo.delete(device.inflight_update)
+        end
+
+      _ = UpdateStats.log_update(device, previous_metadata)
+
+      device
+      |> Device.clear_updates_information_changeset()
+      |> Repo.update()
+    end)
+  end
+
+  @spec status_update(status :: String.t(), device_id :: pos_integer(), info :: map(), opts :: Keyword.t()) ::
+          :ok | {:error, any()}
+  def status_update(status, device_id, info \\ %{}, opts \\ [])
+
+  def status_update("ignored", device_id, info, _opts) do
+    do_status_update(
+      device_id,
+      "ignored",
+      %{reason: info["reason"]},
+      fn device ->
+        _ =
+          if device.inflight_update.deployment_group do
+            blocked_for_mins = device.inflight_update.deployment_group.penalty_timeout_minutes
+
+            blocked_until = DateTime.utc_now(:second) |> DateTime.add(blocked_for_mins, :minute)
+
+            {:ok, _device} = Devices.update_device(device, %{updates_blocked_until: blocked_until})
+          end
+
+        DeviceTemplates.audit_firmware_upgrade_ignored(device, device.inflight_update.deployment_group, info["reason"])
+
+        clear_inflight_update(device_id)
+      end,
+      preload: :deployment
+    )
+  end
+
+  def status_update("rescheduled", device_id, %{"delay_for" => delay_for} = info, _opts) do
+    blocked_until = NaiveDateTime.utc_now(:second) |> NaiveDateTime.add(delay_for, :millisecond)
+    payload = %{blocked_until: blocked_until, reason: info["reason"]}
+
+    callback = fn device ->
+      clear_inflight_update(device_id)
+
+      DeviceTemplates.audit_firmware_upgrade_rescheduled(
+        device,
+        blocked_until,
+        info["reason"]
+      )
+
+      if device.inflight_update.deployment_group do
+        {:ok, _device} = Devices.update_device(device, %{updates_blocked_until: blocked_until})
+      end
+    end
+
+    do_status_update(device_id, "rescheduled", payload, callback, preload: :deployment)
+  end
+
+  def status_update("failed", device_id, info, _opts) do
+    do_status_update(
+      device_id,
+      "failed",
+      %{reason: info["reason"]},
+      fn device ->
+        clear_inflight_update(device_id)
+
+        if device.inflight_update.deployment_group do
+          blocked_for_mins = device.inflight_update.deployment_group.penalty_timeout_minutes
+
+          blocked_until = DateTime.utc_now(:second) |> DateTime.add(blocked_for_mins, :minute)
+
+          DeviceTemplates.audit_firmware_upgrade_failed(device, info["reason"],
+            penalty_timeout_minutes: blocked_for_mins
+          )
+
+          {:ok, _device} = Devices.update_device(device, %{updates_blocked_until: blocked_until})
+        else
+          DeviceTemplates.audit_firmware_upgrade_failed(device, nil, info["reason"])
+        end
+      end,
+      preload: :deployment
+    )
+  end
+
+  def status_update(status, device_id, info, _opts) when status in ["downloading", "updating"] do
+    do_status_update(device_id, status, info, fn %{inflight_update: ifu} ->
+      if to_string(ifu.status) != status or should_persist?(ifu) do
+        InflightUpdate.update_status_changeset(ifu, status, info["progress"])
+        |> Repo.update!()
+      end
+    end)
+  end
+
+  def status_update(status, device_id, info, _opts) do
+    do_status_update(device_id, status, info, fn device ->
+      InflightUpdate.update_status_changeset(device.inflight_update, status, nil)
+      |> Repo.update!()
+    end)
+  end
+
+  defp do_status_update(device_id, status, payload, update_fn, opts \\ []) do
+    Repo.transaction(fn ->
+      device =
+        fetch_device(device_id, opts)
+        |> maybe_update_update_attempts()
+
+      update_fn.(device)
+
+      broadcast_firmware_update_status!(device_id, status, payload)
+
+      {:ok, device}
+    end)
+    |> case do
+      {:ok, _device} ->
+        :ok
+
+      {:error, reason} ->
+        Logging.log_message_to_sentry("Error updating inflight update status", %{reason: reason})
+        {:error, reason}
+    end
+  end
+
+  def update_inflight_update(device_id, status, progress \\ nil, persist_update? \\ true)
+
+  def update_inflight_update(device_id, status, progress, true) do
+    updated_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    InflightUpdate
+    |> where(device_id: ^device_id)
+    |> Repo.update_all(set: [status: status, progress: progress, updated_at: updated_at])
+    |> case do
+      {1, _} -> broadcast_firmware_update_status!(device_id, status, %{percent: progress})
+      _ -> true
+    end
+
+    :ok
+  end
+
+  def update_inflight_update(device_id, status, progress, false) do
+    broadcast_firmware_update_status!(device_id, status, %{percent: progress})
+    :ok
+  end
+
+  def clear_inflight_update(%DeviceInfo{device_id: id}) do
+    clear_inflight_update(id)
+  end
+
+  def clear_inflight_update(%Device{id: id}) do
+    clear_inflight_update(id)
+  end
+
+  def clear_inflight_update(device_id) do
+    InflightUpdate
+    |> where([iu], iu.device_id == ^device_id)
+    |> Repo.delete_all()
+  end
+
+  @spec delete_expired_inflight_updates() :: integer
+  def delete_expired_inflight_updates() do
+    {counts, results} =
+      InflightUpdate
+      |> join(:inner, [iu], d in assoc(iu, :device))
+      |> where([iu], iu.updated_at < fragment("NOW() - INTERVAL '30 minutes'"))
+      |> select([iu, d], %{device_id: d.id})
+      |> Repo.delete_all()
+
+    Enum.each(results, fn result ->
+      update_inflight_update(result.device_id, "expired", nil, false)
+    end)
+
+    counts
+  end
+
+  def inflight_update_for(%Device{id: device_id}) when not is_nil(device_id) do
+    InflightUpdate
+    |> where([iu], iu.device_id == ^device_id)
+    |> Repo.one()
+  end
+
+  def inflight_updates_for(%DeploymentGroup{} = deployment_group) do
+    InflightUpdate
+    |> where([iu], iu.deployment_id == ^deployment_group.id)
+    |> preload([:device])
+    |> Repo.all()
+  end
+
+  @doc """
+  Count inflight updates for a deployment group, excluding priority queue updates.
+  This ensures normal queue capacity is calculated independently.
+  """
+  def count_inflight_updates_for(%DeploymentGroup{} = deployment_group) do
+    InflightUpdate
+    |> where([iu], iu.deployment_id == ^deployment_group.id)
+    |> where([iu], iu.priority_queue == false)
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Count inflight updates that are in the priority queue for a deployment group.
+  """
+  @spec count_inflight_priority_updates_for(DeploymentGroup.t()) :: non_neg_integer()
+  def count_inflight_priority_updates_for(%DeploymentGroup{} = deployment_group) do
+    InflightUpdate
+    |> where([iu], iu.deployment_id == ^deployment_group.id)
+    |> where([iu], iu.priority_queue == true)
+    |> Repo.aggregate(:count)
+  end
+
+  defp broadcast_firmware_update_status!(device_id, status, extra_info) do
+    topic = "internal:device:#{device_id}"
+    payload = Map.put(extra_info, :stage, status)
+    ChannelServer.broadcast_from!(NervesHub.PubSub, self(), topic, "firmware_update_progress", payload)
+  end
+
+  defp maybe_update_update_attempts(%{inflight_update: %{status: :requested}} = device) do
+    {1, _} =
+      Device
+      |> where(id: ^device.id)
+      |> update(push: [update_attempts: ^DateTime.utc_now(:second)])
+      |> Repo.update_all([])
+
+    device
+  end
+
+  defp maybe_update_update_attempts(device), do: device
+
+  defp fetch_device(device_id, opts) do
+    Device
+    |> join(:left, [d], ifu in assoc(d, :inflight_update))
+    |> then(fn query ->
+      if opts[:preload] == :deployment do
+        join(query, :left, [d, ifu], d in assoc(ifu, :deployment_group))
+        |> join(:left, [d, ifu, dg], cr in assoc(dg, :current_release))
+        |> preload([d, ifu, dg, cr], inflight_update: {ifu, deployment_group: {dg, current_release: cr}})
+      else
+        preload(query, [d, ifu], inflight_update: ifu)
+      end
+    end)
+    |> select([d, ifu], [:id, :identifier, :product_id, :org_id, :update_attempts, :updates_blocked_until])
+    |> where([d], d.id == ^device_id)
+    |> Repo.one!()
+    |> case do
+      %{inflight_update: nil} = device ->
+        inflight_update =
+          InflightUpdate.empty_requested_changeset(device.id)
+          |> Repo.insert!()
+
+        Map.put(device, :inflight_update, inflight_update)
+
+      device ->
+        device
+    end
+  end
+
+  defp should_persist?(ifu) do
+    some_secs_ago = NaiveDateTime.utc_now() |> NaiveDateTime.add(-15, :second)
+    NaiveDateTime.before?(ifu.updated_at, some_secs_ago)
+  end
+end

--- a/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
+++ b/lib/nerves_hub/managed_deployments/distributed/orchestrator.ex
@@ -13,6 +13,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias Phoenix.PubSub
@@ -173,7 +174,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
   def available_priority_slots(deployment_group) do
     # Just in case inflight goes higher than concurrent, limit it to 0
     (deployment_group.priority_queue_concurrent_updates -
-       Devices.count_inflight_priority_updates_for(deployment_group))
+       FirmwareUpdates.count_inflight_priority_updates_for(deployment_group))
     |> max(0)
     |> round()
   end
@@ -185,7 +186,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.Orchestrator do
   @spec available_slots(DeploymentGroup.t()) :: non_neg_integer()
   def available_slots(deployment_group) do
     # Just in case inflight goes higher than concurrent, limit it to 0
-    (deployment_group.concurrent_updates - Devices.count_inflight_updates_for(deployment_group))
+    (deployment_group.concurrent_updates - FirmwareUpdates.count_inflight_updates_for(deployment_group))
     |> max(0)
     |> round()
   end

--- a/lib/nerves_hub/workers/expire_inflight_updates.ex
+++ b/lib/nerves_hub/workers/expire_inflight_updates.ex
@@ -9,13 +9,13 @@ defmodule NervesHub.Workers.ExpireInflightUpdates do
     queue: :cleanup,
     max_attempts: 1
 
-  alias NervesHub.Devices
+  alias NervesHub.FirmwareUpdates
 
   require Logger
 
   @impl Oban.Worker
   def perform(_) do
-    count = Devices.delete_expired_inflight_updates()
+    count = FirmwareUpdates.delete_expired_inflight_updates()
 
     if count > 0 && prod?() do
       Logger.info("Expired #{count} inflight updates")

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -42,7 +42,6 @@ defmodule NervesHubWeb.DeviceChannel do
         socket =
           socket
           |> assign(:currently_downloading_uuid, params["currently_downloading_uuid"])
-          |> assign(:update_started?, !!params["currently_downloading_uuid"])
           |> assign(:device_api_version, params["device_api_version"])
           |> update_device_info(device_info)
 
@@ -169,19 +168,9 @@ defmodule NervesHubWeb.DeviceChannel do
         {stage, _} -> {stage, percent}
       end
 
-    last_progress = socket.assigns[:last_firmware_update_progress]
-    now = System.monotonic_time(:second)
+    DeviceLink.status_update(device_info, %{"status" => stage, "progress" => percent})
 
-    {persist_progress?, socket} =
-      if last_progress == nil or abs(last_progress - now) > 10 do
-        {true, assign(socket, :last_firmware_update_progress, now)}
-      else
-        {false, socket}
-      end
-
-    DeviceLink.firmware_update_progress(device_info, stage, percent, persist_progress?)
-
-    {:noreply, maybe_update_update_attempts(socket)}
+    {:noreply, socket}
   end
 
   @decorate with_span("Channels.DeviceChannel.handle_in:connection_types")
@@ -195,16 +184,8 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   @decorate with_span("Channels.DeviceChannel.handle_in:status_update")
-  def handle_in("status_update", %{"stage" => "started"} = params, socket) do
-    socket = maybe_update_update_attempts(socket)
-
-    DeviceLink.status_update(socket.assigns.device_info, params, socket.assigns.update_started?)
-
-    {:noreply, socket}
-  end
-
   def handle_in("status_update", params, socket) do
-    DeviceLink.status_update(socket.assigns.device_info, params, socket.assigns.update_started?)
+    DeviceLink.status_update(socket.assigns.device_info, params)
 
     {:noreply, socket}
   end
@@ -294,19 +275,6 @@ defmodule NervesHubWeb.DeviceChannel do
   defp maybe_sanitize_device_api_version(params) do
     Logger.warning("[DeviceChannel] device_api_version is missing from the connection params")
     Map.put(params, "device_api_version", "1.0.0")
-  end
-
-  # if we know the update has already started, we can move on
-  def maybe_update_update_attempts(%{assigns: %{update_started?: true}} = socket), do: socket
-
-  # if this is the first fwup we see, and we didn't know the update had already started,
-  # then mark it as an update attempt
-  #
-  # we don't need to store the result as this information isn't used anywhere else
-  def maybe_update_update_attempts(socket) do
-    :ok = Devices.update_attempted(socket.assigns.device_info)
-
-    assign(socket, :update_started?, true)
   end
 
   defp send_connecting_code(nil, _, _), do: :ok

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -7,6 +7,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
   alias NervesHub.Devices
   alias NervesHub.Devices.UpdateStats
   alias NervesHub.Firmwares
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias Phoenix.Naming
 
@@ -20,7 +21,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
   def update(%{event: :update_inflight_info}, socket) do
     %{deployment_group: deployment_group} = socket.assigns
 
-    inflight_updates = Devices.inflight_updates_for(deployment_group)
+    inflight_updates = FirmwareUpdates.inflight_updates_for(deployment_group)
 
     socket
     |> assign(:inflight_updates, inflight_updates)
@@ -60,7 +61,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
   def update(assigns, socket) do
     %{deployment_group: deployment_group} = assigns
 
-    inflight_updates = Devices.inflight_updates_for(deployment_group)
+    inflight_updates = FirmwareUpdates.inflight_updates_for(deployment_group)
     updating_count = Devices.updating_count(deployment_group)
 
     socket

--- a/lib/nerves_hub_web/components/fwup_progress.ex
+++ b/lib/nerves_hub_web/components/fwup_progress.ex
@@ -5,40 +5,11 @@ defmodule NervesHubWeb.Components.FwupProgress do
   attr(:stage, :any)
 
   def render(assigns) do
-    assigns = assign(assigns, :stage, to_string(assigns.stage))
-
     assigns =
-      if assigns.stage in ["downloading", "updating"] do
-        assigns
-      else
-        assign(assigns, :progress, 100)
-      end
-
-    message =
-      case assigns.stage do
-        "requested" ->
-          "Firmware update request sent to the device"
-
-        "received" ->
-          "Firmware update request received by the device"
-
-        "started" ->
-          "Firmware update started..."
-
-        stage when stage in ["downloading", "updating"] ->
-          "#{String.capitalize(assigns.stage)} firmware : #{assigns.progress}%"
-
-        "completed" ->
-          "Firmware update complete, waiting for device to restart"
-
-        "expired" ->
-          "Firmware update aborted - no updates received"
-
-        _ ->
-          ""
-      end
-
-    assigns = assign(assigns, :message, message)
+      assigns
+      |> assign(:stage, to_string(assigns.stage))
+      |> assign_progress()
+      |> assign_message()
 
     ~H"""
     <div class="relative -top-[11px] z-100 flex h-0 w-full justify-center">
@@ -50,5 +21,26 @@ defmodule NervesHubWeb.Components.FwupProgress do
       </div>
     </div>
     """
+  end
+
+  defp assign_message(assigns) do
+    assign(assigns, :message, format_message(assigns))
+  end
+
+  defp format_message(%{stage: "requested"}), do: "Firmware update request sent to the device"
+  defp format_message(%{stage: "rescheduled"}), do: "The device has requested firmware updates be delayed"
+  defp format_message(%{stage: "ignored"}), do: "The device has ignored the firmware update request"
+  defp format_message(%{stage: "received"}), do: "Firmware update request received by the device"
+  defp format_message(%{stage: "started"}), do: "Firmware update started..."
+  defp format_message(%{stage: "completed"}), do: "Firmware update complete, waiting for device to restart"
+  defp format_message(%{stage: "expired"}), do: "Firmware update aborted - no updates received"
+  defp format_message(%{stage: stage, progress: progress}), do: "#{String.capitalize(stage)} firmware : #{progress}%"
+
+  defp assign_progress(assigns) do
+    if assigns.stage in ["downloading", "updating"] do
+      assigns
+    else
+      assign(assigns, :progress, 100)
+    end
   end
 end

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
   alias NervesHub.AuditLogs.DeploymentGroupTemplates
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Helpers.Logging
   alias NervesHub.ManagedDeployments
   alias NervesHubWeb.Components.DeploymentGroupPage.Activity, as: ActivityTab
@@ -245,7 +246,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
 
     %{assigns: %{deployment_group: deployment_group}} = socket
 
-    inflight_updates = Devices.inflight_updates_for(deployment_group)
+    inflight_updates = FirmwareUpdates.inflight_updates_for(deployment_group)
 
     send_update(SummaryTab, id: "deployment_group_summary", event: :update_inflight_info)
 

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -10,6 +10,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.Metrics
   alias NervesHub.Firmwares
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias NervesHub.Products
   alias NervesHub.Tracker
@@ -982,7 +983,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
 
   defp update_firmware_progress(%{assigns: %{progress: progress}} = socket, device_id) do
     %Device{id: device_id}
-    |> Devices.inflight_update_for()
+    |> FirmwareUpdates.inflight_update_for()
     |> case do
       nil -> Map.delete(progress, device_id)
       ifu -> Map.put(progress, device_id, %{stage: ifu.status, percent: ifu.progress})
@@ -1094,9 +1095,8 @@ defmodule NervesHubWeb.Live.Devices.Index do
     )
   end
 
-  defp progress_style(nil) do
-    nil
-  end
+  defp progress_style(nil), do: nil
+  defp progress_style(%{percent: nil}), do: nil
 
   defp progress_style(progress_info) do
     """

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -6,6 +6,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
   alias NervesHub.Extensions.Health
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Tracker
   alias NervesHubWeb.Components.DevicePage.ActivityTab
   alias NervesHubWeb.Components.DevicePage.ConsoleTab
@@ -333,7 +334,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
   defp load_inprogress_firmware_update(socket) do
     socket.assigns.device
-    |> Devices.inflight_update_for()
+    |> FirmwareUpdates.inflight_update_for()
     |> case do
       nil ->
         socket

--- a/priv/repo/migrations/20260602032150_change_inflight_update_firmware_columns.exs
+++ b/priv/repo/migrations/20260602032150_change_inflight_update_firmware_columns.exs
@@ -1,0 +1,13 @@
+defmodule NervesHub.Repo.Migrations.ChangeInflightUpdateFirmwareColumns do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change() do
+    alter table(:inflight_updates) do
+      modify(:firmware_id, :integer, null: true)
+      modify(:firmware_uuid, :uuid, null: true)
+    end
+  end
+end

--- a/test/nerves_hub/device_link_test.exs
+++ b/test/nerves_hub/device_link_test.exs
@@ -2,6 +2,7 @@ defmodule NervesHub.DeviceLinkTest do
   use NervesHub.DataCase, async: true
   use Mimic
 
+  alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.DeviceLink
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
@@ -31,7 +32,249 @@ defmodule NervesHub.DeviceLinkTest do
   end
 
   describe "status_update/2" do
-    test "clears inflight update when status contains 'encountered fwup error'", %{
+    test "creates an InflightUpdate if none exists", %{device: device} do
+      # Verify no InflightUpdates exists
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "started"})
+
+      # Verify the inflight update was created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "manually requested firmware update is ignored by the device", %{device: device, firmware: firmware} do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "ignored"})
+
+      device = Repo.reload!(device)
+
+      assert is_nil(device.updates_blocked_until)
+
+      [_, audit_log] = Repo.all(AuditLog)
+      assert audit_log.description =~ "ignored the manual firmware upgrade request"
+
+      # Verify the inflight update is cleared
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "deployment scheduled firmware update is ignored by the device", %{
+      device: device,
+      deployment_group: deployment_group
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, deployment_group)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "ignored"})
+
+      device = Repo.reload!(device)
+
+      refute is_nil(device.updates_blocked_until)
+
+      [_, audit_log] = Repo.all(AuditLog)
+      assert audit_log.description =~ "ignored the scheduled firmware upgrade request"
+
+      # Verify the inflight update is cleared
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "the device requests that the deployment scheduled firmware update is rescheduled", %{
+      device: device,
+      deployment_group: deployment_group
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, deployment_group)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok =
+        DeviceLink.status_update(to_device_info(device), %{
+          "status" => "rescheduled",
+          "delay_for" => to_timeout(minute: 15)
+        })
+
+      device = Repo.reload!(device)
+
+      refute is_nil(device.updates_blocked_until)
+
+      [_, audit_log] = Repo.all(AuditLog)
+      assert audit_log.description =~ "requested firmware upgrades be rescheduled"
+
+      # Verify the inflight update is cleared
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "the device requests that the manual requested firmware update is rescheduled", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok =
+        DeviceLink.status_update(to_device_info(device), %{
+          "status" => "rescheduled",
+          "delay_for" => to_timeout(minute: 15)
+        })
+
+      device = Repo.reload!(device)
+
+      assert is_nil(device.updates_blocked_until)
+
+      [_, audit_log] = Repo.all(AuditLog)
+      assert audit_log.description =~ "requested firmware upgrades be rescheduled"
+      assert audit_log.description =~ "The update will not be automatically retried"
+
+      # Verify the inflight update is cleared
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "a firmware update scheduled by a deployment fails", %{
+      device: device,
+      deployment_group: deployment_group
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, deployment_group)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "failed"})
+
+      device = Repo.reload!(device)
+
+      refute is_nil(device.updates_blocked_until)
+
+      [_, audit_log] = Repo.all(AuditLog)
+      assert audit_log.description =~ "reported an error while trying to update its firmware"
+
+      # Verify the inflight update is cleared
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "a manually requested firmware update fails", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "failed"})
+
+      device = Repo.reload!(device)
+
+      assert is_nil(device.updates_blocked_until)
+
+      [_, audit_log] = Repo.all(AuditLog)
+      assert audit_log.description =~ "reported an error while trying to update its firmware"
+
+      # Verify the inflight update is cleared
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "downloading progress is only updated at most after 15 seconds", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, inflight_update} = Fixtures.inflight_update(device, firmware)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "downloading", "progress" => 15})
+
+      inflight_update = Repo.reload!(inflight_update)
+      assert inflight_update.progress == 15
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "downloading", "progress" => 30})
+      inflight_update = Repo.reload!(inflight_update)
+      refute inflight_update.progress == 30
+
+      {1, _} =
+        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-14, :second)])
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "downloading", "progress" => 30})
+      inflight_update = Repo.reload!(inflight_update)
+      refute inflight_update.progress == 30
+
+      {1, _} =
+        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-16, :second)])
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "downloading", "progress" => 30})
+      inflight_update = Repo.reload!(inflight_update)
+      assert inflight_update.progress == 30
+    end
+
+    test "updating progress is only updated at most after 15 seconds", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, inflight_update} = Fixtures.inflight_update(device, firmware)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "updating", "progress" => 15})
+
+      inflight_update = Repo.reload!(inflight_update)
+      assert inflight_update.progress == 15
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "updating", "progress" => 30})
+      inflight_update = Repo.reload!(inflight_update)
+      refute inflight_update.progress == 30
+
+      {1, _} =
+        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-14, :second)])
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "updating", "progress" => 30})
+      inflight_update = Repo.reload!(inflight_update)
+      refute inflight_update.progress == 30
+
+      {1, _} =
+        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-16, :second)])
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "downloading", "progress" => 30})
+      inflight_update = Repo.reload!(inflight_update)
+      assert inflight_update.progress == 30
+    end
+
+    test "the firmware update completes successfully", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
+
+      # Verify a InflightUpdate is created
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "completed"})
+
+      device = Repo.reload!(device)
+
+      assert is_nil(device.updates_blocked_until)
+
+      # Verify the inflight update is not cleared
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
+    end
+
+    test "clears a device's InflightUpdate when status contains \"encountered fwup error\"", %{
       device: device,
       deployment_group: deployment_group
     } do
@@ -39,25 +282,16 @@ defmodule NervesHub.DeviceLinkTest do
       {:ok, _inflight_update} = Fixtures.inflight_update(device, deployment_group)
 
       # Verify the inflight update exists
-      assert [%InflightUpdate{}] =
-               InflightUpdate
-               |> Repo.all()
-               |> Repo.preload([:device])
-               |> Enum.filter(&(&1.device_id == device.id))
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
 
       # Call status_update with a status containing "encountered fwup error"
-      :ok =
-        DeviceLink.status_update(to_device_info(device), %{"status" => "Update failed: encountered fwup error"}, true)
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "Update failed: encountered fwup error"})
 
       # Verify the inflight update was cleared
-      assert [] =
-               InflightUpdate
-               |> Repo.all()
-               |> Repo.preload([:device])
-               |> Enum.filter(&(&1.device_id == device.id))
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
     end
 
-    test "clears inflight update when status contains 'FWUP error: failure of some sort'", %{
+    test "clears a device's InflightUpdate when status contains \"fwup error\"", %{
       device: device,
       deployment_group: deployment_group
     } do
@@ -65,24 +299,16 @@ defmodule NervesHub.DeviceLinkTest do
       {:ok, _inflight_update} = Fixtures.inflight_update(device, deployment_group)
 
       # Verify the inflight update exists
-      assert [%InflightUpdate{}] =
-               InflightUpdate
-               |> Repo.all()
-               |> Repo.preload([:device])
-               |> Enum.filter(&(&1.device_id == device.id))
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
 
       # Call status_update with a status containing "FWUP error: failure of some sort"
-      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "FWUP error: failure of some sort"}, true)
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "FWUP error: failure of some sort"})
 
       # Verify the inflight update was cleared
-      assert [] =
-               InflightUpdate
-               |> Repo.all()
-               |> Repo.preload([:device])
-               |> Enum.filter(&(&1.device_id == device.id))
+      refute Repo.exists?(where(InflightUpdate, device_id: ^device.id))
     end
 
-    test "does not clear inflight update when status does not contain fwup error", %{
+    test "does not clear a devices InflightUpdate when status does not contain \"fwup error\"", %{
       device: device,
       deployment_group: deployment_group
     } do
@@ -90,24 +316,22 @@ defmodule NervesHub.DeviceLinkTest do
       {:ok, _inflight_update} = Fixtures.inflight_update(device, deployment_group)
 
       # Verify the inflight update exists
-      assert [%InflightUpdate{}] =
-               InflightUpdate
-               |> Repo.all()
-               |> Repo.preload([:device])
-               |> Enum.filter(&(&1.device_id == device.id))
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
 
       # Call status_update with a status that does not contain "fwup error"
-      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "updating"}, true)
+      :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "updating"})
 
       # Verify the inflight update still exists
-      assert [%InflightUpdate{}] =
-               InflightUpdate
-               |> Repo.all()
-               |> Repo.preload([:device])
-               |> Enum.filter(&(&1.device_id == device.id))
+      assert Repo.exists?(where(InflightUpdate, device_id: ^device.id))
     end
 
-    test "'started' messages from device execute telemetry when there's a network interface mismatch", %{device: device} do
+    test "'started' messages from device execute telemetry when there's a network interface mismatch", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
+
       {:ok, _device} = Devices.update_network_interface(device.id, "wlan0")
 
       expect(:telemetry, :execute, fn _event, _measurements, metadata ->
@@ -118,24 +342,22 @@ defmodule NervesHub.DeviceLinkTest do
       device_info = Repo.reload(device) |> to_device_info()
 
       :ok =
-        DeviceLink.status_update(
-          device_info,
-          %{"status" => "started", "downloader_network_interface" => "eth0"},
-          false
-        )
+        DeviceLink.status_update(device_info, %{"status" => "started", "downloader_network_interface" => "eth0"})
     end
 
-    test "'started' messages from device do not blow up if downloader network interface is nil", %{device: device} do
+    test "'started' messages from device do not blow up if downloader network interface is nil", %{
+      device: device,
+      firmware: firmware
+    } do
+      # Create an inflight update
+      {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
+
       expect(:telemetry, :execute, fn _event, _measurements, metadata ->
         assert metadata.identifier == device.identifier
       end)
 
       :ok =
-        DeviceLink.status_update(
-          to_device_info(device),
-          %{"status" => "started", "downloader_network_interface" => nil},
-          false
-        )
+        DeviceLink.status_update(to_device_info(device), %{"status" => "started", "downloader_network_interface" => nil})
     end
   end
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -20,6 +20,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Firmware
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentRelease
@@ -807,7 +808,7 @@ defmodule NervesHub.DevicesTest do
       device = Repo.reload(device)
       assert Enum.count(device.update_attempts) == 1
 
-      {:ok, device} = Devices.firmware_update_successful(device, device.firmware_metadata)
+      {:ok, device} = FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
       assert Enum.empty?(device.update_attempts)
     end
 
@@ -819,7 +820,7 @@ defmodule NervesHub.DevicesTest do
 
       {:ok, inflight_update} = DeviceEvents.schedule_update(device.id, deployment_group)
 
-      {:ok, _device} = Devices.firmware_update_successful(device, device.firmware_metadata)
+      {:ok, _device} = FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
 
       inflight_update = Repo.reload(inflight_update)
       assert is_nil(inflight_update)
@@ -835,7 +836,7 @@ defmodule NervesHub.DevicesTest do
 
       {:ok, _inflight_update} = DeviceEvents.schedule_update(device.id, deployment_group)
 
-      {:ok, _device} = Devices.firmware_update_successful(device, device.firmware_metadata)
+      {:ok, _device} = FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
 
       deployment_group = Repo.reload(deployment_group)
       assert deployment_group.current_updated_devices == 1
@@ -925,7 +926,7 @@ defmodule NervesHub.DevicesTest do
 
       assert device.updates_blocked_until
       assert device.update_attempts == []
-      assert Devices.count_inflight_updates_for(deployment_group) == 0
+      assert FirmwareUpdates.count_inflight_updates_for(deployment_group) == 0
     end
 
     test "device should be rejected for updates based on attempt rate and have it's inflight updates cleared",
@@ -951,7 +952,7 @@ defmodule NervesHub.DevicesTest do
 
       assert device.updates_blocked_until
       assert device.update_attempts == []
-      assert Devices.count_inflight_updates_for(deployment_group) == 0
+      assert FirmwareUpdates.count_inflight_updates_for(deployment_group) == 0
     end
 
     test "device in penalty box should be rejected for updates and have it's inflight updates cleared",
@@ -970,7 +971,7 @@ defmodule NervesHub.DevicesTest do
       {:error, :updates_blocked, _device} =
         Devices.verify_update_eligibility(device, deployment_group, now)
 
-      assert Devices.count_inflight_updates_for(deployment_group) == 0
+      assert FirmwareUpdates.count_inflight_updates_for(deployment_group) == 0
 
       # now
       device = %{device | updates_blocked_until: now}
@@ -1047,9 +1048,9 @@ defmodule NervesHub.DevicesTest do
 
       refute_receive %Broadcast{topic: ^topic, event: "firmware_update_progress", payload: %{stage: "expired"}}, 1_000
 
-      assert 0 = Devices.delete_expired_inflight_updates()
+      assert 0 = FirmwareUpdates.delete_expired_inflight_updates()
 
-      Devices.clear_inflight_update(device)
+      FirmwareUpdates.clear_inflight_update(device)
 
       Fixtures.inflight_update(device, deployment_group)
 
@@ -1063,7 +1064,7 @@ defmodule NervesHub.DevicesTest do
                |> where([i], i.device_id == ^device.id)
                |> Repo.update_all(set: [updated_at: updated_at])
 
-      task = Task.async(fn -> Devices.delete_expired_inflight_updates() end)
+      task = Task.async(fn -> FirmwareUpdates.delete_expired_inflight_updates() end)
 
       assert 1 = Task.await(task)
 

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -12,6 +12,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.UpdateTool.Fwup
   alias NervesHub.Firmwares.Upload.File
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.Distributed.Orchestrator
@@ -166,7 +167,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     {:ok, device} =
       Devices.update_device(device, %{firmware_metadata: %{"uuid" => deployment_group.current_release.firmware.uuid}})
 
-    Devices.firmware_update_successful(device, device.firmware_metadata)
+    FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
 
     # sent by the device after its updated
     assert_receive %Broadcast{topic: ^topic1, event: "updated"}, 500
@@ -1028,17 +1029,17 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
       :ok = Connections.device_connected(conn3.id)
-      assert Devices.count_inflight_priority_updates_for(deployment_group) == 0
+      assert FirmwareUpdates.count_inflight_priority_updates_for(deployment_group) == 0
 
       {:ok, _inflight_update} = DeviceEvents.schedule_update(old_device1.id, deployment_group, priority_queue: true)
-      assert Devices.count_inflight_priority_updates_for(deployment_group) == 1
+      assert FirmwareUpdates.count_inflight_priority_updates_for(deployment_group) == 1
 
       {:ok, _inflight_update} = DeviceEvents.schedule_update(new_device.id, deployment_group, priority_queue: false)
       # Should still be 1, not counting normal queue
-      assert Devices.count_inflight_priority_updates_for(deployment_group) == 1
+      assert FirmwareUpdates.count_inflight_priority_updates_for(deployment_group) == 1
 
       {:ok, _inflight_update} = DeviceEvents.schedule_update(old_device2.id, deployment_group, priority_queue: true)
-      assert Devices.count_inflight_priority_updates_for(deployment_group) == 2
+      assert FirmwareUpdates.count_inflight_priority_updates_for(deployment_group) == 2
     end
 
     test "count_inflight_updates_for/1 counts only normal queue updates", %{
@@ -1090,14 +1091,14 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
-      assert Devices.count_inflight_updates_for(deployment_group) == 0
+      assert FirmwareUpdates.count_inflight_updates_for(deployment_group) == 0
 
       {:ok, _inflight_update} = DeviceEvents.schedule_update(new_device.id, deployment_group, priority_queue: false)
-      assert Devices.count_inflight_updates_for(deployment_group) == 1
+      assert FirmwareUpdates.count_inflight_updates_for(deployment_group) == 1
 
       {:ok, _inflight_update} = DeviceEvents.schedule_update(old_device1.id, deployment_group, priority_queue: true)
       # Should still be 1, not counting priority queue
-      assert Devices.count_inflight_updates_for(deployment_group) == 1
+      assert FirmwareUpdates.count_inflight_updates_for(deployment_group) == 1
     end
 
     test "priority queue empty when threshold is nil", %{org: org, product: product, firmware: firmware, user: user} do

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -407,29 +407,6 @@ defmodule NervesHubWeb.DeviceChannelTest do
     close_cleanly(device_channel)
   end
 
-  test "the first fwup_progress marks an update as happening", %{tmp_dir: tmp_dir} do
-    user = Fixtures.user_fixture()
-    {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
-    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
-
-    {:ok, socket} =
-      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
-
-    {:ok, _join_reply, device_channel} =
-      subscribe_and_join(socket, DeviceChannel, "device:#{device.id}")
-
-    assert_online_and_available(device)
-
-    push(device_channel, "fwup_progress", %{"value" => 10})
-
-    # Since fwup_progress doesn't reply, we need to use sys to grab the socket
-    # _after_ the handle_in has run
-    state = :sys.get_state(device_channel.channel_pid)
-    assert state.assigns.update_started?
-
-    close_cleanly(device_channel)
-  end
-
   test "set connection types for the device", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -4,6 +4,8 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
 
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
+  alias NervesHub.Firmwares
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.Products
   alias NervesHub.Repo
@@ -60,9 +62,9 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     }
 
     # taken from `DeviceChannel`, I don't love just stealing this, but it will do for now
-    with {:ok, metadata} <- NervesHub.Firmwares.metadata_from_device(params, product.id),
-         {:ok, device} <- NervesHub.Devices.update_firmware_metadata(device, metadata, :unknown, false) do
-      NervesHub.Devices.firmware_update_successful(device, device.firmware_metadata)
+    with {:ok, metadata} <- Firmwares.metadata_from_device(params, product.id),
+         {:ok, device} <- Devices.update_firmware_metadata(device, metadata, :unknown, false) do
+      FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
     end
 
     assert {:ok, ["health"], extensions_channel} =

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -12,6 +12,7 @@ defmodule NervesHubWeb.WebsocketTest do
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.UpdateStat
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.Distributed.Orchestrator
@@ -1018,7 +1019,7 @@ defmodule NervesHubWeb.WebsocketTest do
       deployment_group = Repo.preload(deployment_group, :org)
       {:ok, _inflight_update} = DeviceEvents.schedule_update(device.id, deployment_group)
 
-      assert Enum.count(Devices.inflight_updates_for(deployment_group)) == 1
+      assert Enum.count(FirmwareUpdates.inflight_updates_for(deployment_group)) == 1
 
       Fixtures.device_certificate_fixture(device)
 
@@ -1038,7 +1039,7 @@ defmodule NervesHubWeb.WebsocketTest do
 
       assert_online_and_available(device)
 
-      assert Devices.inflight_updates_for(deployment_group) == []
+      assert FirmwareUpdates.inflight_updates_for(deployment_group) == []
 
       close_socket_cleanly(socket)
     end

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -9,6 +9,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias NervesHubWeb.Endpoint
@@ -122,7 +123,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "received", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "received", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
@@ -141,7 +142,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "downloading", 50, true)
+      FirmwareUpdates.update_inflight_update(device.id, "downloading", 50, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
@@ -160,7 +161,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "updating", 50, true)
+      FirmwareUpdates.update_inflight_update(device.id, "updating", 50, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
@@ -179,7 +180,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "expired", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "expired", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
@@ -198,7 +199,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "completed", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "completed", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
@@ -216,32 +217,32 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> visit("/org/#{org.name}/#{product.name}/devices")
       |> assert_has("a", text: device.identifier, timeout: 1_000)
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "requested", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "requested", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "requested")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "received", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "received", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "received")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "started", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "started", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "started")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "downloading", 35, false)
+        FirmwareUpdates.update_inflight_update(device.id, "downloading", 35, false)
         render(view)
       end)
       |> assert_has("div", text: "downloading")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "updating", 70, false)
+        FirmwareUpdates.update_inflight_update(device.id, "updating", 70, false)
         render(view)
       end)
       |> assert_has("div", text: "updating")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "completed", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "completed", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "completed")
@@ -258,7 +259,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "completed", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "completed", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")
@@ -732,7 +733,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> select("Update status", option: "Updating")
       |> assert_has("a", text: device.identifier, timeout: 1000)
 
-      {:ok, _device} = Devices.firmware_update_successful(device, device.firmware_metadata)
+      {:ok, _device} = FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -17,6 +17,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   alias NervesHub.Devices.Metrics
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Firmware
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
   alias NervesHub.Repo
@@ -314,7 +315,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "received", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "received", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -333,7 +334,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "downloading", 50, true)
+      FirmwareUpdates.update_inflight_update(device.id, "downloading", 50, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -352,7 +353,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "updating", 50, true)
+      FirmwareUpdates.update_inflight_update(device.id, "updating", 50, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -371,7 +372,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "expired", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "expired", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -390,7 +391,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "completed", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "completed", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -408,32 +409,32 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("h1", text: device.identifier)
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "requested", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "requested", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "Firmware update request sent to the device")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "received", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "received", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "Firmware update request received by the device")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "started", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "started", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "Firmware update started...")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "downloading", 35, false)
+        FirmwareUpdates.update_inflight_update(device.id, "downloading", 35, false)
         render(view)
       end)
       |> assert_has("div", text: "Downloading firmware : 35%")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "updating", 70, false)
+        FirmwareUpdates.update_inflight_update(device.id, "updating", 70, false)
         render(view)
       end)
       |> assert_has("div", text: "Updating firmware : 70%")
       |> unwrap(fn view ->
-        Devices.update_inflight_update(device.id, "completed", nil, false)
+        FirmwareUpdates.update_inflight_update(device.id, "completed", nil, false)
         render(view)
       end)
       |> assert_has("div", text: "Firmware update complete, waiting for device to restart")
@@ -450,7 +451,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         InflightUpdate.manual_requested_changeset(device.id, firmware)
         |> Repo.insert()
 
-      Devices.update_inflight_update(device.id, "completed", nil, true)
+      FirmwareUpdates.update_inflight_update(device.id, "completed", nil, true)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
 
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias NervesHubWeb.Endpoint
@@ -304,7 +305,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       |> select("Update status", option: "Updating")
       |> assert_has("a", text: device.identifier, timeout: 1000)
 
-      {:ok, _device} = Devices.firmware_update_successful(device, device.firmware_metadata)
+      {:ok, _device} = FirmwareUpdates.firmware_update_successful(device, device.firmware_metadata)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices")

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -413,7 +413,12 @@ defmodule NervesHub.Fixtures do
     %{fixture | db_cert: db_cert}
   end
 
-  def inflight_update(device, deployment_group) do
+  def inflight_update(device, %Firmwares.Firmware{} = firmware) do
+    InflightUpdate.manual_requested_changeset(device.id, firmware)
+    |> Repo.insert()
+  end
+
+  def inflight_update(device, %ManagedDeployments.DeploymentGroup{} = deployment_group) do
     InflightUpdate.deployment_requested_changeset(deployment_group, device.id, false)
     |> Repo.insert()
   end


### PR DESCRIPTION
- functions related to updating or cleaning `InflightUpdate` have been extracted to a new `FirmwareUpdates` context
- `ignored`, `rescheduled`, and `failed` firmware update statuses have been implemented to audit log and block updates, depending if the update was manually requested or scheduled by a deployment
- a fairly complete test suite of the various statuses expected
- modify the `inflight_updates` table to allow for null `firmware_uuid`s and `firmware_id`s so that a devices which are currently updating while a NH deployment don't cause a ton of false-ish errors

next up, saving the 'failed', 'rescheduled', and 'ignored' results as `DeviceFirmware` schemas