### PR TITLE
Add semver_sort_key/1 Postgres function for correct version ordering

### DIFF
--- a/priv/repo/migrations/20260809050021_add_semver_sort_key_function.exs
+++ b/priv/repo/migrations/20260809050021_add_semver_sort_key_function.exs
@@ -1,0 +1,59 @@
+defmodule NervesHub.Repo.Migrations.AddSemverSortKeyFunction do
+  use Ecto.Migration
+
+  # Adds `semver_sort_key(text)`: maps a semver string to a text key whose plain
+  # lexical (`<`/`>`) ordering reproduces SemVer 2.0.0 precedence. It lets us use
+  # a single, index-backed expression for both ORDER BY and range WHERE clauses
+  # instead of the ICU `numeric` collation (mis-sorts pre-releases) and the
+  # hand-rolled `semver_match` plpgsql (diverges from Elixir's `Version`).
+  #
+  # Encoding:
+  #   * major/minor/patch are zero-padded to fixed width so digit runs compare
+  #     numerically;
+  #   * a release gets the sentinel `{` (0x7B) appended and a pre-release gets `-`
+  #     (0x2D) — since `-` < `{`, a pre-release sorts *before* its release
+  #     (SemVer §11: a release has higher precedence than its pre-releases);
+  #   * within the pre-release, numeric identifiers are tagged `0` and padded,
+  #     alphanumeric identifiers are tagged `1`, so numeric < alphanumeric and a
+  #     shorter identifier set sorts before a longer one (SemVer §11.4).
+  #
+  # The function is STRICT and built on `regexp_match/2`, which returns NULL (it
+  # does not raise) for any non-semver input — so a malformed, device-reported
+  # version yields a NULL key rather than erroring a query or a write. NULL keys
+  # must be ordered with `NULLS LAST` at each call site.
+  #
+  # COLLATION — REQUIRED at every call site. The key relies on plain byte
+  # ordering (the `-` (0x2D) < `{` (0x7B) sentinel is what makes a pre-release
+  # sort before its release). Postgres compares/ORDERs `text` under the database
+  # collation, which here is `en_US.utf8` — a locale collation that mis-weights
+  # the hyphen and *inverts* the pre-release/release order. Every comparison and
+  # ORDER BY on the key, and the backing index, MUST be `COLLATE "C"`, e.g.
+  #   ORDER BY semver_sort_key(version) COLLATE "C" DESC NULLS LAST
+  #   WHERE semver_sort_key(a) COLLATE "C" <= semver_sort_key(b) COLLATE "C"
+  #   CREATE INDEX ... ON t ((semver_sort_key(version) COLLATE "C") DESC NULLS LAST)
+  # Without `COLLATE "C"` the ordering is silently wrong for pre-releases.
+  #
+  # Validity note: the `\d+` groups accept a leading zero (e.g. `01.2.3`) that
+  # Elixir's `Version.parse/1` rejects. Firmware/Archive versions are validated
+  # with `Version.parse/1` at the schema boundary, so stored versions never hit
+  # that divergence; device-reported metadata is the only uncontrolled input and
+  # a bad value is simply quarantined via a NULL key.
+  def change() do
+    execute(
+      ~S"""
+      CREATE OR REPLACE FUNCTION semver_sort_key(v text) RETURNS text
+      LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE AS $$
+        SELECT lpad(m[1],10,'0')||'.'||lpad(m[2],10,'0')||'.'||lpad(m[3],10,'0')
+            || coalesce('-' || (
+                 SELECT string_agg(
+                          CASE WHEN id ~ '^\d+$' THEN '0'||lpad(id,10,'0') ELSE '1'||id END,
+                          '.' ORDER BY ord)
+                 FROM unnest(string_to_array(m[4],'.')) WITH ORDINALITY AS t(id, ord)
+               ), '{')
+        FROM regexp_match(v, '^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$') AS m
+      $$;
+      """,
+      "DROP FUNCTION IF EXISTS semver_sort_key(text);"
+    )
+  end
+end

