### PR TITLE
Context cleanup — Phase 1: dead code, spec fixes, auth hardening

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -360,7 +360,11 @@ defmodule NervesHub.Accounts do
 
   """
   def get_user_by_email_and_password(email, password) when is_binary(email) and is_binary(password) do
-    user = Repo.get_by(User, email: email)
+    user =
+      User
+      |> Repo.exclude_deleted()
+      |> Repo.get_by(email: email)
+
     if User.valid_password?(user, password), do: user
   end
 
@@ -487,16 +491,6 @@ defmodule NervesHub.Accounts do
     |> Repo.get!(id)
   end
 
-  def get_org_with_org_keys(id) do
-    Org
-    |> Repo.exclude_deleted()
-    |> Repo.get(id)
-    |> case do
-      nil -> {:error, :not_found}
-      org -> {:ok, org |> Org.with_org_keys()}
-    end
-  end
-
   def get_org_by_name(org_name) do
     Org
     |> Repo.exclude_deleted()
@@ -516,15 +510,6 @@ defmodule NervesHub.Accounts do
     |> where([_, _, o], o.name == ^org_name)
     |> where([_, u], u.id == ^current_scope.user.id)
     |> preload([_, u, o], org: o, user: u)
-    |> Repo.one!()
-  end
-
-  def get_org_by_name_and_user!(org_name, %User{id: user_id}) do
-    Org
-    |> join(:left, [o], u in assoc(o, :users))
-    |> where([o], o.name == ^org_name)
-    |> where([o, u], u.id == ^user_id)
-    |> Repo.exclude_deleted()
     |> Repo.one!()
   end
 
@@ -765,19 +750,6 @@ defmodule NervesHub.Accounts do
     invite
     |> Invite.changeset(%{accepted: true})
     |> Repo.update()
-  end
-
-  @spec user_in_org?(integer(), integer()) :: boolean()
-  def user_in_org?(user_id, org_id) do
-    from(ou in OrgUser,
-      where: ou.user_id == ^user_id and ou.org_id == ^org_id,
-      select: %{}
-    )
-    |> Repo.one()
-    |> case do
-      nil -> false
-      _ -> true
-    end
   end
 
   def create_org_metrics(run_utc_time) do

--- a/lib/nerves_hub/archives.ex
+++ b/lib/nerves_hub/archives.ex
@@ -25,7 +25,7 @@ defmodule NervesHub.Archives do
     |> Repo.one()
   end
 
-  @spec filter(Product.t(), map()) :: {[Product.t()], Flop.Meta.t()}
+  @spec filter(Product.t(), map()) :: {[Archive.t()], Flop.Meta.t()}
   def filter(product, opts \\ %{}) do
     opts = Map.reject(opts, fn {_key, val} -> is_nil(val) end)
 

--- a/lib/nerves_hub/audit_logs.ex
+++ b/lib/nerves_hub/audit_logs.ex
@@ -42,12 +42,6 @@ defmodule NervesHub.AuditLogs do
     |> Repo.all()
   end
 
-  def logs_for_feed(resource) do
-    resource
-    |> query_for_feed()
-    |> Repo.all()
-  end
-
   def logs_for_feed(resource, %{page: page} = opts) when is_binary(page) do
     logs_for_feed(resource, Map.put(opts, :page, String.to_integer(page)))
   end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -18,7 +18,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
-  alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Devices.DeviceFirmwares
@@ -175,22 +174,6 @@ defmodule NervesHub.Devices do
     )
     |> join(:left, [d], dg in assoc(d, :deployment_group), as: :deployment_group)
     |> join(:left, [d], ifu in assoc(d, :inflight_update), as: :inflight_update)
-  end
-
-  def get_minimal_device_location_by_product(product) do
-    Device
-    |> join(:inner, [d], dc in DeviceConnection, on: d.latest_connection_id == dc.id)
-    |> where(product_id: ^product.id)
-    |> select([d, dc], %{
-      id: d.id,
-      identifier: d.identifier,
-      connection_status: dc.status,
-      latitude: fragment("?->'location'->'latitude'", dc.metadata),
-      longitude: fragment("?->'location'->'longitude'", dc.metadata),
-      firmware_uuid: fragment("?->'uuid'", d.firmware_metadata)
-    })
-    |> Repo.exclude_deleted()
-    |> Repo.all()
   end
 
   def get_device_count_by_org_id(org_id) do
@@ -667,10 +650,10 @@ defmodule NervesHub.Devices do
   end
 
   def clean_up_soft_deleted_devices() do
-    two_weeks_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -12, :day)
+    twelve_days_ago = NaiveDateTime.add(NaiveDateTime.utc_now(), -12, :day)
 
     Device
-    |> where([d], d.deleted_at < ^two_weeks_ago)
+    |> where([d], d.deleted_at < ^twelve_days_ago)
     |> Repo.all()
     |> Enum.each(fn device ->
       Repo.transact(fn ->
@@ -1738,11 +1721,6 @@ defmodule NervesHub.Devices do
       _ ->
         :nope
     end)
-  end
-
-  def preload_product(%Device{} = device) do
-    device
-    |> Repo.preload(:product)
   end
 
   @spec get_pinned_devices(Scope.t()) :: [Device.t()]

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -283,12 +283,6 @@ defmodule NervesHub.Firmwares do
     end
   end
 
-  @spec get_firmware_by_product_and_uuid!(Product.t(), String.t()) :: Firmware.t()
-  def get_firmware_by_product_and_uuid!(product, uuid) do
-    get_firmware_by_product_and_uuid_query(product, uuid)
-    |> Repo.one!()
-  end
-
   @spec get_firmware_by_uuid(Scope.t(), String.t()) :: {:ok, Firmware.t()} | {:error, :not_found}
   def get_firmware_by_uuid(%Scope{} = scope, uuid) do
     get_firmware_by_product_and_uuid(scope.product, uuid)
@@ -512,7 +506,7 @@ defmodule NervesHub.Firmwares do
     end
   end
 
-  @spec get_firmware_delta_by_source_and_target(non_neg_integer(), non_neg_integer()) ::
+  @spec get_firmware_delta_by_source_and_target(non_neg_integer(), non_neg_integer(), atom()) ::
           {:ok, FirmwareDelta.t()}
           | {:error, :not_found}
   def get_firmware_delta_by_source_and_target(source_id, target_id, status \\ :all) do
@@ -737,12 +731,6 @@ defmodule NervesHub.Firmwares do
   @spec subscribe_firmware_delta_target(target_id :: integer()) :: :ok
   def subscribe_firmware_delta_target(target_id) do
     _ = NervesHubWeb.Endpoint.subscribe("firmware:#{target_id}")
-    :ok
-  end
-
-  @spec unsubscribe_firmware_delta_target(target_id :: integer()) :: :ok
-  def unsubscribe_firmware_delta_target(target_id) do
-    _ = NervesHubWeb.Endpoint.unsubscribe("firmware:#{target_id}")
     :ok
   end
 

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -506,7 +506,7 @@ defmodule NervesHub.Firmwares do
     end
   end
 
-  @spec get_firmware_delta_by_source_and_target(non_neg_integer(), non_neg_integer(), atom()) ::
+  @spec get_firmware_delta_by_source_and_target(non_neg_integer(), non_neg_integer(), :all | nil | [atom()]) ::
           {:ok, FirmwareDelta.t()}
           | {:error, :not_found}
   def get_firmware_delta_by_source_and_target(source_id, target_id, status \\ :all) do

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -75,7 +75,7 @@ defmodule NervesHub.ManagedDeployments do
     |> Map.new()
   end
 
-  @spec get_device_count(DeploymentGroup.t()) :: term() | nil
+  @spec get_device_count(DeploymentGroup.t()) :: non_neg_integer()
   def get_device_count(%DeploymentGroup{id: id}) do
     Device
     |> where([d], d.deployment_id == ^id)
@@ -481,20 +481,6 @@ defmodule NervesHub.ManagedDeployments do
     end)
   end
 
-  @spec deltas_processing?(DeploymentRelease.t()) :: boolean()
-  def deltas_processing?(%DeploymentRelease{deployment_group_id: deployment_group_id, firmware_id: firmware_id}) do
-    source_ids =
-      deployment_group_id
-      |> Devices.get_device_firmware_for_delta_generation_by_deployment_group()
-      |> Enum.map(fn {source_id, _target_id} -> source_id end)
-
-    FirmwareDelta
-    |> where([fd], fd.source_id in ^source_ids)
-    |> where([fd], fd.target_id == ^firmware_id)
-    |> where([fd], fd.status != :completed)
-    |> Repo.exists?()
-  end
-
   @spec update_deployment_group_status(DeploymentGroup.t(), atom()) ::
           {:ok, DeploymentGroup.t()} | {:error, Changeset.t()}
   def update_deployment_group_status(deployment_group, status) do
@@ -687,16 +673,6 @@ defmodule NervesHub.ManagedDeployments do
     !Version.match?(device_version, version_requirement)
   rescue
     _ -> true
-  end
-
-  @spec preload_firmware_and_archive(DeploymentGroup.t()) :: DeploymentGroup.t()
-  def preload_firmware_and_archive(deployment_group) do
-    %DeploymentGroup{} = Repo.preload(deployment_group, [:archive, :firmware])
-  end
-
-  @spec preload_with_firmware_and_archive(Device.t()) :: Device.t()
-  def preload_with_firmware_and_archive(device) do
-    %Device{} = Repo.preload(device, deployment_group: [:archive, :firmware])
   end
 
   @doc """

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -135,12 +135,6 @@ defmodule NervesHub.Products do
     |> Repo.one!()
   end
 
