### PR TITLE
Run a separate stale connection cleanup of the Analytics Repo

### DIFF
--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -157,15 +157,20 @@ defmodule NervesHub.Devices.Connections do
     :ok
   end
 
-  defp async_device_connection_history_insert(device_connection) do
+  defp async_device_connection_history_insert(%DeviceConnection{} = device_connection) do
+    device_connection
+    |> DeviceConnectionHistory.from_device_connection_changeset()
+    |> async_device_connection_history_insert()
+  end
+
+  defp async_device_connection_history_insert(%Ecto.Changeset{data: %DeviceConnectionHistory{}} = device_connection) do
     _ =
       if Application.get_env(:nerves_hub, :analytics_enabled) do
         Task.Supervisor.start_child(
           {:via, PartitionSupervisor, {NervesHub.AnalyticsEventsProcessing, self()}},
           fn ->
             {:ok, _} =
-              DeviceConnectionHistory.changeset(device_connection)
-              |> NervesHub.AnalyticsRepo.insert()
+              NervesHub.AnalyticsRepo.insert(device_connection)
           end
         )
       end
@@ -284,11 +289,36 @@ defmodule NervesHub.Devices.Connections do
     end
 
     if update_count < update_limit do
-      :ok
+      # Once the DB is cleaned, we can clean Analytics
+      clean_stale_connections_from_analytics()
     else
       # relax stress on Ecto pool and go again
       Process.sleep(2000)
       clean_stale_connections()
     end
+  end
+
+  def clean_stale_connections_from_analytics() do
+    _ =
+      if Application.get_env(:nerves_hub, :analytics_enabled) do
+        interval = Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
+        jitter = Application.get_env(:nerves_hub, :device_last_seen_update_interval_jitter_seconds)
+
+        max_jitter = ceil(jitter / 60)
+        some_time_ago = DateTime.shift(DateTime.utc_now(), minute: -(interval + max_jitter + 1))
+
+        DeviceConnectionHistory
+        |> where([dc], is_nil(dc.disconnected_at))
+        |> where([d], d.last_seen_at < ^some_time_ago)
+        |> select([dc], dc)
+        |> NervesHub.AnalyticsRepo.all(settings: [final: 1])
+        |> Enum.each(fn connection ->
+          connection
+          |> DeviceConnectionHistory.mark_as_stale_and_disconnected_changeset()
+          |> async_device_connection_history_insert()
+        end)
+      end
+
+    :ok
   end
 end

--- a/lib/nerves_hub/devices/device_connection_history.ex
+++ b/lib/nerves_hub/devices/device_connection_history.ex
@@ -29,7 +29,7 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
     field(:version, Ch, type: "UInt64")
   end
 
-  def changeset(%DeviceConnection{} = connection) do
+  def from_device_connection_changeset(%DeviceConnection{} = connection) do
     %__MODULE__{}
     |> change()
     |> put_change(:org_id, connection.org_id)
@@ -43,6 +43,24 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
     |> put_change(:lib, connection.lib)
     |> put_change(:lib_version, connection.lib_version)
     |> put_change(:network_interface, to_string(connection.network_interface))
-    |> put_change(:version, DateTime.to_unix(connection.last_seen_at))
+    |> put_change(:version, DateTime.utc_now() |> DateTime.to_unix())
+  end
+
+  @doc """
+  Builds a new history row from an existing one.
+
+  Used when reconciling stale connections directly against the analytics store:
+  the existing row is carried forward (same `ref`/`established_at`) with the
+  disconnect details applied and a bumped `version` so the `ReplacingMergeTree`
+  collapses to this disconnected state.
+  """
+  def mark_as_stale_and_disconnected_changeset(%__MODULE__{} = connection) do
+    now = DateTime.utc_now()
+
+    connection
+    |> change()
+    |> put_change(:disconnected_at, now)
+    |> put_change(:disconnected_reason, "Stale connection")
+    |> put_change(:version, DateTime.to_unix(now))
   end
 end