--- a/test/nerves_hub/semver_sort_key_test.exs
+++ b/test/nerves_hub/semver_sort_key_test.exs
@@ -1,0 +1,157 @@
+defmodule NervesHub.SemverSortKeyTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Repo
+
+  # Corpus of valid (Version.parse/1-parseable) semver strings covering releases,
+  # pre-releases (alpha/beta/rc, numeric + dotted + mixed identifiers) and build
+  # metadata (which must be ignored for precedence).
+  @versions [
+    "0.0.1",
+    "0.1.0",
+    "0.9.9",
+    "1.0.0",
+    "1.0.1",
+    "1.2.0",
+    "1.9.0",
+    "1.10.0",
+    "1.10.2",
+    "2.0.0",
+    "10.0.0",
+    "1.0.0-alpha",
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.beta",
+    "1.0.0-beta",
+    "1.0.0-beta.2",
+    "1.0.0-beta.11",
+    "1.0.0-rc.1",
+    "1.0.0-rc1",
+    "1.0.0-1",
+    "1.0.0-1.2",
+    "2.0.0-rc.1",
+    "1.2.3+build.5",
+    "1.2.3+build.9",
+    "1.0.0-rc.1+build"
+  ]
+
+  # semver comparator -> the equivalent Postgres operator on the sort key.
+  @op_to_sql %{">=" => ">=", ">" => ">", "<" => "<", "<=" => "<=", "==" => "="}
+
+  defp sort_key(version) do
+    {:ok, %{rows: [[key]]}} = Repo.query("SELECT semver_sort_key($1)", [version])
+    key
+  end
+
+  # Byte-order comparison of two keys, which is exactly Postgres `COLLATE "C"`.
+  # Elixir binary comparison (`<`/`>`) is byte-wise, so we can compare in Elixir.
+  defp key_compare(a, b) do
+    ka = sort_key(a)
+    kb = sort_key(b)
+
+    cond do
+      ka < kb -> :lt
+      ka > kb -> :gt
+      true -> :eq
+    end
+  end
+
+  describe "semver_sort_key/1 ordering" do
+    test "byte-order (COLLATE \"C\") key comparison matches Version.compare/2 for every pair" do
+      for a <- @versions, b <- @versions do
+        assert key_compare(a, b) == Version.compare(a, b),
+               "sort-key order for #{a} vs #{b} was #{key_compare(a, b)}, " <>
+                 "but Version.compare says #{Version.compare(a, b)}"
+      end
+    end
+
+    test "ORDER BY semver_sort_key(v) COLLATE \"C\" reproduces Enum.sort(_, Version)" do
+      # Feed the corpus to Postgres unordered and let the DB sort it.
+      params = @versions
+
+      placeholders =
+        @versions
+        |> Enum.with_index(1)
+        |> Enum.map_join(",", fn {_v, i} -> "($#{i})" end)
+
+      sql = """
+      SELECT v FROM (VALUES #{placeholders}) AS t(v)
+      ORDER BY semver_sort_key(v) COLLATE "C" ASC NULLS LAST
+      """
+
+      {:ok, %{rows: rows}} = Repo.query(sql, params)
+      db_order = List.flatten(rows)
+
+      # The DB order must be a valid ascending Version sort: every adjacent pair
+      # is non-decreasing. (An `==` assertion against Enum.sort would be too
+      # strict — semver-equal versions that differ only in build metadata, e.g.
+      # "1.0.0-rc.1" and "1.0.0-rc.1+build", get the same key and may tie in
+      # either order.)
+      for [a, b] <- Enum.chunk_every(db_order, 2, 1, :discard) do
+        assert Version.compare(a, b) in [:lt, :eq],
+               "DB ordered #{a} before #{b}, but Version.compare says #{Version.compare(a, b)}"
+      end
+    end
+  end
+
+  describe "semver_sort_key/1 matching (equivalent to Version.match?/2, default allow_pre: true)" do
+    # Single-comparator requirements translate directly to a key comparison.
+    # (`~>` and compound `and`/`or` requirements are handled by the PR5
+    # requirement->range translator and covered by its own tests.)
+    cases = [
+      {"1.5.0-rc1", ">=", "1.2.0"},
+      {"1.0.0-rc", ">=", "1.0.0"},
+      {"1.0.0", ">=", "1.0.0"},
+      {"1.0.0-alpha", ">=", "1.0.0-alpha"},
+      {"1.0.0-beta", ">=", "1.0.0-alpha"},
+      {"1.0.0-alpha", ">=", "1.0.0-beta"},
+      {"1.2.0", ">", "1.2.0"},
+      {"1.2.1", ">", "1.2.0"},
+      {"1.10.0", ">", "1.9.0"},
+      {"1.0.0", "<", "1.0.0"},
+      {"1.0.0-rc", "<", "1.0.0"},
+      {"1.0.0", "<=", "1.0.0"},
+      {"2.0.0", "<=", "1.0.0"},
+      {"1.2.3+build.5", "==", "1.2.3"},
+      {"1.2.3", "==", "1.2.4"}
+    ]
+
+    for {version, op, bound} <- cases do
+      requirement = "#{op} #{bound}"
+
+      test "semver_sort_key(#{version}) #{op} semver_sort_key(#{bound}) == Version.match?/2" do
+        sql_op = @op_to_sql[unquote(op)]
+
+        {:ok, %{rows: [[sql_result]]}} =
+          Repo.query(
+            ~s{SELECT semver_sort_key($1) COLLATE "C" #{sql_op} semver_sort_key($2) COLLATE "C"},
+            [unquote(version), unquote(bound)]
+          )
+
+        assert sql_result == Version.match?(unquote(version), unquote(requirement)),
+               "#{unquote(version)} #{unquote(requirement)}: sort-key predicate=#{sql_result}, " <>
+                 "Version.match?=#{Version.match?(unquote(version), unquote(requirement))}"
+      end
+    end
+  end
+
+  describe "semver_sort_key/1 robustness" do
+    test "returns NULL (does not raise) for non-semver input" do
+      for bad <- ["main", "1.x", "1.0", "1.2.3.4", "", "v1.2.3", "latest"] do
+        assert sort_key(bad) == nil, "expected NULL key for #{inspect(bad)}"
+      end
+    end
+
+    test "COLLATE \"C\" is required: a pre-release sorts before its release only under C" do
+      # Guards the design contract in the migration: on a locale-collated database
+      # the key MUST be compared with COLLATE "C". This asserts the C behaviour we
+      # depend on at every call site.
+      {:ok, %{rows: [[c_lt]]}} =
+        Repo.query(
+          ~s{SELECT semver_sort_key($1) COLLATE "C" < semver_sort_key($2) COLLATE "C"},
+          ["1.0.0-rc1", "1.0.0"]
+        )
+
+      assert c_lt == true
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a `semver_sort_key(text)` Postgres function: it maps a semver string to a
text key whose ordering reproduces SemVer 2.0.0 precedence. This is the
foundation for replacing the two divergent version-comparison engines we have
today — the ICU `numeric` collation used for `ORDER BY` (mis-sorts pre-releases)
and the hand-rolled `semver_match` plpgsql used in `WHERE` (diverges from
Elixir's `Version` in several ways) — with one index-backed expression usable for
both ordering and range filtering.

This PR **only installs and proves the function** — no call sites change yet, so
nothing depends on it until the equivalence suite is green. Follow-up PRs swap
the `ORDER BY` sites, replace the `semver_match` `WHERE` caller, and (optionally)
push deployment-group matching into SQL.

## The function

Same encoding proposed in discussion:

- major/minor/patch zero-padded to fixed width so digit runs compare numerically;
- a release gets sentinel `{` (0x7B) appended, a pre-release gets `-` (0x2D) — so
  a pre-release sorts before its release (SemVer §11);
- pre-release identifiers tagged `0` (numeric, padded) or `1` (alphanumeric) so
  numeric < alphanumeric and shorter identifier sets sort first (§11.4);
- build metadata is ignored (correct per §10).

`STRICT` + `regexp_match/2` means any non-semver input returns **NULL, not an
error** — a malformed device-reported version is quarantined (NULL key), never a
raised query/write.

## ⚠️ `COLLATE "C"` is required at every call site

The key relies on **byte ordering**. This database's default collation is
`en_US.utf8`, which mis-weights the hyphen and *inverts* the pre-release/release
order — verified: without `COLLATE "C"`, `semver_sort_key('1.0.0-rc1') <
semver_sort_key('1.0.0')` returns **false**. Every comparison, `ORDER BY`, and
the backing index MUST be `COLLATE "C"`:

```sql
ORDER BY semver_sort_key(version) COLLATE "C" DESC NULLS LAST
WHERE  semver_sort_key(a) COLLATE "C" <= semver_sort_key(b) COLLATE "C"
CREATE INDEX ... ON t ((semver_sort_key(version) COLLATE "C") DESC NULLS LAST)
```

This is documented in the migration and locked by a test. It is the key
constraint for the ordering/`WHERE`/index PRs that build on this one.

## Tests

`test/nerves_hub/semver_sort_key_test.exs` — a deterministic corpus-driven
equivalence suite (no new dependency; `stream_data` could be added later for
fuzzing if the team wants it):

- **Ordering:** byte-order key comparison matches `Version.compare/2` for every
  pair in the corpus; `ORDER BY ... COLLATE "C"` produces a valid ascending
  `Version` sort.
- **Matching:** for single comparators (`>=,>,<,<=,==`),
  `semver_sort_key(v) OP semver_sort_key(x)` equals `Version.match?(v, "OP x")`.
  (NervesHub matches at the default `allow_pre: true`, so matching is pure
  precedence — that's what makes the key usable in `WHERE`.)
- **Robustness:** NULL (not raise) on non-semver input; the `COLLATE "C"`
  contract.

## Notes / limitations

- `lpad(...,10,...)` doesn't truncate, so a numeric component ≥ 10 digits would
  mis-order. Schema validation (follow-up PR) + real firmware ranges make this
  moot; documented in the migration.
- Validity divergence: the regex accepts a leading zero (`01.2.3`) that
  `Version.parse/1` rejects. The follow-up Firmware/Archive validation closes
  this for stored versions.