-  @spec get_product_by_org_id_and_name!(pos_integer(), String.t()) :: Product.t()
-  def get_product_by_org_id_and_name!(org_id, name) do
-    get_product_by_org_id_and_name_query(org_id, name)
-    |> Repo.one!()
-  end
-
   @spec get_product_by_org_id_and_name(pos_integer(), String.t()) ::
           {:ok, Product.t()} | {:error, :not_found}
   def get_product_by_org_id_and_name(org_id, name) do

--- a/lib/nerves_hub/scripts.ex
+++ b/lib/nerves_hub/scripts.ex
@@ -11,7 +11,7 @@ defmodule NervesHub.Scripts do
   alias NervesHub.Repo
   alias NervesHub.Scripts.Script
 
-  @spec filter(Scope.t() | Product.t(), map()) :: {[Product.t()], Flop.Meta.t()}
+  @spec filter(Scope.t() | Product.t(), map()) :: {[Script.t()], Flop.Meta.t()}
   def filter(scope_or_product, opts \\ %{})
 
   def filter(%Scope{product: product}, opts) do

--- a/lib/nerves_hub/uploads.ex
+++ b/lib/nerves_hub/uploads.ex
@@ -10,6 +10,10 @@ defmodule NervesHub.Uploads do
     Application.get_env(:nerves_hub, __MODULE__)[:backend]
   end
 
