### PR TITLE
Move SSL config to the web endpoint

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -160,6 +160,9 @@ config :tailwind,
     cd: Path.expand("..", __DIR__)
   ]
 
+# disable tzdata auto updates as it is currently broken in 1.1.3
+config :tzdata, :autoupdate, :disabled
+
 config :ueberauth, Ueberauth,
   providers: [
     google: {Google, [default_scope: "email profile openid"]}

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,8 +5,6 @@ config :logger, level: :info
 
 config :nerves_hub, NervesHub.Repo, pool_size: 20
 config :nerves_hub, NervesHubWeb.DeviceEndpoint, server: true
-
-config :nerves_hub, NervesHubWeb.Endpoint,
-  server: true
+config :nerves_hub, NervesHubWeb.Endpoint, server: true
 
 config :phoenix, logger: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,7 +7,6 @@ config :nerves_hub, NervesHub.Repo, pool_size: 20
 config :nerves_hub, NervesHubWeb.DeviceEndpoint, server: true
 
 config :nerves_hub, NervesHubWeb.Endpoint,
-  server: true,
-  force_ssl: [rewrite_on: [:x_forwarded_proto]]
+  server: true
 
 config :phoenix, logger: false

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -19,7 +19,7 @@ defmodule NervesHubWeb.Endpoint do
     signing_salt: {__MODULE__, :fetch_signing_salt, []}
   ]
 
-  if Application.compile_env(:nerves_hub, :deploy_env) == "prod" do
+  if Application.compile_env(:nerves_hub, :env) == :prod do
     plug(Plug.SSL, rewrite_on: [:x_forwarded_proto], exclude: ["localhost"])
   end
 

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -19,11 +19,11 @@ defmodule NervesHubWeb.Endpoint do
     signing_salt: {__MODULE__, :fetch_signing_salt, []}
   ]
 
+  plug(ImAlive)
+
   if Application.compile_env(:nerves_hub, :env) == :prod do
     plug(Plug.SSL, rewrite_on: [:x_forwarded_proto], exclude: ["localhost"])
   end
-
-  plug(ImAlive)
 
   socket("/live", Socket, websocket: [connect_info: [session: @session_options]])
 

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -19,6 +19,12 @@ defmodule NervesHubWeb.Endpoint do
     signing_salt: {__MODULE__, :fetch_signing_salt, []}
   ]
 
+  if Application.compile_env(:nerves_hub, :deploy_env) == "prod" do
+    plug Plug.SSL, rewrite_on: [:x_forwarded_proto], exclude: ["localhost"]
+  end
+
+  plug(ImAlive)
+
   socket("/live", Socket, websocket: [connect_info: [session: @session_options]])
 
   socket("/socket", NervesHubWeb.UserSocket, websocket: [connect_info: [session: @session_options]])
@@ -69,8 +75,6 @@ defmodule NervesHubWeb.Endpoint do
     param_key: "request_logger",
     cookie_key: "request_logger"
   )
-
-  plug(ImAlive)
 
   plug(Plug.RequestId)
   plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.Endpoint do
   ]
 
   if Application.compile_env(:nerves_hub, :deploy_env) == "prod" do
-    plug Plug.SSL, rewrite_on: [:x_forwarded_proto], exclude: ["localhost"]
+    plug(Plug.SSL, rewrite_on: [:x_forwarded_proto], exclude: ["localhost"])
   end
 
   plug(ImAlive)


### PR DESCRIPTION
And move the health check to before SSL enforcement. 

This is (almost) required for k8s and ECS so health checks don't get redirected.