### PR TITLE
Order firmware by SemVer precedence (semver_sort_key)

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -60,7 +60,7 @@ defmodule NervesHub.Firmwares do
     FirmwareDelta
     |> where([fd], fd.target_id == ^firmware_id)
     |> join(:inner, [fd], fd in assoc(fd, :source))
-    |> order_by([fd, s], asc: s.version)
+    |> order_by([fd, s], fragment(~s|semver_sort_key(?) COLLATE "C" ASC NULLS LAST|, s.version))
     |> preload([fd, s], source: s)
     |> preload(:target)
     |> Repo.all()
@@ -95,7 +95,7 @@ defmodule NervesHub.Firmwares do
   def get_firmwares_by_product(product_id) do
     Firmware
     |> where([f], f.product_id == ^product_id)
-    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
+    |> order_by_latest_version()
     |> with_product()
     |> Repo.all()
   end
@@ -105,7 +105,7 @@ defmodule NervesHub.Firmwares do
     Firmware
     |> where([f], f.product_id == ^product.id)
     |> where([f], f.platform == ^platform)
-    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
+    |> order_by_latest_version()
     |> limit(25)
     |> Repo.all()
   end
@@ -116,7 +116,7 @@ defmodule NervesHub.Firmwares do
     |> where([f], f.product_id == ^product.id)
     |> where([f], f.platform == ^platform)
     |> where([f], f.architecture == ^architecture)
-    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
+    |> order_by_latest_version()
     |> limit(25)
     |> Repo.all()
   end
@@ -158,14 +158,35 @@ defmodule NervesHub.Firmwares do
     order_by(query, [_f, d], {^direction, d.install_count})
   end
 
+  defp sort_firmware(query, {direction, :version}) do
+    order_by(query, [f], [
+      {^version_sort_direction(direction), fragment(~s|semver_sort_key(?) COLLATE "C"|, f.version)}
+    ])
+  end
+
   defp sort_firmware(query, sort), do: order_by(query, ^sort)
+
+  # Orders a Firmware query by SemVer precedence, newest first, with invalid
+  # versions (a NULL sort key) sorted last. Uses `semver_sort_key/1` under
+  # `COLLATE "C"`: the key relies on plain byte ordering, and the database's
+  # `en_US.utf8` default inverts pre-release/release order without it (see the
+  # `add_semver_sort_key_function` migration).
+  defp order_by_latest_version(query) do
+    order_by(query, [f], [
+      fragment(~s|semver_sort_key(?) COLLATE "C" DESC NULLS LAST|, f.version),
+      desc: :inserted_at
+    ])
+  end
+
+  defp version_sort_direction(:desc), do: :desc_nulls_last
+  defp version_sort_direction(_), do: :asc_nulls_last
 
   def get_firmwares_for_deployment_group(deployment_group) do
     Firmware
     |> where([f], f.product_id == ^deployment_group.product_id)
     |> where([f], f.platform == ^deployment_group.platform)
     |> where([f], f.architecture == ^deployment_group.architecture)
-    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
+    |> order_by_latest_version()
     |> with_product()
     |> Repo.all()
   end
@@ -175,12 +196,12 @@ defmodule NervesHub.Firmwares do
   """
   def get_firmware_versions_by_product(product_id) do
     Firmware
-    |> select([f], f.version)
-    |> distinct(true)
     |> where([f], f.product_id == ^product_id)
+    |> select([f], %{version: f.version, sort_key: fragment(~s|semver_sort_key(?) COLLATE "C"|, f.version)})
+    |> distinct(true)
+    |> order_by([f], fragment(~s|semver_sort_key(?) COLLATE "C" DESC NULLS LAST|, f.version))
     |> Repo.all()
-    |> Enum.sort(Version)
-    |> Enum.reverse()
+    |> Enum.map(& &1.version)
   end
 
   @doc """
@@ -189,7 +210,7 @@ defmodule NervesHub.Firmwares do
   def firmware_versions_and_uuids(product_id) do
     Firmware
     |> where([f], f.product_id == ^product_id)
-    |> order_by([f], [fragment("? collate numeric desc", f.version), desc: :inserted_at])
+    |> order_by_latest_version()
     |> select([f], %{version: f.version, uuid: f.uuid})
     |> Repo.all()
   end
@@ -234,7 +255,7 @@ defmodule NervesHub.Firmwares do
     |> where([f], f.architecture == ^device.firmware_metadata.architecture)
     |> where([f], f.org_id == ^device.org_id)
     |> where([f], f.product_id == ^device.product_id)
-    |> order_by([f], fragment("? collate numeric desc", f.version))
+    |> order_by_latest_version()
     |> Repo.all()
   end
 

--- a/lib/nerves_hub/managed_deployments/deployment_group_filtering.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group_filtering.ex
@@ -65,9 +65,17 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroupFiltering do
     order_by(query, [device_count: dev], {^direction, dev.device_count})
   end
 
+  # Order by SemVer precedence via `semver_sort_key/1`. `COLLATE "C"` is required:
+  # the key relies on byte ordering and the DB's `en_US.utf8` default would invert
+  # pre-release/release order. Invalid versions (NULL key) sort last either way.
   def sort(query, {direction, :firmware_version}) do
-    order_by(query, [firmware: f], {^direction, f.version})
+    order_by(query, [firmware: f], [
+      {^version_sort_direction(direction), fragment(~s|semver_sort_key(?) COLLATE "C"|, f.version)}
+    ])
   end
 
   def sort(query, sort), do: order_by(query, ^sort)