+  def delete(key) do
+    backend().delete(key)
+  end
+
   def upload(file, key, opts \\ []) do
     backend().upload(file, key, opts)
   end

--- a/lib/nerves_hub/workers/delete_archive.ex
+++ b/lib/nerves_hub/workers/delete_archive.ex
@@ -5,8 +5,6 @@ defmodule NervesHub.Workers.DeleteArchive do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"archive_path" => path}}) do
-    backend = Application.fetch_env!(:nerves_hub, NervesHub.Uploads)[:backend]
-
-    backend.delete(path)
+    NervesHub.Uploads.delete(path)
   end
 end


### PR DESCRIPTION
First in a **stacked series** of PRs cleaning up the `NervesHub` context layer. This phase is deliberately mechanical and low-risk (dead-code removal + spec/naming fixes + two small correctness/encapsulation fixes). Later phases (deduplication, encapsulation, module splits) will branch on top of this one.

### Dead code removed (grep-verified: zero call sites in `lib/` and `test/`)
| Module | Removed |
|---|---|
| `Accounts` | `get_org_with_org_keys/1`, `get_org_by_name_and_user!/2`, `user_in_org?/2` |
| `ManagedDeployments` | `deltas_processing?/1`, `preload_firmware_and_archive/1`, `preload_with_firmware_and_archive/1` |
| `Firmwares` | `get_firmware_by_product_and_uuid!/2`, `unsubscribe_firmware_delta_target/1` |
| `Devices` | `preload_product/1`, `get_minimal_device_location_by_product/1` (+ now-unused `DeviceConnection` alias) |
| `Products` | `get_product_by_org_id_and_name!/2` |
| `AuditLogs` | single-arg `logs_for_feed/1` (only the `/2` clause is used) |

### Misleading `@spec` / naming fixes
- `Scripts.filter/2` and `Archives.filter/2` declared `{[Product.t()], …}` but return Scripts/Archives.
- `Firmwares.get_firmware_delta_by_source_and_target` spec was missing its 3rd (`status`) arg.
- `ManagedDeployments.get_device_count` spec was `term() | nil` for a count → `non_neg_integer()`.
- `Devices.clean_up_soft_deleted_devices`: local `two_weeks_ago` actually held a `-12 day` value → renamed `twelve_days_ago` (no behaviour change; if 14 days was intended, change the value in a follow-up).

### Correctness
- **`Accounts.get_user_by_email_and_password/2` skipped `Repo.exclude_deleted`**, unlike the sibling auth paths (`authenticate`, `get_user_by_email`), allowing a soft-deleted user to authenticate. Now excludes deleted users.

### Encapsulation
- Added the missing **`Uploads.delete/1`** facade (the `@callback` existed with no public wrapper) and routed `Workers.DeleteArchive` through it instead of reaching into `Application` config for the backend.

### Deliberately deferred
- The org-metrics **write** path (`create_org_metrics/1`, `create_org_metric/2`) is currently unwired but left in place: `OrgMetric` is still an active feature (rows are deleted via `Accounts.RemoveAccount`), so removing its only writer is a semantic change for a separate PR.

### Verification
- `mix compile --warnings-as-errors` clean.
- Affected context tests pass: accounts, audit_logs, devices, firmwares, managed_deployments, products, scripts, archives (**262 tests, 0 failures**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)