### PR TITLE
Add deployment group lock to prevent device reassignment

### DIFF
--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -651,43 +651,12 @@ defmodule NervesHub.ManagedDeployments do
       when not is_nil(deployment_id) do
     deployment_group =
       DeploymentGroup
-      |> select([:id, :org_id, :name, :conditions, :platform, :architecture])
+      |> select([:id, :org_id, :name, :conditions, :platform, :architecture, :lock_device_membership])
       |> where([d], d.id == ^deployment_id)
       |> Repo.one!()
 
-    bad_version =
-      if deployment_group.conditions.version == "" do
-        false
-      else
-        try do
-          !Version.match?(device_version, deployment_group.conditions.version)
-        rescue
-          _ ->
-            true
-        end
-      end
-
-    bad_platform = device.firmware_metadata.platform != deployment_group.platform
-
-    bad_architecture =
-      device.firmware_metadata.architecture != deployment_group.architecture
-
-    reason =
-      cond do
-        bad_version ->
-          "mismatched version"
-
-        bad_platform ->
-          "mismatched platform"
-
-        bad_architecture ->
-          "mismatched architecture"
-
-        true ->
-          nil
-      end
-
-    if reason do
+    with false <- deployment_group.lock_device_membership,
+         reason when not is_nil(reason) <- membership_mismatch_reason(device, device_version, deployment_group) do
       device =
         device
         |> Ecto.Changeset.change(%{deployment_id: nil})
@@ -697,11 +666,30 @@ defmodule NervesHub.ManagedDeployments do
 
       device
     else
-      device
+      _ -> device
     end
   end
 
   def verify_deployment_group_membership(device), do: device
+
+  defp membership_mismatch_reason(device, device_version, deployment_group) do
+    cond do
+      version_mismatch?(device_version, deployment_group.conditions.version) -> "mismatched version"
+      device.firmware_metadata.platform != deployment_group.platform -> "mismatched platform"
+      device.firmware_metadata.architecture != deployment_group.architecture -> "mismatched architecture"
+      true -> nil
+    end
+  end
+
+  defp version_mismatch?(_device_version, ""), do: false
+
+  defp version_mismatch?(device_version, version_requirement) do
+    try do
+      !Version.match?(device_version, version_requirement)
+    rescue
+      _ -> true
+    end
+  end
 
   @spec preload_firmware_and_archive(DeploymentGroup.t()) :: DeploymentGroup.t()
   def preload_firmware_and_archive(deployment_group) do

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -684,11 +684,9 @@ defmodule NervesHub.ManagedDeployments do
   defp version_mismatch?(_device_version, ""), do: false
 
   defp version_mismatch?(device_version, version_requirement) do
-    try do
-      !Version.match?(device_version, version_requirement)
-    rescue
-      _ -> true
-    end
+    !Version.match?(device_version, version_requirement)
+  rescue
+    _ -> true
   end
 
   @spec preload_firmware_and_archive(DeploymentGroup.t()) :: DeploymentGroup.t()
@@ -702,9 +700,30 @@ defmodule NervesHub.ManagedDeployments do
   end
 
   @doc """
-  Find all potential deployment groups for a device
+  Find all potential deployment groups for a device.
 
-  Based on the product, firmware platform, firmware architecture, and device tags
+  Based on the product, firmware platform, firmware architecture, and device tags.
+
+  Returns `[]` if the device has no `firmware_metadata`.
+
+  Filters deployment groups by:
+  - Same product as the device
+  - `is_active` matches the `active` argument
+  - Firmware platform and architecture match the device's current firmware
+  - Excludes the device's current deployment group
+  - Excludes deployment groups that have enabled `lock_device_membership`
+  - Tag conditions satisfy the group's `tag_operator` (`:and` requires all
+    group tags present on device; `:or` requires any overlap); groups with
+    no tags always match
+  - Version satisfies any semver constraint in the group's conditions
+
+  Results are sorted descending by:
+  1. Firmware version (highest first)
+  2. Matching tag count when versions are equal (more overlap first)
+  3. Deployment group ID when tag counts are also equal (lower/older first)
+
+  The `active` argument defaults to `[true, false]` (all groups). Pass `[true]`
+  to restrict to active-only groups, as `find_eligible_deployment/1` does.
   """
   @spec matching_deployment_groups(Device.t(), [boolean()]) :: [DeploymentGroup.t()]
   def matching_deployment_groups(device, active \\ [true, false])
@@ -717,6 +736,7 @@ defmodule NervesHub.ManagedDeployments do
     |> where([d], d.product_id == ^device.product_id)
     |> where([d], d.is_active in ^active)
     |> ignore_same_deployment_group(device)