--- a/test/nerves_hub/devices/connection_history_test.exs
+++ b/test/nerves_hub/devices/connection_history_test.exs
@@ -26,7 +26,7 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
   end
 
   defp history_for(ref) do
-    AnalyticsRepo.all(DeviceConnectionHistory)
+    AnalyticsRepo.all(DeviceConnectionHistory, settings: [final: 1])
     |> Enum.filter(&(&1.ref == ref))
   end
 
@@ -119,6 +119,102 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
     end
   end
 
+  describe "clean_stale_connections_from_analytics/0" do
+    # an open connection is one whose latest history row has no disconnected_at
+    defp insert_open_connection(device, last_seen_at) do
+      ref = UUIDv7.generate()
+
+      connection = %DeviceConnection{
+        id: ref,
+        org_id: device.org_id,
+        product_id: device.product_id,
+        device_id: device.id,
+        established_at: DateTime.add(last_seen_at, -1, :hour),
+        last_seen_at: last_seen_at,
+        disconnected_at: nil
+      }
+
+      {:ok, _} =
+        connection
+        |> DeviceConnectionHistory.from_device_connection_changeset()
+        |> AnalyticsRepo.insert()
+
+      ref
+    end
+
+    defp stale_time() do
+      interval = Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
+      jitter = Application.get_env(:nerves_hub, :device_last_seen_update_interval_jitter_seconds)
+      max_jitter = ceil(jitter / 60)
+      DateTime.add(DateTime.utc_now(), -(interval + max_jitter + 2), :minute)
+    end
+
+    test "records a disconnected history row for stale open connections", %{device: device} do
+      ref = insert_open_connection(device, stale_time())
+
+      :ok = Connections.clean_stale_connections_from_analytics()
+
+      assert_eventually(
+        Enum.any?(history_for(ref), fn h ->
+          not is_nil(h.disconnected_at) and h.disconnected_reason == "Stale connection"
+        end)
+      )
+    end
+
+    test "carries the original connection's ref and established_at forward", %{device: device} do
+      last_seen_at = stale_time()
+      ref = insert_open_connection(device, last_seen_at)
+      [open] = history_for(ref)
+
+      :ok = Connections.clean_stale_connections_from_analytics()
+
+      assert_eventually(
+        Enum.any?(history_for(ref), fn h ->
+          not is_nil(h.disconnected_at) and h.established_at == open.established_at
+        end)
+      )
+    end
+
+    test "leaves recently seen open connections untouched", %{device: device} do
+      ref = insert_open_connection(device, DateTime.add(DateTime.utc_now(), -1, :minute))
+
+      :ok = Connections.clean_stale_connections_from_analytics()
+
+      # allow any (incorrectly) spawned insert to run before asserting absence
+      Process.sleep(200)
+
+      refute Enum.any?(history_for(ref), fn h -> not is_nil(h.disconnected_at) end)
+    end
+
+    test "ignores connections that are already disconnected", %{device: device} do
+      ref = UUIDv7.generate()
+      now = DateTime.utc_now()
+
+      connection = %DeviceConnection{
+        id: ref,
+        org_id: device.org_id,
+        product_id: device.product_id,
+        device_id: device.id,
+        established_at: DateTime.add(now, -2, :hour),
+        # stale last_seen_at, but the connection is already closed
+        last_seen_at: stale_time(),
+        disconnected_at: DateTime.add(now, -1, :hour),
+        disconnected_reason: "Original reason"
+      }
+
+      {:ok, _} =
+        connection
+        |> DeviceConnectionHistory.from_device_connection_changeset()
+        |> AnalyticsRepo.insert()
+
+      :ok = Connections.clean_stale_connections_from_analytics()
+
+      Process.sleep(200)
+
+      refute Enum.any?(history_for(ref), fn h -> h.disconnected_reason == "Stale connection" end)
+    end
+  end
+
   describe "device_connections_by_date/3" do
     setup %{org: org, product: product, firmware: firmware} do
       device_a = Fixtures.device_fixture(org, product, firmware)
