### PR TITLE
Split dependency submission and review into separate CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - uses: actions/dependency-review-action@v4
 
   compile-and-test:
+    name: "Compile & Test"
+
     runs-on: ubuntu-latest
     timeout-minutes: 14
 
@@ -193,6 +195,8 @@ jobs:
         run: mix test --include mtools
 
   build-and-publish:
+    name: "Build & Publish Docker image"
+
     runs-on: ubuntu-latest
 
     needs: compile-and-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,40 @@ on:
   pull_request:
 
 jobs:
-  report_mix_deps:
-    name: "Report Mix Dependencies"
+  # Submit the dependency graph to GitHub. This needs `contents: write`, which is
+  # only granted on same-repo events — pull_request runs from forks get a
+  # read-only GITHUB_TOKEN regardless of `permissions:`, so submitting there
+  # would always 403. The graph only needs updating from the default branch
+  # anyway, so this never runs on pull_request.
+  submit_deps:
+    name: "Submit Mix Dependencies"
+
+    if: "${{ github.event_name != 'pull_request' }}"
 
     runs-on: ubuntu-latest
 
-    # The API requires write permission on the repository to submit dependencies
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/mix-dependency-submission@v1
+
+  # Review dependency changes introduced by a pull request. Read-only, so it runs
+  # fine on fork PRs.
+  dependency_review:
+    name: "Dependency Review"
+
+    if: "${{ github.event_name == 'pull_request' }}"
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v4
-        if: "${{ github.event_name == 'pull_request' }}"
 
   compile-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The `report_mix_deps` job runs `erlef/mix-dependency-submission`, which submits the dependency graph via GitHub's Dependency Submission API and therefore needs `contents: write`. The job ran on **every** event, including `pull_request`.

For pull requests **from forks**, GitHub grants the workflow a read-only `GITHUB_TOKEN` regardless of the job's `permissions:` block (a deliberate security measure for untrusted forks). So the submit step 403s and the job fails for any contributor outside the org. Org members don't hit it because their PRs are branches on the repo, where the token can be write.

## Fix

Split the single job into two least-privilege jobs:

- **`submit_deps`** — runs on non-PR events (`push` to `main`/tags, `workflow_dispatch`), `contents: write`, submits the dependency graph. The graph only needs updating from the default branch, and fork PRs can't submit it anyway.
- **`dependency_review`** — runs on `pull_request` only, `contents: read`, reviews the PR's dependency changes. It's read-only, so it works on fork PRs.

## Behaviour

- **Fork PR:** `submit_deps` is skipped; `dependency_review` runs read-only → green (unblocks it as a required check).
- **push to `main` / tag / manual dispatch:** `submit_deps` runs with the write token it needs, keeping the graph current.

Note: `submit_deps` is gated `!= 'pull_request'` (rather than strictly `== 'push'`) so it still runs on tag pushes and manual dispatch — the original non-PR triggers — and only PRs are excluded. Easy to tighten to push-only if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
