### PR TITLE
Validate firmware and archive versions are valid SemVer

### DIFF
--- a/lib/mix/tasks/nerves_hub.versions.report_invalid.ex
+++ b/lib/mix/tasks/nerves_hub.versions.report_invalid.ex
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.NervesHub.Versions.ReportInvalid do
+  @shortdoc "Report firmware/archive rows whose version is not valid SemVer"
+
+  @moduledoc """
+  Reports existing `firmwares` and `archives` rows whose `version` does not parse
+  as SemVer according to `Version.parse/1`.
+
+  Version validation is enforced on new firmware/archive at the schema boundary,
+  but pre-existing rows are not retro-rejected. Such rows produce a NULL
+  `semver_sort_key/1` and therefore sort last (with `NULLS LAST`) and never match
+  a version constraint. This read-only task surfaces them so they can be cleaned
+  up. It changes nothing.
+
+  ## Examples
+
+      mix nerves_hub.versions.report_invalid
+  """
+
+  use Mix.Task
+
+  import Ecto.Query
+
+  alias NervesHub.Archives.Archive
+  alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Repo
+
+  @requirements ["app.start"]
+  @preferred_cli_env :dev
+
+  @impl Mix.Task
+  def run(_args) do
+    report("firmwares", Firmware)
+    report("archives", Archive)
+  end
+
+  defp report(label, schema) do
+    invalid =
+      schema
+      |> select([r], %{id: r.id, product_id: r.product_id, uuid: r.uuid, version: r.version})
+      |> Repo.all()
+      |> Enum.reject(&valid_semver?(&1.version))
+
+    case invalid do
+      [] ->
+        Mix.shell().info("#{label}: no invalid versions")
+
+      rows ->
+        Mix.shell().info("#{label}: #{length(rows)} invalid version(s)")
+
+        Enum.each(rows, fn r ->
+          Mix.shell().info("  id=#{r.id} product_id=#{r.product_id} uuid=#{r.uuid} version=#{inspect(r.version)}")
+        end)
+    end
+  end
+
+  defp valid_semver?(version) when is_binary(version) do
+    match?({:ok, _}, Version.parse(version))
+  end
+
+  defp valid_semver?(_), do: false
+end

--- a/lib/nerves_hub/archives/archive.ex
+++ b/lib/nerves_hub/archives/archive.ex
@@ -66,7 +66,19 @@ defmodule NervesHub.Archives.Archive do
       :uuid,
       :version
     ])
+    |> validate_semver_version()
     |> unique_constraint(:uuid, name: :archives_product_id_uuid_index)
     |> foreign_key_constraint(:products)
+  end
+
+  # Archive versions must be valid SemVer so they order correctly via
+  # `semver_sort_key/1`; `Version.parse/1` is the single parsing authority.
+  defp validate_semver_version(changeset) do
+    validate_change(changeset, :version, fn :version, version ->
+      case Version.parse(version) do
+        {:ok, _} -> []
+        :error -> [version: "must be a valid semantic version"]
+      end
+    end)
   end
 end

--- a/lib/nerves_hub/firmwares/firmware.ex
+++ b/lib/nerves_hub/firmwares/firmware.ex
@@ -86,6 +86,7 @@ defmodule NervesHub.Firmwares.Firmware do
     firmware
     |> cast(params, @required_params ++ @optional_params ++ [:checksum, :partials_checksums])
     |> validate_required(@required_params)
+    |> validate_semver_version()
     |> unique_constraint(:uuid, name: :firmwares_product_id_uuid_index)
     |> foreign_key_constraint(:deployment_groups, name: :deployment_groups_firmware_id_fkey)
   end
@@ -94,8 +95,21 @@ defmodule NervesHub.Firmwares.Firmware do
     firmware
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
+    |> validate_semver_version()
     |> unique_constraint(:uuid, name: :firmwares_product_id_uuid_index)
     |> foreign_key_constraint(:deployment_groups, name: :deployment_groups_firmware_id_fkey)