+
+  defp version_sort_direction(:desc), do: :desc_nulls_last
+  defp version_sort_direction(_), do: :asc_nulls_last
 end

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -222,6 +222,60 @@ defmodule NervesHub.FirmwaresTest do
     end
   end
 
+  describe "SemVer version ordering" do
+    setup %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+      product =
+        Fixtures.product_fixture(user, org, %{name: "semver-order-#{System.unique_integer([:positive])}"})
+
+      insert = fn version ->
+        Fixtures.firmware_fixture(org_key, product, %{version: version, dir: tmp_dir})
+      end
+
+      {:ok, %{product: product, insert: insert}}
+    end
+
+    test "get_firmwares_by_product/1 orders by precedence, not lexically", %{
+      product: product,
+      insert: insert
+    } do
+      # Lexical/naive ordering would put 1.9.0 above 1.10.0 and a release below
+      # its pre-release; SemVer precedence must not.
+      for v <- ["1.2.0", "1.9.0", "1.10.0", "1.10.0-rc1"], do: insert.(v)
+
+      versions =
+        product.id
+        |> Firmwares.get_firmwares_by_product()
+        |> Enum.map(& &1.version)
+
+      assert versions == ["1.10.0", "1.10.0-rc1", "1.9.0", "1.2.0"]
+    end
+
+    test "get_firmware_versions_by_product/1 returns distinct versions, newest first", %{
+      product: product,
+      insert: insert
+    } do
+      for v <- ["1.9.0", "1.10.0", "1.10.0-rc1"], do: insert.(v)
+
+      assert Firmwares.get_firmware_versions_by_product(product.id) ==
+               ["1.10.0", "1.10.0-rc1", "1.9.0"]
+    end
+
+    test "get_firmwares_by_product_and_platform/2 orders by precedence", %{
+      product: product,
+      insert: insert
+    } do
+      platform = insert.("1.9.0").platform
+      insert.("1.10.0")
+
+      versions =
+        product
+        |> Firmwares.get_firmwares_by_product_and_platform(platform)
+        |> Enum.map(& &1.version)
+
+      assert versions == ["1.10.0", "1.9.0"]
+    end
+  end
+
   describe "get_firmware/2" do
     test "returns firmwares", %{org: %{id: t_id} = org, firmware: %{id: f_id} = firmware} do
       {:ok, gotten_firmware} = Firmwares.get_firmware(org, firmware.id)


### PR DESCRIPTION
Part of the firmware version-handling work. **Stacks on #2857** (`semver_sort_key/1`) — base is `wall-e/semver-sort-key-function` and will auto-retarget to `main` when #2857 merges.

## What & why
Firmware versions are semver stored as varchars; ordering used the ICU `numeric` collation (mis-sorts pre-releases) plus a few raw lexical `version` sorts. This routes all firmware-version ordering through `semver_sort_key/1`, so ordering follows SemVer 2.0.0 precedence — `1.10.0` sorts above `1.9.0`, and a release outranks its pre-releases.

Every site uses `COLLATE "C"` + `NULLS LAST`:
- `COLLATE "C"` — the key relies on byte ordering; the DB's `en_US.utf8` default inverts pre-release/release order without it (see #2857's migration).
- `NULLS LAST` — `semver_sort_key` returns NULL for a non-semver string, which would otherwise sort to the **top** of a `DESC` "newest first" list.

## Files
- `lib/nerves_hub/firmwares.ex` — the 6 `collate numeric` ORDER BYs via a shared `order_by_latest_version/1`; `get_firmware_versions_by_product/1` sort moved into SQL (was `Enum.sort(Version)`, which *raised* on any invalid stored version); the delta sort; and a new `:version` Flop-sort clause (the firmware-list version column was falling through to a lexical sort).
- `lib/nerves_hub/managed_deployments/deployment_group_filtering.ex` — deployment-group list UI sort by `firmware_version` (was lexical).
- `test/nerves_hub/firmwares_test.exs` — new "SemVer version ordering" tests (1.10 vs 1.9, pre-release precedence, distinct-versions list, product+platform).

## Scope decision
No firmwares index added — these are small, product-scoped reads. The index that matters is on the large `devices` table for the matching `WHERE` (PR4).

## Testing
- `mix test test/nerves_hub/firmwares_test.exs` → 35/35 (pre-existing ordering test + 3 new).
- Full suite: 1415/1418. The 3 non-passes are **not from this change** — 2 are pre-existing `UpdateToolTest` fwup / `same_fat_files?` environment failures (reproduced on the base branch with no diff), 1 is a flaky async-LiveView sandbox `OwnershipError` that passes in isolation.
- `mix format` clean on changed files; compiles `--warnings-as-errors`. (`mix credo --strict` flags only a pre-existing missing `@moduledoc` on `NervesHub.Firmwares`, untouched here.)

## Review focus
- `COLLATE "C"` + `NULLS LAST` on every site — please sanity-check none was missed; dynamic-direction sites map to `:asc_nulls_last` / `:desc_nulls_last`.
- The `SELECT DISTINCT ... ORDER BY semver_sort_key(...)` rewrite in `get_firmware_versions_by_product/1` (Postgres needs the ORDER BY expr in the select list — done via a `sort_key` select field).
- No new inputs / endpoints / authz / secrets. The only semantic change beyond ordering: invalid stored versions now sort last instead of crashing `get_firmware_versions_by_product/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
