### PR TITLE
Add per-product setting requiring unique firmware versions

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -857,7 +857,9 @@ defmodule NervesHub.Firmwares do
   defp resolve_product(params) do
     case Products.get_product_by_org_id_and_name(params.org_id, params.product_name) do
       {:ok, product} ->
-        Map.put(params, :product_id, product.id)
+        params
+        |> Map.put(:product_id, product.id)
+        |> Map.put(:require_unique_firmware_version, product.require_unique_firmware_version)
 
       _ ->
         params

--- a/lib/nerves_hub/firmwares/firmware.ex
+++ b/lib/nerves_hub/firmwares/firmware.ex
@@ -2,12 +2,14 @@ defmodule NervesHub.Firmwares.Firmware do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query
 
   alias __MODULE__
   alias NervesHub.Accounts.Org
   alias NervesHub.Accounts.OrgKey
   alias NervesHub.ManagedDeployments.DeploymentRelease
   alias NervesHub.Products.Product
+  alias NervesHub.Repo
 
   @type t :: %Firmware{
           architecture: String.t(),
@@ -87,6 +89,7 @@ defmodule NervesHub.Firmwares.Firmware do
     |> cast(params, @required_params ++ @optional_params ++ [:checksum, :partials_checksums])
     |> validate_required(@required_params)
     |> validate_semver_version()
+    |> validate_unique_version(params)
     |> unique_constraint(:uuid, name: :firmwares_product_id_uuid_index)
     |> foreign_key_constraint(:deployment_groups, name: :deployment_groups_firmware_id_fkey)
   end
@@ -110,6 +113,41 @@ defmodule NervesHub.Firmwares.Firmware do
         :error -> [version: "must be a valid semantic version"]
       end
     end)
