### PR TITLE
Context cleanup — Phase 3: pull web-layer Repo access into contexts

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -73,6 +73,15 @@ defmodule NervesHub.Accounts do
   end
 
   @doc """
+  Persists a user's selected default columns for the given column set.
+  """
+  def update_user_default_columns(%User{} = user, column_set, selected_columns) do
+    user
+    |> User.update_selected_default_columns_changeset(column_set, selected_columns)
+    |> Repo.update()
+  end
+
+  @doc """
   Creates a new user, and an org if one does not exist yet
   """
   @spec create_user(map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
@@ -283,7 +292,7 @@ defmodule NervesHub.Accounts do
     |> Repo.exists?()
   end
 
-  def get_user_orgs(%User{} = user) do
+  def get_user_orgs(%User{} = user, preloads \\ []) do
     from(
       o in Org,
       full_join: ou in OrgUser,
@@ -294,6 +303,7 @@ defmodule NervesHub.Accounts do
     )
     |> Repo.exclude_deleted()
     |> Repo.all()
+    |> Repo.preload(preloads)
   end
 
   def find_org_user_with_device(user, device_id) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -268,7 +268,26 @@ defmodule NervesHub.Devices do
     |> join_and_preload(preload_assoc)
   end
 
-  def join_and_preload_deployment_group_and_current_release(query) do
+  @doc """
+  Fetch a device by identifier, preloading its org, product, latest connection,
+  deployment group and current release. Raises if the device does not exist.
+  """
+  def get_by_identifier_with_deployment_and_release!(identifier) do
+    Device
+    |> where(identifier: ^identifier)
+    |> join_and_preload_deployment_group_and_current_release()
+    |> preload([:org, :product, :latest_connection])
+    |> Repo.one!()
+  end
+
+  @doc """
+  Preloads a device's certificates. Pass `force: true` to reload them.
+  """
+  def preload_device_certificates(%Device{} = device, opts \\ []) do
+    Repo.preload(device, :device_certificates, opts)
+  end
+
+  defp join_and_preload_deployment_group_and_current_release(query) do
     query
     |> join(:left, [d], dp in assoc(d, :deployment_group), as: :deployment_group)
     |> join(:left, [deployment_group: dg], cr in assoc(dg, :current_release), as: :current_release)

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -239,6 +239,11 @@ defmodule NervesHub.Firmwares do
 
   def get_firmware!(firmware_id), do: Repo.get!(Firmware, firmware_id)
 
+  @doc """
+  Preloads a firmware's product.
+  """
+  def preload_product(%Firmware{} = firmware), do: Repo.preload(firmware, :product)
+
   def get_firmware_for_device(%Device{firmware_metadata: nil}), do: []
 
   def get_firmware_for_device(device) do

--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -5,7 +5,6 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
   alias NervesHub.Extensions
-  alias NervesHub.Repo
   alias NervesHubWeb.Components.Utils
   alias NervesHubWeb.LayoutView.DateTimeFormat
 
@@ -25,7 +24,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   end
 
   def render(assigns) do
-    device = Repo.preload(assigns.device, :device_certificates, force: true)
+    device = Devices.preload_device_certificates(assigns.device, force: true)
 
     assigns = Map.put(assigns, :device, device)
 
@@ -369,7 +368,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   def hooked_event("validate-cert", _, socket), do: {:halt, socket}
 
   def hooked_event("delete-certificate", %{"serial" => serial}, %{assigns: %{device: device}} = socket) do
-    device = %{device_certificates: certs} = Repo.preload(device, :device_certificates)
+    device = %{device_certificates: certs} = Devices.preload_device_certificates(device)
 
     db_cert = Enum.find(certs, &(&1.serial == serial))
 
@@ -440,7 +439,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
     with {:ok, pem_or_der} <- File.read(path),
          {:ok, otp_cert} <- Certificate.from_pem_or_der(pem_or_der),
          {:ok, _db_cert} <- Devices.create_device_certificate(device, otp_cert) do
-      updated = Repo.preload(device, :device_certificates)
+      updated = Devices.preload_device_certificates(device)
 
       assign(socket, :device, updated)
       |> put_flash(:info, "Certificate Upload Successful")

--- a/lib/nerves_hub_web/components/list_settings_sidebar.ex
+++ b/lib/nerves_hub_web/components/list_settings_sidebar.ex
@@ -1,8 +1,7 @@
 defmodule NervesHubWeb.Components.ListSettingsSidebar do
   use NervesHubWeb, :component
 
-  alias NervesHub.Accounts.User
-  alias NervesHub.Repo
+  alias NervesHub.Accounts
   alias Phoenix.LiveView.JS
 
   attr(:available_columns, :list, required: true)
@@ -69,10 +68,7 @@ defmodule NervesHubWeb.Components.ListSettingsSidebar do
       end)
       |> Enum.map(fn {k, _} -> k end)
 
