### PR TITLE
Ensure tests that interact with analytics_enabled env state are not ran async

### DIFF
--- a/test/nerves_hub_web/live/devices/show/logs_tab_test.exs
+++ b/test/nerves_hub_web/live/devices/show/logs_tab_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
-  use NervesHubWeb.ConnCase.Browser, async: true
+  use NervesHubWeb.ConnCase.Browser, async: false
 
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.Device
@@ -8,7 +8,8 @@ defmodule NervesHubWeb.Live.Devices.Show.LogsTabTest do
   alias NervesHub.Repo
 
   setup context do
-    Application.put_env(:nerves_hub, :analytics_enabled, true)
+    original = Application.get_env(:nerves_hub, :analytics_enabled)
+    on_exit(fn -> Application.put_env(:nerves_hub, :analytics_enabled, original) end)
     context
   end
 


### PR DESCRIPTION
We've seen an uptick in flaky tests. A few test modules have been added recently that get and set the env property `analytics_enabled`. They reset the state properly with `on_exit`. However, there is one test that is not async and does not reset the env properly, `NervesHubWeb.Live.Devices.Show.LogsTabTest`. Updating the behavior and making it `async: false` solved the issues. Seed used: `mix test --seed 961929`.