### PR TITLE
Tell Stoplight to make the API docs responsive

### DIFF
--- a/lib/nerves_hub_web/controllers/api/ui_html.ex
+++ b/lib/nerves_hub_web/controllers/api/ui_html.ex
@@ -19,6 +19,7 @@ defmodule NervesHubWeb.API.UIHTML do
           apiDescriptionUrl="/api/openapi"
           router="hash"
           logo="/images/favicon-96x96.png"
+          layout="responsive"
         />
       </body>
     </html>


### PR DESCRIPTION
@jjcarstens helped find this

Not sure why this isn't the default