### PR TITLE
Rework how Support Scripts are selected and run from the Device page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,6 +20,7 @@ import LocalShell from "./hooks/localShell.js"
 import LocalTime from "./hooks/localTime.js"
 import LogLineLocalTime from "./hooks/logLineLocalTime.js"
 import PageVisible from "./hooks/pageVisible.js"
+import ScriptAutocomplete from "./hooks/scriptAutocomplete.js"
 import SharedSecretClipboardClick from "./hooks/sharedSecretClipboardClick.js"
 import SidebarToggle from "./hooks/sidebarToggle.js"
 import SimpleDate from "./hooks/simpleDate.js"
@@ -61,6 +62,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     PageVisible,
     SharedSecretClipboardClick,
     SidebarToggle,
+    ScriptAutocomplete,
     SimpleDate,
     SupportScriptOutput,
     TagAutocomplete,

--- a/assets/js/hooks/scriptAutocomplete.js
+++ b/assets/js/hooks/scriptAutocomplete.js
@@ -1,0 +1,163 @@
+// A searchable single-select combobox for picking a support script.
+//
+// Used in place of a native <select> when a product has many support
+// scripts, so the list can be filtered by typing. The wrapper element
+// carries:
+//   - `data-scripts`: a JSON array of `{ id, name }` objects
+//   - `data-selected-id`: the id of the currently selected script
+// and contains:
+//   - an `<input data-script-search>` the user types into
+//   - a `<ul data-script-suggestions>` the hook populates with matches
+//
+// Matching is case-insensitive on the script name. Selecting a suggestion
+// pushes a `select-script` event (with the script id as a string, matching
+// the native <select> path) so the LiveView updates which script will run.
+export default {
+  mounted() {
+    this.input = this.el.querySelector("[data-script-search]")
+    this.list = this.el.querySelector("[data-script-suggestions]")
+
+    this.loadScripts()
+    this.activeIndex = -1
+
+    this.onInput = () => this.renderSuggestions()
+    this.onFocus = () => this.renderSuggestions()
+    this.onKeydown = (event) => this.handleKeydown(event)
+    // Delay so a mousedown on a suggestion registers before we reset/hide.
+    this.onBlur = () => setTimeout(() => this.commitOrReset(), 150)
+
+    this.input.addEventListener("input", this.onInput)
+    this.input.addEventListener("focus", this.onFocus)
+    this.input.addEventListener("keydown", this.onKeydown)
+    this.input.addEventListener("blur", this.onBlur)
+  },
+
+  updated() {
+    // Scripts or the selection may change after a server round-trip.
+    this.loadScripts()
+    // Don't clobber what the user is actively typing.
+    if (document.activeElement !== this.input) {
+      this.input.value = this.selectedName()
+    }
+  },
+
+  destroyed() {
+    this.input.removeEventListener("input", this.onInput)
+    this.input.removeEventListener("focus", this.onFocus)
+    this.input.removeEventListener("keydown", this.onKeydown)
+    this.input.removeEventListener("blur", this.onBlur)
+  },
+
+  loadScripts() {
+    try {
+      this.scripts = JSON.parse(this.el.dataset.scripts || "[]")
+    } catch {
+      this.scripts = []
+    }
+  },
+
+  selectedName() {
+    const id = String(this.el.dataset.selectedId)
+    const script = this.scripts.find((s) => String(s.id) === id)
+    return script ? script.name : ""
+  },
+
+  matches() {
+    const token = this.input.value.trim().toLowerCase()
+    return this.scripts.filter(
+      (script) => token === "" || script.name.toLowerCase().includes(token)
+    )
+  },
+
+  renderSuggestions() {
+    const matches = this.matches()
+
+    if (matches.length === 0) {
+      this.hide()
+      return
+    }
+
+    this.activeIndex = -1
+    this.list.innerHTML = ""
+
+    matches.forEach((script) => {
+      const li = document.createElement("li")
+      li.textContent = script.name
+      li.setAttribute("role", "option")
+      li.dataset.id = script.id
+      li.className =
+        "cursor-pointer px-2 py-1.5 text-sm text-base-300 hover:bg-base-800"
+      // Use mousedown so the selection happens before the input's blur.
+      li.addEventListener("mousedown", (event) => {
+        event.preventDefault()
+        this.select(script)
+      })
+      this.list.appendChild(li)
+    })
+
+    this.list.hidden = false
+  },
+
+  hide() {
+    this.list.hidden = true
+    this.list.innerHTML = ""
+    this.activeIndex = -1
+  },
+
+  handleKeydown(event) {
+    if (this.list.hidden) return
+
+    const options = Array.from(this.list.children)
+    if (options.length === 0) return
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        this.activeIndex = (this.activeIndex + 1) % options.length
+        this.highlight(options)
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this.activeIndex =
+          (this.activeIndex - 1 + options.length) % options.length
+        this.highlight(options)
+        break
+      case "Enter": {
+        event.preventDefault()
+        const index = this.activeIndex >= 0 ? this.activeIndex : 0
+        const id = options[index].dataset.id
+        this.select(this.scripts.find((s) => String(s.id) === String(id)))
+        break
+      }
+      case "Escape":
+        this.hide()
+        break
+    }
+  },
+
+  highlight(options) {
+    options.forEach((option, index) => {
+      option.classList.toggle("bg-base-800", index === this.activeIndex)
+    })
+    if (this.activeIndex >= 0) {
+      options[this.activeIndex].scrollIntoView({ block: "nearest" })
+    }
+  },
+
+  select(script) {
+    if (!script) return
+
+    this.el.dataset.selectedId = script.id
+    this.input.value = script.name
+    this.hide()
+    // Send the id as a string to match the native <select> change path.
+    this.pushEvent("select-script", { script_id: String(script.id) })
+  },
+
+  // On blur, snap the text back to the selected script's name so the input
+  // never shows a partial or unmatched search string.
+  commitOrReset() {
+    this.hide()
+    this.input.value = this.selectedName()
+  },
+}