+  end
+
+  # When the product requires unique firmware versions (passed through `params`
+  # from the product's setting), reject a version that already exists for the
+  # same product/platform/architecture. The same version built for a different
+  # target is still allowed. This is an application-level check rather than a
+  # unique index because the requirement is a per-product toggle; two
+  # truly-concurrent uploads of the same version leave a small race window that
+  # the check does not close.
+  defp validate_unique_version(changeset, params) do
+    if changeset.valid? and require_unique_version?(params) and version_taken?(changeset) do
+      add_error(changeset, :version, "has already been taken for this product")
+    else
+      changeset
+    end
+  end
+
+  defp require_unique_version?(params) do
+    params[:require_unique_firmware_version] == true or
+      params["require_unique_firmware_version"] == true
+  end
+
+  defp version_taken?(changeset) do
+    product_id = get_field(changeset, :product_id)
+    platform = get_field(changeset, :platform)
+    architecture = get_field(changeset, :architecture)
+    version = get_field(changeset, :version)
+
+    Firmware
+    |> where(
+      [f],
+      f.product_id == ^product_id and f.platform == ^platform and
+        f.architecture == ^architecture and f.version == ^version
+    )
+    |> Repo.exists?()
   end
 
   def delete_changeset(%Firmware{} = firmware) do

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -189,6 +189,16 @@ defmodule NervesHub.Products do
   end
 
   @doc """
+  Updates a product's settings.
+  """
+  @spec update_product(Product.t(), map()) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()}
+  def update_product(%Product{} = product, params) do
+    product
+    |> Product.changeset(params)
+    |> Repo.update()
+  end
+
+  @doc """
   Deletes a Product.
 
   ## Examples

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -38,6 +38,9 @@ defmodule NervesHub.Products.Product do
 
     field(:name, :string)
     field(:deleted_at, :utc_datetime)
+    # Defaults to `true` so new products require unique firmware versions; the DB
+    # column defaults to `false`, so existing products keep the prior behaviour.
+    field(:require_unique_firmware_version, :boolean, default: true)
     embeds_one(:extensions, ProductExtensionsSetting, on_replace: :update)
 
     field(:device_count, :integer, virtual: true)
@@ -56,7 +59,7 @@ defmodule NervesHub.Products.Product do
   @doc false
   def changeset(product, params) do
     product
-    |> cast(params, @required_params)
+    |> cast(params, @required_params ++ [:require_unique_firmware_version])
     |> cast_embed(:extensions)
     |> update_change(:name, &trim/1)
     |> validate_required(@required_params)

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -301,6 +301,9 @@ defmodule NervesHubWeb.Live.Firmware do
       {:error, error} when is_binary(error) ->
         error_feedback(socket, error)
 
+      {:error, %Ecto.Changeset{} = changeset} ->
+        error_feedback(socket, changeset)
+
       _ ->
         error_feedback(socket, "Unknown error uploading firmware. Please contact support.")
     end

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -71,6 +71,34 @@ defmodule NervesHubWeb.Live.Product.Settings do
     end
   end
 
+  def handle_event("update-require-unique-firmware-version", params, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    require_unique = params["value"] == "on"
+
+    socket =
+      case Products.update_product(socket.assigns.product, %{
+             require_unique_firmware_version: require_unique
+           }) do
+        {:ok, product} ->
+          socket
+          |> assign(:product, product)
+          |> put_flash(
+            :info,
+            "Unique firmware versions are now #{(require_unique && "required") || "not required"}."
+          )
+
+        {:error, _changeset} ->
+          put_flash(
+            socket,
+            :error,
+            "Failed to update the unique firmware version setting. Please contact support if this problem persists."
+          )
+      end
+
+    {:noreply, socket}
+  end
+
   def handle_event("update-extension", %{"extension" => extension} = params, socket) do
     value = params["value"]
     available = Extensions.list() |> Enum.map(&to_string/1)

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -63,6 +63,34 @@
 
       <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
         <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
+          <div class="text-base-50 text-base font-medium">Firmware</div>
+        </div>
+
+        <div class="flex flex-col gap-3 p-6">
+          <div class="flex h-16 items-center gap-6 p-2">
+            <div class="bg-base-800 border-base-700 flex h-8 items-center rounded-full border px-2 py-1">
+              <input
+                id="require-unique-firmware-version"
+                name="require-unique-firmware-version"
+                type="checkbox"
+                class="border-base-700 checked:bg-primary text-base-400 rounded focus:ring-0"
+                phx-click="update-require-unique-firmware-version"
+                checked={@product.require_unique_firmware_version}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+            </div>
+            <div class="flex flex-col">
+              <div class="text-base-300 font-medium">Require unique firmware versions</div>
+              <div class="text-base-400 text-xs">
+                Reject uploaded firmware whose version already exists for this product's platform and architecture.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
+        <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
           <div class="text-base-50 text-base font-medium">Device Shared Secret Authentication</div>
         </div>
 

--- a/priv/repo/migrations/20260809074356_add_require_unique_firmware_version_to_products.exs
+++ b/priv/repo/migrations/20260809074356_add_require_unique_firmware_version_to_products.exs
@@ -1,0 +1,15 @@
+defmodule NervesHub.Repo.Migrations.AddRequireUniqueFirmwareVersionToProducts do
+  use Ecto.Migration
+
+  # When on, uploading firmware whose version already exists for the product
+  # (same platform + architecture) is rejected.
+  #
+  # DB default is `false` so all *existing* products keep the current behaviour
+  # (off). New products default to `true` via the schema field default, which is
+  # what gets inserted for records created through `Product.changeset/2`.
+  def change() do
+    alter table(:products) do
+      add(:require_unique_firmware_version, :boolean, default: false, null: false)
+    end
+  end
+end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -2270,12 +2270,21 @@ defmodule NervesHub.DevicesTest do
       org_key_one = Fixtures.org_key_fixture(org_one, user, tmp_dir)
       org_key_two = Fixtures.org_key_fixture(org_two, user, tmp_dir)
 
-      # two products with the same name
+      # two products with the same name (this test uploads two firmwares sharing
+      # a version, so it opts out of the unique-firmware-version requirement)
       {:ok, product_one} =
-        Products.create_product(%{org_id: org_one.id, name: "Same Product Name"})
+        Products.create_product(%{
+          org_id: org_one.id,
+          name: "Same Product Name",
+          require_unique_firmware_version: false
+        })
 
       {:ok, _product_two} =
-        Products.create_product(%{org_id: org_two.id, name: "Same Product Name"})
+        Products.create_product(%{
+          org_id: org_two.id,
+          name: "Same Product Name",
+          require_unique_firmware_version: false
+        })
 
       # create some firmware which can be uploaded to each org
       {:ok, _} =

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -57,6 +57,44 @@ defmodule NervesHub.FirmwaresTest do
       assert {:error, %Ecto.Changeset{errors: [uuid: {"has already been taken", [_ | _]}]}} =
                Firmwares.create_firmware(org, filepath)
     end
+
+    test "rejects a duplicate version when the product requires unique versions",
+         %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+      product = Fixtures.product_fixture(user, org, %{require_unique_firmware_version: true})
+
+      path_a = Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir, version: "9.9.9"})
+      assert {:ok, _} = Firmwares.create_firmware(org, path_a)
+
+      path_b = Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir, version: "9.9.9"})
+      assert {:error, changeset} = Firmwares.create_firmware(org, path_b)
+      assert "has already been taken for this product" in errors_on(changeset).version
+    end
+
+    test "allows the same version for a different platform when unique versions are required",
+         %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+      product = Fixtures.product_fixture(user, org, %{require_unique_firmware_version: true})
+
+      path_a =
+        Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir, version: "9.9.9", platform: "rpi0"})
+
+      assert {:ok, _} = Firmwares.create_firmware(org, path_a)
+
+      path_b =
+        Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir, version: "9.9.9", platform: "rpi4"})
+
+      assert {:ok, _} = Firmwares.create_firmware(org, path_b)
+    end
+
+    test "allows a duplicate version when the product does not require unique versions",
+         %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+      product = Fixtures.product_fixture(user, org, %{require_unique_firmware_version: false})
+
+      path_a = Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir, version: "9.9.9"})
+      assert {:ok, _} = Firmwares.create_firmware(org, path_a)
+
+      path_b = Fixtures.firmware_file_fixture(org_key, product, %{dir: tmp_dir, version: "9.9.9"})
+      assert {:ok, _} = Firmwares.create_firmware(org, path_b)
+    end
   end
 
   describe "delete_firmware/1" do

--- a/test/nerves_hub/products/products_test.exs
+++ b/test/nerves_hub/products/products_test.exs
@@ -41,6 +41,22 @@ defmodule NervesHub.ProductsTest do
       assert {:ok, %Product{}} = Products.create_product(params)
     end
 
+    test "create_product/1 defaults require_unique_firmware_version to true for new products",
+         %{org: org} do
+      params = Enum.into(%{org_id: org.id}, @valid_attrs)
+      assert {:ok, %Product{require_unique_firmware_version: true}} = Products.create_product(params)
+    end
+
+    test "update_product/2 toggles require_unique_firmware_version", %{org: org} do
+      {:ok, product} =
+        Products.create_product(%{name: "toggle me", org_id: org.id, require_unique_firmware_version: false})
+
+      assert product.require_unique_firmware_version == false
+
+      assert {:ok, %Product{require_unique_firmware_version: true}} =
+               Products.update_product(product, %{require_unique_firmware_version: true})
+    end
+
     test "create_product/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Products.create_product(@invalid_attrs)
     end

--- a/test/nerves_hub_web/live/product/settings_test.exs
+++ b/test/nerves_hub_web/live/product/settings_test.exs
@@ -20,6 +20,16 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
     end
   end
 
+  describe "unique firmware version setting" do
+    test "renders the require unique firmware version toggle", %{conn: conn, org: org, user: user} do
+      product = Fixtures.product_fixture(user, org)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/settings")
+      |> assert_has("div", text: "Require unique firmware versions")
+    end
+  end
+
   describe "shared secrets" do
     setup do
       Application.put_env(:nerves_hub, NervesHubWeb.DeviceSocket, shared_secrets: [enabled: false])

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -51,7 +51,11 @@ defmodule NervesHub.Fixtures do
   def product_params() do
     %{
       name: "auto_booper_#{counter()}",
-      extensions: %{health: true, geo: true, logging: true}
+      extensions: %{health: true, geo: true, logging: true},
+      # Fixtures model existing/permissive products; many tests create several
+      # firmwares sharing a version. Enforcement is covered by explicit tests
+      # that set this to true.
+      require_unique_firmware_version: false
     }
   end
 


### PR DESCRIPTION
## What

Adds a per-Product setting, `require_unique_firmware_version`. When enabled,
uploading firmware whose version already exists for the product **(same platform
and architecture)** is rejected. Off for existing products, on for new ones.

Last PR in the firmware-version-handling stack.

## Behaviour

- **Setting default:** the DB column defaults to `false` (existing products keep
  today's behaviour), while the schema field defaults to `true`, so products
  created through `Product.changeset/2` (i.e. new products) get it on.
- **Scope:** uniqueness is per `(product, platform, architecture)`. The same
  version built for different targets (e.g. `1.2.0` for `rpi3` and `rpi4`) is
  still allowed; re-uploading `1.2.0` for the same target is rejected. Firmware
  version comes from the signed fwup metadata.
- **Enforcement:** a `validate_unique_version/2` step in
  `Firmware.create_changeset/2` adds a `:version` error
  (`"has already been taken for this product"`) when the product requires
  uniqueness (flag threaded through params from the product setting) and a
  matching firmware exists. Keeping it in the schema changeset matches the repo
  convention (`DeploymentGroup`/`DeviceCertificate` changesets already query
  `Repo`). The API and LiveView upload surface it the same way they already
  surface the "uuid taken" error; a generic changeset clause was added to the
  upload LiveView so the message shows instead of the generic "Unknown error".
- **UI:** a "Require unique firmware versions" toggle on the product settings
  page (mirrors the existing extension toggles; gated on `product:update`).

## Notes

- **Application-level check, not a unique index.** The requirement is a
  per-product toggle, so a plain/partial unique index can't express it
  (it can't reference the product's setting). This leaves a small TOCTOU window
  for two *truly-concurrent* uploads of the same version, which the check does
  not close — documented in a code comment. Concurrent same-version uploads for
  one product are rare in practice.
- **Test fixtures** default the setting to `false` (`product_params/0`) so the
  many tests that create several firmwares per product are unaffected;
  enforcement is covered by explicit tests that set it `true`.

## Tests

- `firmwares_test.exs`: rejects a duplicate version when required; allows the
  same version for a different platform; allows duplicates when not required.
- `products_test.exs`: new products default the setting to `true`;
  `update_product/2` toggles it.
- `settings_test.exs`: the toggle renders on the product settings page.
- Full `mix check` substantive steps + test suite green (same pre-existing
  fwup/spellcheck non-issues noted in the earlier stack PRs).
