### PR TITLE
Update, and correct, how connection type filtering works

### DIFF
--- a/lib/nerves_hub/devices/advanced_query/compiler.ex
+++ b/lib/nerves_hub/devices/advanced_query/compiler.ex
@@ -200,16 +200,23 @@ defmodule NervesHub.Devices.AdvancedQuery.Compiler do
     dynamic([latest_health: lh], is_nil(lh) or lh.status != ^status)
   end
 
-  # `connection_types` is a JSON array on the latest connection's metadata; a
-  # device can report more than one, so membership uses contains semantics.
-  defp comparison_dynamic("connection_type", "contains", value),
-    do: dynamic([latest_connection: lc], fragment("?::jsonb <@ ?", ^[value], lc.metadata["connection_types"]))
+  # `network_interface` is the latest connection's reported interface, humanized
+  # to one of wifi/ethernet/cellular/unknown. A device that has never connected
+  # (or never reported an interface) has no value, which reads as "unknown".
+  defp comparison_dynamic("connection_type", "=", "unknown"),
+    do: dynamic([latest_connection: lc], lc.network_interface == :unknown or is_nil(lc.network_interface))
 
-  defp comparison_dynamic("connection_type", "not_contains", value) do
-    dynamic(
-      [latest_connection: lc],
-      fragment("NOT (?::jsonb <@ COALESCE(?, '[]'::jsonb))", ^[value], lc.metadata["connection_types"])
-    )
+  defp comparison_dynamic("connection_type", "=", value) do
+    interface = String.to_existing_atom(value)
+    dynamic([latest_connection: lc], lc.network_interface == ^interface)
+  end
+
+  defp comparison_dynamic("connection_type", "!=", "unknown"),
+    do: dynamic([latest_connection: lc], not is_nil(lc.network_interface) and lc.network_interface != :unknown)
+
+  defp comparison_dynamic("connection_type", "!=", value) do
+    interface = String.to_existing_atom(value)
+    dynamic([latest_connection: lc], is_nil(lc.network_interface) or lc.network_interface != ^interface)
   end
 
   defp comparison_dynamic("updates", "=", "enabled"), do: dynamic([d], d.updates_enabled == true)

--- a/lib/nerves_hub/devices/advanced_query/schema.ex
+++ b/lib/nerves_hub/devices/advanced_query/schema.ex
@@ -70,7 +70,7 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
       values: &__MODULE__.health_status_values/1
     },
     "connection_type" => %{
-      operators: ["contains", "not_contains"],
+      operators: ["=", "!="],
       values: &__MODULE__.connection_type_values/1
     },
     "updates" => %{
@@ -204,7 +204,7 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
   def health_status_values(_product_id), do: ["unknown", "healthy", "warning", "unhealthy"]
 
   @doc false
-  def connection_type_values(_product_id), do: ["cellular", "ethernet", "wifi"]
+  def connection_type_values(_product_id), do: ["cellular", "ethernet", "wifi", "unknown"]
 
   @doc false
   def updates_values(_product_id), do: ["enabled", "disabled", "penalty-box"]

--- a/lib/nerves_hub/devices/device_filtering.ex
+++ b/lib/nerves_hub/devices/device_filtering.ex
@@ -86,12 +86,13 @@ defmodule NervesHub.Devices.DeviceFiltering do
     end
   end
 
+  def filter(query, _filters, :connection_type, "unknown") do
+    where(query, [latest_connection: lc], lc.network_interface == :unknown or is_nil(lc.network_interface))
+  end
+
   def filter(query, _filters, :connection_type, value) do
-    where(
-      query,
-      [latest_connection: lc],
-      fragment("?::jsonb <@ ?", ^[value], lc.metadata["connection_types"])
-    )
+    interface = String.to_existing_atom(value)
+    where(query, [latest_connection: lc], lc.network_interface == ^interface)
   end
 
   def filter(query, _filters, :firmware_version, value) do

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -379,7 +379,8 @@
         {"All", ""},
         {"Cellular", "cellular"},
         {"Ethernet", "ethernet"},
-        {"WiFi", "wifi"}
+        {"WiFi", "wifi"},
+        {"Unknown", "unknown"}
       ]}
     />
 

