### PR TITLE
Add support for customizing the columns listed

### DIFF
--- a/lib/nerves_hub/accounts/display_preferences.ex
+++ b/lib/nerves_hub/accounts/display_preferences.ex
@@ -1,0 +1,46 @@
+defmodule NervesHub.Accounts.User.DisplayPreferences do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Accounts.User.DisplayPreferences
+
+  @all_device_list_columns [
+    :health,
+    :firmware,
+    :platform,
+    :connected_info,
+    :deployment_group,
+    :tags
+  ]
+
+  @all_deployment_group_list_columns [
+    :platform,
+    :architecture,
+    :device_count,
+    :release_count,
+    :firmware_version,
+    :tags,
+    :version_constraint
+  ]
+
+  def device_list_columns(), do: @all_device_list_columns
+
+  def deployment_group_list_columns(), do: @all_deployment_group_list_columns
+
+  embedded_schema do
+    field(:device_list_columns, {:array, Ecto.Enum},
+      values: @all_device_list_columns,
+      default: nil
+    )
+
+    field(:deployment_group_list_columns, {:array, Ecto.Enum},
+      values: @all_deployment_group_list_columns,
+      default: nil
+    )
+  end
+
+  def changeset(%DisplayPreferences{} = preferences, attrs \\ %{}) do
+    cast(preferences, attrs, [:device_list_columns, :deployment_group_list_columns])
+  end
+end

--- a/lib/nerves_hub/accounts/user.ex
+++ b/lib/nerves_hub/accounts/user.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Accounts.User do
   alias __MODULE__
   alias Ecto.Changeset
   alias NervesHub.Accounts.OrgUser
+  alias NervesHub.Accounts.User.DisplayPreferences
   alias NervesHub.Accounts.UserToken
   alias NervesHub.Repo
 
@@ -44,6 +45,8 @@ defmodule NervesHub.Accounts.User do
 
     # Platform authentication for routes like the Oban dashboard
     field(:server_role, Ecto.Enum, values: [:admin, :view])
+
+    embeds_one :display_preferences, DisplayPreferences, on_replace: :update
 
     timestamps()
   end
@@ -87,6 +90,14 @@ defmodule NervesHub.Accounts.User do
     |> validate_required([:google_id])
     |> put_change(:google_last_synced_at, now)
     |> maybe_add_confirmed_at()
+  end
+
+  def update_selected_default_columns_changeset(user, column_set, selected_columns) do
+    attrs = %{column_set => selected_columns}
+
+    user
+    |> cast(%{display_preferences: attrs}, [])
+    |> cast_embed(:display_preferences, required: true)
   end
 
   defp maybe_add_confirmed_at(%{data: %{confirmed_at: confirmed_at}} = changeset) when is_nil(confirmed_at) do

