### PR TITLE
feat: add deployment group notes

### DIFF
--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -62,6 +62,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     field(:healthy, :boolean, default: true)
     field(:penalty_timeout_minutes, :integer, default: 1440)
     field(:connecting_code, :string)
+    field(:notes, :string)
     field(:concurrent_updates, :integer, default: 10)
     field(:total_updating_devices, :integer, default: 0)
     field(:current_updated_devices, :integer, default: 0)
@@ -110,7 +111,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
   @spec create_changeset(map(), Product.t(), Firmware.t(), User.t()) :: Ecto.Changeset.t()
   def create_changeset(params, product, firmware, user) do
     %DeploymentGroup{}
-    |> cast(params, [:name, :delta_updatable, :platform, :architecture])
+    |> cast(params, [:name, :delta_updatable, :platform, :architecture, :notes])
     |> cast_embed(:conditions, required: true, with: &conditions_changeset/2)
     |> put_change(:product_id, product.id)
     |> put_change(:org_id, product.org_id)
@@ -119,6 +120,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     |> maybe_add_architecture()
     |> maybe_set_queue_management()
     |> validate_required([:name, :delta_updatable, :product_id, :org_id, :firmware])
+    |> validate_length(:notes, max: 1_000)
     |> validate_firmware(product)
     |> validate_platform()
     |> validate_architecture()
@@ -224,6 +226,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
       :is_active,
       :delta_updatable,
       :connecting_code,
+      :notes,
       :queue_management,
       :priority_queue_enabled,
       :priority_queue_firmware_version_threshold,
@@ -233,6 +236,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     |> cast_and_validate_numeric_fields(params)
     |> cast_embed(:conditions, required: true, with: &conditions_changeset/2)
     |> validate_required([:name, :delta_updatable, :is_active, :queue_management])
+    |> validate_length(:notes, max: 1_000)
     |> unique_constraint(:name, name: :deployments_product_id_name_index)
     |> prepare_current_updated_devices()
     |> prepare_device_count()

--- a/lib/nerves_hub_web/components/core_components.ex
+++ b/lib/nerves_hub_web/components/core_components.ex
@@ -474,6 +474,7 @@ defmodule NervesHubWeb.CoreComponents do
   attr(:multiple, :boolean, default: false, doc: "the multiple flag for select inputs")
 
   attr(:hint, :string, default: nil, doc: "a hint to be displayed next to the label")
+  attr(:class, :string, default: nil, doc: "overrides the default min-height for textarea inputs")
 
   attr(:rest, :global, include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step))
@@ -544,7 +545,8 @@ defmodule NervesHubWeb.CoreComponents do
         name={@name}
         class={[
           "bg-base-900 text-base-400 mt-2 block w-full rounded focus:ring-0 sm:text-sm/6",
-          "phx-no-feedback:border-base-600 phx-no-feedback:focus:border-base-700 min-h-24",
+          "phx-no-feedback:border-base-600 phx-no-feedback:focus:border-base-700",
+          @class || "min-h-24",
           @errors == [] && "border-base-600 focus:border-base-700",
           @errors != [] && "border-alert focus:border-alert"
         ]}

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -38,6 +38,14 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
                   for more information on delta updates.
                 </:rich_hint>
               </.input>
+              <.input
+                field={@form[:notes]}
+                type="textarea"
+                rows={4}
+                label="Notes"
+                placeholder="Why is this deployment group being created?"
+                phx-debounce="blur"
+              />
             </div>
           </div>
         </div>

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -433,6 +433,13 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     {@deployment_group.connecting_code}
               </pre>
             </div>
+
+            <div :if={not is_nil(@deployment_group.notes) and @deployment_group.notes != ""} class="border-base-700 border-t pt-4">
+              <div class="flex flex-col gap-1">
+                <span class="text-base-500 text-sm">Notes:</span>
+                <span class="text-base-300 text-sm whitespace-pre-wrap">{@deployment_group.notes}</span>
+              </div>
+            </div>
           </div>
 
           <div class="bg-surface-raised border-base-700 shadow-device-details-content flex flex-col gap-2 rounded border p-4">

