### PR TITLE
Fix flaky DeviceLink test

### DIFF
--- a/test/nerves_hub/device_link_test.exs
+++ b/test/nerves_hub/device_link_test.exs
@@ -240,15 +240,17 @@ defmodule NervesHub.DeviceLinkTest do
       inflight_update = Repo.reload!(inflight_update)
       refute inflight_update.progress == 30
 
+      # update to some reasonable time before 15s
       {1, _} =
-        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-14, :second)])
+        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-10, :second)])
 
       :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "updating", "progress" => 30})
       inflight_update = Repo.reload!(inflight_update)
       refute inflight_update.progress == 30
 
+      # update to some reasonable time after 15s
       {1, _} =
-        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-16, :second)])
+        Repo.update_all(InflightUpdate, set: [updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.add(-20, :second)])
 
       :ok = DeviceLink.status_update(to_device_info(device), %{"status" => "downloading", "progress" => 30})
       inflight_update = Repo.reload!(inflight_update)


### PR DESCRIPTION
This test uses -14 and -16 seconds to represent before and after 15s, which is the amount of time `FirmwareUpdates.should_persist?/1` uses and is the function being tested. Claude reasoned that since Postgres rounds to seconds, if this test runs near the top of the second the -14s could effectively be -15s, failing the comparison and test. I think this makes sense.