--- a/lib/nerves_hub_web/components/list_settings_sidebar.ex
+++ b/lib/nerves_hub_web/components/list_settings_sidebar.ex
@@ -1,0 +1,91 @@
+defmodule NervesHubWeb.Components.ListSettingsSidebar do
+  use NervesHubWeb, :component
+
+  alias NervesHub.Accounts.User
+  alias NervesHub.Repo
+
+  attr(:show, :boolean, required: true)
+  attr(:available_columns, :list, required: true)
+  attr(:selected_columns, :list, required: true)
+  attr(:on_toggle, :any, default: "toggle-settings")
+  attr(:on_update, :any, default: "update-settings")
+
+  def render(assigns) do
+    params = Map.new(assigns.available_columns, fn key -> {to_string(key), false} end)
+
+    assigns = assign(assigns, :form, to_form(params))
+
+    assigns =
+      update(assigns, :selected_columns, fn selected_columns ->
+        Enum.map(selected_columns || [], &Kernel.to_string/1)
+      end)
+
+    ~H"""
+    <div class="pointer-events-none fixed inset-y-0 right-0 z-40 flex max-w-full pl-10 sm:pl-16">
+      <div class={[
+        "bg-surface-muted border-base-700 shadow-filter-slider pointer-events-auto mt-[55px] flex h-full w-screen max-w-80 flex-col border-t border-l transition-transform",
+        !@show && "translate-x-full",
+        !@show && "invisible"
+      ]}>
+        <div class="h-0 flex-1 overflow-y-auto">
+          <div class="border-base-700 flex h-14 items-center border-b px-4 py-3">
+            <h4 class="text-base font-semibold">Settings</h4>
+
+            <button class="ml-auto cursor-pointer p-1.5" type="button" phx-click={@on_toggle} phx-value-toggle={to_string(@show)}>
+              <span class="lucide-x--light text-base-300 size-5" />
+            </button>
+          </div>
+
+          <div class="border-base-700 flex flex-col px-4 py-3">
+            <span>Customize which columns you would like to see listed.</span>
+            <.form :let={f} id="settings-form" for={@form} phx-change={@on_update}>
+              <div :for={column <- @available_columns} class="mt-6">
+                <.input field={f[column]} type="checkbox" label={to_column_name(column)} checked={selected?(column, @selected_columns)} />
+              </div>
+            </.form>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def show_column?(nil, _column_set, _column) do
+    true
+  end
+
+  def show_column?(display_preferences, column_set, column) do
+    Map.get(display_preferences, column_set)
+    |> case do
+      nil -> true
+      selected_columns -> column in selected_columns
+    end
+  end
+
+  def update_displayed_columns(user, column_set, params) do
+    selected_columns =
+      Enum.reject(params, fn {col, selected?} ->
+        String.starts_with?(col, "_") || selected? != "true"
+      end)
+      |> Enum.map(fn {k, _} -> k end)
+
+    user =
+      User.update_selected_default_columns_changeset(user, column_set, selected_columns)
+
+    Repo.update(user)
+  end
+
+  defp to_column_name(column) do
+    to_string(column)
+    |> String.split("_")
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  defp selected?(column, selected_columns) do
+    if Enum.empty?(selected_columns) do
+      true
+    else
+      to_string(column) in selected_columns
+    end
+  end
+end

--- a/lib/nerves_hub_web/live/deployment_groups/index.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias NervesHubWeb.Components.FilterSidebar
+  alias NervesHubWeb.Components.ListSettingsSidebar
   alias NervesHubWeb.Components.Pager
   alias NervesHubWeb.Components.Sorting
 
@@ -67,6 +68,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
     |> assign(:current_filters, @default_filters)
     |> assign(:currently_filtering, false)
     |> assign(:show_filters, false)
+    |> assign(:show_settings, false)
     |> ok()
   end
 
@@ -125,6 +127,15 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
     socket
     |> push_patch(to: self_path(socket, @default_filters))
     |> noreply()
+  end
+
+  def handle_event("toggle-settings", %{"toggle" => toggle}, socket) do
+    {:noreply, assign(socket, :show_settings, toggle != "true")}
+  end
+
+  def handle_event("update-settings", params, %{assigns: %{current_scope: scope}} = socket) do
+    {:ok, user} = ListSettingsSidebar.update_displayed_columns(scope.user, :deployment_group_list_columns, params)
+    {:noreply, assign(socket, :current_scope, %{scope | user: user})}
   end
 
   # Handles event of user clicking the same field that is already sorted
@@ -220,4 +231,8 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Index do
   defp version(%DeploymentGroup{conditions: %{version: version}}), do: version
 
   defp tags(%DeploymentGroup{conditions: %{tags: tags}}), do: tags
+
+  defp show_column?(user, column) do
+    ListSettingsSidebar.show_column?(user.display_preferences, :deployment_group_list_columns, column)
+  end
 end

--- a/lib/nerves_hub_web/live/deployment_groups/index.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/index.html.heex
@@ -1,7 +1,7 @@
 <NervesHubWeb.Layouts.sidebar flash={@flash} current_scope={@current_scope} sidebar_tab={@sidebar_tab}>
   <div class="bg-surface-muted border-base-700 h-topbar flex justify-end border-b"></div>
 
-  <div class="h-0 flex-1 overflow-y-auto">
+  <div id="deployment-groups-container" class="h-0 flex-1 overflow-y-auto">
     <div class="border-base-700 h-header flex items-center gap-4 border-b px-6 py-7 text-sm font-medium">
       <h1 class="text-base-50 text-xl leading-[30px] font-semibold">All Deployment Groups</h1>
       <div class="bg-base-800 text-base-300 mr-auto rounded-sm px-1.5 py-0.5 text-xs">{@pager_meta.total_count}</div>
@@ -33,7 +33,10 @@
         <.icon name="add" /> Create Deployment Group
       </.button>
       <.button type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
-        <.icon name="filter" /> Filters
+        <.icon name="filter" />
+      </.button>
+      <.button type="button" phx-click="toggle-settings" phx-value-toggle={to_string(@show_settings)}>
+        <span class="lucide-settings--light text-base-300 size-5" />
       </.button>
     </div>
 
@@ -50,25 +53,25 @@
               <th phx-click="sort" phx-value-sort="name" class="w-1/5 cursor-pointer">
                 <Sorting.sort_icon text="Name" field="name" selected_field={@current_sort} selected_direction={@sort_direction} />
               </th>
-              <th phx-click="sort" phx-value-sort="platform" class="cursor-pointer">
+              <th :if={show_column?(@current_scope.user, :platform)} phx-click="sort" phx-value-sort="platform" class="cursor-pointer">
                 <Sorting.sort_icon text="Platform" field="platform" selected_field={@current_sort} selected_direction={@sort_direction} />
               </th>
-              <th phx-click="sort" phx-value-sort="architecture" class="cursor-pointer">
+              <th :if={show_column?(@current_scope.user, :architecture)} phx-click="sort" phx-value-sort="architecture" class="cursor-pointer">
                 <Sorting.sort_icon text="Architecture" field="architecture" selected_field={@current_sort} selected_direction={@sort_direction} />
               </th>
-              <th phx-click="sort" phx-value-sort="device_count" class="cursor-pointer">
+              <th :if={show_column?(@current_scope.user, :device_count)} phx-click="sort" phx-value-sort="device_count" class="cursor-pointer">
                 <Sorting.sort_icon text="Devices" field="device_count" selected_field={@current_sort} selected_direction={@sort_direction} />
               </th>
-              <th phx-click="sort" phx-value-sort="releases_count" class="cursor-pointer">
+              <th :if={show_column?(@current_scope.user, :release_count)} phx-click="sort" phx-value-sort="releases_count" class="cursor-pointer">
                 <Sorting.sort_icon text="Releases" field="releases_count" selected_field={@current_sort} selected_direction={@sort_direction} />
               </th>
-              <th phx-click="sort" phx-value-sort="firmware_version" class="min-w-fit cursor-pointer">
+              <th :if={show_column?(@current_scope.user, :firmware_version)} phx-click="sort" phx-value-sort="firmware_version" class="min-w-fit cursor-pointer">
                 <Sorting.sort_icon text="Firmware version" field="firmware_version" selected_field={@current_sort} selected_direction={@sort_direction} />
               </th>
-              <th>
+              <th :if={show_column?(@current_scope.user, :tags)}>
                 Device Tags
               </th>
-              <th>
+              <th :if={show_column?(@current_scope.user, :version_constraint)}>
                 Version Constraint
               </th>
             </tr>
@@ -77,7 +80,7 @@
             <tr :for={deployment_group <- @entries} class={["border-base-800 border-b"]}>
               <td>
                 <.link navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/deployment_groups/#{deployment_group}"}>
-                  <div class="flex h-[40px] w-full items-center gap-[8px]">
+                  <div class="flex h-10 w-full items-center gap-2">
                     <svg class={["size-1.5", (deployment_group.is_active && "fill-success") || "fill-base-500"]} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
                       <circle cx="3" cy="3" r="3" />
                     </svg>
@@ -87,23 +90,23 @@
                 </.link>
               </td>
 
-              <td>
+              <td :if={show_column?(@current_scope.user, :platform)}>
                 {deployment_group.platform}
               </td>
 
-              <td>
+              <td :if={show_column?(@current_scope.user, :architecture)}>
                 {deployment_group.architecture}
               </td>
 
-              <td>
+              <td :if={show_column?(@current_scope.user, :device_count)}>
                 {deployment_group.device_count || 0}
               </td>
 
-              <td>
+              <td :if={show_column?(@current_scope.user, :release_count)}>
                 {deployment_group.releases_count || 0}
               </td>
 
-              <td class="min-w-fit">
+              <td :if={show_column?(@current_scope.user, :firmware_version)} class="min-w-fit">
                 <span class="bg-base-800 inline-block items-center rounded px-2 py-1 whitespace-nowrap">
                   <.link navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/firmware/#{deployment_group.current_release.firmware}"} class="flex items-center">
                     <span class="text-base-300 mr-1 text-sm">
@@ -122,8 +125,8 @@
                 </span>
               </td>
 
-              <td>
-                <div class="flex items-center gap-[4px]">
+              <td :if={show_column?(@current_scope.user, :tags)}>
+                <div class="flex items-center gap-1">
                   <%= if Enum.count(tags(deployment_group)) > 0 do %>
                     <%= for tag <- tags(deployment_group) do %>
                       <span class="badge">
@@ -136,7 +139,7 @@
                 </div>
               </td>
 
-              <td>
+              <td :if={show_column?(@current_scope.user, :version_contraint)}>
                 {version(deployment_group)}
               </td>
             </tr>
@@ -151,6 +154,12 @@
     <:filter attr="platform" label="Platform" type={:select} values={[{"All", ""} | Enum.map(@platforms, &{if(&1, do: &1, else: "Unknown"), &1})]} />
     <:filter attr="architecture" label="Architecture" type={:select} values={[{"All", ""} | Enum.map(@architectures, &{if(&1, do: &1, else: "Unknown"), &1})]} />
   </FilterSidebar.render>
+
+  <ListSettingsSidebar.render
+    show={@show_settings}
+    available_columns={NervesHub.Accounts.User.DisplayPreferences.deployment_group_list_columns()}
+    selected_columns={get_in(@current_scope.user.display_preferences.deployment_group_list_columns)}
+  />
 
   <Pager.render_with_page_sizes pager={@pager_meta} page_sizes={@paginate_opts.page_sizes} />
 </NervesHubWeb.Layouts.sidebar>

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -17,6 +17,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHubWeb.Components.DeviceUpdateStatus
   alias NervesHubWeb.Components.FilterSidebar
   alias NervesHubWeb.Components.HealthStatus
+  alias NervesHubWeb.Components.ListSettingsSidebar
   alias NervesHubWeb.Components.Pager
   alias NervesHubWeb.Components.Sorting
   alias NervesHubWeb.LayoutView.DateTimeFormat
@@ -107,6 +108,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:firmware_versions, firmware_versions(product.id))
     |> assign(:platforms, [])
     |> assign(:show_filters, false)
+    |> assign(:show_settings, false)
     |> assign(:current_filters, @default_filters)
     |> assign(:currently_filtering, false)
     |> assign(:selected_devices, [])
@@ -242,6 +244,15 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:selected_devices, [])
     |> push_patch(to: self_path(socket, Map.merge(@default_filters, page_params)))
     |> noreply()
+  end
+
+  def handle_event("toggle-settings", %{"toggle" => toggle}, socket) do
+    {:noreply, assign(socket, :show_settings, toggle != "true")}
+  end
+
+  def handle_event("update-settings", params, %{assigns: %{current_scope: scope}} = socket) do
+    {:ok, user} = ListSettingsSidebar.update_displayed_columns(scope.user, :device_list_columns, params)
+    {:noreply, assign(socket, :current_scope, %{scope | user: user})}
   end
 
   @decorate requires_permission(:"device:update")
@@ -1205,6 +1216,10 @@ defmodule NervesHubWeb.Live.Devices.Index do
   defp parse_device_id(topic) do
     "internal:device:" <> device_id = topic
     String.to_integer(device_id)
+  end
+
+  defp show_column?(user, column) do
+    ListSettingsSidebar.show_column?(user.display_preferences, :device_list_columns, column)
   end
 
   defp onboarding_nhl_host() do

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -36,14 +36,17 @@
           </svg>
         </div>
       </form>
-      <.button :if={has_results?(@devices, @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org}/#{@product}/devices/export"} download>
-        <.icon name="export" /> Export
-      </.button>
       <.button type="link" navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/devices/new"} aria-label="Add new device">
-        <.icon name="add" /> Add Device
+        <span class="lucide-plus--light text-base-300 size-5" /> Add Device
+      </.button>
+      <.button :if={has_results?(@devices, @currently_filtering)} type="link" aria-label="Export devices" href={~p"/org/#{@org}/#{@product}/devices/export"} download>
+        <span class="lucide-download--light text-base-300 size-5" />
       </.button>
       <.button :if={has_results?(@devices, @currently_filtering) || @soft_deleted_devices_exist} type="button" phx-click="toggle-filters" phx-value-toggle={to_string(@show_filters)}>
-        <.icon name="filter" /> Filters
+        <.icon name="filter" />
+      </.button>
+      <.button type="button" phx-click="toggle-settings" phx-value-toggle={to_string(@show_settings)}>
+        <span class="lucide-settings--light text-base-300 size-5" />
       </.button>
     </div>
 
@@ -195,18 +198,23 @@
                   <th phx-click="sort" phx-value-sort="identifier" class="cursor-pointer">
                     <Sorting.sort_icon text="Identifier" field="identifier" selected_field={@current_sort} selected_direction={@sort_direction} />
                   </th>
-                  <th class="w-24">
+                  <th :if={show_column?(@current_scope.user, :health)} class="w-24">
                     <div class="flex justify-center">
                       <span>Health</span>
                     </div>
                   </th>
-                  <th>Firmware</th>
-                  <th>Platform</th>
-                  <th phx-click="sort" phx-value-sort="connection_established_at" class="cursor-pointer">
+                  <th :if={show_column?(@current_scope.user, :firmware)}>Firmware</th>
+                  <th :if={show_column?(@current_scope.user, :platform)}>Platform</th>
+                  <th
+                    :if={show_column?(@current_scope.user, :connected_info)}
+                    phx-click="sort"
+                    phx-value-sort="connection_established_at"
+                    class="cursor-pointer"
+                  >
                     <Sorting.sort_icon text="Connected for" field="connection_established_at" selected_field={@current_sort} selected_direction={@sort_direction} />
                   </th>
-                  <th>Deployment Group</th>
-                  <th phx-click="sort" phx-value-sort="tags" class="cursor-pointer">
+                  <th :if={show_column?(@current_scope.user, :deployment_group)}>Deployment Group</th>
+                  <th :if={show_column?(@current_scope.user, :tags)} phx-click="sort" phx-value-sort="tags" class="cursor-pointer">
                     <Sorting.sort_icon text="Tags" field="tags" selected_field={@current_sort} selected_direction={@sort_direction} />
                   </th>
                 </tr>
@@ -284,13 +292,13 @@
                     </div>
                   </td>
 
-                  <td>
+                  <td :if={show_column?(@current_scope.user, :health)}>
                     <div class="flex items-center justify-center gap-2">
                       <HealthStatus.render device_id={device.id} health={device.latest_health} tooltip_position="top" />
                     </div>
                   </td>
 
-                  <td>
+                  <td :if={show_column?(@current_scope.user, :firmware)}>
                     <div class="flex items-center gap-2">
                       <span class="font-mono">
                         <%= if is_nil(device.firmware_metadata) do %>
@@ -303,7 +311,7 @@
                     </div>
                   </td>
 
-                  <td>
+                  <td :if={show_column?(@current_scope.user, :platform)}>
                     <span>
                       <%= if is_nil(device.firmware_metadata) do %>
                         Unknown
@@ -313,13 +321,13 @@
                     </span>
                   </td>
 
-                  <td>
+                  <td :if={show_column?(@current_scope.user, :connected_info)}>
                     <div :if={device.latest_connection} title={connection_established_at(device.latest_connection)}>
                       {connection_established_at(device.latest_connection)}
                     </div>
                   </td>
 
-                  <td>
+                  <td :if={show_column?(@current_scope.user, :deployment_group)}>
                     <span :if={device.deployment_id} class="bg-base-800 border-base-700 flex w-fit items-center gap-1 rounded-full border py-0.5 pr-2.5 pl-1.5">
                       <svg class="size-1.5" viewBox="0 0 6 6" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <circle cx="3" cy="3" r="3" fill="#10B981" />
@@ -328,7 +336,7 @@
                     </span>
                   </td>
 
-                  <td>
+                  <td :if={show_column?(@current_scope.user, :tags)}>
                     <div class="flex items-center gap-1 text-nowrap">
                       <%= if !is_nil(device.tags) do %>
                         <%= for tag <- device.tags do %>
@@ -425,6 +433,12 @@
     />
     <:filter attr="only_updating" label="Update status" type={:select} values={[{"All", "false"}, {"Updating", "true"}]} />
   </FilterSidebar.render>
+
+  <ListSettingsSidebar.render
+    show={@show_settings}
+    available_columns={NervesHub.Accounts.User.DisplayPreferences.device_list_columns()}
+    selected_columns={get_in(@current_scope.user.display_preferences.device_list_columns)}
+  />
 
   <div class="pointer-events-none fixed inset-y-0 right-0 z-40 mb-[119px] flex max-w-full pl-10 sm:pl-16">
     <div class={[

--- a/priv/repo/migrations/20260618082034_add_display_preferences_to_user.exs
+++ b/priv/repo/migrations/20260618082034_add_display_preferences_to_user.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddDisplayPreferencesToUser do
+  use Ecto.Migration
+
+  def change() do
+    alter table(:users) do
+      add(:display_preferences, :map)
+    end
+  end
+end

--- a/test/nerves_hub_web/live/deployment_groups/index_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/index_test.exs
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.IndexTest do
   alias NervesHub.Devices
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
+  alias NervesHubWeb.Components.ListSettingsSidebar
 
   test "no deployment groups", %{conn: conn, user: user, org: org} do
     product = Fixtures.product_fixture(user, org, %{name: "Spaghetti"})
@@ -134,6 +135,80 @@ defmodule NervesHubWeb.Live.DeploymentGroups.IndexTest do
         render_change(view, "reset-filters", %{})
       end)
       |> assert_has("a", text: deployment_group.name)
+    end
+  end
+
+  describe "customize columns listed" do
+    test "all columns are shown, as the default", %{conn: conn, fixture: fixture} do
+      %{user: user} = fixture
+
+      assert is_nil(user.display_preferences)
+
+      conn
+      |> visit("/org/#{fixture.org.name}/#{fixture.product.name}/deployment_groups")
+      |> assert_has("th", text: "Platform")
+      |> assert_has("th", text: "Architecture")
+      |> assert_has("th", text: "Devices")
+      |> assert_has("th", text: "Releases")
+      |> assert_has("th", text: "Firmware version")
+      |> assert_has("th", text: "Device Tags")
+      |> assert_has("th", text: "Version Constraint")
+    end
+
+    for {column, label} <- [
+          {:platform, "Platform"},
+          {:architecture, "Architecture"},
+          {:device_count, "Devices"},
+          {:release_count, "Releases"},
+          {:firmware_version, "Firmware version"},
+          {:tags, "Tags"},
+          {:version_constraint, "Version Constraint"}
+        ] do
+      @column column
+      @label label
+      @friendly_column_name to_string(@column) |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
+
+      test "#{column} column can be removed", %{conn: conn, fixture: fixture} do
+        %{user: user} = fixture
+
+        assert is_nil(user.display_preferences)
+
+        conn
+        |> visit("/org/#{fixture.org.name}/#{fixture.product.name}/deployment_groups")
+        |> assert_has("th", text: @label)
+        |> click_button("#deployment-groups-container button[phx-click=toggle-settings]", "")
+        |> uncheck(@friendly_column_name)
+        |> refute_has("th", text: @label, timeout: 1_000)
+      end
+
+      test "#{column} column can be added", %{conn: conn, fixture: %{user: user} = fixture} do
+        assert is_nil(user.display_preferences)
+
+        default_column_payload = %{
+          "_target" => [to_string(@column)],
+          "architecture" => true,
+          "device_count" => true,
+          "firmware_version" => true,
+          "platform" => true,
+          "release_count" => true,
+          "tags" => true,
+          "version_constraint" => true
+        }
+
+        {:ok, _user} =
+          ListSettingsSidebar.update_displayed_columns(
+            user,
+            :deployment_group_list_columns,
+            Map.put(default_column_payload, to_string(@column), "false")
+          )
+
+        conn
+        |> visit("/org/#{fixture.org.name}/#{fixture.product.name}/deployment_groups")
+        |> refute_has("th", text: @label)
+        |> click_button("#deployment-groups-container button[phx-click=toggle-settings]", "")
+        |> check(@friendly_column_name)
+        |> assert_has("th", text: @label, timeout: 1_000)
+      end
     end
   end
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -12,6 +12,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.Repo
+  alias NervesHubWeb.Components.ListSettingsSidebar
   alias NervesHubWeb.Endpoint
   alias Phoenix.Socket.Broadcast
 
@@ -301,7 +302,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> fill_in("Identifier", with: device.identifier)
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       |> assert_has("div a", text: device.identifier)
@@ -317,7 +318,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> visit(device_index_path(fixture))
       |> assert_has("div a", text: device.identifier, timeout: 1000)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> fill_in("Identifier", with: "foo")
       |> assert_has("#device-count", text: "0", timeout: 1000)
     end
@@ -328,7 +329,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       conn
       |> visit(device_index_path(fixture))
       |> assert_has("div a", text: device.identifier, timeout: 1000)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> fill_in("Identifier", with: "device-")
       |> assert_has("#device-count", text: "1", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
@@ -342,7 +343,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       conn
       |> visit(device_index_path(fixture))
       |> assert_has("div a", text: device.identifier, timeout: 1000)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> fill_in("Identifier", with: just_the_tail)
       |> assert_has("#device-count", text: "1", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
@@ -354,7 +355,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       conn
       |> visit(device_index_path(fixture))
       |> assert_has("div a", text: device.identifier, timeout: 1000)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> fill_in("Identifier", with: "ice-")
       |> assert_has("#device-count", text: "1", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
@@ -425,11 +426,11 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
-      |> fill_in("Tags", with: "filter-test-no-show")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "filter-test-no-show")
       |> assert_has("#device-count", text: "0", timeout: 1_000)
       |> refute_has("div a", text: device2.identifier)
-      |> fill_in("Tags", with: "filter-test")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "filter-test")
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       |> assert_has("div a", text: device2.identifier)
     end
@@ -451,7 +452,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Metrics", option: "cpu_temp")
       |> assert_has("label", text: "Operator", timeout: 1000)
       |> select("Metrics Operator", option: "Greater Than")
@@ -483,14 +484,14 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
-      |> fill_in("Tags", with: "filter-test-no-show")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "filter-test-no-show")
       |> assert_has("#device-count", text: "0", timeout: 1_000)
       |> refute_has("div a", text: device2.identifier)
-      |> fill_in("Tags", with: "filter-test")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "filter-test")
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       |> assert_has("div a", text: device2.identifier)
-      |> fill_in("Tags", with: "filter-test, test-filter")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "filter-test, test-filter")
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       |> assert_has("div a", text: device2.identifier)
     end
@@ -504,8 +505,8 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> visit(device_index_path(fixture))
       |> assert_has("div a", text: device.identifier, timeout: 1000)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
-      |> fill_in("Tags", with: "does_not_matter")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "does_not_matter")
       |> assert_has("#device-count", text: "0", timeout: 1000)
       |> refute_has("div a", text: device2.identifier)
     end
@@ -522,7 +523,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
       |> assert_has("div a", text: device3.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Untagged", option: "Only untagged")
       |> assert_has("#device-count", text: "1", timeout: 1000)
       |> assert_has("div a", text: device2.identifier)
@@ -542,7 +543,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Alarm Status", option: "Has Alarms")
       |> assert_has("#device-count", text: "1", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
@@ -562,7 +563,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Alarm Status", option: "No Alarms")
       |> assert_has("#device-count", text: "1", timeout: 1000)
       |> assert_has("div a", text: device2.identifier)
@@ -583,7 +584,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Alarm", option: alarm)
       |> assert_path(device_index_path(fixture), query_params: %{alarm: alarm})
       |> assert_has("#device-count", text: "1", timeout: 1000)
@@ -610,7 +611,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("#device-count", text: "2", timeout: 1000)
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Deployment Group", option: deployment_group.name)
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       |> assert_has("div a", text: device.identifier)
@@ -623,7 +624,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       conn
       |> visit(device_index_path(fixture))
       |> assert_has("button", text: "Filters", timeout: 1000)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Deployment Group", option: "All")
       |> assert_has("#device-count", text: "1", timeout: 1000)
     end
@@ -759,12 +760,86 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> assert_has("div a", text: device.identifier)
       |> assert_has("div a", text: device2.identifier)
       |> assert_has("div a", text: device3.identifier)
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Deployment Group", option: deployment_group.name)
       |> assert_has("#device-count", text: "2", timeout: 1_000)
       |> select("Platform", option: "platform")
       |> assert_has("#device-count", text: "2", timeout: 1_000)
       |> assert_has("#input_deployment_id:has(> option[selected])")
+    end
+  end
+
+  describe "customize columns listed" do
+    test "all columns are shown, as the default", %{conn: conn, fixture: fixture} do
+      %{user: user} = fixture
+
+      assert is_nil(user.display_preferences)
+
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("#device-count", text: "1", timeout: 1000)
+      |> assert_has("th", text: "Health")
+      |> assert_has("th", text: "Firmware")
+      |> assert_has("th", text: "Platform")
+      |> assert_has("th", text: "Connected for")
+      |> assert_has("th", text: "Deployment Group")
+      |> assert_has("th", text: "Tags")
+    end
+
+    for {column, label} <- [
+          {:health, "Health"},
+          {:firmware, "Firmware"},
+          {:platform, "Platform"},
+          {:connected_info, "Connected for"},
+          {:deployment_group, "Deployment Group"},
+          {:tags, "Tags"}
+        ] do
+      @column column
+      @label label
+      @friendly_column_name to_string(@column) |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
+
+      test "#{column} column can be removed", %{conn: conn, fixture: fixture} do
+        %{user: user} = fixture
+
+        assert is_nil(user.display_preferences)
+
+        conn
+        |> visit(device_index_path(fixture))
+        |> assert_has("#device-count", text: "1", timeout: 1000)
+        |> assert_has("th", text: @label)
+        |> click_button("#device-container button[phx-click=toggle-settings]", "")
+        |> uncheck(@friendly_column_name)
+        |> refute_has("th", text: @label, timeout: 1_000)
+      end
+
+      test "#{column} column can be added", %{conn: conn, fixture: %{user: user} = fixture} do
+        assert is_nil(user.display_preferences)
+
+        default_column_payload = %{
+          "_target" => [to_string(@column)],
+          "connected_info" => "true",
+          "deployment_group" => "true",
+          "firmware" => "true",
+          "health" => "true",
+          "platform" => "true",
+          "tags" => "true"
+        }
+
+        {:ok, _user} =
+          ListSettingsSidebar.update_displayed_columns(
+            user,
+            :device_list_columns,
+            Map.put(default_column_payload, to_string(@column), "false")
+          )
+
+        conn
+        |> visit(device_index_path(fixture))
+        |> assert_has("#device-count", text: "1", timeout: 1000)
+        |> refute_has("th", text: @label)
+        |> click_button("#device-container button[phx-click=toggle-settings]", "")
+        |> check(@friendly_column_name)
+        |> assert_has("th", text: @label, timeout: 1_000)
+      end
     end
   end
 
@@ -1463,7 +1538,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> visit(device_index_path(fixture))
       |> assert_has("div a", text: device.identifier, timeout: 1_000)
       # Filter by platform to reveal the firmware push option
-      |> click_button("button[phx-click=toggle-filters]", "Filters")
+      |> click_button("#device-container button[phx-click=toggle-filters]", "")
       |> select("Platform", option: "platform")
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       # Select the device

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -223,10 +223,10 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       |> visit("/org/#{org.name}/#{product.name}/devices")
       |> assert_has("a", text: device.identifier, timeout: 1000)
       |> assert_has("a", text: device2.identifier)
-      |> fill_in("Tags", with: "beta")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "beta")
       |> assert_has("a", text: device.identifier, timeout: 1000)
       |> refute_has("a", text: device2.identifier)
-      |> fill_in("Tags", with: "foo")
+      |> fill_in("#filter-form .sidebar-text-input", "Tags", with: "foo")
       |> assert_has("a", text: device2.identifier, timeout: 1000)
       |> refute_has("a", text: device.identifier)
     end


### PR DESCRIPTION
Add support for user-selectable columns on the Devices and Deployment Groups pages.

https://github.com/user-attachments/assets/c11eaa49-6a72-4846-9de6-e9b4496190e3

