### PR TITLE
Fix concurrency issue with CLI Session cache

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -1077,22 +1077,28 @@ defmodule NervesHub.Accounts do
   end
 
   def verify_cli_session_token(user, token) do
-    with {:ok, cli_session} <- CLISessionCache.get(token),
-         %{status: :waiting} <- cli_session,
-         user_token = create_user_api_token(user, cli_session.note),
-         cli_session = %{cli_session | status: :ready, user_id: user.id, user_token: user_token},
-         :ok <- CLISessionCache.put(token, cli_session) do
-      :ok
-    else
-      %{status: :ready, user_id: user_id} when user_id == user.id ->
-        :ok
+    CLISessionCache.get_and_update(token, fn
+      {:ok, %{status: :waiting} = cli_session} ->
+        user_token = create_user_api_token(user, cli_session.note)
 
-      %{status: :ready} ->
-        {:error, :already_verified}
+        cli_session = %{
+          cli_session
+          | status: :ready,
+            user_id: user.id,
+            user_token: user_token
+        }
+
+        {:ok, {:put, cli_session}}
+
+      {:ok, %{status: :ready, user_id: user_id}} when user_id == user.id ->
+        {:ok, :noop}
+
+      {:ok, %{status: :ready}} ->
+        {{:error, :already_verified}, :noop}
 
       _ ->
-        {:error, :not_found}
-    end
+        {{:error, :not_found}, :noop}
+    end)
   end
 
   def generate_cli_session_token(note) do
@@ -1103,20 +1109,18 @@ defmodule NervesHub.Accounts do
       |> DateTime.add(5, :minute)
       |> DateTime.to_unix()
 
-    with :error <- CLISessionCache.get(token),
-         cli_session = %UserCLISession{
-           token: token,
-           status: :waiting,
-           expires_at: expires_at,
-           confirmation_code: Enum.random(100_000..999_999),
-           note: note
-         },
-         :ok <- CLISessionCache.put(token, cli_session) do
-      {:ok, cli_session}
-    else
-      _ ->
-        {:error, :invalid_request}
-    end
+    cli_session = %UserCLISession{
+      token: token,
+      status: :waiting,
+      expires_at: expires_at,
+      confirmation_code: Enum.random(100_000..999_999),
+      note: note
+    }
+
+    CLISessionCache.get_and_update(token, fn
+      :error -> {{:ok, cli_session}, {:put, cli_session}}
+      {:ok, _existing} -> {{:error, :invalid_request}, :noop}
+    end)
   end
 
   def cli_session_waiting?(user, token) do
@@ -1131,17 +1135,16 @@ defmodule NervesHub.Accounts do
   end
 
   def check_cli_session_ready(token) do
-    with {:ok, cli_session} <- CLISessionCache.get(token),
-         %{status: status} = cli_session when status == :ready <- cli_session,
-         cli_session = %{cli_session | status: :verified},
-         :ok <- CLISessionCache.put(token, cli_session) do
-      {:ok, cli_session}
-    else
-      %{status: :waiting} = cli_session ->
-        {:ok, cli_session}
+    CLISessionCache.get_and_update(token, fn
+      {:ok, %{status: :ready} = cli_session} ->
+        cli_session = %{cli_session | status: :verified}
+        {{:ok, cli_session}, {:put, cli_session}}
+
+      {:ok, %{status: :waiting} = cli_session} ->
+        {{:ok, cli_session}, :noop}
 
       _ ->
-        {:error, :not_found}
-    end
+        {{:error, :not_found}, :noop}
+    end)
   end
 end

--- a/lib/nerves_hub/cli_session_cache.ex
+++ b/lib/nerves_hub/cli_session_cache.ex
@@ -28,8 +28,17 @@ defmodule NervesHub.CLISessionCache do
     {:ok, %{}}
   end
 
-  def handle_info({:put, key, value}, state) do
-    _ = put(key, value)
+  def handle_info({:put, origin, _key, _value}, state) when origin == node() do
+    # Our own write echoed back over PubSub. The ETS table was already updated
+    # synchronously in `put/2`, so there is nothing to do.
+    {:noreply, state}
+  end
+
+  def handle_info({:put, _origin, key, value}, state) do
+    # A write from a peer node. Apply it locally, but do NOT re-broadcast:
+    # otherwise every node re-emits every message it receives and they
+    # ping-pong across the cluster forever.
+    :ets.insert(@table, {key, value, value.expires_at})
     {:noreply, state}
   end
 
@@ -41,8 +50,57 @@ defmodule NervesHub.CLISessionCache do
 
   def put(key, cli_session) do
     :ets.insert(@table, {key, cli_session, cli_session.expires_at})
