### PR TITLE
Support API Token auth with the `UserConsoleChannel` and `UserLocalShellChannel`

### DIFF
--- a/assets/js/hooks/console.js
+++ b/assets/js/hooks/console.js
@@ -54,8 +54,11 @@ export default {
     })
     this.socket.connect()
 
-    const deviceId = this.el.dataset.deviceId
-    const channel = this.socket.channel(`user:console:${deviceId}`, {})
+    const deviceIdentifier = this.el.dataset.deviceIdentifier
+    const channel = this.socket.channel(
+      `user:console:identifier-${deviceIdentifier}`,
+      {},
+    )
 
     // init terminal, load addons
     // use previous scrollback if available, default to 1000 lines

--- a/assets/js/hooks/localShell.js
+++ b/assets/js/hooks/localShell.js
@@ -53,8 +53,11 @@ export default {
     })
     this.socket.connect()
 
-    const deviceId = this.el.dataset.deviceId
-    const channel = this.socket.channel(`user:local_shell:${deviceId}`, {})
+    const deviceIdentifier = this.el.dataset.deviceIdentifier
+    const channel = this.socket.channel(
+      `user:local_shell:identifier-${deviceIdentifier}`,
+      {},
+    )
 
     // init terminal, load addons
     // use previous scrollback if available, default to 1000 lines

--- a/lib/nerves_hub_web/channels/api_socket.ex
+++ b/lib/nerves_hub_web/channels/api_socket.ex
@@ -1,4 +1,9 @@
-defmodule NervesHubWeb.UserSocket do
+defmodule NervesHubWeb.APISocket do
+  @moduledoc """
+  Authentication using API tokens has been encapsulated in this socket as
+  it will allow us to add *future* restrictions around how many concurrent
+  websocket connections a user can have open at one time.
+  """
   use Phoenix.Socket
 
   alias NervesHub.Accounts
@@ -7,8 +12,8 @@ defmodule NervesHubWeb.UserSocket do
   channel("user:local_shell:*", NervesHubWeb.UserLocalShellChannel)
 
   def connect(%{"token" => token}, socket) do
-    with {:ok, user_id} <- Phoenix.Token.verify(socket, "user salt", token, max_age: 86_400),
-         {:ok, user} <- Accounts.get_user(user_id) do
+    with {:ok, user, user_token} <- Accounts.fetch_user_by_api_token(token),
+         :ok <- Accounts.mark_last_used(user_token) do
       {:ok, assign(socket, :user, user)}
     else
       _ -> :error
@@ -20,7 +25,7 @@ defmodule NervesHubWeb.UserSocket do
   end
 
   def id(%{assigns: %{user: user}}) do
-    "user_socket:#{user.id}"
+    "api_socket:#{user.id}"
   end
 
   def id(_socket) do

--- a/lib/nerves_hub_web/channels/user_console_channel.ex
+++ b/lib/nerves_hub_web/channels/user_console_channel.ex
@@ -2,14 +2,20 @@ defmodule NervesHubWeb.UserConsoleChannel do
   use NervesHubWeb, :channel
 
   alias NervesHub.Accounts
+  alias NervesHub.Accounts.OrgUser
+  alias NervesHub.Accounts.Scope
+  alias NervesHub.Devices
   alias NervesHubWeb.Helpers.Authorization
   alias Phoenix.Socket.Broadcast
 
-  def join("user:console:" <> device_id, _, socket) do
-    if authorized?(socket.assigns.user, device_id) do
-      topic = "device:console:#{device_id}"
+  def join("user:console:identifier-" <> identifier, _, socket) do
+    if device = authorized?(socket.assigns.user, identifier) do
+      :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "user:console:#{device.id}")
+
+      topic = "device:console:#{device.id}"
       _ = Phoenix.PubSub.broadcast(NervesHub.PubSub, topic, {:connect, self()})
