### PR TITLE
Advanced search fixes

### DIFF
--- a/assets/js/hooks/advancedQueryEditor.js
+++ b/assets/js/hooks/advancedQueryEditor.js
@@ -426,7 +426,7 @@ export default {
 
     this.appliedValue = this.el.dataset.value || ""
     this.editor.textContent = this.appliedValue
-    this.highlight()
+    if (this.appliedValue !== "") { this.highlight() }
     this.updateClearButtonVisibility()
     this.applyRestingWidth({ animate: false })
 

--- a/assets/js/hooks/advancedQueryEditor.js
+++ b/assets/js/hooks/advancedQueryEditor.js
@@ -258,16 +258,14 @@ export function closeUnterminatedString(value) {
 //
 //   {type: "accept", index} - insert the suggestion at `index`
 //   {type: "apply"}         - submit the query
-//   {type: "advance"}       - leave the current token and suggest what comes next
 //   {type: "none"}          - swallow the key
 //
 // Tab always completes, using the highlighted suggestion or else the first
 // one. So does Enter, except that with nothing highlighted it only completes
 // mid-word (a non-empty prefix) - otherwise a finished query could never be
-// submitted while the "and"/"or" hints are on display. When Enter falls
-// through to submitting, an incomplete query advances to the next slot
-// (e.g. out of the operator, into the value) instead of running a search
-// that is guaranteed to fail.
+// submitted while the "and"/"or" hints are on display. Enter always submits
+// when no suggestion is selected — incomplete input is sent to the server
+// which handles it as free-text search.
 export function commitAction(key, ctx) {
   const listOpen = ctx.suggestionsVisible && ctx.suggestionCount > 0
 
@@ -281,7 +279,7 @@ export function commitAction(key, ctx) {
 
   if (key === "Tab") return { type: "none" }
 
-  return ctx.empty || ctx.complete ? { type: "apply" } : { type: "advance" }
+  return { type: "apply" }
 }
 
 const TOKEN_CLASSES = "rounded border px-1"

--- a/assets/js/hooks/advancedQueryEditor.test.js
+++ b/assets/js/hooks/advancedQueryEditor.test.js
@@ -246,25 +246,25 @@ describe("commitAction", () => {
     })
   })
 
-  it("Enter advances out of a finished operator instead of failing the search", () => {
+  it("Enter submits a finished operator as free-text search", () => {
     assert.deepEqual(actionFor("Enter", "description like"), {
-      type: "advance",
+      type: "apply",
     })
   })
 
-  it("Enter advances out of a finished column name", () => {
-    assert.deepEqual(actionFor("Enter", "health"), { type: "advance" })
+  it("Enter submits a finished column name as free-text search", () => {
+    assert.deepEqual(actionFor("Enter", "health"), { type: "apply" })
   })
 
-  it("Enter advances rather than submit a dangling connective", () => {
+  it("Enter submits a dangling connective as free-text search", () => {
     assert.deepEqual(actionFor("Enter", 'health = "ok" and'), {
-      type: "advance",
+      type: "apply",
     })
   })
 
-  it("Enter advances rather than submit an unclosed paren group", () => {
+  it("Enter submits an unclosed paren group as free-text search", () => {
     assert.deepEqual(actionFor("Enter", '(health = "ok" '), {
-      type: "advance",
+      type: "apply",
     })
   })
 
@@ -278,9 +278,9 @@ describe("commitAction", () => {
     assert.deepEqual(actionFor("Enter", ""), { type: "apply" })
   })
 
-  it("dismissed suggestions never get accepted", () => {
+  it("dismissed suggestions submit as free-text search", () => {
     assert.deepEqual(actionFor("Enter", "hea", { visible: false }), {
-      type: "advance",
+      type: "apply",
     })
     assert.deepEqual(actionFor("Tab", "hea", { visible: false }), {
       type: "none",
@@ -293,13 +293,8 @@ describe("commitAction", () => {
 })
 
 describe("typing flows", () => {
-  it("advancing out of an operator lands on value suggestions", () => {
-    // `description like` + Enter advances; the hook appends the separator
-    // space via exitToTail, after which the value suggestions show.
-    assert.deepEqual(actionFor("Enter", "description like"), {
-      type: "advance",
-    })
-
+  it("after operator, a trailing space lands on value suggestions", () => {
+    // `description like ` (with trailing space) puts context in value state.
     const after = editorState("description like ")
     assert.equal(after.ctx.state, "value")
   })


### PR DESCRIPTION
- Enter now submits incomplete queries as free-text search — previously, pressing Enter with plain text (e.g. a device identifier) would "advance" to the next token slot instead of submitting. This was missed in #2829, probably because a change was made and the tests use `unwrap`, which foregos real page interaction.
- Fix input auto-focusing on page load — highlight() was called unconditionally on mount, which triggered addRange() and implicitly focused the contenteditable editor in WebKit browsers. Now skipped when the editor is empty, so share links still work.