-    _ = Phoenix.PubSub.broadcast_from(NervesHub.PubSub, self(), "cli_session_cache", {:put, key, cli_session})
+
+    _ =
+      Phoenix.PubSub.broadcast(
+        NervesHub.PubSub,
+        "cli_session_cache",
+        {:put, node(), key, cli_session}
+      )
+
     :ok
+  end
+
+  @doc """
+  Atomically read a session and conditionally write it back.
+
+  Runs `fun` inside the cache process so concurrent callers on this node cannot
+  interleave a read and a write (e.g. a double-clicked confirmation or a retried
+  request). `fun` receives the current value as `{:ok, cli_session}` or `:error`
+  and must return `{return_value, action}` where `action` is `{:put, cli_session}`
+  or `:noop`.
+
+  Note: this serializes within a node only. Two different nodes can still race
+  on their node-local ETS copies until the PubSub write propagates between them,
+  matching the cache's best-effort cross-node consistency. Closing that window
+  fully would require single-owner routing per token or a DB-level uniqueness
+  guard on the minted token.
+  """
+  def get_and_update(key, fun) do
+    case GenServer.call(__MODULE__, {:get_and_update, key, fun}) do
+      {:raise, exception, stacktrace} -> reraise(exception, stacktrace)
+      return -> return
+    end
+  end
+
+  def handle_call({:get_and_update, key, fun}, _from, state) do
+    current = get(key)
+
+    try do
+      case fun.(current) do
+        {return, {:put, cli_session}} ->
+          _ = put(key, cli_session)
+          {:reply, return, state}
+
+        {return, :noop} ->
+          {:reply, return, state}
+      end
+    rescue
+      exception ->
+        # Never let a caller-supplied function crash the cache process; that
+        # would destroy the ETS table (it has no heir) and drop every session.
+        {:reply, {:raise, exception, __STACKTRACE__}, state}
+    end
   end
 
   def get(key) do

--- a/test/nerves_hub/cli_session_cache_test.exs
+++ b/test/nerves_hub/cli_session_cache_test.exs
@@ -1,8 +1,10 @@
 defmodule NervesHub.CLISessionCacheTest do
   use NervesHub.DataCase, async: false
 
+  alias NervesHub.Accounts
   alias NervesHub.Accounts.UserCLISession
   alias NervesHub.CLISessionCache
+  alias NervesHub.Fixtures
 
   setup do
     CLISessionCache.clear()
@@ -10,6 +12,61 @@ defmodule NervesHub.CLISessionCacheTest do
     on_exit(fn ->
       CLISessionCache.clear()
     end)
+  end
+
+  test "applying a :put broadcast from another node does not re-broadcast (no cluster storm)" do
+    # Simulate a broadcast arriving from a peer node by subscribing as if we
+    # were a remote CLISessionCache and sending the GenServer the same message
+    # Phoenix.PubSub would deliver.
+    :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "cli_session_cache")
+
+    token = Ecto.UUID.generate()
+
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.add(5, :minute)
+      |> DateTime.to_unix()
+
+    session = %UserCLISession{token: token, status: :waiting, expires_at: expires_at}
+
+    send(CLISessionCache, {:put, :peer@example, token, session})
+
+    # The value must be applied locally...
+    assert eventually(fn -> CLISessionCache.get(token) == {:ok, session} end)
+
+    # ...but applying it must NOT emit another broadcast, otherwise every node
+    # re-emits every message it receives and they ping-pong forever.
+    refute_receive {:put, _origin, ^token, _}, 200
+  end
+
+  test "concurrent verify_cli_session_token only mints a single API token" do
+    user = Fixtures.user_fixture()
+    {:ok, %{token: token}} = Accounts.generate_cli_session_token("test-token")
+
+    # Two nodes (or a double-clicked confirm / retried request) verifying the
+    # same waiting session at once. The read-modify-write is not atomic, so
+    # every caller can read :waiting and mint its own token.
+    results =
+      1..10
+      |> Enum.map(fn _ ->
+        Task.async(fn -> Accounts.verify_cli_session_token(user, token) end)
+      end)
+      |> Task.await_many(5000)
+
+    assert Enum.all?(results, &(&1 == :ok))
+
+    tokens = Accounts.get_user_api_tokens(user)
+
+    assert length(tokens) == 1,
+           "expected exactly one API token to be minted, got #{length(tokens)}"
+  end
+
+  defp eventually(fun, attempts \\ 50) do
+    cond do
+      fun.() -> true
+      attempts == 0 -> false
+      true -> Process.sleep(5) && eventually(fun, attempts - 1)
+    end
   end
 
   test "are cleaned up after they expire (5 mins ttl)" do


### PR DESCRIPTION
Claude flagged a concurrency issue in the new cache mechanism that was covered by mnesia transaction support previously.

This seems to make sense.