-      {:ok, assign(socket, :device_id, device_id)}
+
+      {:ok, assign(socket, :device_id, device.id)}
     else
       {:error, %{reason: "unauthorized"}}
     end
@@ -77,13 +83,16 @@ defmodule NervesHubWeb.UserConsoleChannel do
     socket
   end
 
-  defp authorized?(user, device_id) do
-    case Accounts.find_org_user_with_device(user, device_id) do
-      nil ->
-        false
+  defp authorized?(user, identifier) do
+    scope = Scope.for_user(user)
 
-      org_user ->
-        Authorization.authorized?(:"device:console", org_user)
+    with {:ok, device} <- Devices.get_by_identifier(scope, identifier),
+         %OrgUser{} = org_user <- Accounts.find_org_user_with_device(user, device.id),
+         true <- Authorization.authorized?(:"device:console", org_user) do
+      device
+    else
+      _ ->
+        nil
     end
   end
 end

--- a/lib/nerves_hub_web/channels/user_local_shell_channel.ex
+++ b/lib/nerves_hub_web/channels/user_local_shell_channel.ex
@@ -2,15 +2,22 @@ defmodule NervesHubWeb.UserLocalShellChannel do
   use NervesHubWeb, :channel
 
   alias NervesHub.Accounts
+  alias NervesHub.Accounts.OrgUser
+  alias NervesHub.Accounts.Scope
+  alias NervesHub.Devices
   alias NervesHub.Extensions.LocalShell
   alias NervesHubWeb.Helpers.Authorization
+  alias Phoenix.Socket.Broadcast
 
-  def join("user:local_shell:" <> device_id, _, socket) do
-    if authorized?(socket.assigns.user, device_id) do
-      topic = "device:#{device_id}:extensions"
+  def join("user:local_shell:identifier-" <> identifier, _, socket) do
+    if device = authorized?(socket.assigns.user, identifier) do
+      :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "user:local_shell:#{device.id}")
+
+      topic = "device:#{device.id}:extensions"
       message = {LocalShell, {:connect, self()}}
       _ = Phoenix.PubSub.broadcast(NervesHub.PubSub, topic, message)
-      {:ok, assign(socket, :device_id, device_id)}
+
+      {:ok, assign(socket, :device_id, device.id)}
     else
       {:error, %{reason: "unauthorized"}}
     end
@@ -30,6 +37,11 @@ defmodule NervesHubWeb.UserLocalShellChannel do
     {:noreply, socket}
   end
 
+  def handle_info(%Broadcast{event: "output", payload: payload}, socket) do
+    push(socket, "output", payload)
+    {:noreply, socket}
+  end
+
   def handle_info({:cache, lines}, socket) do
     push(socket, "output", %{data: lines})
     {:noreply, socket}
@@ -39,13 +51,16 @@ defmodule NervesHubWeb.UserLocalShellChannel do
     {:noreply, socket}
   end
 
-  defp authorized?(user, device_id) do
-    case Accounts.find_org_user_with_device(user, device_id) do
-      nil ->
-        false
+  defp authorized?(user, identifier) do
+    scope = Scope.for_user(user)
 
-      org_user ->
-        Authorization.authorized?(:"device:extensions:local_shell", org_user)
+    with {:ok, device} <- Devices.get_by_identifier(scope, identifier),
+         %OrgUser{} = org_user <- Accounts.find_org_user_with_device(user, device.id),
+         true <- Authorization.authorized?(:"device:console", org_user) do
+      device
+    else
+      _ ->
+        nil
     end
   end
 end

--- a/lib/nerves_hub_web/channels/user_socket.ex
+++ b/lib/nerves_hub_web/channels/user_socket.ex
@@ -7,16 +7,11 @@ defmodule NervesHubWeb.UserSocket do
   channel("user:local_shell:*", NervesHubWeb.UserLocalShellChannel)
 
   def connect(%{"token" => token}, socket) do