--- a/lib/nerves_hub_web/controllers/api/deployment_group_json.ex
+++ b/lib/nerves_hub_web/controllers/api/deployment_group_json.ex
@@ -20,7 +20,8 @@ defmodule NervesHubWeb.API.DeploymentGroupJSON do
       conditions: conditions(deployment_group.conditions),
       delta_updatable: deployment_group.delta_updatable,
       device_count: deployment_group.device_count,
-      releases_count: deployment_group.releases_count
+      releases_count: deployment_group.releases_count,
+      notes: deployment_group.notes
     }
   end
 

--- a/lib/nerves_hub_web/controllers/api/schemas/deployment_group_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/deployment_group_schemas.ex
@@ -77,7 +77,12 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
         conditions: Conditions,
         delta_updatable: %Schema{type: :boolean},
         device_count: %Schema{type: :integer},
-        releases_count: %Schema{type: :integer}
+        releases_count: %Schema{type: :integer},
+        notes: %Schema{
+          type: :string,
+          description: "Free-text notes describing why this deployment group exists",
+          nullable: true
+        }
       },
       example: %{
         "name" => "production",
@@ -101,7 +106,8 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
         },
         "delta_updatable" => false,
         "device_count" => 42,
-        "releases_count" => 3
+        "releases_count" => 3,
+        "notes" => "Rolled out for the summer campaign hardware batch"
       }
     })
   end
@@ -135,7 +141,11 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
         firmware: %Schema{type: :string, description: "Firmware UUID"},
         conditions: Conditions,
         state: %Schema{type: :string, enum: ["on", "off"]},
-        delta_updatable: %Schema{type: :boolean}
+        delta_updatable: %Schema{type: :boolean},
+        notes: %Schema{
+          type: :string,
+          description: "Free-text notes describing why this deployment group is being created"
+        }
       },
       required: [:name, :firmware],
       example: %{
@@ -145,7 +155,8 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
           "version" => ">= 1.0.0",
           "tags" => ["prod"]
         },
-        "state" => "on"
+        "state" => "on",
+        "notes" => "Rolled out for the summer campaign hardware batch"
       }
     })
   end
@@ -161,7 +172,8 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
             firmware: %Schema{type: :string, description: "Firmware UUID"},
             conditions: Conditions,
             state: %Schema{type: :string, enum: ["on", "off"]},
-            delta_updatable: %Schema{type: :boolean}
+            delta_updatable: %Schema{type: :boolean},
+            notes: %Schema{type: :string, description: "Free-text notes describing why this deployment group exists"}
           }
         }
       },
@@ -171,7 +183,8 @@ defmodule NervesHubWeb.API.Schemas.DeploymentGroupSchemas do
           "conditions" => %{
             "version" => ">= 1.0.0",
             "tags" => ["prod"]
-          }
+          },
+          "notes" => "Rolled out for the summer campaign hardware batch"
         }
       }
     })

--- a/lib/nerves_hub_web/live/deployment_groups/new.html.heex
+++ b/lib/nerves_hub_web/live/deployment_groups/new.html.heex
@@ -37,6 +37,15 @@
                   for more information on delta updates.
                 </:rich_hint>
               </.input>
+              <.input
+                field={@form[:notes]}
+                type="textarea"
+                rows={1}
+                class="min-h-9"
+                label="Notes"
+                placeholder="Why is this deployment group being created?"
+                phx-debounce="blur"
+              />
             </div>
           </div>
 

--- a/priv/repo/migrations/20260715003305_add_notes_to_deployment_groups.exs
+++ b/priv/repo/migrations/20260715003305_add_notes_to_deployment_groups.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddNotesToDeploymentGroups do
+  use Ecto.Migration
+
+  def change() do
+    alter table(:deployments) do
+      add(:notes, :text, null: true)
+    end
+  end
+end

--- a/test/nerves_hub/managed_deployments/deployment_group_test.exs
+++ b/test/nerves_hub/managed_deployments/deployment_group_test.exs
@@ -96,6 +96,48 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
       refute changeset.valid?
       assert errors_on(changeset).conditions.version == ["must be valid Elixir version requirement string"]
     end