--- a/assets/js/hooks/supportScriptOutput.js
+++ b/assets/js/hooks/supportScriptOutput.js
@@ -30,8 +30,8 @@ const defaultTermOptions = {
     cyan: "#00D8EB",
     brightCyan: "#67FFF0",
     white: "#FFFFFF",
-    brightWhite: "#FFFFFF"
-  }
+    brightWhite: "#FFFFFF",
+  },
 }
 
 export default {
@@ -41,7 +41,7 @@ export default {
     let contentRows = content.split("\n")
 
     if (contentRows.length <= 20) {
-      defaultTermOptions["rows"] = contentRows.length + 1
+      defaultTermOptions["rows"] = 15
     }
 
     const term = new Terminal(defaultTermOptions)
@@ -52,5 +52,5 @@ export default {
     term.open(this.el)
 
     term.writeln(contentRows.join("\n\r"))
-  }
+  },
 }

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -20,6 +20,10 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
 
   @keys_to_cleanup [
     :support_scripts,
+    :selected_support_script,
+    :support_script_running,
+    :recently_run_support_script,
+    :recently_run_support_script_output,
     :firmwares,
     :update_information,
     :alarms,
@@ -53,13 +57,15 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     assign(socket, :metadata, Map.drop(metadata, standard_keys(device)))
   end
 
-  defp assign_support_scripts(socket) do
-    scripts =
-      socket.assigns.product
-      |> Scripts.all_by_product()
-      |> Enum.map(&Map.merge(&1, %{output: nil, running?: false}))
+  defp assign_support_scripts(%{assigns: %{product: product}} = socket) do
+    scripts = Scripts.all_by_product(product)
 
-    assign(socket, :support_scripts, scripts)
+    socket
+    |> assign(:support_scripts, scripts)
+    |> assign(:selected_support_script, nil)
+    |> assign(:support_script_running, false)
+    |> assign(:recently_run_support_script, nil)
+    |> assign(:recently_run_support_script_output, nil)
   end
 
   # Tags already on the device are excluded so the "add tag" suggestions only
@@ -542,23 +548,76 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
             <span class="text-base-500 text-sm">No support scripts have been configured.</span>
           </div>
 
-          <div :if={Enum.any?(@support_scripts)} class="flex flex-col gap-2 px-4 pt-2 pb-6">
-            <div :for={script <- @support_scripts} class="flex flex-col gap-2">
-              <div class="flex items-center gap-4">
-                <span class="text-base-300 text-base">{script.name}</span>
+          <% searchable_scripts? = length(@support_scripts) > 10 %>
+          <div :if={Enum.any?(@support_scripts)} class="flex flex-col gap-3 px-4 pt-2 pb-6">
+            <div class="flex w-full items-center gap-2">
+              <form :if={!searchable_scripts?} id="run-script-form" phx-change="select-script" class="grid grow grid-cols-1">
+                <label for="script_id" class="hidden">Support script</label>
+                <select
+                  id="script_id"
+                  name="script_id"
+                  class="bg-base-900 border-base-600 focus:outline-focus-ring text-base-400 col-start-1 row-start-1 appearance-none rounded border py-1.5 pr-8 pl-3 text-sm focus:outline focus:-outline-offset-1"
+                >
+                  <option value="" selected={is_nil(@selected_support_script)}>Select a support script</option>
+                  <option :for={script <- @support_scripts} value={script.id} selected={@selected_support_script && script.id == @selected_support_script.id}>
+                    {script.name}
+                  </option>
+                </select>
+              </form>
 
-                <button :if={!script.running?} class="bg-base-800 border-success rounded-full border p-1" type="button" phx-click="run-script" phx-value-id={script.id}>
-                  <svg class="stroke-success size-3" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M8 19V5L18 12L8 19Z" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-                  </svg>
-                </button>
+              <div
+                :if={searchable_scripts?}
+                id="script-autocomplete"
+                class="relative grow"
+                phx-hook="ScriptAutocomplete"
+                data-scripts={Jason.encode!(Enum.map(@support_scripts, &%{id: &1.id, name: &1.name}))}
+                data-selected-id={@selected_support_script && @selected_support_script.id}
+              >
+                <label for="script_search" class="hidden">Search support scripts</label>
+                <input
+                  type="text"
+                  id="script_search"
+                  data-script-search
+                  autocomplete="off"
+                  placeholder="Search support scripts..."
+                  value={@selected_support_script && @selected_support_script.name}
+                  class="bg-base-900 border-base-600 focus:outline-focus-ring text-base-400 w-full rounded border px-3 py-1.5 text-sm focus:outline focus:-outline-offset-1"
+                />
+                <ul
+                  id="script_search-suggestions"
+                  data-script-suggestions
+                  phx-update="ignore"
+                  role="listbox"
+                  hidden
+                  class="bg-base-900 border-base-600 absolute z-10 mt-1 max-h-56 w-full overflow-y-auto rounded border py-1 shadow-lg"
+                >
+                </ul>
+              </div>
 
-                <svg :if={script.running?} class="text-primary mr-3 -ml-1 size-5 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <.button
+                type="button"
+                aria-label="Run support script"
+                phx-click="run-script"
+                phx-value-id={@selected_support_script && @selected_support_script.id}
+                disabled={is_nil(@selected_support_script) || @support_script_running || disconnected?(@device_connection)}
+              >
+                <svg :if={@selected_support_script && @support_script_running} class="-ml-1 size-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                   <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
+                Run script
+              </.button>
+            </div>
 
-                <button :if={script.output} class="bg-base-800 border-alert rounded-full border p-1" type="button" phx-click="clear-script-output" phx-value-id={script.id}>
+            <div :if={@recently_run_support_script && @recently_run_support_script_output} class="flex flex-col gap-2">
+              <div class="flex items-center justify-between">
+                <span class="text-base-500 text-sm">Output for "{@recently_run_support_script.name}"</span>
+                <button
+                  class="bg-base-800 border-alert rounded-full border p-1"
+                  type="button"
+                  aria-label="Clear script output"
+                  phx-click="clear-script-output"
+                >
                   <svg class="stroke-alert size-3" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
                       d="M8 8H16M16 12H8M8 16H12M20 13V6C20 4.89543 19.1046 4 18 4H6C4.89543 4 4 4.89543 4 6V18C4 19.1046 4.89543 20 6 20H13M19 19L21 17M19 19L17 17M19 19L21 21M19 19L17 21"
@@ -569,17 +628,11 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
                   </svg>
                 </button>
               </div>
-              <div :if={script.output} class="bg-base-950 border-base-700 mt-2 rounded border p-2">
-                <div id={"support-script-#{script.id}"} phx-hook="SupportScriptOutput" data-output-id={"support-script-output-#{script.id}"} class="overflow-x-scroll"></div>
-                <div id={"support-script-output-#{script.id}"} class="hidden" phx-no-format>{script.output}</div>
+              <div class="bg-base-950 border-base-700 rounded border p-2">
+                <div id="support-script-term" phx-update="ignore" phx-hook="SupportScriptOutput" class="min-h-44 overflow-x-scroll"></div>
+                <div id="support-script-output" class="hidden" phx-no-format>{@recently_run_support_script_output}</div>
               </div>
             </div>
-          </div>
-
-          <div class="border-base-700 flex items-center gap-4 border-t p-4">
-            <.button type="link" navigate={~p"/org/#{@org}/#{@product}/scripts/new"} aria-label="Add a support script">
-              <.icon name="add" />Add a support script
-            </.button>
           </div>
         </div>
       </div>
@@ -813,24 +866,38 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     |> halt()
   end
 
-  def hooked_event("run-script", %{"id" => id}, socket) do
-    %{assigns: %{device: device, support_scripts: scripts, current_scope: scope}} = socket
-
-    authorized!(:"support_script:run", scope)
-
-    script = Enum.find(scripts, fn script -> script.id == String.to_integer(id) end)
-
+  def hooked_event("select-script", %{"script_id" => ""}, socket) do
     socket
-    |> start_async({:run_script, id}, fn -> Scripts.Runner.send(device, script) end)
-    |> assign(:support_scripts, update_script(scripts, id, %{output: nil, running?: true}))
+    |> assign(:selected_support_script, nil)
     |> halt()
   end
 
-  def hooked_event("clear-script-output", %{"id" => id}, socket) do
-    %{assigns: %{support_scripts: scripts}} = socket
+  def hooked_event("select-script", %{"script_id" => id}, %{assigns: %{support_scripts: scripts}} = socket) do
+    script = Enum.find(scripts, fn script -> script.id == String.to_integer(id) end)
 
     socket
-    |> assign(:support_scripts, update_script(scripts, id, %{output: nil, running?: false}))
+    |> assign(:selected_support_script, script)
+    |> halt()
+  end
+
+  def hooked_event("run-script", _params, socket) do
+    %{assigns: %{device: device, selected_support_script: script, current_scope: scope}} = socket
+
+    authorized!(:"support_script:run", scope)
+
+    socket
+    |> start_async(:run_script, fn -> Scripts.Runner.send(device, script) end)
+    |> assign(:support_script_running, true)
+    |> assign(:recently_run_support_script, script)
+    |> assign(:recently_run_support_script_output, nil)
+    |> halt()
+  end
+
+  def hooked_event("clear-script-output", _params, socket) do
+    socket
+    |> assign(:support_script_running, false)
+    |> assign(:recently_run_support_script, nil)
+    |> assign(:recently_run_support_script_output, nil)
     |> halt()
   end
 
@@ -916,9 +983,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
 
   def hooked_info(_event, socket), do: {:cont, socket}
 
-  def hooked_async({:run_script, id}, result, socket) do
-    %{assigns: %{support_scripts: scripts}} = socket
-
+  def hooked_async(:run_script, result, socket) do
     output =
       case result do
         {:ok, {:ok, output}} ->
@@ -931,10 +996,9 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
           inspect(e)
       end
 
-    scripts = update_script(scripts, id, %{output: output, running?: false})
-
     socket
-    |> assign(:support_scripts, scripts)
+    |> assign(:support_script_running, false)
+    |> assign(:recently_run_support_script_output, output)
     |> halt()
   end
 
@@ -951,18 +1015,6 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
 
   defp health_extension_enabled?(product, device) do
     product.extensions.health and device.extensions.health
-  end
-
-  defp update_script(scripts, id, new_info) when is_binary(id) do
-    update_script(scripts, String.to_integer(id), new_info)
-  end
-
-  defp update_script(scripts, id, new_info) do
-    index = Enum.find_index(scripts, fn script -> script.id == id end)
-
-    List.update_at(scripts, index, fn script ->
-      Map.merge(script, new_info)
-    end)
   end
 
   # TODO: this is duplicated code, find a new way to reuse it

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -889,8 +889,35 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("div", text: "Support Scripts")
-      |> assert_has("div", text: "MOTD")
-      |> assert_has("button[phx-value-id=\"#{script.id}\"]")
+      |> assert_has("select#script_id option[value=\"#{script.id}\"]", text: "MOTD")
+      # No script is selected by default, so a placeholder option is shown
+      # and the run button stays disabled.
+      |> assert_has("select#script_id option[value=\"\"]", text: "Select a support script")
+      |> assert_has("button[disabled]", text: "Run script")
+      # With a small number of scripts, the native dropdown is used (no search).
+      |> refute_has("#script-autocomplete")
+    end
+
+    test "more than 10 scripts switches to a searchable autocomplete", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device,
+      user: user
+    } do
+      for i <- 1..11 do
+        {:ok, _script} =
+          NervesHub.Scripts.create(product, user, %{name: "Script #{i}", text: "ignored"})
+      end
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("div", text: "Support Scripts")
+      # The native <select> is replaced by the searchable combobox.
+      |> refute_has("select#script_id")
+      |> assert_has("#script-autocomplete[phx-hook=\"ScriptAutocomplete\"]")
+      |> assert_has("input#script_search")
+      |> assert_has("button", text: "Run script")
     end
   end
 

