### PR TITLE
Add support for last 24 hours and last 4 weeks to the device connection history graph

### DIFF
--- a/assets/js/hooks/barChart.js
+++ b/assets/js/hooks/barChart.js
@@ -1,4 +1,63 @@
 import Chart from "chart.js/auto"
+import { format } from "date-fns"
+
+// First letter of each weekday, indexed by `Date#getDay()` (0 = Sunday).
+const WEEKDAY_INITIALS = ["S", "M", "T", "W", "T", "F", "S"]
+
+// Formats an hour-of-day (0-23) as a friendly label, e.g. 0 -> "12am",
+// 12 -> "midday", 15 -> "3pm".
+function formatHour(hour) {
+  if (hour === 0) return "12am"
+  if (hour === 12) return "midday"
+  return `${hour % 12}${hour < 12 ? "am" : "pm"}`
+}
+
+// x-axis tick label for the hourly (24 hour) chart: only label ticks every
+// 3 hours (12am, 3am, 6am, 9am, midday, 3pm, 6pm, 9pm), hiding any others.
+function hourTickLabel(date) {
+  const hour = date.getHours()
+  return hour % 3 === 0 ? formatHour(hour) : null
+}
+
+// x-axis tick label for the 4 week chart: the day-of-week initial, except
+// Mondays which also show the date (e.g. "1 Jun") on a second line below the
+// initial to anchor each week. Returning an array renders a multi-line label.
+function fourWeekTickLabel(date) {
+  const initial = WEEKDAY_INITIALS[date.getDay()]
+  return date.getDay() === 1 ? [initial, format(date, "d MMM")] : initial
+}
+
+// Returns the x-axis tick label function for the given period.
+function tickLabelFor(period) {
+  switch (period) {
+    case "twenty_four_hours":
+      return (_value, index, ticks) => hourTickLabel(new Date(ticks[index].value))
+    case "four_weeks":
+      return (_value, index, ticks) => fourWeekTickLabel(new Date(ticks[index].value))
+    // 14 days: a label on every (daily) tick, e.g. "Jun 12".
+    default:
+      return (_value, index, ticks) => format(new Date(ticks[index].value), "MMM d")
+  }
+}
+
+// Replaces the x-axis ticks with one at every 3rd hour of the clock (00:00,
+// 03:00, ... 21:00) within the scale's range. Stepping via `setHours` keeps the
+// ticks aligned to the wall clock across a daylight-saving change.
+function buildThreeHourlyTicks(scale) {
+  const cursor = new Date(scale.min)
+  cursor.setMinutes(0, 0, 0)
+  while (cursor.getHours() % 3 !== 0) {
+    cursor.setHours(cursor.getHours() + 1)
+  }
+
+  const ticks = []
+  while (cursor.getTime() <= scale.max) {
+    ticks.push({ value: cursor.getTime() })
+    cursor.setHours(cursor.getHours() + 3)
+  }
+
+  scale.ticks = ticks
+}
 
 const valueLabels = {
   id: "valueLabels",
@@ -70,6 +129,7 @@ export default {
     let minDate = JSON.parse(this.el.dataset.mindate)
 
     let unit = this.el.dataset.unit
+    let period = this.el.dataset.period
 
     const areaChartDataset = {
       type: "bar",
@@ -140,10 +200,14 @@ export default {
             time: {
               unit: unit,
             },
+            // For the hourly chart, force a tick at every 3rd hour (12am, 3am,
+            // ... 9pm) instead of relying on chart.js's width-based spacing.
+            afterBuildTicks: unit === "hour" ? buildThreeHourlyTicks : undefined,
             ticks: {
               source: "auto",
               display: true,
               autoSkip: false,
+              callback: tickLabelFor(period),
               font: {
                 family:
                   "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -249,6 +249,50 @@ defmodule NervesHub.Devices.Connections do
     NervesHub.AnalyticsRepo.all(query)
   end
 
+  @doc """
+  Buckets the count of unique connected devices per hour, from `from` (a
+  `DateTime`) up to now.
+
+  Mirrors `device_connections_by_date/3` but at hourly granularity, for the
+  shorter "last 24 hours" view of the connection history graph. The returned
+  rows use a `:day` key (holding the hour as a `NaiveDateTime`) so the chart can
+  consume both day- and hour-bucketed data without changes.
+  """
+  def device_connections_by_hour(org_id, product_id, %DateTime{} = from) do
+    window_start = from
+    window_end = DateTime.utc_now()
+
+    inner =
+      from c in "device_connection_history",
+        where: c.org_id == ^org_id,
+        where: c.product_id == ^product_id,
+        where: c.established_at <= ^window_end,
+        where: is_nil(c.disconnected_at) or c.disconnected_at >= ^window_start,
+        select: %{
+          device_id: c.device_id,
+          hour:
+            fragment(
+              "toDateTime(arrayJoin(range(toUInt32(toStartOfHour(greatest(?, ?))), toUInt32(toStartOfHour(least(coalesce(?, ?), ?))) + 3600, 3600)))",
+              c.established_at,
+              ^window_start,
+              c.disconnected_at,
+              ^window_end,
+              ^window_end
+            )
+        }
+
+    query =
+      from s in subquery(inner),
+        group_by: s.hour,
+        order_by: s.hour,
+        select: %{
+          day: s.hour,
+          count: fragment("uniqExact(?)", s.device_id)
+        }
+
+    NervesHub.AnalyticsRepo.all(query)
+  end
+
   def clean_stale_connections() do
     interval = Application.get_env(:nerves_hub, :device_last_seen_update_interval_minutes)
     jitter = Application.get_env(:nerves_hub, :device_last_seen_update_interval_jitter_seconds)

--- a/lib/nerves_hub_web/live/product/insights.ex
+++ b/lib/nerves_hub_web/live/product/insights.ex
@@ -6,6 +6,8 @@ defmodule NervesHubWeb.Live.Product.Insights do
   alias NervesHub.ProductNotifications
   alias NervesHub.Products
 
+  @graph_periods ~w(twenty_four_hours fourteen_days four_weeks)
+
   @impl Phoenix.LiveView
   def mount(_params, _session, %{assigns: %{current_scope: scope}} = socket) do
     product = Products.load_shared_secret_auth(scope.product)
@@ -37,6 +39,18 @@ defmodule NervesHubWeb.Live.Product.Insights do
     |> noreply()
   end
 
+  def handle_event("select-graph-time-period", %{"period" => period}, socket) when period in @graph_periods do
+    socket
+    |> maybe_assign_device_connections_graph(String.to_existing_atom(period))
+    |> noreply()
+  end
+
+  def handle_event("select-graph-time-period", _params, socket) do
+    socket
+    |> put_flash(:error, "Invalid graph period selected")
+    |> noreply()
+  end
+
   @impl Phoenix.LiveView
   def handle_info(:poll_device_counts, socket) do
     socket
@@ -57,20 +71,45 @@ defmodule NervesHubWeb.Live.Product.Insights do
     |> assign(:fleet_size, Devices.total_count(scope.product))
   end
 
-  defp maybe_assign_device_connections_graph(%{assigns: %{current_scope: scope}} = socket) do
-    if Application.get_env(:nerves_hub, :analytics_enabled) do
-      from = Date.utc_today() |> Date.add(-14)
+  defp maybe_assign_device_connections_graph(socket, period \\ :fourteen_days)
 
-      data = Connections.device_connections_by_date(scope.org.id, scope.product.id, from)
+  defp maybe_assign_device_connections_graph(%{assigns: %{current_scope: scope}} = socket, period) do
+    if Application.get_env(:nerves_hub, :analytics_enabled) do
+      {from, to, unit, data} = device_connections_graph(scope, period)
 
       socket
-      |> assign(:device_connections_graph_from, from)
-      |> assign(:device_connections_graph_to, Date.utc_today())
       |> assign(:device_connections_graph_enabled, true)
+      |> assign(:device_connections_graph_from, from)
+      |> assign(:device_connections_graph_to, to)
+      |> assign(:device_connections_graph_unit, unit)
       |> assign(:device_connections_graph_data, data)
+      |> assign(:connected_devices_period, period)
     else
       assign(socket, :device_connections_graph_enabled, false)
     end
+  end
+
+  defp device_connections_graph(scope, :twenty_four_hours) do
+    # Snap the window to the top of the hour so the chart's axis bounds line up
+    # with the hourly buckets (which are themselves aligned via `toStartOfHour`),
+    # letting the bars sit flush against both edges.
+    to = %{DateTime.utc_now() | minute: 0, second: 0, microsecond: {0, 0}}
+    from = DateTime.add(to, -24, :hour)
+    data = Connections.device_connections_by_hour(scope.org.id, scope.product.id, from)
+
+    {from, to, "hour", data}
+  end
+
+  defp device_connections_graph(scope, :four_weeks), do: device_connections_graph_by_day(scope, 28)
+
+  defp device_connections_graph(scope, :fourteen_days), do: device_connections_graph_by_day(scope, 14)
+
+  defp device_connections_graph_by_day(scope, days) do
+    to = Date.utc_today()
+    from = Date.add(to, -days)
+    data = Connections.device_connections_by_date(scope.org.id, scope.product.id, from)
+
+    {from, to, "day", data}
   end
 
   defp maybe_assign_flapping_connections(%{assigns: %{current_scope: scope}} = socket) do

--- a/lib/nerves_hub_web/live/product/insights.html.heex
+++ b/lib/nerves_hub_web/live/product/insights.html.heex
@@ -112,20 +112,47 @@
     </div>
 
     <div :if={@device_connections_graph_enabled} class="bg-surface-raised border-base-700 shadow-device-details-content flex flex-col gap-5 rounded border p-5">
-      <div class="text-base-50 flex items-center leading-6 font-medium">
-        Connected Devices — Last 14 Days
+      <div class="flex justify-between">
+        <div class="text-base-50 flex items-center leading-6 font-medium">
+          Connected Device History
+        </div>
+
+        <div role="tablist" class="bg-surface-muted border-b-default border-t-default inline-flex gap-0.5 rounded-md border p-0.5">
+          <button
+            role="tab"
+            data-selected={@connected_devices_period == :twenty_four_hours}
+            phx-click="select-graph-time-period"
+            phx-value-period="twenty_four_hours"
+            class="text-content-muted cursor-pointer appearance-none rounded-sm border-0 bg-transparent px-3 py-1.5 text-xs leading-none font-medium whitespace-nowrap shadow-none transition-colors duration-120 hover:bg-indigo-500/80 hover:text-white data-selected:bg-indigo-500 data-selected:font-semibold data-selected:text-white data-selected:shadow-[0_1px_2px_rgba(0,0,0,0.18)]"
+          >Last 24 hours</button>
+          <button
+            role="tab"
+            data-selected={@connected_devices_period == :fourteen_days}
+            phx-click="select-graph-time-period"
+            phx-value-period="fourteen_days"
+            class="text-content-muted cursor-pointer appearance-none rounded-sm border-0 bg-transparent px-3 py-1.5 text-xs leading-none font-medium whitespace-nowrap shadow-none transition-colors duration-120 hover:bg-indigo-500/80 hover:text-white data-selected:bg-indigo-500 data-selected:font-semibold data-selected:text-white data-selected:shadow-[0_1px_2px_rgba(0,0,0,0.18)]"
+          >14 days</button>
+          <button
+            role="tab"
+            phx-click="select-graph-time-period"
+            phx-value-period="four_weeks"
+            data-selected={@connected_devices_period == :four_weeks}
+            class="text-content-muted cursor-pointer appearance-none rounded-sm border-0 bg-transparent px-3 py-1.5 text-xs leading-none font-medium whitespace-nowrap shadow-none transition-colors duration-120 hover:bg-indigo-500/80 hover:text-white data-selected:bg-indigo-500 data-selected:font-semibold data-selected:text-white data-selected:shadow-[0_1px_2px_rgba(0,0,0,0.18)]"
+          >4 weeks</button>
+        </div>
       </div>
 
       <div class="h-[160px] grow">
         <canvas
-          id="daily-device-counts-chart"
+          id={"daily-device-counts-chart-#{@connected_devices_period}"}
           phx-hook="BarChart"
           phx-update="ignore"
           data-metrics={Jason.encode!(@device_connections_graph_data)}
           data-title=""
           data-mindate={Jason.encode!(@device_connections_graph_from)}
           data-maxdate={Jason.encode!(@device_connections_graph_to)}
-          data-unit="day"
+          data-unit={@device_connections_graph_unit}
+          data-period={@connected_devices_period}
         ></canvas>
       </div>
     </div>

--- a/test/nerves_hub/devices/connection_history_test.exs
+++ b/test/nerves_hub/devices/connection_history_test.exs
@@ -326,4 +326,103 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       assert Connections.device_connections_by_date(org.id, product.id, from) == []
     end
   end
+
+  describe "device_connections_by_hour/3" do
+    setup %{org: org, product: product, firmware: firmware} do
+      device_a = Fixtures.device_fixture(org, product, firmware)
+      device_b = Fixtures.device_fixture(org, product, firmware)
+
+      %{device_a: device_a, device_b: device_b}
+    end
+
+    defp hours_ago(n), do: DateTime.add(DateTime.utc_now(), -n, :hour)
+
+    test "buckets unique connected devices per hour across the window", %{
+      org: org,
+      product: product,
+      device_a: device_a,
+      device_b: device_b
+    } do
+      # device_a was connected from 5 hours ago until 3 hours ago
+      insert_history(device_a, hours_ago(5), hours_ago(3))
+      # device_b connected 2 hours ago and is still connected
+      insert_history(device_b, hours_ago(2), nil)
+
+      from = DateTime.add(DateTime.utc_now(), -24, :hour)
+      results = Connections.device_connections_by_hour(org.id, product.id, from)
+
+      counts =
+        Map.new(results, fn %{day: hour, count: count} ->
+          {NaiveDateTime.truncate(hour, :second), count}
+        end)
+
+      hour = fn n ->
+        DateTime.utc_now()
+        |> DateTime.add(-n, :hour)
+        |> DateTime.to_naive()
+        |> NaiveDateTime.truncate(:second)
+        |> Map.put(:minute, 0)
+        |> Map.put(:second, 0)
+      end
+
+      # device_a present on the -5, -4 and -3 hour buckets
+      assert counts[hour.(5)] == 1
+      assert counts[hour.(4)] == 1
+      assert counts[hour.(3)] == 1
+
+      # device_b present on the -2, -1 and current hour buckets
+      assert counts[hour.(2)] == 1
+      assert counts[hour.(1)] == 1
+      assert counts[hour.(0)] == 1
+    end
+
+    test "counts each device once per hour even with overlapping connections", %{
+      org: org,
+      product: product,
+      device_a: device_a,
+      device_b: device_b
+    } do
+      insert_history(device_a, hours_ago(0), nil)
+      insert_history(device_b, hours_ago(0), nil)
+      # device_a has a second (overlapping) connection this hour
+      insert_history(device_a, hours_ago(0), nil)
+
+      from = DateTime.add(DateTime.utc_now(), -24, :hour)
+      results = Connections.device_connections_by_hour(org.id, product.id, from)
+
+      total = results |> Enum.map(& &1.count) |> Enum.max(fn -> 0 end)
+
+      # two unique devices, despite three connection rows
+      assert total == 2
+    end
+
+    test "only includes connections for the requested org and product", %{
+      org: org,
+      product: product,
+      device_a: device_a,
+      user: user,
+      tmp_dir: tmp_dir
+    } do
+      insert_history(device_a, hours_ago(1), nil)
+
+      other_org = Fixtures.org_fixture(user, %{name: "other-org-hourly"})
+      other_product = Fixtures.product_fixture(user, other_org)
+      other_org_key = Fixtures.org_key_fixture(other_org, user, tmp_dir)
+      other_firmware = Fixtures.firmware_fixture(other_org_key, other_product, %{dir: tmp_dir})
+      other_device = Fixtures.device_fixture(other_org, other_product, other_firmware)
+      insert_history(other_device, hours_ago(1), nil)
+
+      from = DateTime.add(DateTime.utc_now(), -24, :hour)
+      results = Connections.device_connections_by_hour(org.id, product.id, from)
+
+      # every bucket only ever sees device_a — the other org/product is excluded
+      assert Enum.all?(results, &(&1.count == 1))
+      refute results == []
+    end
+
+    test "returns no rows when there is no connection history", %{org: org, product: product} do
+      from = DateTime.add(DateTime.utc_now(), -24, :hour)
+      assert Connections.device_connections_by_hour(org.id, product.id, from) == []
+    end
+  end
 end

--- a/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
+++ b/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
@@ -51,7 +51,7 @@ defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
 
       {:ok, view, html} = live(conn, insights_path(org, product))
 
-      assert html =~ "Connected Devices — Last 14 Days"
+      assert html =~ "Connected Device History"
       assert html =~ "daily-device-counts-chart"
       assert html =~ ~s(phx-hook="BarChart")
 
@@ -94,8 +94,101 @@ defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
     } do
       {:ok, view, html} = live(conn, insights_path(org, product))
 
-      assert html =~ "Connected Devices — Last 14 Days"
+      assert html =~ "Connected Device History"
       assert :sys.get_state(view.pid).socket.assigns.device_connections_graph_data == []
+    end
+
+    test "defaults to the 14 day period", %{conn: conn, org: org, product: product} do
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert assigns.connected_devices_period == :fourteen_days
+      assert assigns.device_connections_graph_unit == "day"
+      assert assigns.device_connections_graph_from == Date.add(Date.utc_today(), -14)
+      assert assigns.device_connections_graph_to == Date.utc_today()
+    end
+
+    test "renders a tab for each available period", %{conn: conn, org: org, product: product} do
+      {:ok, _view, html} = live(conn, insights_path(org, product))
+
+      assert html =~ ~s(phx-value-period="twenty_four_hours")
+      assert html =~ ~s(phx-value-period="fourteen_days")
+      assert html =~ ~s(phx-value-period="four_weeks")
+    end
+
+    test "selecting the 4 week period extends the window to 28 days", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      view
+      |> element(~s(button[phx-value-period="four_weeks"]))
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert assigns.connected_devices_period == :four_weeks
+      assert assigns.device_connections_graph_unit == "day"
+      assert assigns.device_connections_graph_from == Date.add(Date.utc_today(), -28)
+      assert assigns.device_connections_graph_to == Date.utc_today()
+    end
+
+    test "selecting the 24 hour period switches to hourly granularity", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      insert_history(device, DateTime.add(DateTime.utc_now(), -2, :hour), nil)
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      view
+      |> element(~s(button[phx-value-period="twenty_four_hours"]))
+      |> render_click()
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert assigns.connected_devices_period == :twenty_four_hours
+      assert assigns.device_connections_graph_unit == "hour"
+      assert %DateTime{} = assigns.device_connections_graph_from
+      assert %DateTime{} = assigns.device_connections_graph_to
+
+      # the window spans roughly the last 24 hours
+      diff = DateTime.diff(assigns.device_connections_graph_to, assigns.device_connections_graph_from, :hour)
+      assert diff == 24
+
+      # the device connected 2 hours ago shows up in the hourly data
+      assert Enum.sum(Enum.map(assigns.device_connections_graph_data, & &1.count)) >= 1
+    end
+
+    test "marks the active period tab as selected", %{conn: conn, org: org, product: product} do
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      html =
+        view
+        |> element(~s(button[phx-value-period="four_weeks"]))
+        |> render_click()
+
+      # the chart's id is keyed on the active period, forcing the hook to remount
+      assert html =~ "daily-device-counts-chart-four_weeks"
+    end
+
+    test "an unknown period is rejected with a flash message", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      html = render_click(view, "select-graph-time-period", %{"period" => "all_time"})
+
+      assert html =~ "Invalid graph period selected"
+      # the period is unchanged
+      assert :sys.get_state(view.pid).socket.assigns.connected_devices_period == :fourteen_days
     end
   end
 
@@ -110,7 +203,7 @@ defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
     test "does not render the connections graph", %{conn: conn, org: org, product: product} do
       {:ok, view, html} = live(conn, insights_path(org, product))
 
-      refute html =~ "Connected Devices — Last 14 Days"
+      refute html =~ "Connected Device History"
       refute html =~ "daily-device-counts-chart"
 
       refute :sys.get_state(view.pid).socket.assigns.device_connections_graph_enabled


### PR DESCRIPTION
**Last 24 Hours**
<img width="1215" height="273" alt="Screenshot 2026-06-26 at 8 51 32 PM" src="https://github.com/user-attachments/assets/28ef3af4-9458-4200-923e-f3829ade96e6" />

**Last 14 Days**
<img width="1206" height="271" alt="Screenshot 2026-06-26 at 8 51 46 PM" src="https://github.com/user-attachments/assets/ec956eb0-c990-4d3a-a212-0409fbd4a7bf" />

**Last 4 Weeks**
<img width="1206" height="273" alt="Screenshot 2026-06-26 at 8 52 40 PM" src="https://github.com/user-attachments/assets/12782553-994f-4e6a-8391-258ed06c3474" />
