### PR TITLE
Use the users timezone for the insights device connections graph

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -44,8 +44,16 @@ let execJS = (selector, attr) => {
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content")
+
+let time_zone = Intl.DateTimeFormat().resolvedOptions().timeZone
+let timezone_offset = -(new Date().getTimezoneOffset() / 60)
+
 let liveSocket = new LiveSocket("/live", Socket, {
-  params: { _csrf_token: csrfToken },
+  params: {
+    _csrf_token: csrfToken,
+    time_zone: time_zone,
+    timezone_offset: timezone_offset,
+  },
   hooks: {
     AdvancedQueryEditor,
     BarChart,

--- a/assets/js/hooks/barChart.js
+++ b/assets/js/hooks/barChart.js
@@ -184,6 +184,8 @@ export default {
           },
           tooltip: false,
           valueLabels: {
+            // hide the label for empty (zero-filled) intervals
+            display: (c) => c.value.count !== 0,
             formatter: (v) => `${v.count}`,
           },
         },

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -214,9 +214,18 @@ defmodule NervesHub.Devices.Connections do
     end
   end
 
-  def device_connections_by_date(org_id, product_id, from) do
+  @doc """
+  Buckets the count of unique connected devices per day, for the (local) dates
+  in `from..to`.
+
+  Days are bucketed in `time_zone` (an IANA name, e.g. "Pacific/Auckland") so
+  the graph reflects the viewer's local calendar days. Every date in the window
+  is returned (via a `generate_series` left join), with `0` for days that had no
+  connections. The returned `:day` key holds a `Date`.
+  """
+  def device_connections_by_date(org_id, product_id, %Date{} = from, %Date{} = to, time_zone) do
     window_start = Date.add(from, -1)
-    window_end = Date.utc_today()
+    window_end = to
 
     inner =
       from c in "device_connection_history",
@@ -228,66 +237,105 @@ defmodule NervesHub.Devices.Connections do
           device_id: c.device_id,
           day:
             fragment(
-              "toDate(arrayJoin(range(toUInt32(greatest(toDate(?), ?)), toUInt32(least(coalesce(toDate(?), ?), ?)) + 1)))",
+              "toDate(arrayJoin(range(toUInt32(greatest(toDate(?, ?), ?)), toUInt32(least(coalesce(toDate(?, ?), ?), ?)) + 1)))",
               c.established_at,
+              ^time_zone,
               type(^window_start, :date),
               c.disconnected_at,
+              ^time_zone,
               type(^window_end, :date),
               type(^window_end, :date)
             )
         }
 
-    query =
+    counts =
       from s in subquery(inner),
         group_by: s.day,
-        order_by: s.day,
+        select: %{day: s.day, count: fragment("uniqExact(?)", s.device_id)}
+
+    # A row for every date in the window, so days with no connections come back
+    # as 0 rather than being absent.
+    series =
+      from g in fragment(
+             "generate_series(toUInt32(?), toUInt32(?), 1)",
+             type(^from, :date),
+             type(^to, :date)
+           ),
+           select: %{day_number: fragment("generate_series")}
+
+    query =
+      from s in subquery(series),
+        left_join: c in subquery(counts),
+        on: s.day_number == fragment("toUInt32(?)", c.day),
+        order_by: s.day_number,
         select: %{
-          day: s.day,
-          count: fragment("uniqExact(?)", s.device_id)
+          day: fragment("toDate(?)", s.day_number),
+          count: fragment("coalesce(?, 0)", c.count)
         }
 
     NervesHub.AnalyticsRepo.all(query)
   end
 
   @doc """
-  Buckets the count of unique connected devices per hour, from `from` (a
-  `DateTime`) up to now.
+  Buckets the count of unique connected devices per hour, for the window
+  `from..to` (both `DateTime`s).
 
-  Mirrors `device_connections_by_date/3` but at hourly granularity, for the
-  shorter "last 24 hours" view of the connection history graph. The returned
-  rows use a `:day` key (holding the hour as a `NaiveDateTime`) so the chart can
-  consume both day- and hour-bucketed data without changes.
+  Mirrors `device_connections_by_date/5` but at hourly granularity, for the
+  shorter "last 24 hours" view of the connection history graph. Hours are
+  bucketed in `time_zone` (an IANA name) and the `:day` key holds a zoned
+  `DateTime` in that timezone, so it serialises with its offset and the browser
+  renders it in the viewer's local time, consistent with the graph's bounds.
+  Every hour in the window is returned (via a `generate_series` left join), with
+  `0` for hours that had no connections.
   """
-  def device_connections_by_hour(org_id, product_id, %DateTime{} = from) do
-    window_start = from
-    window_end = DateTime.utc_now()
-
+  def device_connections_by_hour(org_id, product_id, %DateTime{} = from, %DateTime{} = to, time_zone) do
     inner =
       from c in "device_connection_history",
         where: c.org_id == ^org_id,
         where: c.product_id == ^product_id,
-        where: c.established_at <= ^window_end,
-        where: is_nil(c.disconnected_at) or c.disconnected_at >= ^window_start,
+        where: c.established_at <= ^to,
+        where: is_nil(c.disconnected_at) or c.disconnected_at >= ^from,
         select: %{
           device_id: c.device_id,
           hour:
             fragment(
-              "toDateTime(arrayJoin(range(toUInt32(toStartOfHour(greatest(?, ?))), toUInt32(toStartOfHour(least(coalesce(?, ?), ?))) + 3600, 3600)))",
+              "toDateTime(arrayJoin(range(toUInt32(toStartOfHour(greatest(?, ?), ?)), toUInt32(toStartOfHour(least(coalesce(?, ?), ?), ?)) + 3600, 3600)), ?)",
               c.established_at,
-              ^window_start,
+              ^from,
+              ^time_zone,
               c.disconnected_at,
-              ^window_end,
-              ^window_end
+              ^to,
+              ^to,
+              ^time_zone,
+              ^time_zone
             )
         }
 
-    query =
+    counts =
       from s in subquery(inner),
         group_by: s.hour,
-        order_by: s.hour,
+        select: %{hour: s.hour, count: fragment("uniqExact(?)", s.device_id)}
+
+    # An hour-start for every hour in the window, so hours with no connections
+    # come back as 0 rather than being absent.
+    series =
+      from g in fragment(
+             "generate_series(toUInt32(toStartOfHour(?, ?)), toUInt32(toStartOfHour(?, ?)), 3600)",
+             ^from,
+             ^time_zone,
+             ^to,
+             ^time_zone
+           ),
+           select: %{ts: fragment("generate_series")}
+
+    query =
+      from s in subquery(series),
+        left_join: c in subquery(counts),
+        on: s.ts == fragment("toUInt32(?)", c.hour),
+        order_by: s.ts,
         select: %{
-          day: s.hour,
-          count: fragment("uniqExact(?)", s.device_id)
+          day: fragment("toDateTime(?, ?)", s.ts, ^time_zone),
+          count: fragment("coalesce(?, 0)", c.count)
         }
 
     NervesHub.AnalyticsRepo.all(query)

--- a/lib/nerves_hub_web/live/product/insights.ex
+++ b/lib/nerves_hub_web/live/product/insights.ex
@@ -74,8 +74,11 @@ defmodule NervesHubWeb.Live.Product.Insights do
   defp maybe_assign_device_connections_graph(socket, period \\ :fourteen_days)
 
   defp maybe_assign_device_connections_graph(%{assigns: %{current_scope: scope}} = socket, period) do
-    if Application.get_env(:nerves_hub, :analytics_enabled) do
-      {from, to, unit, data} = device_connections_graph(scope, period)
+    # Only load graph data on the connected mount: the disconnected (dead) render
+    # has no client timezone yet, and we'd otherwise run the ClickHouse queries
+    # twice on every page load.
+    if connected?(socket) and Application.get_env(:nerves_hub, :analytics_enabled) do
+      {from, to, unit, data} = device_connections_graph(scope, socket.assigns.time_zone, period)
 
       socket
       |> assign(:device_connections_graph_enabled, true)
@@ -89,27 +92,43 @@ defmodule NervesHubWeb.Live.Product.Insights do
     end
   end
 
-  defp device_connections_graph(scope, :twenty_four_hours) do
-    # Snap the window to the top of the hour so the chart's axis bounds line up
-    # with the hourly buckets (which are themselves aligned via `toStartOfHour`),
-    # letting the bars sit flush against both edges.
-    to = %{DateTime.utc_now() | minute: 0, second: 0, microsecond: {0, 0}}
+  defp device_connections_graph(scope, time_zone, :twenty_four_hours) do
+    {time_zone, now} = local_now(time_zone)
+
+    # Snap the window to the top of the (local) hour so the chart's axis bounds
+    # line up with the hourly buckets (aligned via `toStartOfHour`), letting the
+    # bars sit flush against both edges.
+    to = %{now | minute: 0, second: 0, microsecond: {0, 0}}
     from = DateTime.add(to, -24, :hour)
-    data = Connections.device_connections_by_hour(scope.org.id, scope.product.id, from)
+    data = Connections.device_connections_by_hour(scope.org.id, scope.product.id, from, to, time_zone)
 
     {from, to, "hour", data}
   end
 
-  defp device_connections_graph(scope, :four_weeks), do: device_connections_graph_by_day(scope, 28)
+  defp device_connections_graph(scope, time_zone, :four_weeks),
+    do: device_connections_graph_by_day(scope, time_zone, 28)
 
-  defp device_connections_graph(scope, :fourteen_days), do: device_connections_graph_by_day(scope, 14)
+  defp device_connections_graph(scope, time_zone, :fourteen_days),
+    do: device_connections_graph_by_day(scope, time_zone, 14)
 
-  defp device_connections_graph_by_day(scope, days) do
-    to = Date.utc_today()
+  defp device_connections_graph_by_day(scope, time_zone, days) do
+    {time_zone, now} = local_now(time_zone)
+
+    to = DateTime.to_date(now)
     from = Date.add(to, -days)
-    data = Connections.device_connections_by_date(scope.org.id, scope.product.id, from)
+    data = Connections.device_connections_by_date(scope.org.id, scope.product.id, from, to, time_zone)
 
     {from, to, "day", data}
+  end
+
+  # Resolves the viewer's "now" in their timezone, falling back to UTC if the
+  # timezone name isn't recognised. Returns the (validated) timezone alongside,
+  # so the same name is handed to the ClickHouse bucketing functions.
+  defp local_now(time_zone) do
+    case DateTime.now(time_zone) do
+      {:ok, now} -> {time_zone, now}
+      {:error, _} -> {"Etc/UTC", DateTime.utc_now()}
+    end
   end
 
   defp maybe_assign_flapping_connections(%{assigns: %{current_scope: scope}} = socket) do

--- a/lib/nerves_hub_web/mounts/set_users_timezone.ex
+++ b/lib/nerves_hub_web/mounts/set_users_timezone.ex
@@ -1,0 +1,26 @@
+defmodule NervesHubWeb.Mounts.SetUsersTimezone do
+  @moduledoc """
+  Add user information to the Sentry context
+  """
+
+  import Phoenix.Component
+  import Phoenix.LiveView
+
+  def on_mount(:default, _params, _session, socket) do
+    time_zone =
+      if connected?(socket) do
+        get_connect_params(socket)["time_zone"] || "UTC"
+      else
+        "UTC"
+      end
+
+    timezone_offset =
+      if connected?(socket) do
+        get_connect_params(socket)["timezone_offset"] || 0
+      else
+        0
+      end
+
+    {:cont, assign(socket, time_zone: time_zone, timezone_offset: timezone_offset)}
+  end
+end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -23,6 +23,7 @@ defmodule NervesHubWeb.Router do
   alias NervesHubWeb.API.UI
   alias NervesHubWeb.Mounts.CurrentPath
   alias NervesHubWeb.Mounts.EnrichSentryContext
+  alias NervesHubWeb.Mounts.SetUsersTimezone
   alias NervesHubWeb.Plugs.OpenApiSpec
   alias NervesHubWeb.Plugs.Redirector
   alias NervesHubWeb.Plugs.ServerAuth
@@ -280,6 +281,7 @@ defmodule NervesHubWeb.Router do
         {NervesHubWeb.Auth, :assign_org_to_scope},
         {NervesHubWeb.Auth, :assign_product_to_scope},
         {NervesHubWeb.Auth, :require_authenticated},
+        SetUsersTimezone,
         EnrichSentryContext,
         CurrentPath
       ] do

--- a/test/nerves_hub/devices/connection_history_test.exs
+++ b/test/nerves_hub/devices/connection_history_test.exs
@@ -215,7 +215,7 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
     end
   end
 
-  describe "device_connections_by_date/3" do
+  describe "device_connections_by_date/5" do
     setup %{org: org, product: product, firmware: firmware} do
       device_a = Fixtures.device_fixture(org, product, firmware)
       device_b = Fixtures.device_fixture(org, product, firmware)
@@ -258,7 +258,7 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       insert_history(device_b, days_ago(2), nil)
 
       from = Date.add(Date.utc_today(), -14)
-      results = Connections.device_connections_by_date(org.id, product.id, from)
+      results = Connections.device_connections_by_date(org.id, product.id, from, Date.utc_today(), "Etc/UTC")
 
       counts = Map.new(results, fn %{day: day, count: count} -> {day, count} end)
 
@@ -288,7 +288,7 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       insert_history(device_a, days_ago(0), nil)
 
       from = Date.add(Date.utc_today(), -14)
-      results = Connections.device_connections_by_date(org.id, product.id, from)
+      results = Connections.device_connections_by_date(org.id, product.id, from, Date.utc_today(), "Etc/UTC")
 
       counts = Map.new(results, fn %{day: day, count: count} -> {day, count} end)
 
@@ -314,20 +314,25 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       insert_history(other_device, days_ago(1), nil)
 
       from = Date.add(Date.utc_today(), -14)
-      results = Connections.device_connections_by_date(org.id, product.id, from)
+      results = Connections.device_connections_by_date(org.id, product.id, from, Date.utc_today(), "Etc/UTC")
 
       counts = Map.new(results, fn %{day: day, count: count} -> {day, count} end)
 
       assert counts[Date.add(Date.utc_today(), -1)] == 1
     end
 
-    test "returns no rows when there is no connection history", %{org: org, product: product} do
-      from = Date.add(Date.utc_today(), -14)
-      assert Connections.device_connections_by_date(org.id, product.id, from) == []
+    test "fills every day with 0 when there is no connection history", %{org: org, product: product} do
+      to = Date.utc_today()
+      from = Date.add(to, -14)
+      results = Connections.device_connections_by_date(org.id, product.id, from, to, "Etc/UTC")
+
+      # the full window is returned (inclusive of both ends), every day at 0
+      assert Enum.map(results, & &1.day) == Enum.map(0..14, &Date.add(from, &1))
+      assert Enum.all?(results, &(&1.count == 0))
     end
   end
 
-  describe "device_connections_by_hour/3" do
+  describe "device_connections_by_hour/5" do
     setup %{org: org, product: product, firmware: firmware} do
       device_a = Fixtures.device_fixture(org, product, firmware)
       device_b = Fixtures.device_fixture(org, product, firmware)
@@ -349,20 +354,20 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       insert_history(device_b, hours_ago(2), nil)
 
       from = DateTime.add(DateTime.utc_now(), -24, :hour)
-      results = Connections.device_connections_by_hour(org.id, product.id, from)
+      results = Connections.device_connections_by_hour(org.id, product.id, from, DateTime.utc_now(), "Etc/UTC")
 
-      counts =
-        Map.new(results, fn %{day: hour, count: count} ->
-          {NaiveDateTime.truncate(hour, :second), count}
-        end)
+      # each hour is a zoned DateTime (here UTC), so it serialises with an offset
+      # and the browser renders it in local time (consistent with the bounds)
+      assert Enum.all?(results, &match?(%DateTime{time_zone: "Etc/UTC"}, &1.day))
+
+      # key by unix second to compare instants without depending on struct fields
+      counts = Map.new(results, fn %{day: hour, count: count} -> {DateTime.to_unix(hour), count} end)
 
       hour = fn n ->
         DateTime.utc_now()
+        |> Map.merge(%{minute: 0, second: 0, microsecond: {0, 0}})
         |> DateTime.add(-n, :hour)
-        |> DateTime.to_naive()
-        |> NaiveDateTime.truncate(:second)
-        |> Map.put(:minute, 0)
-        |> Map.put(:second, 0)
+        |> DateTime.to_unix()
       end
 
       # device_a present on the -5, -4 and -3 hour buckets
@@ -388,7 +393,7 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       insert_history(device_a, hours_ago(0), nil)
 
       from = DateTime.add(DateTime.utc_now(), -24, :hour)
-      results = Connections.device_connections_by_hour(org.id, product.id, from)
+      results = Connections.device_connections_by_hour(org.id, product.id, from, DateTime.utc_now(), "Etc/UTC")
 
       total = results |> Enum.map(& &1.count) |> Enum.max(fn -> 0 end)
 
@@ -413,16 +418,45 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       insert_history(other_device, hours_ago(1), nil)
 
       from = DateTime.add(DateTime.utc_now(), -24, :hour)
-      results = Connections.device_connections_by_hour(org.id, product.id, from)
+      results = Connections.device_connections_by_hour(org.id, product.id, from, DateTime.utc_now(), "Etc/UTC")
 
-      # every bucket only ever sees device_a — the other org/product is excluded
-      assert Enum.all?(results, &(&1.count == 1))
-      refute results == []
+      # device_a is counted (never more than once per hour) and the other
+      # org/product never inflates a bucket
+      assert Enum.any?(results, &(&1.count == 1))
+      assert Enum.all?(results, &(&1.count <= 1))
     end
 
-    test "returns no rows when there is no connection history", %{org: org, product: product} do
-      from = DateTime.add(DateTime.utc_now(), -24, :hour)
-      assert Connections.device_connections_by_hour(org.id, product.id, from) == []
+    test "fills every hour with 0 when there is no connection history", %{org: org, product: product} do
+      to = DateTime.utc_now()
+      from = DateTime.add(to, -24, :hour)
+      results = Connections.device_connections_by_hour(org.id, product.id, from, to, "Etc/UTC")
+
+      # every hour in the 24h window (inclusive of both ends) is present at 0
+      assert length(results) == 25
+      assert Enum.all?(results, &(&1.count == 0))
+    end
+
+    test "buckets hours in the requested timezone", %{
+      org: org,
+      product: product,
+      device_a: device_a
+    } do
+      time_zone = "Pacific/Auckland"
+      insert_history(device_a, hours_ago(1), nil)
+
+      now = DateTime.now!(time_zone)
+      to = %{now | minute: 0, second: 0, microsecond: {0, 0}}
+      from = DateTime.add(to, -24, :hour)
+
+      results = Connections.device_connections_by_hour(org.id, product.id, from, to, time_zone)
+
+      refute results == []
+      # buckets come back as DateTimes zoned in the requested timezone, and each
+      # one sits on a local hour boundary
+      assert Enum.all?(results, fn %{day: hour} ->
+               match?(%DateTime{time_zone: ^time_zone}, hour) and
+                 hour.minute == 0 and hour.second == 0
+             end)
     end
   end
 end

--- a/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
+++ b/test/nerves_hub_web/live/product/insights_connections_graph_test.exs
@@ -87,7 +87,7 @@ defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
       assert encoded =~ "day"
     end
 
-    test "still renders the graph (with empty data) when there is no history", %{
+    test "still renders the graph (zero-filled) when there is no history", %{
       conn: conn,
       org: org,
       product: product
@@ -95,7 +95,28 @@ defmodule NervesHubWeb.Live.Product.InsightsConnectionsGraphTest do
       {:ok, view, html} = live(conn, insights_path(org, product))
 
       assert html =~ "Connected Device History"
-      assert :sys.get_state(view.pid).socket.assigns.device_connections_graph_data == []
+
+      # generate_series still returns a bucket per day, all zero
+      data = :sys.get_state(view.pid).socket.assigns.device_connections_graph_data
+      refute data == []
+      assert Enum.all?(data, &(&1.count == 0))
+    end
+
+    test "does not load the graph on the disconnected (dead) mount", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      insert_history(device, DateTime.add(DateTime.utc_now(), -2, :hour), nil)
+
+      # the static (disconnected) render must not run the analytics queries
+      html = conn |> get(insights_path(org, product)) |> html_response(200)
+      refute html =~ "daily-device-counts-chart"
+
+      # once connected, the graph loads
+      {:ok, _view, connected_html} = live(conn, insights_path(org, product))
+      assert connected_html =~ "daily-device-counts-chart"
     end
 
     test "defaults to the 14 day period", %{conn: conn, org: org, product: product} do


### PR DESCRIPTION
This fixes an issue with the 24 hour graph while also improving it further so that the 14 day and 4 week graphs use the users timezone.