--- a/test/nerves_hub_web/live/devices/support_scripts_test.exs
+++ b/test/nerves_hub_web/live/devices/support_scripts_test.exs
@@ -11,21 +11,15 @@ defmodule NervesHubWeb.Live.Devices.SupportScriptsTest do
   setup :set_mimic_global
 
   describe "support scripts" do
-    # Reproduces https://github.com/nerves-hub/nerves_hub_web/issues/2607
+    # The Support Scripts section presents a dropdown of all scripts and a
+    # single "Run script" button. Running a script shows its output below
+    # the dropdown, and selecting a different script swaps the visible
+    # output for that script.
     #
-    # When more than one support script has output assigned at the same
-    # time, the device-details template renders the same DOM ids
-    # ("support-script" + "support-script-output") for each script. The
-    # xterm.js hook calls document.getElementById("support-script-output"),
-    # which always returns the first match, so each subsequent script's
-    # terminal renders the earlier script's output (FIFO).
-    #
-    # Phoenix.LiveViewTest also enforces unique ids on render, so this
-    # test currently fails with `(RuntimeError) Duplicate id found while
-    # testing LiveView: support-script` — that error IS the bug. The fix
-    # should make each script's output panel ids unique (e.g. by
-    # appending the script's id), at which point this test will pass.
-    test "running multiple scripts produces uniquely identifiable output panels (#2607)", %{
+    # The output panel DOM ids are derived from the selected script's id
+    # (regression cover for https://github.com/nerves-hub/nerves_hub_web/issues/2607),
+    # so each script renders its own uniquely identifiable terminal.
+    test "running the selected script shows its output, switching scripts swaps the output", %{
       conn: conn,
       org: org,
       product: product,
@@ -55,54 +49,45 @@ defmodule NervesHubWeb.Live.Devices.SupportScriptsTest do
       {:ok, view, _html} =
         live(conn, "/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
 
+      # No script is selected by default, so pick the first one before running.
+      render_change(view, "select-script", %{"script_id" => to_string(script_1.id)})
       render_click(view, "run-script", %{"id" => to_string(script_1.id)})
-      render_click(view, "run-script", %{"id" => to_string(script_2.id)})
 
       assert_receive {:runner_called, "Script 1"}, 1_000
+
+      html = eventually_output(view, "output for Script 1")
+      assert html =~ "output for Script 1"
+      refute html =~ "output for Script 2"
+      assert html =~ "support-script-output"
+
+      # Switch the dropdown to the second script and run it; its output
+      # replaces the first script's output.
+      render_change(view, "select-script", %{"script_id" => to_string(script_2.id)})
+      render_click(view, "run-script", %{"id" => to_string(script_2.id)})
+
       assert_receive {:runner_called, "Script 2"}, 1_000
 
-      html = eventually_both_outputs(view)
-
-      assert html =~ "output for Script 1"
+      html = eventually_output(view, "output for Script 2")
       assert html =~ "output for Script 2"
-
-      {:ok, document} = Floki.parse_document(html)
-
-      hook_ids =
-        document
-        |> Floki.find("[phx-hook=\"SupportScriptOutput\"]")
-        |> Enum.flat_map(&Floki.attribute(&1, "id"))
-
-      hidden_output_ids =
-        document
-        |> Floki.find("[id^=\"support-script-output\"]")
-        |> Enum.flat_map(&Floki.attribute(&1, "id"))
-
-      assert length(hook_ids) == 2,
-             "Expected an xterm container per running script, got ids: #{inspect(hook_ids)}"
-
-      assert hook_ids == Enum.uniq(hook_ids),
-             "Each script's xterm container needs a unique DOM id (issue #2607). Got: #{inspect(hook_ids)}"
-
-      assert hidden_output_ids == Enum.uniq(hidden_output_ids),
-             "Each script's hidden output element needs a unique DOM id (issue #2607). Got: #{inspect(hidden_output_ids)}"
+      refute html =~ "output for Script 1"
+      assert html =~ "support-script-output"
     end
   end
 
-  defp eventually_both_outputs(view, attempts \\ 40)
+  defp eventually_output(view, expected, attempts \\ 40)
 
-  defp eventually_both_outputs(_view, 0) do
-    flunk("LiveView never rendered both script outputs")
+  defp eventually_output(_view, expected, 0) do
+    flunk("LiveView never rendered #{inspect(expected)}")
   end
 
-  defp eventually_both_outputs(view, attempts) do
+  defp eventually_output(view, expected, attempts) do
     html = render(view)
 
-    if html =~ "output for Script 1" and html =~ "output for Script 2" do
+    if html =~ expected do
       html
     else
       Process.sleep(50)
-      eventually_both_outputs(view, attempts - 1)
+      eventually_output(view, expected, attempts - 1)
     end
   end
 end


### PR DESCRIPTION
This squashes a UI bug, and deals with long support script lists better 
(combo select and autocomplete when more than 10 scripts)

https://github.com/user-attachments/assets/6200364b-c9ec-4d27-afb0-f40cd448fc23

https://github.com/user-attachments/assets/bb5f359a-5f86-4ac9-b818-e59ca0444f54

