### PR TITLE
Context cleanup — Phase 2: deduplication (Repo.fetch + extension settings)

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -236,11 +236,7 @@ defmodule NervesHub.Accounts do
 
   def get_org_user(org, user_id) do
     get_org_user_query(org, user_id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      org_user -> {:ok, org_user}
-    end
+    |> Repo.fetch()
   end
 
   defp get_org_user_query(org, user_id) do
@@ -376,11 +372,7 @@ defmodule NervesHub.Accounts do
 
     query
     |> Repo.exclude_deleted()
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      user -> {:ok, user}
-    end
+    |> Repo.fetch()
   end
 
   def get_user!(user_id) do
@@ -554,20 +546,12 @@ defmodule NervesHub.Accounts do
 
   def get_org_key(%Scope{org: org}, tk_id) do
     get_org_key_query(org.id, tk_id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      key -> {:ok, key}
-    end
+    |> Repo.fetch()
   end
 
   def get_org_key(%Org{id: org_id}, tk_id) do
     get_org_key_query(org_id, tk_id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      key -> {:ok, key}
-    end
+    |> Repo.fetch()
   end
 
   def get_org_key!(%Org{id: org_id}, tk_id) do
@@ -592,11 +576,7 @@ defmodule NervesHub.Accounts do
       )
 
     query
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      key -> {:ok, key}
-    end
+    |> Repo.fetch()
   end
 
   def update_org_key(%OrgKey{} = org_key, params) do
@@ -845,11 +825,7 @@ defmodule NervesHub.Accounts do
 
   def get_user_token(token) do
     from(UserToken, where: [token: ^token], preload: [:user])
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      ut -> {:ok, ut}
-    end
+    |> Repo.fetch()
   end
 
   def get_user_token(user, id) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -208,11 +208,7 @@ defmodule NervesHub.Devices do
   def get_device_by_org(%Org{id: org_id}, device_id) do
     device_by_org_query(org_id, device_id)
     |> Repo.exclude_deleted()
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      device -> {:ok, device}
-    end
+    |> Repo.fetch()
   end
 
   @spec get_by_identifier!(String.t()) :: Device.t()
@@ -248,11 +244,7 @@ defmodule NervesHub.Devices do
   def get_by_identifier(%Scope{} = scope, identifier, preload_assoc \\ [:product, :latest_connection])
       when is_binary(identifier) do
     get_by_identifier_query(scope, identifier, preload_assoc)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      device -> {:ok, device}
-    end
+    |> Repo.fetch()
   end
 
   defp get_by_identifier_query(%Scope{org: org}, identifier, preload_assoc) when not is_nil(org) do
@@ -330,11 +322,7 @@ defmodule NervesHub.Devices do
     |> join(:inner, [d], dc in assoc(d, :device_certificates))
     |> where([_, _, dc], dc.fingerprint == ^fingerprint)
     |> preload([_d, p], product: p)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      device -> {:ok, device}
-    end
+    |> Repo.fetch()
   end
 
   @spec get_shared_secret_auth(String.t()) ::
@@ -347,11 +335,7 @@ defmodule NervesHub.Devices do
     |> where([ssa], is_nil(ssa.deactivated_at))
     |> where([_, d], is_nil(d.deleted_at))
     |> preload([ssa, d, p], [:product_shared_secret_auth, device: {d, product: p}])
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      auth -> {:ok, auth}
-    end
+    |> Repo.fetch()
   end
 
   @spec create_shared_secret_auth(Device.t()) ::
@@ -490,11 +474,7 @@ defmodule NervesHub.Devices do
     |> where(fingerprint: ^fingerprint)
     |> join(:inner, [dc], d in assoc(dc, :device))
     |> preload([_dc, d], device: d)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      certificate -> {:ok, certificate}
-    end
+    |> Repo.fetch()
   end
 
   def get_device_by_public_key(otp_cert) do
@@ -516,14 +496,7 @@ defmodule NervesHub.Devices do
       )
 
     query
-    |> Repo.one()
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      device_certificate ->
-        {:ok, device_certificate}
-    end
+    |> Repo.fetch()
   end
 
   def update_device_certificate(%DeviceCertificate{} = certificate, params) do
@@ -581,12 +554,8 @@ defmodule NervesHub.Devices do
 
   @spec get_ca_certificate_by_aki(binary) :: {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_aki(aki) do
-    q = from(CACertificate, where: [aki: ^aki], preload: [jitp: :product])
-
-    case Repo.one(q) do
-      nil -> {:error, :not_found}
-      ca_cert -> {:ok, ca_cert}
-    end
+    from(CACertificate, where: [aki: ^aki], preload: [jitp: :product])
+    |> Repo.fetch()
   end
 
   @spec known_ca_ski?(binary) :: boolean()
@@ -603,40 +572,24 @@ defmodule NervesHub.Devices do
     |> join(:left, [_cac, jitp], p in assoc(jitp, :product))
     |> where([cac], cac.ski == ^ski)
     |> preload([_cac, jitp, p], jitp: {jitp, product: p})
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      ca_cert -> {:ok, ca_cert}
-    end
+    |> Repo.fetch()
   end
 
   @spec get_ca_certificate_by_serial(binary) :: {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_serial(serial) do
-    q = from(CACertificate, where: [serial: ^serial], preload: [jitp: :product])
-
-    case Repo.one(q) do
-      nil -> {:error, :not_found}
-      ca_cert -> {:ok, ca_cert}
-    end
+    from(CACertificate, where: [serial: ^serial], preload: [jitp: :product])
+    |> Repo.fetch()
   end
 
   @spec get_ca_certificate_by_org_and_serial(Org.t(), binary) ::
           {:ok, CACertificate.t()} | {:error, any()}
   def get_ca_certificate_by_org_and_serial(%Org{id: org_id}, serial) do
-    query =
-      from(
-        ca in CACertificate,
-        where: ca.serial == ^serial and ca.org_id == ^org_id,
-        preload: [jitp: :product]
-      )
-
-    case Repo.one(query) do
-      nil ->
-        {:error, :not_found}
-
-      ca_cert ->
-        {:ok, ca_cert}
-    end
+    from(
+      ca in CACertificate,
+      where: ca.serial == ^serial and ca.org_id == ^org_id,
+      preload: [jitp: :product]
+    )
+    |> Repo.fetch()
   end
 
   def update_ca_certificate(%CACertificate{} = certificate, params) do
@@ -1696,27 +1649,22 @@ defmodule NervesHub.Devices do
   end
 
   def enable_extension_setting(%Device{} = device, extension_string) do
-    device = get_device(device.id)
-
-    Device.changeset(device, %{"extensions" => %{extension_string => true}})
-    |> Repo.update()
-    |> tap(fn
-      {:ok, _} ->
-        Extensions.broadcast_extension_event(device, "attach", extension_string)
-
-      _ ->
-        :nope
-    end)
+    set_extension_setting(device, extension_string, true)
   end
 
   def disable_extension_setting(%Device{} = device, extension_string) do
-    device = get_device(device.id)
+    set_extension_setting(device, extension_string, false)
+  end
 
-    Device.changeset(device, %{"extensions" => %{extension_string => false}})
+  defp set_extension_setting(%Device{} = device, extension_string, enabled?) do
+    device = get_device(device.id)
+    event = if enabled?, do: "attach", else: "detach"
+
+    Device.changeset(device, %{"extensions" => %{extension_string => enabled?}})
     |> Repo.update()
     |> tap(fn
       {:ok, _} ->
-        Extensions.broadcast_extension_event(device, "detach", extension_string)
+        Extensions.broadcast_extension_event(device, event, extension_string)
 
       _ ->
         :nope

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -227,22 +227,14 @@ defmodule NervesHub.Firmwares do
     |> with_product()
     |> where([f], f.id == ^id)
     |> where([f, p], p.org_id == ^org_id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
+    |> Repo.fetch()
   end
 
   def get_firmware(%Product{id: product_id}, id) do
     Firmware
     |> where([f], f.id == ^id)
     |> where([f], f.product_id == ^product_id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
+    |> Repo.fetch()
   end
 
   def get_firmware!(firmware_id), do: Repo.get!(Firmware, firmware_id)
@@ -276,11 +268,7 @@ defmodule NervesHub.Firmwares do
 
   def get_firmware_by_product_id_and_uuid(product_id, uuid) do
     get_firmware_by_product_and_uuid_query(%Product{id: product_id}, uuid)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
+    |> Repo.fetch()
   end
 
   @spec get_firmware_by_uuid(Scope.t(), String.t()) :: {:ok, Firmware.t()} | {:error, :not_found}
@@ -299,11 +287,7 @@ defmodule NervesHub.Firmwares do
           | {:error, :not_found}
   def get_firmware_by_product_and_uuid(%Product{} = product, uuid) do
     get_firmware_by_product_and_uuid_query(product, uuid)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
+    |> Repo.fetch()
   end
 
   defp get_firmware_by_product_and_uuid_query(%Product{id: product_id}, uuid) do
@@ -520,11 +504,7 @@ defmodule NervesHub.Firmwares do
         where(query, [fd], fd.status in ^status)
       end
     end)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      firmware_delta -> {:ok, firmware_delta}
-    end
+    |> Repo.fetch()
   end
 
   @spec get_firmware_url(Firmware.t() | FirmwareDelta.t()) ::

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -92,14 +92,7 @@ defmodule NervesHub.ManagedDeployments do
   def get_deployment_group(deployment_id) do
     full_deployment_group_query()
     |> where([d], d.id == ^deployment_id)
-    |> Repo.one()
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      deployment ->
-        {:ok, deployment}
-    end
+    |> Repo.fetch()
   end
 
   defp full_deployment_group_query() do
@@ -160,14 +153,7 @@ defmodule NervesHub.ManagedDeployments do
           {:ok, DeploymentGroup.t()} | {:error, :not_found}
   def get_deployment_group_by_name(product, name) do
     get_by_product_and_name_query(product, name)
-    |> Repo.one()
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      deployment_group ->
-        {:ok, deployment_group}
-    end
+    |> Repo.fetch()
   end
 
   defp get_by_product_and_name_query(%Product{id: product_id}, name) do

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -139,11 +139,7 @@ defmodule NervesHub.Products do
           {:ok, Product.t()} | {:error, :not_found}
   def get_product_by_org_id_and_name(org_id, name) do
     get_product_by_org_id_and_name_query(org_id, name)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      product -> {:ok, product}
-    end
+    |> Repo.fetch()
   end
 
   def get_product_by_org_id_and_name_query(org_id, name) do
@@ -166,11 +162,7 @@ defmodule NervesHub.Products do
     |> where([_, o], is_nil(o.deleted_at))
     |> where(id: ^id)
     |> where([_, _, ou], ou.user_id == ^user.id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      product -> {:ok, product}
-    end
+    |> Repo.fetch()
   end
 
   @doc """
@@ -232,11 +224,7 @@ defmodule NervesHub.Products do
     |> join(:inner, [ssa], p in assoc(ssa, :product))
     |> where([ssa], ssa.id == ^auth_id)
     |> where([_, p], p.id == ^product_id)
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      auth -> {:ok, auth}
-    end
+    |> Repo.fetch()
   end
 
   @spec get_shared_secret_auth(String.t()) :: {:ok, SharedSecretAuth.t()} | {:error, :not_found}
@@ -246,11 +234,7 @@ defmodule NervesHub.Products do
     |> where([ssa], ssa.key == ^key)
     |> where([ssa], is_nil(ssa.deactivated_at))
     |> where([_, p], is_nil(p.deleted_at))
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      auth -> {:ok, auth}
-    end
+    |> Repo.fetch()
   end
 
   @spec load_shared_secret_auth(Product.t()) :: Product.t()
@@ -344,27 +328,22 @@ defmodule NervesHub.Products do
   end
 
   def enable_extension_setting(%Product{} = product, extension_string) do
-    product = get_product!(product.id)
-
-    Product.changeset(product, %{"extensions" => %{extension_string => true}})
-    |> Repo.update()
-    |> tap(fn
-      {:ok, _} ->
-        Extensions.broadcast_extension_event(product, "attach", extension_string)
-
-      _ ->
-        :nope
-    end)
+    set_extension_setting(product, extension_string, true)
   end
 
   def disable_extension_setting(%Product{} = product, extension_string) do
-    product = get_product!(product.id)
+    set_extension_setting(product, extension_string, false)
+  end
 
-    Product.changeset(product, %{"extensions" => %{extension_string => false}})
+  defp set_extension_setting(%Product{} = product, extension_string, enabled?) do
+    product = get_product!(product.id)
+    event = if enabled?, do: "attach", else: "detach"
+
+    Product.changeset(product, %{"extensions" => %{extension_string => enabled?}})
     |> Repo.update()
     |> tap(fn
       {:ok, _} ->
-        Extensions.broadcast_extension_event(product, "detach", extension_string)
+        Extensions.broadcast_extension_event(product, event, extension_string)
 
       _ ->
         :nope

--- a/lib/nerves_hub/repo.ex
+++ b/lib/nerves_hub/repo.ex
@@ -51,6 +51,19 @@ defmodule NervesHub.Repo do
 
   def destroy(struct_or_changeset), do: delete(struct_or_changeset)
 
+  @doc """
+  Fetches a single result and wraps it in an ok/error tuple.
+
+  Returns `{:ok, result}` when a row is found, or `{:error, error}` (default
+  `:not_found`) when the query returns nothing.
+  """
+  def fetch(queryable, error \\ :not_found) do
+    case one(queryable) do
+      nil -> {:error, error}
+      result -> {:ok, result}
+    end
+  end
+
   # verify_fun/3 is used in config/runtime.exs to verify self signed certs
   # that would normally return {:bad_cert, :selfsigned_peer}. This is used
   # in environments where the database uses a self signed cert instead of a

--- a/lib/nerves_hub/scripts.ex
+++ b/lib/nerves_hub/scripts.ex
@@ -68,14 +68,7 @@ defmodule NervesHub.Scripts do
     |> where([c], c.id == ^id and c.product_id == ^product.id)
     |> join(:left, [s], cb in assoc(s, :created_by))
     |> preload([s, cb], created_by: cb)
-    |> Repo.one()
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      command ->
-        {:ok, command}
-    end
+    |> Repo.fetch()
   end
 
   def get(_, _) do


### PR DESCRIPTION
Second in the **stacked** context-cleanup series. **Base is the Phase 1 branch** (`cleanup/phase-1-dead-code-and-fixes`, #2873), not `main` — review/merge Phase 1 first. Net **−125 lines**.

### `Repo.fetch/2`
Adds a small helper and removes the pervasive not-found boilerplate:
```elixir
def fetch(queryable, error \\ :not_found) do
  case one(queryable) do
    nil -> {:error, error}
    result -> {:ok, result}
  end
end
```
Replaced the repeated `|> Repo.one() |> case do nil -> {:error, :not_found}; x -> {:ok, x} end` with `Repo.fetch/1` across **28 getters** in `accounts`, `devices`, `products`, `firmwares`, `managed_deployments`, `scripts` (incl. 3 prefix-form `case Repo.one(...)` variants). Behaviour is identical.

Left untouched: sites with a different error atom (`:org_not_found`, `:invite_not_found`) or a transformed success branch (e.g. `{:ok, Org.with_org_keys(org)}`).

### Extension settings
Collapsed the near-identical `enable_extension_setting`/`disable_extension_setting` pairs in `Products` and `Devices` into a private `set_extension_setting/3` (parameterized on `enabled?` + the `"attach"`/`"detach"` event).

### Deliberately NOT deduplicated (with reasons)
- **`platforms/1` + `architectures/1`** (Devices): parameterizing the JSON key breaks `SELECT DISTINCT … ORDER BY` — Postgres binds the select and order-by as *different* params (`$1` vs `$3`) and rejects it with `ORDER BY expressions must appear in select list`. (Caught by the test suite; kept as separate literal-fragment queries.)
- **The `*_count` families** (Devices): their `WHERE` clauses and join targets differ enough (`Device` vs `InflightUpdate`, `latest_connection` vs `latest_health`) that a shared counter would reduce readability.

### Verification
- `mix format` ✓, credo (no new issues) ✓, dialyzer (0 unskipped) ✓
- **Full test suite: 1396 passing, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)