### PR TITLE
Switch icons for collapsing/expanding the sidebar

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -31,6 +31,11 @@
   --color-surface-raised: #1c1c1f; /* cards, chips, inputs — between surface-muted and zinc-800 */
   --color-surface-overlay: #18181b; /* menus, popovers, modals */
 
+  --color-strong: #fafafa; /* zinc-50  — headings, key values */
+  --color-body: #d4d4d8; /* zinc-300 — default body text */
+  --color-muted: #a1a1aa; /* zinc-400 — secondary / labels */
+  --color-faint: #71717a; /* zinc-500 — placeholder / disabled */
+
   /* Neutral ramp — low = bright text, high = recessed surface; inverts in light */
   --color-base-50: var(--color-zinc-50);
   --color-base-100: var(--color-zinc-100);
@@ -107,11 +112,6 @@
   --alert-rgb: 239 68 68;
   --veil-rgb: 63 63 70;
 
-  --text-strong: #fafafa; /* zinc-50  — headings, key values */
-  --text-body: #d4d4d8; /* zinc-300 — default body text */
-  --text-muted: #a1a1aa; /* zinc-400 — secondary / labels */
-  --text-faint: #71717a; /* zinc-500 — placeholder / disabled */
-
   --border: #3f3f46; /* zinc-700 — default hairline */
   --border-strong: #52525b; /* zinc-600 — inputs, buttons */
   --border-subtle: #27272a; /* zinc-800 — faint divider */
@@ -168,10 +168,10 @@
   --color-alert-soft: var(--color-red-50);
 
   /* Semantic roles + neutral veil flip on the light canvas */
-  --text-strong: #18181b; /* zinc-900 */
-  --text-body: #3f3f46; /* zinc-700 */
-  --text-muted: #52525b; /* zinc-600 */
-  --text-faint: #71717a; /* zinc-500 (shared) */
+  --color-strong: var(--color-zinc-900); /* zinc-900 */
+  --color-body: var(--color-zinc-700); /* zinc-700 */
+  --color-muted: var(--color-zinc-500); /* zinc-600 */
+  --color-faint: var(--color-zinc-300); /* zinc-500 (shared) */
 
   --border: #e4e4e7; /* zinc-200 */
   --border-strong: #d4d4d8; /* zinc-300 */
@@ -189,7 +189,7 @@
 /* The sidebar collapses to an icon rail when the user toggles it
    (`data-sidebar="collapsed"`) OR whenever the viewport is below `lg`. */
 @custom-variant collapsed {
-  &:where([data-sidebar=collapsed], [data-sidebar=collapsed] *) {
+  &:where([data-sidebar="collapsed"], [data-sidebar="collapsed"] *) {
     @slot;
   }
   @media (width < 64rem) {

--- a/lib/nerves_hub_web/components/layouts/sidebar.html.heex
+++ b/lib/nerves_hub_web/components/layouts/sidebar.html.heex
@@ -11,8 +11,8 @@
         aria-label="Collapse or expand the sidebar"
         class="hover:text-base-50 text-base-400 flex size-7 shrink-0 items-center justify-center rounded hover:cursor-pointer"
       >
-        <span class="collapsed:hidden lucide-chevrons-left--light size-5"></span>
-        <span class="collapsed:block lucide-chevrons-right--light hidden size-5"></span>
+        <span class="collapsed:hidden lucide-panel-left-close--light text-muted size-5"></span>
+        <span class="collapsed:block lucide-panel-left-open--light text-muted hidden size-5"></span>
       </button>
     </div>
 


### PR DESCRIPTION
**Collapse:**
<img width="407" height="221" alt="Screenshot 2026-06-19 at 4 37 29 PM" src="https://github.com/user-attachments/assets/937cfa29-7d91-4c8c-9ab7-db71f9db60b2" />

**Expand:**
<img width="146" height="149" alt="Screenshot 2026-06-19 at 4 37 44 PM" src="https://github.com/user-attachments/assets/3772b381-a3a0-49eb-9968-765a4d158e42" />