+  end
+
+  # Firmware versions must be valid SemVer: they feed `semver_sort_key/1` for
+  # ordering and version-constrained deployment matching, and `Version.parse/1`
+  # is the single parsing authority those paths rely on.
+  defp validate_semver_version(changeset) do
+    validate_change(changeset, :version, fn :version, version ->
+      case Version.parse(version) do
+        {:ok, _} -> []
+        :error -> [version: "must be a valid semantic version"]
+      end
+    end)
   end
 
   def delete_changeset(%Firmware{} = firmware) do

--- a/test/nerves_hub/archives/archive_test.exs
+++ b/test/nerves_hub/archives/archive_test.exs
@@ -1,0 +1,17 @@
+defmodule NervesHub.Archives.ArchiveTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Archives.Archive
+
+  describe "version SemVer validation" do
+    test "create_changeset rejects a non-semver version" do
+      changeset = Archive.create_changeset(%Archive{}, %{version: "not-a-version"})
+      assert "must be a valid semantic version" in errors_on(changeset).version
+    end
+
+    test "create_changeset accepts a valid semver version" do
+      changeset = Archive.create_changeset(%Archive{}, %{version: "0.9.0+build.7"})
+      refute Map.has_key?(errors_on(changeset), :version)
+    end
+  end
+end

--- a/test/nerves_hub/firmwares/firmware_test.exs
+++ b/test/nerves_hub/firmwares/firmware_test.exs
@@ -1,0 +1,27 @@
+defmodule NervesHub.Firmwares.FirmwareTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Firmwares.Firmware
+
+  describe "version SemVer validation" do
+    test "create_changeset rejects a non-semver version" do
+      changeset = Firmware.create_changeset(%Firmware{}, %{version: "not-a-version"})
+      assert "must be a valid semantic version" in errors_on(changeset).version
+    end
+
+    test "create_changeset rejects a partial version" do
+      changeset = Firmware.create_changeset(%Firmware{}, %{version: "1.2"})
+      assert "must be a valid semantic version" in errors_on(changeset).version
+    end
+
+    test "create_changeset accepts a valid semver version" do
+      changeset = Firmware.create_changeset(%Firmware{}, %{version: "1.2.3-rc.1"})
+      refute Map.has_key?(errors_on(changeset), :version)
+    end
+
+    test "update_changeset rejects a non-semver version" do
+      changeset = Firmware.update_changeset(%Firmware{}, %{version: "latest"})
+      assert "must be a valid semantic version" in errors_on(changeset).version
+    end
+  end
+end


### PR DESCRIPTION
## What

Validates that `firmwares.version` and `archives.version` are valid SemVer at the
schema boundary, and adds a read-only task to surface any pre-existing rows that
aren't.

Part of the firmware-version-handling work. `Version.parse/1` is the single
parsing authority the ordering (`semver_sort_key/1`) and version-constrained
matching paths rely on; enforcing it on write keeps stored versions consistent
with that authority and prevents new unparseable rows.

## Changes

- `Firmware.create_changeset/2` and `update_changeset/2`: reject a `version` that
  is not valid SemVer (`"must be a valid semantic version"`).
- `Archive.create_changeset/2`: same.
- `mix nerves_hub.versions.report_invalid`: read-only report listing existing
  `firmwares`/`archives` rows whose version doesn't parse. Changes nothing.

## Notes

- **Write-time only.** Existing rows are not retro-rejected. An unparseable
  legacy version yields a NULL `semver_sort_key/1`, so it sorts last (with
  `NULLS LAST`) and never matches a version constraint. The report task is how
  operators find and clean those up.
- This closes a real gap: the `semver_sort_key` regex accepts a leading zero
  (`01.2.3`) that `Version.parse/1` rejects — validating on write means stored
  firmware/archive versions never hit that divergence.
- Device-reported `firmware_metadata.version` is deliberately **not** covered
  here: it's device-controlled and rejecting a check-in could strand a device on
  a bad version. That input is handled by NULL-key quarantine, not rejection.

## Tests

- `firmware_test.exs` / `archive_test.exs`: changeset accepts valid SemVer
  (including pre-release / build metadata) and rejects non-semver and partial
  (`"1.2"`) versions.
- Full `mix check` green.