-    user =
-      User.update_selected_default_columns_changeset(user, column_set, selected_columns)
-
-    Repo.update(user)
+    Accounts.update_user_default_columns(user, column_set, selected_columns)
   end
 
   defp to_column_name(column) do

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -1,17 +1,13 @@
 defmodule NervesHubWeb.API.DeviceController do
   use NervesHubWeb, :api_controller
 
-  import Ecto.Query
-
   alias NervesHub.Accounts
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
-  alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Firmwares
   alias NervesHub.Products
-  alias NervesHub.Repo
   alias NervesHubWeb.API.PaginationHelpers
   alias NervesHubWeb.Endpoint
   alias NervesHubWeb.Helpers.RoleValidateHelpers
@@ -69,7 +65,7 @@ defmodule NervesHubWeb.API.DeviceController do
       |> Map.put("product_id", product.id)
 
     with {:ok, device} <- Devices.create_device(params) do
-      device = preload_device(device)
+      device = Devices.get_by_identifier_with_deployment_and_release!(device.identifier)
 
       conn
       |> put_status(:created)
@@ -109,7 +105,7 @@ defmodule NervesHubWeb.API.DeviceController do
 
   def update(%{assigns: %{device: device}} = conn, params) do
     with {:ok, updated_device} <- Devices.update_device(device, params) do
-      updated_device = preload_device(updated_device)
+      updated_device = Devices.get_by_identifier_with_deployment_and_release!(updated_device.identifier)
 
       conn
       |> put_status(201)
@@ -123,7 +119,7 @@ defmodule NervesHubWeb.API.DeviceController do
          {:ok, %DeviceCertificate{device_id: device_id}} <-
            Devices.get_device_certificate_by_x509(cert),
          {:ok, device} <- Devices.get_device_by_org(org, device_id) do
-      device = preload_device(device)
+      device = Devices.get_by_identifier_with_deployment_and_release!(device.identifier)
 
       conn
       |> put_status(200)
@@ -208,7 +204,7 @@ defmodule NervesHubWeb.API.DeviceController do
          {:ok, product} <- Products.get_product_by_org_id_and_name(move_to_org.id, product_name) do
       case Devices.move(device, product, user) do
         {:ok, device} ->
-          device = preload_device(device)
+          device = Devices.get_by_identifier_with_deployment_and_release!(device.identifier)
 
           conn
           |> assign(:device, device)
@@ -219,13 +215,5 @@ defmodule NervesHubWeb.API.DeviceController do
           {:error, changeset}
       end
     end
-  end
-
-  defp preload_device(%{identifier: identifier}) do
-    Device
-    |> where(identifier: ^identifier)
-    |> Devices.join_and_preload_deployment_group_and_current_release()
-    |> preload([:org, :product, :latest_connection])
-    |> Repo.one!()
   end
 end

--- a/lib/nerves_hub_web/controllers/api/firmware_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/firmware_controller.ex
@@ -3,7 +3,6 @@ defmodule NervesHubWeb.API.FirmwareController do
   use OpenApiSpex.ControllerSpecs
 
   alias NervesHub.Firmwares
-  alias NervesHub.Repo
   alias NervesHubWeb.API.OpenAPI.SchemaHelpers
   alias NervesHubWeb.API.Schemas.ErrorSchemas
   alias NervesHubWeb.API.Schemas.FirmwareSchemas
@@ -54,7 +53,7 @@ defmodule NervesHubWeb.API.FirmwareController do
 
     with {%{path: filepath}, _params} <- Map.pop(params, "firmware"),
          {:ok, firmware} <- Firmwares.create_firmware(org, filepath) do
