### PR TITLE
Match priority-queue version threshold via semver_sort_key

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -930,14 +930,20 @@ defmodule NervesHub.Devices do
 
   defp maybe_version_threshold(query, nil), do: query
 
+  # Eligible when the device's reported version is at or below the threshold.
+  # Uses `semver_sort_key/1` (SemVer precedence via byte ordering) under
+  # `COLLATE "C"` — the DB's `en_US.utf8` default would invert pre-release order.
+  # A non-semver device version yields a NULL key, so the comparison is NULL and
+  # the device is excluded (quarantined) rather than raising, as the previous
+  # `semver_match` did when casting a malformed version to int[].
   defp maybe_version_threshold(query, version_threshold) do
     where(
       query,
       [d],
       fragment(
-        "semver_match(? #>> '{\"version\"}', ?)",
+        ~s|semver_sort_key(? #>> '{"version"}') COLLATE "C" <= semver_sort_key(?) COLLATE "C"|,
         d.firmware_metadata,
-        ^"<= #{version_threshold}"
+        ^version_threshold
       )
     )
   end

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -968,6 +968,61 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
       assert old_device2.id in device_ids
     end
 
+    test "device with an unparseable version is quarantined, not raised", %{
+      deployment_group: deployment_group,
+      product: product,
+      org: org,
+      firmware: firmware,
+      user: user
+    } do
+      deployment_group = Repo.preload(deployment_group, :org)
+
+      {:ok, deployment_group} =
+        ManagedDeployments.update_deployment_group(
+          deployment_group,
+          %{
+            priority_queue_enabled: true,
+            priority_queue_concurrent_updates: 2,
+            priority_queue_firmware_version_threshold: "1.0.0"
+          },
+          user
+        )
+
+      eligible = Fixtures.device_fixture(org, product, firmware, %{tags: [], identifier: "eligible_device"})
+      bad = Fixtures.device_fixture(org, product, firmware, %{tags: [], identifier: "bad_version_device"})
+
+      {:ok, eligible} =
+        Devices.update_firmware_metadata(
+          eligible,
+          %{"version" => "0.9.0", "uuid" => Ecto.UUID.generate()},
+          :unknown,
+          false
+        )
+
+      {:ok, bad} =
+        Devices.update_firmware_metadata(
+          bad,
+          %{"version" => "not-a-semver", "uuid" => Ecto.UUID.generate()},
+          :unknown,
+          false
+        )
+
+      eligible = Devices.update_deployment_group(eligible, deployment_group)
+      bad = Devices.update_deployment_group(bad, deployment_group)
+
+      for device <- [eligible, bad] do
+        {:ok, conn} = Connections.device_connecting(device.org_id, device.product_id, device.id)
+        :ok = Connections.device_connected(conn.id)
+      end
+
+      # The old `semver_match` raised casting "not-a-semver" to int[]; a NULL
+      # `semver_sort_key` excludes the malformed device and the query succeeds.
+      device_ids = deployment_group |> Devices.available_for_priority_update(10) |> Enum.map(& &1.id)
+
+      assert eligible.id in device_ids
+      refute bad.id in device_ids
+    end
+
     test "count_inflight_priority_updates_for/1 counts only priority queue updates", %{
       deployment_group: deployment_group,
       product: product,


### PR DESCRIPTION
Part of the firmware version-handling work. **Stacks on #2857** (`semver_sort_key/1`) — base is `wall-e/semver-sort-key-function`, auto-retargets to `main` when #2857 merges. Independent of #2859 (different files).

## What & why
`maybe_version_threshold/2` (`devices.ex`) — the priority-queue eligibility filter behind `available_for_priority_update/2` — was the **only remaining caller** of the hand-rolled `semver_match` plpgsql. It matched a device's reported version against a deployment group's `priority_queue_firmware_version_threshold`.

Replaced with `semver_sort_key/1` under `COLLATE "C"`:
```
semver_sort_key(firmware_metadata #>> '{"version"}') COLLATE "C" <= semver_sort_key(threshold) COLLATE "C"
```
Under the default `allow_pre` semantics used throughout NervesHub, key comparison reproduces `Version.match?(version, "<= threshold")` exactly.

**Robustness / quarantine:** a non-semver device version now yields a NULL key and is excluded, instead of **raising** — `semver_match` cast the version to `int[]`, so a device reporting e.g. `"1.x"` would crash the eligibility query. New test asserts a device with an unparseable version is quarantined and the query still returns the eligible devices.

## Scope decisions (flagging divergences from the plan sketch)
- **No index.** This predicate runs on an already-narrowed set (devices in the deployment group, connected, otherwise eligible), so a devices-wide expression index wouldn't help it. The index that matters is for the broad `do_matched_devices` matching path — deferred to that PR (PR5).
- **`semver_match` not dropped here.** It (and `compare_prerelease*`) plus its test are now unused, but I drop them together with the `numeric` collation in the single cleanup PR (PR6) rather than writing a verbose reversible drop migration here. After this + #2859 merge, both the collation and the function are unreferenced.

## Files
- `lib/nerves_hub/devices.ex` — rewrite `maybe_version_threshold/2`.
- `test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs` — new "unparseable version is quarantined, not raised" test.

## Testing
- `mix test .../orchestrator_test.exs` → 28/28 (existing threshold test + new quarantine test), verified on this PR1-based branch with #2859's changes **not** present.
- Full suite: 3 non-passes, **all pre-existing / flaky, none from this change** — 2 `UpdateToolTest` fwup `same_fat_files?` env failures and 1 seed-dependent `ConnectionHistoryTest` flake; all three reproduce on the base branch with the same seeds and no diff.
- `mix format` clean; compiles `--warnings-as-errors`. (`mix credo --strict` flags only a pre-existing missing `@moduledoc` on `NervesHub.Devices`.)

## Review focus
- Security surface: this is a device-eligibility filter over **device-reported** version strings. The quarantine-on-NULL behaviour is the intended handling; please confirm excluding malformed versions from the priority queue is the desired product behaviour (vs. surfacing them).
- The `COLLATE "C"` on both sides of the comparison (byte-order correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