+
+    test "notes can be set", %{
+      deployment_group_params: deployment_group_params,
+      product: product,
+      user: user,
+      firmware: firmware
+    } do
+      changeset =
+        deployment_group_params
+        |> Map.put(:notes, "Created for the summer campaign hardware batch")
+        |> DeploymentGroup.create_changeset(product, firmware, user)
+
+      assert changeset.valid?
+      assert changeset.changes.notes == "Created for the summer campaign hardware batch"
+    end
+
+    test "notes defaults to nil when not provided", %{
+      deployment_group_params: deployment_group_params,
+      product: product,
+      user: user,
+      firmware: firmware
+    } do
+      changeset = DeploymentGroup.create_changeset(deployment_group_params, product, firmware, user)
+
+      assert changeset.valid?
+      refute Map.has_key?(changeset.changes, :notes)
+    end
+
+    test "notes cannot exceed 1000 characters", %{
+      deployment_group_params: deployment_group_params,
+      product: product,
+      user: user,
+      firmware: firmware
+    } do
+      changeset =
+        deployment_group_params
+        |> Map.put(:notes, String.duplicate("a", 1001))
+        |> DeploymentGroup.create_changeset(product, firmware, user)
+
+      refute changeset.valid?
+      assert errors_on(changeset).notes == ["should be at most 1000 character(s)"]
+    end
   end
 
   describe "update_changeset/2" do
@@ -170,6 +212,33 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupTest do
       assert changeset.valid?
       deployment_group = Repo.update!(changeset)
       assert deployment_group.current_updated_devices == 0
+    end
+
+    test "notes can be set", %{deployment_group: deployment_group} do
+      changeset =
+        DeploymentGroup.update_changeset(deployment_group, %{notes: "Created for the summer campaign hardware batch"})
+
+      assert changeset.valid?
+      assert changeset.changes.notes == "Created for the summer campaign hardware batch"
+    end
+
+    test "notes can be cleared", %{deployment_group: deployment_group} do
+      deployment_group =
+        deployment_group
+        |> DeploymentGroup.update_changeset(%{notes: "some reason"})
+        |> Repo.update!()
+
+      changeset = DeploymentGroup.update_changeset(deployment_group, %{notes: ""})
+
+      assert changeset.valid?
+      assert changeset.changes.notes == nil
+    end
+
+    test "notes cannot exceed 1000 characters", %{deployment_group: deployment_group} do
+      changeset = DeploymentGroup.update_changeset(deployment_group, %{notes: String.duplicate("a", 1001)})
+
+      refute changeset.valid?
+      assert errors_on(changeset).notes == ["should be at most 1000 character(s)"]
     end
   end
 

--- a/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/deployment_controller_test.exs
@@ -75,6 +75,9 @@ defmodule NervesHubWeb.API.DeploymentGroupControllerTest do
       current_release = data["current_release"]
       assert current_release["number"] >= 1
       assert current_release["firmware"]["uuid"]
+
+      assert Map.has_key?(data, "notes")
+      assert data["notes"] == nil
     end
 
     test "includes device_count reflecting assigned devices", %{
@@ -170,6 +173,24 @@ defmodule NervesHubWeb.API.DeploymentGroupControllerTest do
     test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do
       conn = post(conn, Routes.api_deployment_group_path(conn, :create, org.name, product.name))
       assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders deployment group with notes when provided", %{
+      conn: conn,
+      org: org,
+      params: params,
+      product: product
+    } do
+      params = Map.put(params, :notes, "Created for the summer campaign hardware batch")
+
+      conn =
+        post(
+          conn,
+          Routes.api_deployment_group_path(conn, :create, org.name, product.name),
+          params
+        )
+
+      assert json_response(conn, 201)["data"]["notes"] == "Created for the summer campaign hardware batch"
     end
   end
 
@@ -410,6 +431,37 @@ defmodule NervesHubWeb.API.DeploymentGroupControllerTest do
 
       conn = put(conn, path, deployment: %{is_active: "1234"})
       assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "can update notes", %{
+      conn: conn,
+      deployment_group: deployment_group,
+      org: org,
+      product: product
+    } do
+      path =
+        Routes.api_deployment_group_path(
+          conn,
+          :update,
+          org.name,
+          product.name,
+          deployment_group.name
+        )
+
+      conn = put(conn, path, deployment: %{"notes" => "Created for the summer campaign hardware batch"})
+      assert %{"notes" => "Created for the summer campaign hardware batch"} = json_response(conn, 200)["data"]
+
+      path =
+        Routes.api_deployment_group_path(
+          conn,
+          :show,
+          org.name,
+          product.name,
+          deployment_group.name
+        )
+
+      conn = get(conn, path)
+      assert json_response(conn, 200)["data"]["notes"] == "Created for the summer campaign hardware batch"
     end
   end
 