-      firmware = Repo.preload(firmware, :product)
+      firmware = Firmwares.preload_product(firmware)
 
       conn
       |> put_status(:created)

--- a/lib/nerves_hub_web/controllers/api/org_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/org_controller.ex
@@ -3,7 +3,6 @@ defmodule NervesHubWeb.API.OrgController do
   use OpenApiSpex.ControllerSpecs
 
   alias NervesHub.Accounts
-  alias NervesHub.Repo
   alias NervesHubWeb.API.OpenAPI.SchemaHelpers
   alias NervesHubWeb.API.Schemas.OrgSchemas.OrgListResponse
 
@@ -33,10 +32,7 @@ defmodule NervesHubWeb.API.OrgController do
   def index(%{assigns: %{current_scope: %{user: user}}} = conn, params) do
     preloads = parse_includes(params)
 
-    orgs =
-      user
-      |> Accounts.get_user_orgs()
-      |> Repo.preload(preloads)
+    orgs = Accounts.get_user_orgs(user, preloads)
 
     render(conn, :index, orgs: orgs)
   end

--- a/lib/nerves_hub_web/live/support_scripts/index.ex
+++ b/lib/nerves_hub_web/live/support_scripts/index.ex
@@ -1,7 +1,6 @@
 defmodule NervesHubWeb.Live.SupportScripts.Index do
   use NervesHubWeb, :live_view
 
-  alias NervesHub.Repo
   alias NervesHub.Scripts
   alias NervesHubWeb.Components.Sorting
 
@@ -120,11 +119,9 @@ defmodule NervesHubWeb.Live.SupportScripts.Index do
   def handle_event("delete-support-script", %{"script_id" => script_id}, socket) do
     authorized!(:"support_script:delete", socket.assigns.current_scope)
 
-    %{product: product} = socket.assigns
+    %{product: product, current_scope: %{user: user}} = socket.assigns
 
-    {:ok, script} = Scripts.get(product, script_id)
-
-    Repo.delete!(script)
+    {:ok, _script} = Scripts.delete(script_id, product, user)
 
     socket
     |> put_flash(:info, "Script deleted")


### PR DESCRIPTION
Third in the **stacked** context-cleanup series. **Base is the Phase 2 branch** (`cleanup/phase-2-deduplication`, #2874) — review/merge Phases 1 and 2 first.

Removes **every** direct `Repo.*` call and raw `Ecto.Query` from the web layer (8 sites across 6 files), moving each behind a context function so contexts own all DB access.

### New / extended context functions
| Function | Replaces |
|---|---|
| `Accounts.update_user_default_columns/3` | inline `User` changeset + `Repo.update` in `ListSettingsSidebar` |
| `Accounts.get_user_orgs/2` (now takes preloads) | `Repo.preload` in API `OrgController` |
| `Devices.preload_device_certificates/2` | 3× `Repo.preload` in the device settings tab |
| `Devices.get_by_identifier_with_deployment_and_release!/1` | raw identifier query run inline in API `DeviceController` (create/update/auth/move) |
| `Firmwares.preload_product/1` | `Repo.preload` in API `FirmwareController` |

`get_by_identifier_with_deployment_and_release!/1` was the **only external caller** of `join_and_preload_deployment_group_and_current_release/1`, so that helper is now **private** (a leftover from the Phase 1 analysis).

### Behavior note
Support-scripts deletion now goes through `Scripts.delete/3` instead of a raw `Repo.delete!`. **Deletions are now audit-logged**, matching `create`/`update` (previously silent). Full suite still green, so no test asserted the old silent behavior.

### Cleanup
Dropped the now-unused `import Ecto.Query` and `alias NervesHub.Repo`/`Device` from the touched web modules.

### Deferred to a later phase
Cross-context relocations (Products→Devices CSV export, Devices→Accounts signing keys, FirmwareUpdates→ManagedDeployments counter) are also encapsulation, but distinct from "web layer touches Repo" — left for a follow-up to keep this PR focused.

### Verification
- `mix format` ✓, credo (no new issues) ✓, dialyzer (0 unskipped) ✓
- **Full test suite: 1396 passing, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)