+    |> where([d], not d.lock_device_membership)
     |> where([d, firmware: f], f.platform == ^device.firmware_metadata.platform)
     |> where([d, firmware: f], f.architecture == ^device.firmware_metadata.architecture)
     |> where(

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -70,6 +70,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     field(:queue_management, Ecto.Enum, values: [:FIFO, :LIFO], default: :FIFO)
 
     field(:delta_updatable, :boolean, default: true)
+    field(:lock_device_membership, :boolean, default: false)
 
     field(:status, Ecto.Enum, values: [:ready, :preparing, :deltas_failed, :unknown_error], default: :ready)
 
@@ -225,6 +226,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
       :name,
       :is_active,
       :delta_updatable,
+      :lock_device_membership,
       :connecting_code,
       :notes,
       :queue_management,

--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -38,6 +38,11 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
                   for more information on delta updates.
                 </:rich_hint>
               </.input>
+              <.input field={@form[:lock_device_membership]} type="checkbox" label="Lock device membership">
+                <:rich_hint>
+                  When enabled, devices will not be automatically assigned to or removed from this deployment group.
+                </:rich_hint>
+              </.input>
               <.input
                 field={@form[:notes]}
                 type="textarea"

--- a/priv/repo/migrations/20260805214755_add_lock_device_membership_to_deployment_groups.exs
+++ b/priv/repo/migrations/20260805214755_add_lock_device_membership_to_deployment_groups.exs
@@ -1,0 +1,9 @@
+defmodule NervesHub.Repo.Migrations.AddLockDeviceMembershipToDeploymentGroups do
+  use Ecto.Migration
+
+  def change() do
+    alter table(:deployments) do
+      add(:lock_device_membership, :boolean, default: false, null: false)
+    end
+  end
+end

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -1022,6 +1022,33 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       assert deployment_group.conditions.tag_operator == :and
     end
+
+    test "excludes deployment groups with lock_device_membership enabled", state do
+      %{user: user, org: org, product: product, firmware: firmware} = state
+
+      %{id: open_group_id} =
+        Fixtures.deployment_group_fixture(firmware, %{
+          name: "open",
+          conditions: %{"tags" => ["beta"], "version" => ""},
+          user: user
+        })
+
+      locked_group =
+        Fixtures.deployment_group_fixture(firmware, %{
+          name: "locked",
+          conditions: %{"tags" => ["beta"], "version" => ""},
+          user: user
+        })
+
+      {:ok, _} =
+        locked_group
+        |> Ecto.Changeset.change(%{lock_device_membership: true})
+        |> NervesHub.Repo.update()
+
+      device = Fixtures.device_fixture(org, product, firmware, %{tags: ["beta"]})
+
+      assert [%{id: ^open_group_id}] = ManagedDeployments.matching_deployment_groups(device)
+    end
   end
 
   describe "verify_deployment_group_membership/1" do

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -1118,6 +1118,25 @@ defmodule NervesHub.ManagedDeploymentsTest do
       [audit_log | _] = AuditLogs.logs_for(deployment_group)
       assert audit_log.description =~ "no longer matches deployment group"
     end
+
+    test "does nothing when lock_device_membership is true, even when conditions don't match",
+         %{
+           device: device,
+           deployment_group: deployment_group
+         } do
+      {:ok, deployment_group} =
+        deployment_group
+        |> Ecto.Changeset.change(%{lock_device_membership: true})
+        |> Repo.update()
+
+      {:ok, device} =
+        device
+        |> Devices.update_deployment_group(deployment_group)
+        |> Devices.update_firmware_metadata(%{"platform" => "foobar"}, :unknown, false)
+
+      device = ManagedDeployments.verify_deployment_group_membership(device)
+      assert device.deployment_id == deployment_group.id
+    end
   end
 
   describe "matched_devices_count/2" do

--- a/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
@@ -177,17 +177,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
     assert Repo.reload(deployment_group).notes == nil
   end
 
-  test "can enable lock_device_membership", %{conn: conn, deployment_group: deployment_group} do
-    refute Repo.reload(deployment_group).lock_device_membership
-
-    conn
-    |> check("Lock device membership")
-    |> submit()
-
-    assert Repo.reload(deployment_group).lock_device_membership
-  end
-
-  test "can disable lock_device_membership", %{
+  test "can enable and disable lock_device_membership", %{
     conn: conn,
     org: org,
     product: product,

--- a/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
@@ -177,6 +177,36 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
     assert Repo.reload(deployment_group).notes == nil
   end
 
+  test "can enable lock_device_membership", %{conn: conn, deployment_group: deployment_group} do
+    refute Repo.reload(deployment_group).lock_device_membership
+
+    conn
+    |> check("Lock device membership")
+    |> submit()
+
+    assert Repo.reload(deployment_group).lock_device_membership
+  end
+
+  test "can disable lock_device_membership", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group
+  } do
+    conn
+    |> check("Lock device membership")
+    |> submit()
+
+    assert Repo.reload(deployment_group).lock_device_membership
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/settings")
+    |> uncheck("Lock device membership")
+    |> submit()
+
+    refute Repo.reload(deployment_group).lock_device_membership
+  end
+
   test "you can delete a deployment group with devices attached to it", %{
     conn: conn,
     org: org,


### PR DESCRIPTION
This feature will help alleviate the opaque behavior that is device deployment group membership on connect. Sometimes, you don't want any devices in or out automatically. This PR does that, as well as:

- Don't consider locked deployment groups when looking for an appropriate group for a device; and a test
- Refactor `ManagedDeployments.verify_deployment_group_membership`, it's needed it for awhile (my bad)
- Claude wrote a function doc for `ManagedDeployments.matching_deployment_groups/2`. I'm getting tired of re-reading that SQL to remember what it does every 3-4 months 😆 