### PR TITLE
Use Clickhouse for device connection history

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -7,6 +7,7 @@ import "chartjs-adapter-date-fns"
 import TimeAgo from "javascript-time-ago"
 import en from "javascript-time-ago/locale/en"
 
+import BarChart from "./hooks/barChart.js"
 import Chart from "./hooks/chart.js"
 import Console from "./hooks/console.js"
 import CrossFadeOnUpdate from "./hooks/crossFadeOnUpdate.js"
@@ -43,6 +44,7 @@ let csrfToken = document
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
   hooks: {
+    BarChart,
     Chart,
     Console,
     CrossFadeOnUpdate,

--- a/assets/js/hooks/barChart.js
+++ b/assets/js/hooks/barChart.js
@@ -1,0 +1,171 @@
+import Chart from "chart.js/auto"
+
+const valueLabels = {
+  id: "valueLabels",
+  afterDatasetsDraw(chart, _args, opts) {
+    const { ctx } = chart
+    const o = {
+      font: "12px ui-monospace, SF Mono",
+      color: "#71717a",
+      offset: 10,
+      formatter: (v) => v,
+      display: true,
+      ...opts,
+    }
+    const resolve = (v, c) => (typeof v === "function" ? v(c) : v)
+
+    ctx.save()
+    chart.data.datasets.forEach((dataset, di) => {
+      const meta = chart.getDatasetMeta(di)
+      if (meta.hidden || meta.type !== "bar") return
+
+      meta.data.forEach((bar, i) => {
+        const value = dataset.data[i]
+        if (value === null || value === undefined) return
+
+        const c = { chart, dataset, datasetIndex: di, dataIndex: i, value }
+        if (!resolve(o.display, c)) return
+
+        const { x, y, base } = bar.getProps(["x", "y", "base"], true)
+        const horizontal = meta.iScale.axis === "y"
+        const text = String(o.formatter(value, c))
+
+        ctx.font = resolve(o.font, c)
+        ctx.fillStyle = resolve(o.color, c)
+
+        if (horizontal) {
+          ctx.textBaseline = "middle"
+          if (x >= base) {
+            // grows right
+            ctx.textAlign = "left"
+            ctx.fillText(text, x + o.offset, y)
+          } else {
+            // grows left (negative)
+            ctx.textAlign = "right"
+            ctx.fillText(text, x - o.offset, y)
+          }
+        } else {
+          ctx.textAlign = "center"
+          if (y <= base) {
+            // grows up
+            ctx.textBaseline = "bottom"
+            ctx.fillText(text, x, y - o.offset)
+          } else {
+            // grows down (negative)
+            ctx.textBaseline = "top"
+            ctx.fillText(text, x, y + o.offset)
+          }
+        }
+      })
+    })
+    ctx.restore()
+  },
+}
+
+export default {
+  mounted() {
+    let metrics = JSON.parse(this.el.dataset.metrics)
+
+    let maxDate = JSON.parse(this.el.dataset.maxdate)
+    let minDate = JSON.parse(this.el.dataset.mindate)
+
+    let unit = this.el.dataset.unit
+
+    const areaChartDataset = {
+      type: "bar",
+      data: {
+        datasets: [
+          {
+            radius: 2,
+            data: metrics,
+            parsing: {
+              xAxisKey: "day",
+              yAxisKey: "count",
+            },
+            backgroundColor: function (context) {
+              const chart = context.chart
+              const { ctx, chartArea } = chart
+
+              // Prevent errors during the initial layout render
+              if (!chartArea) {
+                return null
+              }
+
+              // Define coordinates: (startX, startY, endX, endY)
+              // Vertical gradient goes from chart top to chart bottom
+              const gradient = ctx.createLinearGradient(
+                0,
+                chartArea.top,
+                0,
+                chartArea.bottom,
+              )
+
+              gradient.addColorStop(0, "rgba(97, 95, 255, 1)")
+              gradient.addColorStop(1, "rgba(97, 95, 255, 0.1)")
+
+              return gradient
+            },
+          },
+        ],
+      },
+      options: {
+        plugins: {
+          title: {
+            display: false,
+          },
+          legend: {
+            display: false,
+          },
+          tooltip: false,
+          valueLabels: {
+            formatter: (v) => `${v.count}`,
+          },
+        },
+        scales: {
+          x: {
+            grid: {
+              display: false,
+              color: null,
+            },
+            border: {
+              display: false,
+            },
+            type: "time",
+            time: {
+              unit: unit,
+            },
+            ticks: {
+              source: "auto",
+              display: true,
+              autoSkip: false,
+            },
+            min: minDate,
+            max: maxDate,
+          },
+          y: {
+            grid: {
+              display: false,
+              color: null,
+            },
+            border: {
+              display: false,
+            },
+            ticks: {
+              display: false,
+            },
+            type: "linear",
+            suggestedMin: 0,
+            suggestedMax: 10,
+          },
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+      },
+      plugins: [valueLabels],
+    }
+
+    const chart = new Chart(this.el, areaChartDataset)
+
+    this.el.chart = chart
+  },
+}

--- a/assets/js/hooks/toolTip.js
+++ b/assets/js/hooks/toolTip.js
@@ -15,16 +15,16 @@ export default {
         top: 15,
         right: 10,
         bottom: 15,
-        left: 10
+        left: 10,
       }[this.placement]
 
       computePosition(this.el, this.content, {
         placement,
-        middleware: [offset(sideOffset), arrow({ element: this.arrow })]
+        middleware: [offset(sideOffset), arrow({ element: this.arrow })],
       }).then(({ x, y, middlewareData, placement }) => {
         Object.assign(this.content.style, {
           left: `${x}px`,
-          top: `${y}px`
+          top: `${y}px`,
         })
 
         const side = placement.split("-")[0]
@@ -33,7 +33,7 @@ export default {
           top: "bottom",
           right: "left",
           bottom: "top",
-          left: "right"
+          left: "right",
         }[side]
 
         if (middlewareData.arrow) {
@@ -43,7 +43,7 @@ export default {
             top: "0 1px 1px 0",
             right: "0 0 1px 1px",
             bottom: "1px 0 0 1px",
-            left: "1px 1px 0 0"
+            left: "1px 1px 0 0",
           }[this.placement]
 
           Object.assign(this.arrow.style, {
@@ -54,8 +54,7 @@ export default {
             right: "",
             bottom: "",
             [staticSide]: `${(-arrowLen - 1) / 2}px`,
-            transform: "rotate(45deg)",
-            "border-width": border
+            "border-width": border,
           })
         }
       })
@@ -78,5 +77,5 @@ export default {
 
     this.el.addEventListener("mouseover", this.showTooltip.bind(this))
     this.el.addEventListener("mouseout", this.hideTooltip.bind(this))
-  }
+  },
 }

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -8,6 +8,7 @@ defmodule NervesHub.DeviceLink do
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
+  alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Firmwares
   alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
@@ -78,6 +79,7 @@ defmodule NervesHub.DeviceLink do
   @spec refresh_device_info(DeviceInfo.t()) :: DeviceInfo.t()
   def refresh_device_info(device_info) do
     device = Devices.get_device(device_info.device_id)
+    device_connection = Devices.Connections.get_latest_for_device(device_info.device_id)
 
     %{
       device_info
@@ -89,7 +91,7 @@ defmodule NervesHub.DeviceLink do
         firmware_metadata: device.firmware_metadata,
         device_updates_enabled: device.updates_enabled,
         device_updates_blocked_until: device.updates_blocked_until,
-        device_network_interface: device.network_interface
+        device_network_interface: device_connection.network_interface
     }
   end
 
@@ -294,7 +296,8 @@ defmodule NervesHub.DeviceLink do
   defp firmware_update_start_telemetry(%{device_identifier: identifier, device_network_interface: device_interface}, %{
          "downloader_network_interface" => downloader_interface
        }) do
-    if is_nil(device_interface) or device_interface == Device.humanized_network_interface_name(downloader_interface) do
+    if is_nil(device_interface) or
+         device_interface == DeviceConnection.humanized_network_interface_name(downloader_interface) do
       :ok
     else
       :telemetry.execute([:nerves_hub, :devices, :network_interface_mismatch], %{count: 1}, %{

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -811,13 +811,6 @@ defmodule NervesHub.Devices do
     end
   end
 
-  @spec update_network_interface(pos_integer(), binary()) :: {:ok, Device.t()} | {:error, Ecto.Changeset.t()}
-  def update_network_interface(device_id, network_interface) do
-    %Device{id: device_id}
-    |> Device.update_network_interface_changeset(network_interface)
-    |> Repo.update()
-  end
-
   @doc """
   Fetch devices associated with a deployment for updating.
 
@@ -921,7 +914,7 @@ defmodule NervesHub.Devices do
   end
 
   defp maybe_filter_by_network_interfaces(query, interfaces) do
-    where(query, [d], d.network_interface in ^interfaces)
+    where(query, [latest_connection: lc], lc.network_interface in ^interfaces)
   end
 
   defp maybe_version_threshold(query, nil), do: query

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -168,6 +168,24 @@ defmodule NervesHub.Devices.Connections do
     :ok
   end
 
+  def update_network_interface(ref_id, network_interface) do
+    humanized = DeviceConnection.humanized_network_interface_name(network_interface)
+
+    DeviceConnection
+    |> where(id: ^ref_id)
+    |> select([dc], dc)
+    |> update([dc], set: [network_interface: ^humanized])
+    |> Repo.update_all([])
+    |> case do
+      {1, [device_connection]} ->
+        async_device_connection_history_insert(device_connection)
+        {:ok, device_connection}
+
+      res ->
+        {:error, res}
+    end
+  end
+
   @doc """
   Updates the connection `metadata` by merging in new metadata.
   """

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -5,6 +5,7 @@ defmodule NervesHub.Devices.Connections do
   import Ecto.Query
 
   alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.DeviceConnectionHistory
   alias NervesHub.Repo
   alias NervesHub.Tracker
 
@@ -21,9 +22,9 @@ defmodule NervesHub.Devices.Connections do
   @doc """
   Creates a device connection, reported from device socket
   """
-  @spec device_connecting(pos_integer()) ::
+  @spec device_connecting(pos_integer(), pos_integer(), pos_integer()) ::
           {:ok, DeviceConnection.t()} | {:error, Ecto.Changeset.t()}
-  def device_connecting(device_id) do
+  def device_connecting(org_id, product_id, device_id) do
     conflict_query =
       DeviceConnection
       |> update([ldc],
@@ -38,10 +39,12 @@ defmodule NervesHub.Devices.Connections do
         ]
       )
 
-    DeviceConnection.connecting_changeset(device_id)
+    DeviceConnection.connecting_changeset(org_id, product_id, device_id)
     |> Repo.insert(on_conflict: conflict_query, conflict_target: [:device_id])
     |> case do
       {:ok, device_connection} ->
+        async_device_connection_history_insert(device_connection)
+
         Tracker.connecting(device_id)
 
         {:ok, device_connection}
@@ -59,7 +62,7 @@ defmodule NervesHub.Devices.Connections do
     DeviceConnection
     |> where(id: ^connection_id)
     |> where([dc], not (dc.status == :disconnected))
-    |> select([dc], %{device_id: dc.device_id})
+    |> select([dc], dc)
     |> Repo.update_all(
       set: [
         last_seen_at: DateTime.utc_now(),
@@ -67,8 +70,11 @@ defmodule NervesHub.Devices.Connections do
       ]
     )
     |> case do
-      {1, [%{device_id: device_id}]} ->
+      {1, [%{device_id: device_id} = device_connection]} ->
+        async_device_connection_history_insert(device_connection)
+
         Tracker.online(device_id)
+
         :ok
 
       _ ->
@@ -84,7 +90,7 @@ defmodule NervesHub.Devices.Connections do
     DeviceConnection
     |> where([dc], dc.id == ^id)
     |> where([dc], not (dc.status == :disconnected))
-    |> select([dc], %{device_id: dc.device_id})
+    |> select([dc], dc)
     |> Repo.update_all(
       set: [
         status: :connected,
@@ -92,8 +98,11 @@ defmodule NervesHub.Devices.Connections do
       ]
     )
     |> case do
-      {1, [%{device_id: device_id}]} ->
+      {1, [%{device_id: device_id} = device_connection]} ->
+        async_device_connection_history_insert(device_connection)
+
         Tracker.heartbeat(device_id)
+
         :ok
 
       _ ->
@@ -111,7 +120,7 @@ defmodule NervesHub.Devices.Connections do
 
     DeviceConnection
     |> where(id: ^ref_id)
-    |> select([dc], %{device_id: dc.device_id})
+    |> select([dc], dc)
     |> Repo.update_all(
       set: [
         last_seen_at: now,
@@ -121,13 +130,42 @@ defmodule NervesHub.Devices.Connections do
       ]
     )
     |> case do
-      {1, [%{device_id: device_id}]} ->
+      {1, [%{device_id: device_id} = device_connection]} ->
+        async_device_connection_history_insert(device_connection)
+
         Tracker.offline(device_id)
+
         :ok
 
       res ->
         {:error, res}
     end
+  end
+
+  defp async_device_connection_history_insert(device_connections) when is_list(device_connections) do
+    if Application.get_env(:nerves_hub, :analytics_enabled) do
+      Enum.each(device_connections, fn device_connection ->
+        async_device_connection_history_insert(device_connection)
+      end)
+    end
+
+    :ok
+  end
+
+  defp async_device_connection_history_insert(device_connection) do
+    _ =
+      if Application.get_env(:nerves_hub, :analytics_enabled) do
+        Task.Supervisor.start_child(
+          {:via, PartitionSupervisor, {NervesHub.AnalyticsEventsProcessing, self()}},
+          fn ->
+            {:ok, _} =
+              DeviceConnectionHistory.changeset(device_connection)
+              |> NervesHub.AnalyticsRepo.insert()
+          end
+        )
+      end
+
+    :ok
   end
 
   @doc """
@@ -143,6 +181,41 @@ defmodule NervesHub.Devices.Connections do
       {1, _} -> :ok
       result -> {:error, result}
     end
+  end
+
+  def device_connections_by_date(org_id, product_id, from) do
+    window_start = Date.add(from, -1)
+    window_end = Date.utc_today()
+
+    inner =
+      from c in "device_connection_history",
+        where: c.org_id == ^org_id,
+        where: c.product_id == ^product_id,
+        where: c.established_at < fragment("? + 1", type(^window_end, :date)),
+        where: is_nil(c.disconnected_at) or c.disconnected_at >= type(^window_start, :date),
+        select: %{
+          device_id: c.device_id,
+          day:
+            fragment(
+              "toDate(arrayJoin(range(toUInt32(greatest(toDate(?), ?)), toUInt32(least(coalesce(toDate(?), ?), ?)) + 1)))",
+              c.established_at,
+              type(^window_start, :date),
+              c.disconnected_at,
+              type(^window_end, :date),
+              type(^window_end, :date)
+            )
+        }
+
+    query =
+      from s in subquery(inner),
+        group_by: s.day,
+        order_by: s.day,
+        select: %{
+          day: s.day,
+          count: fragment("uniqExact(?)", s.device_id)
+        }
+
+    NervesHub.AnalyticsRepo.all(query)
   end
 
   def clean_stale_connections() do
@@ -164,7 +237,8 @@ defmodule NervesHub.Devices.Connections do
 
     {update_count, _} =
       DeviceConnection
-      |> where([d], d.id in subquery(query))
+      |> where([dc], dc.id in subquery(query))
+      |> select([dc], dc)
       |> Repo.update_all(
         [
           set: [
@@ -175,6 +249,12 @@ defmodule NervesHub.Devices.Connections do
         ],
         timeout: 60_000
       )
+      |> case do
+        {_count, device_connections} = results ->
+          async_device_connection_history_insert(device_connections)
+
+          results
+      end
 
     if update_count > 0 do
       :telemetry.execute([:nerves_hub, :devices, :stale_connections], %{count: update_count})

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -92,8 +92,8 @@ defmodule NervesHub.Devices.Device do
 
     # To be removed in a migration in the next release
     # field(:priority_updates, :boolean, default: false)
+    # field(:network_interface, Ecto.Enum, values: [:wifi, :ethernet, :cellular, :unknown])
 
-    field(:network_interface, Ecto.Enum, values: [:wifi, :ethernet, :cellular, :unknown])
     field(:deleted_at, :utc_datetime)
 
     timestamps()
@@ -150,32 +150,5 @@ defmodule NervesHub.Devices.Device do
     device
     |> change()
     |> put_change(:firmware_validation_status, :validated)
-  end
-
-  def update_network_interface_changeset(%Device{} = device, nil) do
-    add_error(
-      change(device),
-      :network_interface,
-      "cannot be set to nil"
-    )
-  end
-
-  def update_network_interface_changeset(%Device{} = device, network_interface) do
-    humanized_interface_name = humanized_network_interface_name(network_interface)
-
-    device
-    |> change(%{network_interface: humanized_interface_name})
-    |> cast(%{network_interface: humanized_interface_name}, [:network_interface])
-    |> validate_required([:network_interface])
-  end
-
-  @spec humanized_network_interface_name(String.t()) :: :wifi | :ethernet | :cellular | :unknown
-  def humanized_network_interface_name(interface) do
-    cond do
-      String.starts_with?(interface, "wlan") -> :wifi
-      String.starts_with?(interface, "eth") or String.starts_with?(interface, "en") -> :ethernet
-      String.starts_with?(interface, "wwan") -> :cellular
-      true -> :unknown
-    end
   end
 end

--- a/lib/nerves_hub/devices/device_connection.ex
+++ b/lib/nerves_hub/devices/device_connection.ex
@@ -31,8 +31,7 @@ defmodule NervesHub.Devices.DeviceConnection do
     field(:lib, :string)
     field(:lib_version, :string)
 
-    field(:interface, :string)
-    field(:available_interfaces, :string)
+    field(:network_interface, Ecto.Enum, values: [:wifi, :ethernet, :cellular, :unknown])
   end
 
   def connecting_changeset(org_id, product_id, device_id) do
@@ -46,5 +45,19 @@ defmodule NervesHub.Devices.DeviceConnection do
     |> put_change(:established_at, now)
     |> put_change(:last_seen_at, now)
     |> put_change(:status, :connecting)
+  end
+
+  @spec humanized_network_interface_name(any()) :: :wifi | :ethernet | :cellular | :unknown
+  def humanized_network_interface_name(interface) when is_binary(interface) do
+    cond do
+      String.starts_with?(interface, "wlan") -> :wifi
+      String.starts_with?(interface, "eth") or String.starts_with?(interface, "en") -> :ethernet
+      String.starts_with?(interface, "wwan") -> :cellular
+      true -> :unknown
+    end
+  end
+
+  def humanized_network_interface_name(_interface) do
+    :unknown
   end
 end

--- a/lib/nerves_hub/devices/device_connection.ex
+++ b/lib/nerves_hub/devices/device_connection.ex
@@ -3,31 +3,45 @@ defmodule NervesHub.Devices.DeviceConnection do
 
   import Ecto.Changeset
 
+  alias NervesHub.Accounts.Org
   alias NervesHub.Devices.Device
+  alias NervesHub.Products.Product
 
   @type t :: %__MODULE__{}
   @primary_key {:id, UUIDv7, autogenerate: true}
 
   schema "latest_device_connections" do
+    belongs_to(:org, Org)
+    belongs_to(:product, Product)
     belongs_to(:device, Device)
 
     field(:established_at, :utc_datetime_usec)
     field(:last_seen_at, :utc_datetime_usec)
     field(:disconnected_at, :utc_datetime_usec)
+
     field(:disconnected_reason, :string)
+
     field(:metadata, :map, default: %{})
 
     field(:status, Ecto.Enum,
       values: [:connecting, :connected, :disconnected],
       default: :connecting
     )
+
+    field(:lib, :string)
+    field(:lib_version, :string)
+
+    field(:interface, :string)
+    field(:available_interfaces, :string)
   end
 
-  def connecting_changeset(device_id) do
+  def connecting_changeset(org_id, product_id, device_id) do
     now = DateTime.utc_now()
 
     %__MODULE__{}
     |> change()
+    |> put_change(:org_id, org_id)
+    |> put_change(:product_id, product_id)
     |> put_change(:device_id, device_id)
     |> put_change(:established_at, now)
     |> put_change(:last_seen_at, now)

--- a/lib/nerves_hub/devices/device_connection_history.ex
+++ b/lib/nerves_hub/devices/device_connection_history.ex
@@ -1,0 +1,48 @@
+defmodule NervesHub.Devices.DeviceConnectionHistory do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Devices.DeviceConnection
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  schema "device_connection_history" do
+    field(:ref, Ch, type: "UUID")
+
+    field(:established_at, Ch, type: "DateTime64(6, 'UTC')")
+    field(:last_seen_at, Ch, type: "DateTime64(6, 'UTC')")
+    field(:disconnected_at, Ch, type: "Nullable(DateTime64(6, 'UTC'))")
+
+    field(:org_id, Ch, type: "UInt64")
+    field(:product_id, Ch, type: "UInt64")
+    field(:device_id, Ch, type: "UInt64")
+
+    field(:disconnected_reason, Ch, type: "LowCardinality(String)")
+
+    field(:lib, Ch, type: "LowCardinality(String)")
+    field(:lib_version, Ch, type: "LowCardinality(String)")
+
+    field(:interface, Ch, type: "LowCardinality(String)")
+
+    field(:version, Ch, type: "UInt64")
+  end
+
+  def changeset(%DeviceConnection{} = connection) do
+    %__MODULE__{}
+    |> change()
+    |> put_change(:org_id, connection.org_id)
+    |> put_change(:product_id, connection.product_id)
+    |> put_change(:device_id, connection.device_id)
+    |> put_change(:established_at, connection.established_at)
+    |> put_change(:last_seen_at, connection.last_seen_at)
+    |> put_change(:disconnected_at, connection.disconnected_at)
+    |> put_change(:ref, connection.id)
+    |> put_change(:disconnected_reason, connection.disconnected_reason)
+    |> put_change(:lib, connection.lib)
+    |> put_change(:lib_version, connection.lib_version)
+    |> put_change(:interface, connection.interface)
+    |> put_change(:version, DateTime.to_unix(connection.last_seen_at))
+  end
+end

--- a/lib/nerves_hub/devices/device_connection_history.ex
+++ b/lib/nerves_hub/devices/device_connection_history.ex
@@ -24,7 +24,7 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
     field(:lib, Ch, type: "LowCardinality(String)")
     field(:lib_version, Ch, type: "LowCardinality(String)")
 
-    field(:interface, Ch, type: "LowCardinality(String)")
+    field(:network_interface, Ch, type: "LowCardinality(String)")
 
     field(:version, Ch, type: "UInt64")
   end
@@ -42,7 +42,7 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
     |> put_change(:disconnected_reason, connection.disconnected_reason)
     |> put_change(:lib, connection.lib)
     |> put_change(:lib_version, connection.lib_version)
-    |> put_change(:interface, connection.interface)
+    |> put_change(:network_interface, to_string(connection.network_interface))
     |> put_change(:version, DateTime.to_unix(connection.last_seen_at))
   end
 end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -24,7 +24,7 @@ defmodule NervesHubWeb.DeviceChannel do
 
   alias NervesHub.DeviceLink
   alias NervesHub.Devices
-  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.Connections
   alias Phoenix.Socket.Broadcast
 
   require Logger
@@ -231,12 +231,13 @@ defmodule NervesHubWeb.DeviceChannel do
         %{"interface" => interface},
         %{assigns: %{device_info: device_info}} = socket
       ) do
-    if Device.humanized_network_interface_name(interface) == device_info.device_network_interface do
+    if Devices.DeviceConnection.humanized_network_interface_name(interface) == device_info.device_network_interface do
       {:noreply, socket}
     else
-      case Devices.update_network_interface(device_info.device_id, interface) do
-        {:ok, device} ->
-          {:noreply, assign(socket, :device_info, %{device_info | device_network_interface: device.network_interface})}
+      case Connections.update_network_interface(device_info.connection_ref, interface) do
+        {:ok, device_connection} ->
+          {:noreply,
+           assign(socket, :device_info, %{device_info | device_network_interface: device_connection.network_interface})}
 
         {:error, changeset} ->
           Logger.warning(

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -281,7 +281,8 @@ defmodule NervesHubWeb.DeviceSocket do
   @decorate with_span("Channels.DeviceSocket.on_connect")
   defp on_connect(%{assigns: %{device_info: device_info}} = socket) do
     # Report connection and use connection id as reference
-    {:ok, %DeviceConnection{id: connection_id}} = Connections.device_connecting(device_info.device_id)
+    {:ok, %DeviceConnection{id: connection_id}} =
+      Connections.device_connecting(device_info.org_id, device_info.product_id, device_info.device_id)
 
     :telemetry.execute([:nerves_hub, :devices, :connect], %{count: 1}, %{
       ref_id: connection_id,

--- a/lib/nerves_hub_web/live/product/insights.ex
+++ b/lib/nerves_hub_web/live/product/insights.ex
@@ -2,6 +2,7 @@ defmodule NervesHubWeb.Live.Product.Insights do
   use NervesHubWeb, :live_view
 
   alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
   alias NervesHub.ProductNotifications
   alias NervesHub.Products
 
@@ -12,6 +13,7 @@ defmodule NervesHubWeb.Live.Product.Insights do
     socket
     |> assign(:product, product)
     |> update_information()
+    |> maybe_assign_device_connections_graph()
     |> fleet_health_information()
     |> assign_notifications()
     |> assign(:page_title, "#{scope.product.name} Insights")
@@ -52,6 +54,22 @@ defmodule NervesHubWeb.Live.Product.Insights do
     |> assign(:not_seen_in_7_days, Devices.not_seen_in_x_days_count(scope.product, 7))
     |> assign(:not_seen_in_14_days, Devices.not_seen_in_x_days_count(scope.product, 14))
     |> assign(:fleet_size, Devices.total_count(scope.product))
+  end
+
+  defp maybe_assign_device_connections_graph(%{assigns: %{current_scope: scope}} = socket) do
+    if Application.get_env(:nerves_hub, :analytics_enabled) do
+      from = Date.utc_today() |> Date.add(-14)
+
+      data = Connections.device_connections_by_date(scope.org.id, scope.product.id, from)
+
+      socket
+      |> assign(:device_connections_graph_from, from)
+      |> assign(:device_connections_graph_to, Date.utc_today())
+      |> assign(:device_connections_graph_enabled, true)
+      |> assign(:device_connections_graph_data, data)
+    else
+      assign(socket, :device_connections_graph_enabled, false)
+    end
   end
 
   defp fleet_health_information(%{assigns: %{current_scope: scope}} = socket) do

--- a/lib/nerves_hub_web/live/product/insights.html.heex
+++ b/lib/nerves_hub_web/live/product/insights.html.heex
@@ -104,11 +104,24 @@
       </div>
     </div>
 
-    <%!-- <div class="bg-surface-raised border-base-700 shadow-device-details-content flex h-[132px] flex-col rounded border">
-      <div class="text-base-50 flex h-14 items-center pr-3 pl-4 leading-6 font-medium">
-        Devices Seen — Last 14 Days
+    <div :if={@device_connections_graph_enabled} class="bg-surface-raised border-base-700 shadow-device-details-content flex h-[250px] flex-col gap-5 rounded border p-5">
+      <div class="text-base-50 flex items-center leading-6 font-medium">
+        Connected Devices — Last 14 Days
       </div>
-    </div> --%>
+
+      <div class="h-[230]">
+        <canvas
+          id="daily-device-counts-chart"
+          phx-hook="BarChart"
+          phx-update="ignore"
+          data-metrics={Jason.encode!(@device_connections_graph_data)}
+          data-title=""
+          data-mindate={Jason.encode!(@device_connections_graph_from)}
+          data-maxdate={Jason.encode!(@device_connections_graph_to)}
+          data-unit="day"
+        ></canvas>
+      </div>
+    </div>
 
     <div class="grid grid-cols-2 gap-4">
       <div class="flex flex-col gap-4">

--- a/priv/analytics_repo/migrations/20260620213616_add_device_connection_history_table.exs
+++ b/priv/analytics_repo/migrations/20260620213616_add_device_connection_history_table.exs
@@ -27,7 +27,7 @@ defmodule NervesHub.AnalyticsRepo.Migrations.AddDeviceConnectionHistoryTable do
       add(:lib, :"LowCardinality(String)")
       add(:lib_version, :"LowCardinality(String)")
 
-      add(:interface, :"LowCardinality(String)")
+      add(:network_interface, :"LowCardinality(String)")
 
       add(:version, :UInt64)
     end

--- a/priv/analytics_repo/migrations/20260620213616_add_device_connection_history_table.exs
+++ b/priv/analytics_repo/migrations/20260620213616_add_device_connection_history_table.exs
@@ -1,0 +1,35 @@
+defmodule NervesHub.AnalyticsRepo.Migrations.AddDeviceConnectionHistoryTable do
+  use Ecto.Migration
+
+  def change() do
+    options = [
+      partition_by: "toDate(established_at)",
+      order_by: "(org_id, product_id, device_id, established_at)"
+    ]
+
+    create table(:device_connection_history,
+             primary_key: false,
+             engine: "ReplacingMergeTree(version)",
+             options: options
+           ) do
+      add(:org_id, :UInt64)
+      add(:product_id, :UInt64)
+      add(:device_id, :UInt64)
+
+      add(:established_at, :"DateTime64(6, 'UTC')")
+      add(:last_seen_at, :"DateTime64(6, 'UTC')")
+      add(:disconnected_at, :"Nullable(DateTime64(6, 'UTC'))")
+
+      add(:disconnected_reason, :"LowCardinality(String)")
+
+      add(:ref, :UUID)
+
+      add(:lib, :"LowCardinality(String)")
+      add(:lib_version, :"LowCardinality(String)")
+
+      add(:interface, :"LowCardinality(String)")
+
+      add(:version, :UInt64)
+    end
+  end
+end

--- a/priv/repo/migrations/20260620235408_update_latest_device_connections_table.exs
+++ b/priv/repo/migrations/20260620235408_update_latest_device_connections_table.exs
@@ -1,0 +1,16 @@
+defmodule NervesHub.Repo.Migrations.UpdateLatestDeviceConnectionsTable do
+  use Ecto.Migration
+
+  def change() do
+    alter table(:latest_device_connections) do
+      add(:org_id, references("orgs", on_delete: :nilify_all))
+      add(:product_id, references("products", on_delete: :nilify_all))
+
+      add(:lib, :string)
+      add(:lib_version, :string)
+
+      add(:interface, :string)
+      add(:available_interfaces, {:array, :string})
+    end
+  end
+end

--- a/priv/repo/migrations/20260620235408_update_latest_device_connections_table.exs
+++ b/priv/repo/migrations/20260620235408_update_latest_device_connections_table.exs
@@ -9,8 +9,7 @@ defmodule NervesHub.Repo.Migrations.UpdateLatestDeviceConnectionsTable do
       add(:lib, :string)
       add(:lib_version, :string)
 
-      add(:interface, :string)
-      add(:available_interfaces, {:array, :string})
+      add(:network_interface, :string)
     end
   end
 end

--- a/test/nerves_hub/database/index_test.exs
+++ b/test/nerves_hub/database/index_test.exs
@@ -36,6 +36,8 @@ defmodule NervesHub.Database.IndexTest do
     "invites.invited_by_id",
     "invites.org_id",
     "jitp.product_id",
+    "latest_device_connections.org_id",
+    "latest_device_connections.product_id",
     "org_keys.created_by_id",
     "org_users.org_id",
     "org_users.user_id",

--- a/test/nerves_hub/device_link_test.exs
+++ b/test/nerves_hub/device_link_test.exs
@@ -5,7 +5,8 @@ defmodule NervesHub.DeviceLinkTest do
   alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.DeviceLink
   alias NervesHub.DeviceLink.DeviceInfo
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Fixtures
   alias NervesHub.Repo
@@ -332,7 +333,12 @@ defmodule NervesHub.DeviceLinkTest do
       # Create an inflight update
       {:ok, _inflight_update} = Fixtures.inflight_update(device, firmware)
 
-      {:ok, _device} = Devices.update_network_interface(device.id, "wlan0")
+      assert {:ok, %DeviceConnection{id: ref, status: :connecting} = connection} =
+               Connections.device_connecting(device.org_id, device.product_id, device.id)
+
+      refute connection.network_interface
+
+      {:ok, _connection} = Connections.update_network_interface(ref, "eth0")
 
       expect(:telemetry, :execute, fn _event, _measurements, metadata ->
         assert metadata.downloader_network_interface == "eth0"

--- a/test/nerves_hub/devices/connection_history_test.exs
+++ b/test/nerves_hub/devices/connection_history_test.exs
@@ -1,0 +1,233 @@
+defmodule NervesHub.Devices.ConnectionHistoryTest do
+  # These tests are not async because they interact with the AnalyticsRepo,
+  # which is a ClickHouse database that does not support concurrent writes.
+  use NervesHub.DataCase, async: false
+  use AssertEventually, timeout: 2000, interval: 50
+
+  alias NervesHub.AnalyticsRepo
+  alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.DeviceConnectionHistory
+  alias NervesHub.Fixtures
+
+  setup %{tmp_dir: tmp_dir} do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    AnalyticsRepo.query!("TRUNCATE TABLE device_connection_history")
+
+    on_exit(fn -> AnalyticsRepo.query!("TRUNCATE TABLE device_connection_history") end)
+
+    {:ok, %{user: user, org: org, product: product, firmware: firmware, device: device}}
+  end
+
+  defp history_for(ref) do
+    AnalyticsRepo.all(DeviceConnectionHistory)
+    |> Enum.filter(&(&1.ref == ref))
+  end
+
+  describe "history is recorded for the connection lifecycle" do
+    test "device_connecting/3 records a history row", %{device: device} do
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
+
+      assert_eventually([%DeviceConnectionHistory{} = history] = history_for(connection.id))
+
+      assert history.org_id == device.org_id
+      assert history.product_id == device.product_id
+      assert history.device_id == device.id
+      assert is_nil(history.disconnected_at)
+    end
+
+    test "device_connected/1 records a history row", %{device: device} do
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
+      assert_eventually([_] = history_for(connection.id))
+
+      :ok = Connections.device_connected(connection.id)
+
+      # connecting + connected share the same ref/established_at, so the
+      # ReplacingMergeTree may keep both rows until merged; both are present.
+      assert_eventually(history_for(connection.id) != [])
+    end
+
+    test "device_disconnected/2 records a history row with the disconnect details", %{
+      device: device
+    } do
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
+      :ok = Connections.device_connected(connection.id)
+      :ok = Connections.device_disconnected(connection.id, "Stale connection")
+
+      assert_eventually(
+        Enum.any?(history_for(connection.id), fn h ->
+          not is_nil(h.disconnected_at) and h.disconnected_reason == "Stale connection"
+        end)
+      )
+    end
+
+    test "device_heartbeat/1 records a history row", %{device: device} do
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
+      :ok = Connections.device_connected(connection.id)
+
+      :ok = Connections.device_heartbeat(connection.id)
+
+      assert_eventually(history_for(connection.id) != [])
+    end
+
+    test "clean_stale_connections/0 records history for connections it marks stale", %{
+      device: device
+    } do
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
+      :ok = Connections.device_connected(connection.id)
+
+      interval = Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
+      jitter = Application.get_env(:nerves_hub, :device_last_seen_update_interval_jitter_seconds)
+      max_jitter = ceil(jitter / 60)
+      stale_time = DateTime.utc_now() |> DateTime.add(-(interval + max_jitter + 2), :minute)
+
+      connection
+      |> Ecto.Changeset.change(%{last_seen_at: stale_time})
+      |> Repo.update!()
+
+      :ok = Connections.clean_stale_connections()
+
+      assert_eventually(
+        Enum.any?(history_for(connection.id), fn h ->
+          h.disconnected_reason == "Stale connection"
+        end)
+      )
+    end
+
+    test "no history is recorded when analytics is disabled", %{device: device} do
+      original = Application.get_env(:nerves_hub, :analytics_enabled)
+
+      try do
+        Application.put_env(:nerves_hub, :analytics_enabled, false)
+
+        {:ok, connection} =
+          Connections.device_connecting(device.org_id, device.product_id, device.id)
+
+        # give any (erroneously) spawned task a chance to run before asserting absence
+        Process.sleep(200)
+
+        assert history_for(connection.id) == []
+      after
+        Application.put_env(:nerves_hub, :analytics_enabled, original)
+      end
+    end
+  end
+
+  describe "device_connections_by_date/3" do
+    setup %{org: org, product: product, firmware: firmware} do
+      device_a = Fixtures.device_fixture(org, product, firmware)
+      device_b = Fixtures.device_fixture(org, product, firmware)
+
+      %{device_a: device_a, device_b: device_b}
+    end
+
+    # Insert a history row directly so we can control established/disconnected
+    # timestamps precisely without relying on the async insert path.
+    defp insert_history(device, established_at, disconnected_at) do
+      last_seen_at = disconnected_at || DateTime.utc_now()
+
+      connection = %DeviceConnection{
+        id: UUIDv7.generate(),
+        org_id: device.org_id,
+        product_id: device.product_id,
+        device_id: device.id,
+        established_at: established_at,
+        last_seen_at: last_seen_at,
+        disconnected_at: disconnected_at
+      }
+
+      {:ok, _} =
+        connection
+        |> DeviceConnectionHistory.changeset()
+        |> AnalyticsRepo.insert()
+    end
+
+    defp days_ago(n), do: DateTime.add(DateTime.utc_now(), -n, :day)
+
+    test "buckets unique connected devices per day across the window", %{
+      org: org,
+      product: product,
+      device_a: device_a,
+      device_b: device_b
+    } do
+      # device_a was connected from 5 days ago until 3 days ago
+      insert_history(device_a, days_ago(5), days_ago(3))
+      # device_b connected 2 days ago and is still connected
+      insert_history(device_b, days_ago(2), nil)
+
+      from = Date.add(Date.utc_today(), -14)
+      results = Connections.device_connections_by_date(org.id, product.id, from)
+
+      counts = Map.new(results, fn %{day: day, count: count} -> {day, count} end)
+
+      today = Date.utc_today()
+
+      # device_a present on days -5, -4, -3
+      assert counts[Date.add(today, -5)] == 1
+      assert counts[Date.add(today, -4)] == 1
+      assert counts[Date.add(today, -3)] == 1
+
+      # device_b present on days -2, -1, and today
+      assert counts[Date.add(today, -2)] == 1
+      assert counts[Date.add(today, -1)] == 1
+      assert counts[today] == 1
+    end
+
+    test "counts each device once per day even with overlapping connections", %{
+      org: org,
+      product: product,
+      device_a: device_a,
+      device_b: device_b
+    } do
+      # both devices connected today
+      insert_history(device_a, days_ago(0), nil)
+      insert_history(device_b, days_ago(0), nil)
+      # device_a has a second (overlapping) connection today
+      insert_history(device_a, days_ago(0), nil)
+
+      from = Date.add(Date.utc_today(), -14)
+      results = Connections.device_connections_by_date(org.id, product.id, from)
+
+      counts = Map.new(results, fn %{day: day, count: count} -> {day, count} end)
+
+      # two unique devices, despite three connection rows
+      assert counts[Date.utc_today()] == 2
+    end
+
+    test "only includes connections for the requested org and product", %{
+      org: org,
+      product: product,
+      device_a: device_a,
+      user: user,
+      tmp_dir: tmp_dir
+    } do
+      insert_history(device_a, days_ago(1), nil)
+
+      # a device belonging to a different product should not be counted
+      other_org = Fixtures.org_fixture(user, %{name: "other-org"})
+      other_product = Fixtures.product_fixture(user, other_org)
+      other_org_key = Fixtures.org_key_fixture(other_org, user, tmp_dir)
+      other_firmware = Fixtures.firmware_fixture(other_org_key, other_product, %{dir: tmp_dir})
+      other_device = Fixtures.device_fixture(other_org, other_product, other_firmware)
+      insert_history(other_device, days_ago(1), nil)
+
+      from = Date.add(Date.utc_today(), -14)
+      results = Connections.device_connections_by_date(org.id, product.id, from)
+
+      counts = Map.new(results, fn %{day: day, count: count} -> {day, count} end)
+
+      assert counts[Date.add(Date.utc_today(), -1)] == 1
+    end
+
+    test "returns no rows when there is no connection history", %{org: org, product: product} do
+      from = Date.add(Date.utc_today(), -14)
+      assert Connections.device_connections_by_date(org.id, product.id, from) == []
+    end
+  end
+end

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -72,6 +72,45 @@ defmodule NervesHub.Devices.ConnectionsTest do
     end
   end
 
+  describe "update_network_interface/2" do
+    test "updates device.network_interface", %{device: device} do
+      assert {:ok, %DeviceConnection{id: ref, status: :connecting} = connection} =
+               Connections.device_connecting(device.org_id, device.product_id, device.id)
+
+      refute connection.network_interface
+
+      {:ok, device} = Connections.update_network_interface(ref, "eth0")
+      assert device.network_interface == :ethernet
+
+      {:ok, device} = Connections.update_network_interface(ref, "en0")
+      assert device.network_interface == :ethernet
+
+      {:ok, device} = Connections.update_network_interface(ref, "wlan0")
+      assert device.network_interface == :wifi
+
+      {:ok, device} = Connections.update_network_interface(ref, "wwan0")
+      assert device.network_interface == :cellular
+    end
+
+    test "sets to 'unknown' for invalid values", %{device: device} do
+      assert {:ok, %DeviceConnection{id: ref, status: :connecting}} =
+               Connections.device_connecting(device.org_id, device.product_id, device.id)
+
+      {:ok, device} = Connections.update_network_interface(ref, "foobarbaz")
+
+      assert device.network_interface == :unknown
+    end
+
+    test "sets to 'unknown' for nil", %{device: device} do
+      assert {:ok, %DeviceConnection{id: ref, status: :connecting}} =
+               Connections.device_connecting(device.org_id, device.product_id, device.id)
+
+      {:ok, device} = Connections.update_network_interface(ref, nil)
+
+      assert device.network_interface == :unknown
+    end
+  end
+
   describe "clean_stale_connections/0" do
     test "marks stale connected connections as disconnected", %{device: device} do
       {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)

--- a/test/nerves_hub/devices/connections_test.exs
+++ b/test/nerves_hub/devices/connections_test.exs
@@ -27,7 +27,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
       Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
 
       assert {:ok, %DeviceConnection{id: ref, status: :connecting}} =
-               Connections.device_connecting(device.id)
+               Connections.device_connecting(device.org_id, device.product_id, device.id)
 
       assert %DeviceConnection{status: :connecting} = Connections.get_latest_for_device(device.id)
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "connecting"}}, 500
@@ -52,7 +52,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
       Phoenix.PubSub.subscribe(NervesHub.PubSub, topic)
 
       assert {:ok, %DeviceConnection{id: connection_id, last_seen_at: first_seen_at} = connection} =
-               Connections.device_connecting(device.id)
+               Connections.device_connecting(device.org_id, device.product_id, device.id)
 
       assert_receive %Broadcast{topic: ^topic, event: "connection:change", payload: %{status: "connecting"}}, 500
 
@@ -74,7 +74,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
 
   describe "clean_stale_connections/0" do
     test "marks stale connected connections as disconnected", %{device: device} do
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
 
       # Get the configured interval and jitter
@@ -98,7 +98,7 @@ defmodule NervesHub.Devices.ConnectionsTest do
     end
 
     test "does not mark recent connections as stale", %{device: device} do
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
 
       # Set last_seen_at to recent time

--- a/test/nerves_hub/devices/device_connection_history_test.exs
+++ b/test/nerves_hub/devices/device_connection_history_test.exs
@@ -1,0 +1,95 @@
+defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
+  # Pure changeset mapping, no database access required.
+  use ExUnit.Case, async: true
+
+  alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.DeviceConnectionHistory
+
+  describe "changeset/1" do
+    test "maps the fields from a device connection onto the history record" do
+      established_at = ~U[2026-06-20 10:00:00.000000Z]
+      last_seen_at = ~U[2026-06-20 10:05:00.000000Z]
+      disconnected_at = ~U[2026-06-20 10:10:00.000000Z]
+      ref = UUIDv7.generate()
+
+      connection = %DeviceConnection{
+        id: ref,
+        org_id: 1,
+        product_id: 2,
+        device_id: 3,
+        established_at: established_at,
+        last_seen_at: last_seen_at,
+        disconnected_at: disconnected_at,
+        disconnected_reason: "Stale connection",
+        lib: "nerves_hub_link",
+        lib_version: "2.0.0",
+        interface: "eth0",
+        status: :disconnected
+      }
+
+      changes = DeviceConnectionHistory.changeset(connection).changes
+
+      assert changes.org_id == 1
+      assert changes.product_id == 2
+      assert changes.device_id == 3
+      assert changes.established_at == established_at
+      assert changes.last_seen_at == last_seen_at
+      assert changes.disconnected_at == disconnected_at
+      assert changes.disconnected_reason == "Stale connection"
+      assert changes.lib == "nerves_hub_link"
+      assert changes.lib_version == "2.0.0"
+      assert changes.interface == "eth0"
+      assert changes.ref == ref
+    end
+
+    test "the ref points back to the originating connection's id" do
+      ref = UUIDv7.generate()
+
+      changes =
+        %DeviceConnection{
+          id: ref,
+          org_id: 1,
+          product_id: 2,
+          device_id: 3,
+          established_at: DateTime.utc_now(),
+          last_seen_at: DateTime.utc_now()
+        }
+        |> DeviceConnectionHistory.changeset()
+        |> Map.fetch!(:changes)
+
+      assert changes.ref == ref
+    end
+
+    test "the version is derived from the connection's last_seen_at so newer rows win" do
+      last_seen_at = ~U[2026-06-20 10:05:00.000000Z]
+
+      connection = %DeviceConnection{
+        id: UUIDv7.generate(),
+        org_id: 1,
+        product_id: 2,
+        device_id: 3,
+        established_at: ~U[2026-06-20 10:00:00.000000Z],
+        last_seen_at: last_seen_at
+      }
+
+      changes = DeviceConnectionHistory.changeset(connection).changes
+
+      assert changes.version == DateTime.to_unix(last_seen_at)
+    end
+
+    test "a later last_seen_at produces a higher version" do
+      base = %DeviceConnection{
+        id: UUIDv7.generate(),
+        org_id: 1,
+        product_id: 2,
+        device_id: 3,
+        established_at: ~U[2026-06-20 10:00:00.000000Z]
+      }
+
+      earlier = DeviceConnectionHistory.changeset(%{base | last_seen_at: ~U[2026-06-20 10:00:00Z]})
+      later = DeviceConnectionHistory.changeset(%{base | last_seen_at: ~U[2026-06-20 10:05:00Z]})
+
+      assert later.changes.version > earlier.changes.version
+    end
+  end
+end

--- a/test/nerves_hub/devices/device_connection_history_test.exs
+++ b/test/nerves_hub/devices/device_connection_history_test.exs
@@ -23,7 +23,7 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         disconnected_reason: "Stale connection",
         lib: "nerves_hub_link",
         lib_version: "2.0.0",
-        interface: "eth0",
+        network_interface: "eth0",
         status: :disconnected
       }
 
@@ -38,7 +38,7 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
       assert changes.disconnected_reason == "Stale connection"
       assert changes.lib == "nerves_hub_link"
       assert changes.lib_version == "2.0.0"
-      assert changes.interface == "eth0"
+      assert changes.network_interface == "eth0"
       assert changes.ref == ref
     end
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -1488,23 +1488,21 @@ defmodule NervesHub.DevicesTest do
       device_cellular = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
       device_unknown = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
 
-      # Set network interfaces and prepare for updates
-      {:ok, device_wifi} = Devices.update_network_interface(device_wifi.id, "wlan0")
-      device_wifi = Repo.reload(device_wifi)
-      {:ok, device_ethernet} = Devices.update_network_interface(device_ethernet.id, "eth0")
-      device_ethernet = Repo.reload(device_ethernet)
-      {:ok, device_cellular} = Devices.update_network_interface(device_cellular.id, "wwan0")
-      device_cellular = Repo.reload(device_cellular)
-      {:ok, device_unknown} = Devices.update_network_interface(device_unknown.id, "hmmmmmmm")
-      device_unknown = Repo.reload(device_unknown)
+      # Set up connections, interfaces, and different firmware versions for all devices
+      for {device, interface} <- [
+            {device_wifi, "wlan0"},
+            {device_ethernet, "eth0"},
+            {device_cellular, "wwan0"},
+            {device_unknown, "hmmmmmmm"}
+          ] do
+        humanized = DeviceConnection.humanized_network_interface_name(interface)
 
-      # Set up connections and different firmware versions for all devices
-      for device <- [device_wifi, device_ethernet, device_cellular, device_unknown] do
         Ecto.Changeset.change(%DeviceConnection{}, %{
           device_id: device.id,
           established_at: DateTime.utc_now(),
           last_seen_at: DateTime.utc_now(),
-          status: :connected
+          status: :connected,
+          network_interface: humanized
         })
         |> Repo.insert!()
 
@@ -1545,19 +1543,16 @@ defmodule NervesHub.DevicesTest do
       device_wifi = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
       device_cellular = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
 
-      {:ok, device_wifi} = Devices.update_network_interface(device_wifi.id, "wlan0")
-      device_wifi = Repo.reload(device_wifi)
-
-      {:ok, device_cellular} = Devices.update_network_interface(device_cellular.id, "wwan0")
-      device_cellular = Repo.reload(device_cellular)
-
       # Set up connections and different firmware versions
-      for device <- [device_wifi, device_cellular] do
+      for {device, interface} <- [{device_wifi, "wlan0"}, {device_cellular, "wwan0"}] do
+        humanized = DeviceConnection.humanized_network_interface_name(interface)
+
         Ecto.Changeset.change(%DeviceConnection{}, %{
           device_id: device.id,
           established_at: DateTime.utc_now(),
           last_seen_at: DateTime.utc_now(),
-          status: :connected
+          status: :connected,
+          network_interface: humanized
         })
         |> Repo.insert!()
 
@@ -1715,28 +1710,25 @@ defmodule NervesHub.DevicesTest do
       device_ethernet_prod = Fixtures.device_fixture(org, product, deployment_group.current_release.firmware)
 
       {:ok, device_wifi_prod} = Devices.update_device(device_wifi_prod, %{tags: ["production"]})
-      {:ok, device_wifi_prod} = Devices.update_network_interface(device_wifi_prod.id, "wlan0")
-      device_wifi_prod = Repo.reload(device_wifi_prod)
-
       {:ok, device_wifi_dev} = Devices.update_device(device_wifi_dev, %{tags: ["development"]})
-      {:ok, device_wifi_dev} = Devices.update_network_interface(device_wifi_dev.id, "wlan0")
-      device_wifi_dev = Repo.reload(device_wifi_dev)
-
       {:ok, device_cellular_prod} = Devices.update_device(device_cellular_prod, %{tags: ["production"]})
-      {:ok, device_cellular_prod} = Devices.update_network_interface(device_cellular_prod.id, "wwan0")
-      device_cellular_prod = Repo.reload(device_cellular_prod)
-
       {:ok, device_ethernet_prod} = Devices.update_device(device_ethernet_prod, %{tags: ["production"]})
-      {:ok, device_ethernet_prod} = Devices.update_network_interface(device_ethernet_prod.id, "eth0")
-      device_ethernet_prod = Repo.reload(device_ethernet_prod)
 
       # Set up connections and different firmware versions for all devices
-      for device <- [device_wifi_prod, device_wifi_dev, device_cellular_prod, device_ethernet_prod] do
+      for {device, interface} <- [
+            {device_wifi_prod, "wlan0"},
+            {device_wifi_dev, "wlan0"},
+            {device_cellular_prod, "wwan0"},
+            {device_ethernet_prod, "eth0"}
+          ] do
+        humanized = DeviceConnection.humanized_network_interface_name(interface)
+
         Ecto.Changeset.change(%DeviceConnection{}, %{
           device_id: device.id,
           established_at: DateTime.utc_now(),
           last_seen_at: DateTime.utc_now(),
-          status: :connected
+          status: :connected,
+          network_interface: humanized
         })
         |> Repo.insert!()
 
@@ -2504,34 +2496,6 @@ defmodule NervesHub.DevicesTest do
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 
       assert String.ends_with?(url, "#{target_firmware.uuid}.fw")
-    end
-  end
-
-  describe "update_network_interface/2" do
-    test "updates device.network_interface", %{device: device} do
-      refute device.network_interface
-
-      {:ok, device} = Devices.update_network_interface(device.id, "eth0")
-      assert device.network_interface == :ethernet
-
-      {:ok, device} = Devices.update_network_interface(device.id, "en0")
-      assert device.network_interface == :ethernet
-
-      {:ok, device} = Devices.update_network_interface(device.id, "wlan0")
-      assert device.network_interface == :wifi
-
-      {:ok, device} = Devices.update_network_interface(device.id, "wwan0")
-      assert device.network_interface == :cellular
-    end
-
-    test "sets to 'unknown' for invalid values", %{device: device} do
-      {:ok, device} = Devices.update_network_interface(device.id, "foobarbaz")
-      assert device.network_interface == :unknown
-    end
-
-    test "cannot be explicitly set to nil", %{device: device} do
-      {:error, changeset} = Devices.update_network_interface(device.id, nil)
-      {"cannot be set to nil", []} = changeset.errors[:network_interface]
     end
   end
 

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -79,7 +79,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
 
     device1 = Devices.update_deployment_group(device1, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device1.id)
+    {:ok, connection} = Connections.device_connecting(device1.org_id, device1.product_id, device1.id)
     :ok = Connections.device_connected(connection.id)
     to_device_info(device1) |> Devices.deployment_device_online()
 
@@ -94,7 +94,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic2)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.org_id, device2.product_id, device2.id)
     :ok = Connections.device_connected(connection.id)
     to_device_info(device2) |> Devices.deployment_device_online()
 
@@ -106,7 +106,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic3)
 
     device3 = Devices.update_deployment_group(device3, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device3.id)
+    {:ok, connection} = Connections.device_connecting(device3.org_id, device3.product_id, device3.id)
     :ok = Connections.device_connected(connection.id)
     to_device_info(device3) |> Devices.deployment_device_online()
 
@@ -130,11 +130,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     deployment_group = Repo.preload(deployment_group, current_release: :firmware)
 
     device = Devices.update_deployment_group(device, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device.id)
+    {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
     :ok = Connections.device_connected(connection.id)
 
     device2 = Devices.update_deployment_group(device2, deployment_group)
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.org_id, device2.product_id, device2.id)
     :ok = Connections.device_connected(connection.id)
 
     topic1 = "device:#{device.id}"
@@ -195,7 +195,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     device = Devices.update_deployment_group(device, deployment_group)
     {:ok, device} = Devices.update_device(device, %{firmware_validation_status: "not_validated"})
-    {:ok, connection} = Connections.device_connecting(device.id)
+    {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
     :ok = Connections.device_connected(connection.id)
 
     topic1 = "device:#{device.id}"
@@ -283,7 +283,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-added"}, 500
 
-    {:ok, connection} = Connections.device_connecting(device1.id)
+    {:ok, connection} = Connections.device_connecting(device1.org_id, device1.product_id, device1.id)
     :ok = Connections.device_connected(connection.id)
 
     to_device_info(device1) |> Devices.deployment_device_online()
@@ -313,7 +313,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     Mimic.reject(&Devices.available_for_update/2)
 
-    {:ok, connection} = Connections.device_connecting(device2.id)
+    {:ok, connection} = Connections.device_connecting(device2.org_id, device2.product_id, device2.id)
     :ok = Connections.device_connected(connection.id)
 
     to_device_info(device2) |> Devices.deployment_device_online()
@@ -416,7 +416,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     device1 = Devices.update_deployment_group(device1, deployment_group)
     {:ok, device1} = Devices.update_device(device1, %{updates_enabled: false})
 
-    {:ok, connection} = Connections.device_connecting(device1.id)
+    {:ok, connection} = Connections.device_connecting(device1.org_id, device1.product_id, device1.id)
     :ok = Connections.device_connected(connection.id)
 
     to_device_info(device1) |> Devices.deployment_device_online()
@@ -593,7 +593,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       Fixtures.device_fixture(org, product, other_firmware)
       |> Devices.update_deployment_group(deployment_group)
 
-    {:ok, connection} = Connections.device_connecting(device.id)
+    {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
     :ok = Connections.device_connected(connection.id)
 
     deployment_group =
@@ -709,9 +709,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id)
-      {:ok, conn3} = Connections.device_connecting(new_device.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
+      {:ok, conn3} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -776,7 +776,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       :ok = Connections.device_connected(conn1.id)
       assert Orchestrator.available_priority_slots(deployment_group) == 2
 
@@ -830,8 +830,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
-      {:ok, conn2} = Connections.device_connecting(new_device.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -867,7 +867,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       device = Devices.update_deployment_group(device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(device.id)
+      {:ok, conn} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(conn.id)
 
       # Should return empty list since priority queue is disabled
@@ -906,7 +906,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(new_device.id)
+      {:ok, conn} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
       :ok = Connections.device_connected(conn.id)
       # new_device has version 1.5.0, threshold is 1.0.0
       available = Devices.available_for_priority_update(deployment_group, 10)
@@ -955,8 +955,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -1022,9 +1022,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id)
-      {:ok, conn3} = Connections.device_connecting(new_device.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
+      {:ok, conn3} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -1086,8 +1086,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
-      {:ok, conn2} = Connections.device_connecting(new_device.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -1124,7 +1124,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
       device = Devices.update_deployment_group(device, deployment_group)
 
-      {:ok, conn} = Connections.device_connecting(device.id)
+      {:ok, conn} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(conn.id)
 
       assert Devices.available_for_priority_update(deployment_group, 10) == []
@@ -1201,10 +1201,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       device_2_0 = Devices.update_deployment_group(device_2_0, deployment_group)
       device_1_1 = Devices.update_deployment_group(device_1_1, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(device_1_10.id)
-      {:ok, conn2} = Connections.device_connecting(device_1_9.id)
-      {:ok, conn3} = Connections.device_connecting(device_2_0.id)
-      {:ok, conn4} = Connections.device_connecting(device_1_1.id)
+      {:ok, conn1} = Connections.device_connecting(device_1_10.org_id, device_1_10.product_id, device_1_10.id)
+      {:ok, conn2} = Connections.device_connecting(device_1_9.org_id, device_1_9.product_id, device_1_9.id)
+      {:ok, conn3} = Connections.device_connecting(device_2_0.org_id, device_2_0.product_id, device_2_0.id)
+      {:ok, conn4} = Connections.device_connecting(device_1_1.org_id, device_1_1.product_id, device_1_1.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -1281,9 +1281,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
       new_device = Devices.update_deployment_group(new_device, deployment_group)
 
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
-      {:ok, conn2} = Connections.device_connecting(old_device2.id)
-      {:ok, conn3} = Connections.device_connecting(new_device.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
+      {:ok, conn3} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
 
       :ok = Connections.device_connected(conn1.id)
       :ok = Connections.device_connected(conn2.id)
@@ -1384,13 +1384,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       # Device 3 should be third (2 minutes ago)
       # Device 4 should be last (newest connection - 1 minute ago)
       now = DateTime.utc_now()
-      {:ok, conn1} = Connections.device_connecting(old_device1.id)
+      {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       conn1 = Ecto.Changeset.change(conn1, established_at: DateTime.add(now, -240, :second)) |> Repo.update!()
-      {:ok, conn2} = Connections.device_connecting(old_device2.id)
+      {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
       conn2 = Ecto.Changeset.change(conn2, established_at: DateTime.add(now, -180, :second)) |> Repo.update!()
-      {:ok, conn3} = Connections.device_connecting(old_device3.id)
+      {:ok, conn3} = Connections.device_connecting(old_device3.org_id, old_device3.product_id, old_device3.id)
       conn3 = Ecto.Changeset.change(conn3, established_at: DateTime.add(now, -120, :second)) |> Repo.update!()
-      {:ok, conn4} = Connections.device_connecting(old_device4.id)
+      {:ok, conn4} = Connections.device_connecting(old_device4.org_id, old_device4.product_id, old_device4.id)
       conn4 = Ecto.Changeset.change(conn4, established_at: DateTime.add(now, -60, :second)) |> Repo.update!()
 
       :ok = Connections.device_connected(conn1.id)

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -67,7 +67,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
       for key <- Map.keys(params) do
         case Map.get(deployment_group, key) do
           %Conditions{} = value ->
-            Map.from_struct(value) == Map.get(params, key)
+            Map.equal?(Map.from_struct(value), Map.get(params, key))
 
           value ->
             value == Map.get(params, key)

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
   alias NervesHub.AuditLogs
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
+  alias NervesHub.Devices.Connections
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
@@ -586,39 +587,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
       push(device_channel, "report_network_interface", %{"interface" => "eth0"})
       _socket = :sys.get_state(device_channel.channel_pid)
 
-      assert Repo.reload(device) |> Map.get(:network_interface) == :ethernet
-
-      close_cleanly(device_channel)
-    end
-
-    test "doesn't update when incoming interface is the same as the current one",
-         %{tmp_dir: tmp_dir} do
-      user = Fixtures.user_fixture()
-      {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
-      %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
-      {:ok, device} = Devices.update_network_interface(device.id, "wlan0")
-      device = Repo.reload(device)
-
-      subscribe_for_updates(device)
-
-      {:ok, socket} =
-        connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
-
-      params =
-        for {k, v} <- Map.from_struct(device.firmware_metadata), into: %{} do
-          {"nerves_fw_#{k}", v}
-        end
-        |> Map.put("device_api_version", "2.2.0")
-
-      {:ok, _join_reply, device_channel} =
-        subscribe_and_join(socket, DeviceChannel, "device:#{device.id}", params)
-
-      assert_online_and_available(device)
-
-      allow(Devices, self(), device_channel.channel_pid)
-      reject(&Devices.update_network_interface/2)
-
-      push(device_channel, "report_network_interface", %{"interface" => "wlan0"})
+      connection = Connections.get_latest_for_device(device.id)
+      assert connection.network_interface == :ethernet
 
       close_cleanly(device_channel)
     end

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -198,7 +198,9 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit(device_show_path(fixture))
       |> assert_has("svg[data-connection-status=unknown]")
       |> unwrap(fn view ->
-        {:ok, connection} = Connections.device_connecting(fixture.device.id)
+        {:ok, connection} =
+          Connections.device_connecting(fixture.device.org_id, fixture.device.product_id, fixture.device.id)
+
         :ok = Connections.device_connected(connection.id)
         render(view)
       end)
@@ -221,7 +223,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       # Set device status to :provisioned for deployment group eligibility
       %{status: :provisioned} = device = Devices.set_as_provisioned!(device)
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
 
       # mismatch device and deployment group firmware so "Send Update" form doesn't display
@@ -262,7 +264,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
         {:ok, _} = Metrics.save_metrics(device.id, %{"cpu_usage_percent" => 22})
 
-        {:ok, connection} = Connections.device_connecting(device.id)
+        {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
         :ok = Connections.device_connected(connection.id)
 
         topic = "device:#{device.id}:extensions"
@@ -502,7 +504,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{}})
 
@@ -519,7 +521,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{"latitude" => nil, "longitude" => nil}})
 
@@ -536,7 +538,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, %{"location" => %{"latitude" => "", "longitude" => ""}})
 
@@ -552,7 +554,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "location" => %{"error_code" => "BOOP", "error_description" => "BEEP"}
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
@@ -574,7 +576,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         }
       }
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.merge_update_metadata(connection.id, metadata)
 
@@ -799,7 +801,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
 
       {:ok, {_release, deployment_group}} =
@@ -842,7 +844,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         |> Ecto.Changeset.change(%{deployment_id: deployment_group.id})
         |> Repo.update!()
 
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
 
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -1070,7 +1072,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
@@ -1104,7 +1106,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
@@ -1157,7 +1159,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       assert device.updates_enabled
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 
@@ -1207,7 +1209,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       Devices.update_device(device, %{firmware_metadata: metadata})
 
       device = Devices.update_deployment_group(device, deployment_group)
-      {:ok, connection} = Connections.device_connecting(device.id)
+      {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
 

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -74,7 +74,7 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       _ = Fixtures.device_fixture(org, product, firmware)
 
       device = Fixtures.device_fixture(org, product, firmware)
-      {:ok, device_connection} = Connections.device_connecting(device.id)
+      {:ok, device_connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       Connections.device_connected(device_connection.id)
 
       conn

--- a/test/nerves_hub_web/live/orgs/index_test.exs
+++ b/test/nerves_hub_web/live/orgs/index_test.exs
@@ -59,7 +59,7 @@ defmodule NervesHubWeb.Live.Orgs.IndexTest do
       _ = Fixtures.device_fixture(org, product, firmware)
 
       device = Fixtures.device_fixture(org, product, firmware)
-      {:ok, device_connection} = Connections.device_connecting(device.id)
+      {:ok, device_connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
 
       Connections.device_connected(device_connection.id)
 

--- a/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
+++ b/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
@@ -1,0 +1,119 @@
+defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
+  # Not async: these tests read/write the AnalyticsRepo (ClickHouse) and toggle
+  # the global :analytics_enabled application env.
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias NervesHub.AnalyticsRepo
+  alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.DeviceConnectionHistory
+  alias NervesHub.Fixtures
+
+  setup %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+    product = Fixtures.product_fixture(user, org, %{name: "Connections Graph"})
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    AnalyticsRepo.query!("TRUNCATE TABLE device_connection_history")
+
+    %{product: product, firmware: firmware, device: device}
+  end
+
+  defp insights_path(org, product), do: ~p"/org/#{org}/#{product}/insights"
+
+  defp insert_history(device, established_at, disconnected_at) do
+    connection = %DeviceConnection{
+      id: UUIDv7.generate(),
+      org_id: device.org_id,
+      product_id: device.product_id,
+      device_id: device.id,
+      established_at: established_at,
+      last_seen_at: disconnected_at || DateTime.utc_now(),
+      disconnected_at: disconnected_at
+    }
+
+    {:ok, _} =
+      connection
+      |> DeviceConnectionHistory.changeset()
+      |> AnalyticsRepo.insert()
+  end
+
+  describe "when analytics is enabled" do
+    test "renders the connections graph with the per-day connection data", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      # device connected 2 days ago and is still connected
+      insert_history(device, DateTime.add(DateTime.utc_now(), -2, :day), nil)
+
+      {:ok, view, html} = live(conn, insights_path(org, product))
+
+      assert html =~ "Connected Devices — Last 14 Days"
+      assert html =~ "daily-device-counts-chart"
+      assert html =~ ~s(phx-hook="BarChart")
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert assigns.device_connections_graph_enabled
+      assert assigns.device_connections_graph_from == Date.add(Date.utc_today(), -14)
+      assert assigns.device_connections_graph_to == Date.utc_today()
+
+      counts =
+        Map.new(assigns.device_connections_graph_data, fn %{day: day, count: count} ->
+          {day, count}
+        end)
+
+      assert counts[Date.utc_today()] == 1
+      assert counts[Date.add(Date.utc_today(), -1)] == 1
+    end
+
+    test "encodes the graph data into the chart's data-metrics attribute", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      insert_history(device, DateTime.add(DateTime.utc_now(), -1, :day), nil)
+
+      {:ok, _view, html} = live(conn, insights_path(org, product))
+
+      [_, encoded] = Regex.run(~r/data-metrics="([^"]*)"/, html)
+
+      # the chart receives a (HTML-escaped) JSON array of day/unique_devices entries
+      assert encoded =~ "count"
+      assert encoded =~ "day"
+    end
+
+    test "still renders the graph (with empty data) when there is no history", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      {:ok, view, html} = live(conn, insights_path(org, product))
+
+      assert html =~ "Connected Devices — Last 14 Days"
+      assert :sys.get_state(view.pid).socket.assigns.device_connections_graph_data == []
+    end
+  end
+
+  describe "when analytics is disabled" do
+    setup do
+      original = Application.get_env(:nerves_hub, :analytics_enabled)
+      Application.put_env(:nerves_hub, :analytics_enabled, false)
+      on_exit(fn -> Application.put_env(:nerves_hub, :analytics_enabled, original) end)
+      :ok
+    end
+
+    test "does not render the connections graph", %{conn: conn, org: org, product: product} do
+      {:ok, view, html} = live(conn, insights_path(org, product))
+
+      refute html =~ "Connected Devices — Last 14 Days"
+      refute html =~ "daily-device-counts-chart"
+
+      refute :sys.get_state(view.pid).socket.assigns.device_connections_graph_enabled
+    end
+  end
+end


### PR DESCRIPTION
This feature is opt-in and requires that a ClickHouse DB be configured in the runtime settings.

<img width="3024" height="1654" alt="image" src="https://github.com/user-attachments/assets/e18875b7-7701-4e34-9aea-cc3153ead89b" />