--- a/test/nerves_hub/devices/advanced_query/compiler_test.exs
+++ b/test/nerves_hub/devices/advanced_query/compiler_test.exs
@@ -148,7 +148,7 @@ defmodule NervesHub.Devices.AdvancedQuery.CompilerTest do
 
       Fixtures.device_connection_fixture(disconnected, %{
         status: :disconnected,
-        metadata: %{"connection_types" => ["wifi"]},
+        network_interface: :wifi,
         last_seen_at: DateTime.add(DateTime.utc_now(), -5, :day)
       })
 
@@ -172,13 +172,19 @@ defmodule NervesHub.Devices.AdvancedQuery.CompilerTest do
       assert run(product, ~s|health_status != "healthy"|) == ["connected", "never_connected", "untagged"]
     end
 
-    test "connection_type contains", %{product: product} do
-      assert run(product, ~s|connection_type contains "wifi"|) == ["connected"]
-      assert run(product, ~s|connection_type contains "ethernet"|) == []
+    test "connection_type equality matches the latest connection's network interface", %{product: product} do
+      assert run(product, ~s|connection_type = "wifi"|) == ["connected"]
+      assert run(product, ~s|connection_type = "ethernet"|) == []
     end
 
-    test "connection_type not_contains includes devices with no connection metadata", %{product: product} do
-      assert run(product, ~s|connection_type not_contains "wifi"|) == ["never_connected", "tagged", "untagged"]
+    test "connection_type unknown matches devices with no reported interface", %{product: product} do
+      # "tagged"/"untagged"/"never_connected" have no connection (nil interface).
+      assert run(product, ~s|connection_type = "unknown"|) == ["never_connected", "tagged", "untagged"]
+      assert run(product, ~s|connection_type != "unknown"|) == ["connected"]
+    end
+
+    test "connection_type inequality includes devices with no reported interface", %{product: product} do
+      assert run(product, ~s|connection_type != "wifi"|) == ["never_connected", "tagged", "untagged"]
     end
 
     test "updates enabled/disabled", %{product: product} do

--- a/test/nerves_hub/devices/advanced_query/schema_test.exs
+++ b/test/nerves_hub/devices/advanced_query/schema_test.exs
@@ -24,6 +24,7 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
   describe "operators/1 and operator?/2" do
     test "returns the operators for known columns" do
       assert Schema.operators("platform") == ["=", "!="]
+      assert Schema.operators("connection_type") == ["=", "!="]
       assert Schema.operators("tags") == ["contains", "not_contains"]
       assert Schema.operators("update_status") == ["is", "is not"]
       assert Schema.operators("identifier") == ["like", "not like"]
@@ -58,6 +59,14 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
       assert Schema.value?("identifier", "anything", 1)
       assert Schema.value?("identifier", "%wild_card%", 1)
       refute Schema.value?("identifier", "", 1)
+    end
+
+    test "connection_type accepts the network interfaces and unknown" do
+      for value <- ["cellular", "ethernet", "wifi", "unknown"] do
+        assert Schema.value?("connection_type", value, 1)
+      end
+
+      refute Schema.value?("connection_type", "bogus", 1)
     end
   end
 

--- a/test/support/advanced_query_fixtures.ex
+++ b/test/support/advanced_query_fixtures.ex
@@ -42,7 +42,7 @@ defmodule NervesHub.AdvancedQueryFixtures do
     connected =
       Fixtures.device_fixture(org, product, firmware, %{identifier: "connected", tags: [], status: :provisioned})
 
-    Fixtures.device_connection_fixture(connected, %{status: :connected, metadata: %{"connection_types" => ["wifi"]}})
+    Fixtures.device_connection_fixture(connected, %{status: :connected, network_interface: :wifi})
 
     never_connected =
       Fixtures.device_fixture(org, product, firmware, %{


### PR DESCRIPTION
This PR fixes non working connection type filters due to a change in how and where the info is stored.