### PR TITLE
Drop the old `device_connections` table

### DIFF
--- a/priv/repo/migrations/20260619015013_remove_device_connections_table.exs
+++ b/priv/repo/migrations/20260619015013_remove_device_connections_table.exs
@@ -1,0 +1,13 @@
+defmodule NervesHub.Repo.Migrations.RemoveDeviceConnectionsTable do
+  use Ecto.Migration
+
+  def up() do
+    drop(table("device_connections"))
+  end
+
+  def down() do
+    # Note: This cannot be safely reversed as it would require
+    # all existing rows to have a non-null firmware_id and archive_id
+    raise "This migration cannot be reversed"
+  end
+end


### PR DESCRIPTION
Fixes an issue where destroying old devices can fail due to foreign key constraints