@@ -144,7 +240,7 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
 
       {:ok, _} =
         connection
-        |> DeviceConnectionHistory.changeset()
+        |> DeviceConnectionHistory.from_device_connection_changeset()
         |> AnalyticsRepo.insert()
     end
 

--- a/test/nerves_hub/devices/device_connection_history_test.exs
+++ b/test/nerves_hub/devices/device_connection_history_test.exs
@@ -27,7 +27,7 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         status: :disconnected
       }
 
-      changes = DeviceConnectionHistory.changeset(connection).changes
+      changes = DeviceConnectionHistory.from_device_connection_changeset(connection).changes
 
       assert changes.org_id == 1
       assert changes.product_id == 2
@@ -54,30 +54,33 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
           established_at: DateTime.utc_now(),
           last_seen_at: DateTime.utc_now()
         }
-        |> DeviceConnectionHistory.changeset()
+        |> DeviceConnectionHistory.from_device_connection_changeset()
         |> Map.fetch!(:changes)
 
       assert changes.ref == ref
     end
 
-    test "the version is derived from the connection's last_seen_at so newer rows win" do
-      last_seen_at = ~U[2026-06-20 10:05:00.000000Z]
-
+    test "the version is set from the insert time so the most recently written row wins" do
       connection = %DeviceConnection{
         id: UUIDv7.generate(),
         org_id: 1,
         product_id: 2,
         device_id: 3,
-        established_at: ~U[2026-06-20 10:00:00.000000Z],
-        last_seen_at: last_seen_at
+        # an old last_seen_at must not drag the version backwards
+        established_at: ~U[2020-01-01 00:00:00.000000Z],
+        last_seen_at: ~U[2020-01-01 00:05:00.000000Z]
       }
 
-      changes = DeviceConnectionHistory.changeset(connection).changes
+      before = DateTime.utc_now() |> DateTime.to_unix()
+      changes = DeviceConnectionHistory.from_device_connection_changeset(connection).changes
+      later = DateTime.utc_now() |> DateTime.to_unix()
 
-      assert changes.version == DateTime.to_unix(last_seen_at)
+      # version tracks the current time at insert, independent of last_seen_at
+      assert changes.version >= before
+      assert changes.version <= later
     end
 
-    test "a later last_seen_at produces a higher version" do
+    test "the version does not depend on last_seen_at" do
       base = %DeviceConnection{
         id: UUIDv7.generate(),
         org_id: 1,
@@ -86,10 +89,17 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         established_at: ~U[2026-06-20 10:00:00.000000Z]
       }
 
-      earlier = DeviceConnectionHistory.changeset(%{base | last_seen_at: ~U[2026-06-20 10:00:00Z]})
-      later = DeviceConnectionHistory.changeset(%{base | last_seen_at: ~U[2026-06-20 10:05:00Z]})
+      now = DateTime.utc_now() |> DateTime.to_unix()
 
-      assert later.changes.version > earlier.changes.version
+      old_last_seen =
+        DeviceConnectionHistory.from_device_connection_changeset(%{base | last_seen_at: ~U[2020-01-01 00:00:00Z]})
+
+      new_last_seen =
+        DeviceConnectionHistory.from_device_connection_changeset(%{base | last_seen_at: ~U[2026-06-20 10:05:00Z]})
+
+      # both are versioned by insert time, not by their (very different) last_seen_at
+      assert_in_delta old_last_seen.changes.version, now, 2
+      assert_in_delta new_last_seen.changes.version, now, 2
     end
   end
 end

--- a/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
+++ b/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
@@ -35,7 +35,7 @@ defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
 
     {:ok, _} =
       connection
-      |> DeviceConnectionHistory.changeset()
+      |> DeviceConnectionHistory.from_device_connection_changeset()
       |> AnalyticsRepo.insert()
   end
 


### PR DESCRIPTION
Its possible for the Analytic repo to have rows that aren't cleaned up when the DB is cleaned up, so we need to run a cleanup especially for it