### PR TITLE
Add `text` to the API accepts plug

### DIFF
--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -44,7 +44,7 @@ defmodule NervesHubWeb.Router do
   end
 
   pipeline :api do
-    plug(:accepts, ["json"])
+    plug(:accepts, ["json", "text"])
     plug(PutApiSpec, module: NervesHubWeb.ApiSpec)
     plug(FetchCurrentUser)
     plug(:assign_org_to_scope)


### PR DESCRIPTION
Found when testing the API for sending a script to a Device

(otherwise you get a 406 error)