### PR TITLE
Add per-product setting to require unique firmware versions

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -332,6 +332,7 @@ defmodule NervesHub.Firmwares do
     Repo.transact(
       fn ->
         with {:ok, params} <- build_firmware_params(org, filepath),
+             :ok <- validate_version_uniqueness(params),
              {:ok, firmware} <- insert_firmware(params),
              :ok <- upload_file_2.(filepath, firmware.upload_metadata) do
           {:ok, firmware}
@@ -769,6 +770,45 @@ defmodule NervesHub.Firmwares do
     %Firmware{}
     |> Firmware.create_changeset(params)
     |> Repo.insert()
+  end
+
+  # When the product has `require_unique_firmware_version` enabled, reject an
+  # upload whose version already exists for the same platform/architecture in the
+  # product. This is enforced in the app (not a DB unique index) because the rule
+  # is conditional on a setting that lives on the products table.
+  defp validate_version_uniqueness(%{product_id: product_id} = params) when not is_nil(product_id) do
+    product = Products.get_product!(product_id)
+
+    if product.require_unique_firmware_version and firmware_version_taken?(params) do
+      changeset =
+        %Firmware{}
+        |> Firmware.create_changeset(params)
+        |> Changeset.add_error(
+          :version,
+          "has already been used by another firmware in this product"
+        )
+
+      {:error, changeset}
+    else
+      :ok
+    end
+  end
+
+  # No resolved product; let insert_firmware/1 fail on the required product_id.
+  defp validate_version_uniqueness(_params), do: :ok
+
+  defp firmware_version_taken?(%{
+         product_id: product_id,
+         platform: platform,
+         architecture: architecture,
+         version: version
+       }) do
+    Firmware
+    |> where([f], f.product_id == ^product_id)
+    |> where([f], f.platform == ^platform)
+    |> where([f], f.architecture == ^architecture)
+    |> where([f], f.version == ^version)
+    |> Repo.exists?()
   end
 
   @spec time_out_firmware_delta_generations(

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -189,6 +189,16 @@ defmodule NervesHub.Products do
   end
 
   @doc """
+  Updates a Product's settings.
+  """
+  @spec update_product(Product.t(), map()) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()}
+  def update_product(%Product{} = product, params) do
+    product
+    |> Product.changeset(params)
+    |> Repo.update()
+  end
+
+  @doc """
   Deletes a Product.
 
   ## Examples

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -38,6 +38,9 @@ defmodule NervesHub.Products.Product do
 
     field(:name, :string)
     field(:deleted_at, :utc_datetime)
+    # Defaults to `true` so new products require unique firmware versions; the
+    # migration's column default is `false`, leaving existing products opted out.
+    field(:require_unique_firmware_version, :boolean, default: true)
     embeds_one(:extensions, ProductExtensionsSetting, on_replace: :update)
 
     field(:device_count, :integer, virtual: true)
@@ -56,7 +59,7 @@ defmodule NervesHub.Products.Product do
   @doc false
   def changeset(product, params) do
     product
-    |> cast(params, @required_params)
+    |> cast(params, @required_params ++ [:require_unique_firmware_version])
     |> cast_embed(:extensions)
     |> update_change(:name, &trim/1)
     |> validate_required(@required_params)

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -71,6 +71,31 @@ defmodule NervesHubWeb.Live.Product.Settings do
     end
   end
 
+  def handle_event("update-require-unique-firmware-version", params, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    enabled = params["value"] == "on"
+
+    socket =
+      case Products.update_product(socket.assigns.product, %{
+             require_unique_firmware_version: enabled
+           }) do
+        {:ok, product} ->
+          socket
+          |> assign(:product, product)
+          |> assign(:form, to_form(Ecto.Changeset.change(product)))
+          |> put_flash(
+            :info,
+            "Unique firmware versions #{if enabled, do: "required", else: "no longer required"}."
+          )
+
+        {:error, _changeset} ->
+          put_flash(socket, :error, "Failed to update the firmware version setting.")
+      end
+
+    {:noreply, socket}
+  end
+
   def handle_event("update-extension", %{"extension" => extension} = params, socket) do
     value = params["value"]
     available = Extensions.list() |> Enum.map(&to_string/1)

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -18,6 +18,38 @@
 
       <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
         <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
+          <div class="text-base-50 text-base font-medium">Firmware settings</div>
+        </div>
+
+        <div class="flex flex-col gap-3 p-6">
+          <div class="flex h-16 items-center gap-6 p-2">
+            <div class="bg-base-800 border-base-700 flex h-8 items-center rounded-full border px-2 py-1">
+              <input
+                id="require-unique-firmware-version"
+                name="require_unique_firmware_version"
+                type="checkbox"
+                class="border-base-700 checked:bg-primary text-base-400 rounded focus:ring-0"
+                phx-click="update-require-unique-firmware-version"
+                checked={@product.require_unique_firmware_version}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+            </div>
+            <div class="flex flex-col">
+              <div class="flex gap-2">
+                <div class="text-base-300 font-medium">
+                  Require unique firmware versions
+                </div>
+              </div>
+              <div class="text-base-400 text-xs">
+                When enabled, uploaded firmware must have a version not already used by another firmware for the same platform and architecture in this product.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
+        <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
           <div class="text-base-50 text-base font-medium">Device Extensions</div>
         </div>
 

--- a/priv/repo/migrations/20260809190000_add_require_unique_firmware_version_to_products.exs
+++ b/priv/repo/migrations/20260809190000_add_require_unique_firmware_version_to_products.exs
@@ -1,0 +1,16 @@
+defmodule NervesHub.Repo.Migrations.AddRequireUniqueFirmwareVersionToProducts do
+  use Ecto.Migration
+
+  # Product setting: when on, uploaded firmware must have a version not already
+  # used by another firmware for the same platform/architecture in the product.
+  #
+  # The column default is `false` so existing products are unaffected (opt-out).
+  # New products default to `true` via the schema field default in
+  # NervesHub.Products.Product, so the setting is on for products created from
+  # now on.
+  def change() do
+    alter table(:products) do
+      add(:require_unique_firmware_version, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -2270,12 +2270,21 @@ defmodule NervesHub.DevicesTest do
       org_key_one = Fixtures.org_key_fixture(org_one, user, tmp_dir)
       org_key_two = Fixtures.org_key_fixture(org_two, user, tmp_dir)
 
-      # two products with the same name
+      # two products with the same name (version uniqueness off: this test uploads
+      # multiple firmwares sharing a version to exercise delta resolution)
       {:ok, product_one} =
-        Products.create_product(%{org_id: org_one.id, name: "Same Product Name"})
+        Products.create_product(%{
+          org_id: org_one.id,
+          name: "Same Product Name",
+          require_unique_firmware_version: false
+        })
 
       {:ok, _product_two} =
-        Products.create_product(%{org_id: org_two.id, name: "Same Product Name"})
+        Products.create_product(%{
+          org_id: org_two.id,
+          name: "Same Product Name",
+          require_unique_firmware_version: false
+        })
 
       # create some firmware which can be uploaded to each org
       {:ok, _} =

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -59,6 +59,80 @@ defmodule NervesHub.FirmwaresTest do
     end
   end
 
+  describe "require_unique_firmware_version" do
+    setup %{user: user, org: org, tmp_dir: tmp_dir} do
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      product =
+        Fixtures.product_fixture(user, org, %{
+          name: "unique-ver-#{System.unique_integer([:positive])}",
+          require_unique_firmware_version: true
+        })
+
+      %{org_key: org_key, product: product}
+    end
+
+    test "rejects a version already used for the same platform/architecture", %{
+      org: org,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      _first = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.0", dir: tmp_dir})
+
+      dup = Fixtures.firmware_file_fixture(org_key, product, %{version: "1.0.0", dir: tmp_dir})
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Firmwares.create_firmware(org, dup)
+
+      assert %{version: ["has already been used by another firmware in this product"]} =
+               errors_on(changeset)
+    end
+
+    test "allows the same version for a different platform", %{
+      org: org,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      _first =
+        Fixtures.firmware_fixture(org_key, product, %{
+          version: "1.0.0",
+          platform: "rpi0",
+          dir: tmp_dir
+        })
+
+      other_platform =
+        Fixtures.firmware_file_fixture(org_key, product, %{
+          version: "1.0.0",
+          platform: "rpi4",
+          dir: tmp_dir
+        })
+
+      assert {:ok, firmware} = Firmwares.create_firmware(org, other_platform)
+      assert firmware.version == "1.0.0"
+      assert firmware.platform == "rpi4"
+    end
+
+    test "allows a duplicate version when the setting is off", %{
+      user: user,
+      org: org,
+      org_key: org_key,
+      tmp_dir: tmp_dir
+    } do
+      product =
+        Fixtures.product_fixture(user, org, %{
+          name: "dup-ok-#{System.unique_integer([:positive])}",
+          require_unique_firmware_version: false
+        })
+
+      _first = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.0", dir: tmp_dir})
+      dup = Fixtures.firmware_file_fixture(org_key, product, %{version: "1.0.0", dir: tmp_dir})
+
+      assert {:ok, firmware} = Firmwares.create_firmware(org, dup)
+      assert firmware.version == "1.0.0"
+    end
+  end
+
   describe "delete_firmware/1" do
     test "delete firmware", %{org: org, org_key: org_key, product: product, tmp_dir: tmp_dir} do
       firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})

--- a/test/nerves_hub/products/products_test.exs
+++ b/test/nerves_hub/products/products_test.exs
@@ -18,6 +18,34 @@ defmodule NervesHub.ProductsTest do
       %{user: user, org: org, product: product}
     end
 
+    test "new products require unique firmware versions by default", %{org: org} do
+      {:ok, product} =
+        Products.create_product(%{
+          name: "unique-default-#{System.unique_integer([:positive])}",
+          org_id: org.id
+        })
+
+      assert product.require_unique_firmware_version
+    end
+
+    test "the unique-version requirement can be opted out at creation", %{org: org} do
+      {:ok, product} =
+        Products.create_product(%{
+          name: "opt-out-#{System.unique_integer([:positive])}",
+          org_id: org.id,
+          require_unique_firmware_version: false
+        })
+
+      refute product.require_unique_firmware_version
+    end
+
+    test "update_product/2 toggles the unique-version requirement", %{product: product} do
+      assert {:ok, updated} =
+               Products.update_product(product, %{require_unique_firmware_version: true})
+
+      assert updated.require_unique_firmware_version
+    end
+
     test "get_products_by_user_and_org returns products for user", %{
       product: product,
       user: user,

--- a/test/nerves_hub_web/live/product/settings_test.exs
+++ b/test/nerves_hub_web/live/product/settings_test.exs
@@ -20,6 +20,32 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
     end
   end
 
+  describe "firmware version uniqueness setting" do
+    test "toggle is checked when the product requires unique versions", %{
+      conn: conn,
+      org: org,
+      user: user
+    } do
+      product = Fixtures.product_fixture(user, org, %{require_unique_firmware_version: true})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/settings")
+      |> assert_has("input#require-unique-firmware-version[checked]")
+    end
+
+    test "toggle is unchecked when the product does not require unique versions", %{
+      conn: conn,
+      org: org,
+      user: user
+    } do
+      product = Fixtures.product_fixture(user, org, %{require_unique_firmware_version: false})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/settings")
+      |> refute_has("input#require-unique-firmware-version[checked]")
+    end
+  end
+
   describe "shared secrets" do
     setup do
       Application.put_env(:nerves_hub, NervesHubWeb.DeviceSocket, shared_secrets: [enabled: false])

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -51,7 +51,10 @@ defmodule NervesHub.Fixtures do
   def product_params() do
     %{
       name: "auto_booper_#{counter()}",
-      extensions: %{health: true, geo: true, logging: true}
+      extensions: %{health: true, geo: true, logging: true},
+      # Off by default so fixtures can create multiple firmwares sharing a version;
+      # the "on for new products" default is covered directly in products_test.exs.
+      require_unique_firmware_version: false
     }
   end
 


### PR DESCRIPTION
The final PR in the firmware version-handling stack. **Base is #2858** (current stack tip), so this sits on top of the whole chain.

## What & why
Adds a `require_unique_firmware_version` boolean setting on products. When on, uploading firmware whose version is already used **for the same platform + architecture** in the product is rejected with a changeset error on `:version`.

**Defaults (per Josh's ask — off for existing, on for new):**
- Migration column default `false` → existing products unaffected.
- Schema field default `true` → products created from now on require unique versions. `create_product/1` picks this up; test fixtures opt out via `product_params/0` so they can keep creating multiple firmwares sharing a version (the real "on for new" default is asserted directly in `products_test`).

**Uniqueness scope: per (product, platform, architecture, version).** Multi-platform products legitimately reuse a version across platforms (1.0.0 for rpi4 *and* rpi0), so only a same-target re-upload is blocked. (Flagged this in the channel; building on that lean — easy to tighten to product-wide if you'd prefer.)

**Why app-level, not a DB unique index:** the rule is conditional on a setting that lives on the `products` table, which a partial unique index on `firmwares` can't reference. Enforced in `create_firmware/3` inside the existing transaction.

## Files
- `products` migration + `Product` schema field/changeset; `Products.update_product/2`.
- `Firmwares.create_firmware/3`: `validate_version_uniqueness/1` step + `firmware_version_taken?/1`.
- Product → Settings LiveView + template: a "Require unique firmware versions" toggle (a real product setting, separate from device extensions).
- `product_params/0` fixture defaults the setting off; one delta test (`devices_test`) that creates products directly + uploads same-version firmware opts out explicitly.

## Testing
- New tests: create-time default (`true`), opt-out at creation, `update_product/2` toggle, upload enforcement (reject same target / allow across platforms / allow when off), and the settings-toggle render state.
- Full suite: **1417/1419**, the only 2 failures being the pre-existing `UpdateToolTest` fwup `same_fat_files?` environment failures (reproduce on the base branch). `mix format` clean on changed files; compiles `--warnings-as-errors`. (`mix credo --strict` flags only the pre-existing missing `@moduledoc` on `NervesHub.Firmwares` / `NervesHub.Products`.)

## Review focus
- **Security/robustness:** new upload-time validation over firmware metadata; the check runs inside the create transaction. There's a small TOCTOU window (two concurrent uploads of the same version could both pass) — acceptable for firmware uploads, and noted here rather than hidden.
- **Concurrency default note:** confirm the uniqueness scope (per platform+arch vs product-wide) matches intent.
- The migration-default-`false` / schema-default-`true` split is what delivers "off for existing, on for new" — worth a sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