-    case Phoenix.Token.verify(socket, "user salt", token, max_age: 86_400) do
-      {:ok, user_id} ->
-        case Accounts.get_user(user_id) do
-          {:ok, user} ->
-            socket = assign(socket, :user, user)
-            {:ok, socket}
-
-          {:error, _} ->
-            :error
-        end
+    authenticate(socket, token)
+    |> case do
+      {:ok, user} ->
+        socket = assign(socket, :user, user)
+        {:ok, socket}
 
       {:error, _} ->
         :error
@@ -33,5 +28,23 @@ defmodule NervesHubWeb.UserSocket do
 
   def id(_socket) do
     nil
+  end
+
+  defp authenticate(_socket, "nhu_" <> _ = token) do
+    with {:ok, user, user_token} <- Accounts.fetch_user_by_api_token(token),
+         :ok <- Accounts.mark_last_used(user_token) do
+      {:ok, user}
+    else
+      _ -> {:error, :invalid_token}
+    end
+  end
+
+  defp authenticate(socket, token) do
+    with {:ok, user_id} <- Phoenix.Token.verify(socket, "user salt", token, max_age: 86_400),
+         {:ok, user} <- Accounts.get_user(user_id) do
+      {:ok, user}
+    else
+      _ -> {:error, :invalid_token}
+    end
   end
 end

--- a/lib/nerves_hub_web/components/device_page/console_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/console_tab.ex
@@ -103,7 +103,7 @@ defmodule NervesHubWeb.Components.DevicePage.ConsoleTab do
           </:failed>
           <div id="console-and-chat" class="flex size-full bg-black" phx-update="ignore" style="background-color: rgb(14, 16, 25);">
             <div :if={authorized?(:"device:console", @current_scope) && online?} id="dropzone" class="relative flex grow gap-6 p-12" style="background-color: rgb(14, 16, 25);">
-              <div id="console" phx-hook="Console" data-user-token={@user_token} data-device-id={@device.id} class="z-10 size-full"></div>
+              <div id="console" phx-hook="Console" data-user-token={@user_token} data-device-identifier={@device.identifier} class="z-10 size-full"></div>
               <div id="immersive-device" class="text-base-800 pointer-events-none absolute top-4 left-6 z-20 hidden">
                 <div class="flex items-center gap-3">
                   <%= if Map.get(@device_connection || %{}, :status) == :connected do %>

--- a/lib/nerves_hub_web/components/device_page/local_shell_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/local_shell_tab.ex
@@ -93,7 +93,7 @@ defmodule NervesHubWeb.Components.DevicePage.LocalShellTab do
               class="relative flex grow gap-6 p-12"
               style="background-color: rgb(14, 16, 25);"
             >
-              <div id="local-shell" phx-hook="LocalShell" data-user-token={@user_token} data-device-id={@device.id} class="z-10 size-full"></div>
+              <div id="local-shell" phx-hook="LocalShell" data-user-token={@user_token} data-device-identifier={@device.identifier} class="z-10 size-full"></div>
               <div id="immersive-device" class="text-base-800 pointer-events-none absolute top-4 left-6 z-20 hidden">
                 <div class="flex items-center gap-3">
                   <svg

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -23,6 +23,8 @@ defmodule NervesHubWeb.Endpoint do
 
   socket("/socket", NervesHubWeb.UserSocket, websocket: [connect_info: [session: @session_options]])
 
