### PR TITLE
Fix error handling when updating network interface

### DIFF
--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -181,6 +181,7 @@ defmodule NervesHub.Devices.Connections do
     :ok
   end
 
+  @spec update_network_interface(binary(), atom()) :: {:ok, DeviceConnection.t()} | :error
   def update_network_interface(ref_id, network_interface) do
     humanized = DeviceConnection.humanized_network_interface_name(network_interface)
 
@@ -194,8 +195,8 @@ defmodule NervesHub.Devices.Connections do
         async_device_connection_history_insert(device_connection)
         {:ok, device_connection}
 
-      res ->
-        {:error, res}
+      _ ->
+        :error
     end
   end
 

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -239,9 +239,9 @@ defmodule NervesHubWeb.DeviceChannel do
           {:noreply,
            assign(socket, :device_info, %{device_info | device_network_interface: device_connection.network_interface})}
 
-        {:error, changeset} ->
+        :error ->
           Logger.warning(
-            "[DeviceChannel] could not update device network interface because: #{inspect(changeset.errors)}"
+            "[DeviceChannel] could not update device network interface."
           )
 
           {:noreply, socket}

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -240,9 +240,7 @@ defmodule NervesHubWeb.DeviceChannel do
            assign(socket, :device_info, %{device_info | device_network_interface: device_connection.network_interface})}
 
         :error ->
-          Logger.warning(
-            "[DeviceChannel] could not update device network interface."
-          )
+          Logger.warning("[DeviceChannel] could not update device network interface.")
 
           {:noreply, socket}
       end


### PR DESCRIPTION
Caught this in our Sentry. The only failure state for `Connections.update_network_interface/2` is when `update_all/2` doesn't update any records; no changeset will ever be returned.