### PR TITLE
Decorate device penalty box logging with useful info

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1211,7 +1211,17 @@ defmodule NervesHub.Devices do
     :ok = DeviceTemplates.audit_firmware_upgrade_blocked(deployment_group, device)
     _ = FirmwareUpdates.clear_inflight_update(device)
 
-    Logger.info("Device #{device.identifier} put in penalty box until #{blocked_until}")
+    device =
+      Repo.preload(device, [:org, :product, :current_device_firmware, deployment_group: [current_release: :firmware]])
+
+    Logger.info("Device #{device.identifier} put in penalty box until #{blocked_until}", %{
+      identifier: device.identifier,
+      org: device.org.name,
+      product: device.product.name,
+      platform: deployment_group.platform,
+      current_firmware_version: device.current_device_firmware.firmware_metadata.version,
+      upgrading_firmware_version: device.deployment_group.current_release.firmware.version
+    })
 
     update_device(device, %{updates_blocked_until: blocked_until, update_attempts: []})
   end


### PR DESCRIPTION
This will allow us to create useful graphs and alerts with observaiblity tools until we get penalty box introspecition from the Deployment Workflows feature. I didn't add a test because `NervesHub.DevicesTest` has multiple test scenarios that put a device in a penalty box. Preload work was done inline because context of callers differs greatly.