--- a/test/nerves_hub_web/live/deployment_groups/new_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/new_test.exs
@@ -150,4 +150,31 @@ defmodule NervesHubWeb.Live.DelploymentGroups.NewTest do
     |> assert_path("/org/#{org.name}/#{product.name}/deployment_groups/new")
     |> assert_has("p", text: "must be valid Elixir version requirement string")
   end
+
+  test "can set notes when creating a deployment group", %{conn: conn, org: org, product: product} do
+    conn
+    |> fill_in("Name", with: "Canaries")
+    |> fill_in("Notes", with: "Created for the summer campaign hardware batch")
+    |> select("Platform", option: "platform")
+    |> select("Architecture", option: "x86_64")
+    |> select("Firmware", option: "1.0.0", exact_option: false)
+    |> submit()
+    |> assert_path(~p"/org/#{org}/#{product}/deployment_groups/Canaries")
+
+    deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert deployment_group.notes == "Created for the summer campaign hardware batch"
+  end
+
+  test "notes is optional when creating a deployment group", %{conn: conn, org: org, product: product} do
+    conn
+    |> fill_in("Name", with: "Canaries")
+    |> select("Platform", option: "platform")
+    |> select("Architecture", option: "x86_64")
+    |> select("Firmware", option: "1.0.0", exact_option: false)
+    |> submit()
+    |> assert_path(~p"/org/#{org}/#{product}/deployment_groups/Canaries")
+
+    deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert deployment_group.notes == nil
+  end
 end

--- a/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
@@ -148,6 +148,35 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
     assert log.description =~ ~r/deleted deployment/
   end
 
+  test "can update notes", %{conn: conn, deployment_group: deployment_group} do
+    conn
+    |> fill_in("Notes", with: "Created for the summer campaign hardware batch")
+    |> submit()
+
+    deployment_group = Repo.reload(deployment_group)
+    assert deployment_group.notes == "Created for the summer campaign hardware batch"
+  end
+
+  test "can clear notes", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group
+  } do
+    conn
+    |> fill_in("Notes", with: "some reason")
+    |> submit()
+
+    assert Repo.reload(deployment_group).notes == "some reason"
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/settings")
+    |> fill_in("Notes", with: "")
+    |> submit()
+
+    assert Repo.reload(deployment_group).notes == nil
+  end
+
   test "you can delete a deployment group with devices attached to it", %{
     conn: conn,
     org: org,

--- a/test/nerves_hub_web/live/deployment_groups/show/summary_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/summary_tab_test.exs
@@ -411,4 +411,27 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SummaryTabTest do
       assert Repo.reload(device1) |> Map.get(:deployment_id)
     end)
   end
+
+  test "shows notes when present", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group
+  } do
+    {:ok, deployment_group} =
+      ManagedDeployments.update_deployment_group(
+        deployment_group,
+        %{notes: "Created for the summer campaign hardware batch"},
+        nil
+      )
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}")
+    |> assert_has("span", text: "Created for the summer campaign hardware batch")
+  end
+
+  test "hides notes block when absent", %{conn: conn} do
+    conn
+    |> refute_has("span", text: "Notes:")
+  end
 end


### PR DESCRIPTION
Closes #2821 

### Local tests



- Made sure that the introduced optional `<input>` that sets deployments notes is minimalistic by default:


<img width="912" height="518" alt="Screenshot 2026-07-15 at 2 36 52 PM" src="https://github.com/user-attachments/assets/cb906439-d77b-4ced-b3fd-05d7f8e31f8f" />

- Explored locally making sure that a deployments notes with 1000 characters would still render nicely:


<img width="818" height="620" alt="Screenshot 2026-07-15 at 2 37 25 PM" src="https://github.com/user-attachments/assets/fee52a99-47a1-474b-8214-3e56b61fc775" />

- Explored creation/update, and removal (by setting to empty):

<img width="813" height="377" alt="Screenshot 2026-07-15 at 2 49 24 PM" src="https://github.com/user-attachments/assets/268b03c8-64fd-44c1-b31a-5b0ab3d83ba3" />