+  socket("/api/socket", NervesHubWeb.APISocket, websocket: true)
+
   socket("/events-socket", NervesHubWeb.EventStreamSocket, websocket: true)
 
   socket(

--- a/test/nerves_hub_web/channels/user_console_channel_test.exs
+++ b/test/nerves_hub_web/channels/user_console_channel_test.exs
@@ -1,0 +1,70 @@
+defmodule NervesHubWeb.UserConsoleChannelTest do
+  use NervesHubWeb.ChannelCase
+
+  alias NervesHub.Accounts
+  alias NervesHub.Fixtures
+  alias NervesHubWeb.UserConsoleChannel
+  alias NervesHubWeb.UserSocket
+
+  describe "join/3" do
+    test "authorized users can join the device channel", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+
+      device = device_fixture(user, %{identifier: "test-device-123"}, tmp_dir)
+
+      user_token = Accounts.create_user_api_token(user, "test-token")
+
+      {:ok, socket} = connect(UserSocket, %{"token" => user_token})
+
+      assert {:ok, _reply, _channel} =
+               subscribe_and_join(
+                 socket,
+                 UserConsoleChannel,
+                 "user:console:identifier-#{device.identifier}"
+               )
+    end
+
+    test "unauthorized user cannot join the device channel", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      other_user = Fixtures.user_fixture()
+
+      device = device_fixture(user, %{identifier: "test-device-123"}, tmp_dir)
+
+      other_user_token = Accounts.create_user_api_token(other_user, "test-token")
+
+      # Connect with unauthorized user's token
+      {:ok, socket} = connect(UserSocket, %{"token" => other_user_token})
+
+      assert {:error, %{reason: _reason}} =
+               subscribe_and_join(
+                 socket,
+                 UserConsoleChannel,
+                 "user:console:identifier-#{device.identifier}"
+               )
+    end
+  end
+
+  defp device_fixture(user, device_params, tmp_dir) do
+    org = Fixtures.org_fixture(user)
+    {:ok, org_user} = Accounts.get_org_user(org, user)
+
+    # Use the lowest permissioned org user possible for the channel.
+    {:ok, _updated_org_user} = Accounts.change_org_user_role(org_user, :manage)
+
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+    firmware =
+      Fixtures.firmware_fixture(org_key, product, %{
+        version: "0.0.1",
+        dir: tmp_dir
+      })
+
+    Fixtures.device_fixture(
+      org,
+      product,
+      firmware,
+      device_params
+    )
+  end
+end

--- a/test/nerves_hub_web/channels/user_local_shell_channel_test.exs
+++ b/test/nerves_hub_web/channels/user_local_shell_channel_test.exs
@@ -1,10 +1,10 @@
-defmodule NervesHubWeb.UserConsoleChannelTest do
+defmodule NervesHubWeb.UserLocalShellChannelTest do
   use NervesHubWeb.ChannelCase
 
   alias NervesHub.Accounts
   alias NervesHub.Fixtures
   alias NervesHubWeb.APISocket
-  alias NervesHubWeb.UserConsoleChannel
+  alias NervesHubWeb.UserLocalShellChannel
 
   describe "API Token : join/3" do
     test "authorized users can join the device channel", %{tmp_dir: tmp_dir} do
@@ -19,8 +19,8 @@ defmodule NervesHubWeb.UserConsoleChannelTest do
       assert {:ok, _reply, _channel} =
                subscribe_and_join(
                  socket,
-                 UserConsoleChannel,
-                 "user:console:identifier-#{device.identifier}"
+                 UserLocalShellChannel,
+                 "user:local_shell:identifier-#{device.identifier}"
                )
     end
 
@@ -38,8 +38,8 @@ defmodule NervesHubWeb.UserConsoleChannelTest do
       assert {:error, %{reason: _reason}} =
                subscribe_and_join(
                  socket,
-                 UserConsoleChannel,
-                 "user:console:identifier-#{device.identifier}"
+                 UserLocalShellChannel,
+                 "user:local_shell:identifier-#{device.identifier}"
                )
     end
   end


### PR DESCRIPTION
This has been implemented with a new socket `APISocket` attached to `/api/socket`. This will allow us to add connection restrictions without affecting the web UI code path. eg. a user can have no more than 3 active websockets open, and no more than 5 active device consoles. (this has not been implemented yet)

I've also updated the `UserConsoleChannel` and `UserLocalShellChannel` to use the device identifier instead of the device id, making the API easier to work with for a CLI feature I'm working on.