### PR TITLE
Context cleanup — Phase 4a: extract Devices.CACertificates sub-context

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -15,7 +15,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.DeploymentOrchestratorEvents
   alias NervesHub.DeviceEvents
   alias NervesHub.DeviceLink.DeviceInfo
-  alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceFiltering
@@ -529,96 +528,6 @@ defmodule NervesHub.Devices do
           | {:error, Changeset.t()}
   def delete_device_certificate(%DeviceCertificate{} = device_certificate) do
     Repo.delete(device_certificate)
-  end
-
-  @spec create_ca_certificate(Org.t(), map()) ::
-          {:ok, CACertificate.t()}
-          | {:error, Changeset.t()}
-  def create_ca_certificate(%Org{} = org, params) do
-    org
-    |> Ecto.build_assoc(:ca_certificates)
-    |> CACertificate.changeset(params)
-    |> Repo.insert()
-    |> case do
-      {:ok, ca_certificate} ->
-        {:ok, Repo.preload(ca_certificate, jitp: :product)}
-
-      err ->
-        err
-    end
-  end
-
-  @spec create_ca_certificate_from_x509(Org.t(), X509.Certificate.t(), binary() | nil) ::
-          {:ok, CACertificate.t()} | {:error, Ecto.Changeset.t()}
-  def create_ca_certificate_from_x509(%Org{} = org, otp_cert, description \\ nil) when is_tuple(otp_cert) do
-    {not_before, not_after} = Certificate.get_validity(otp_cert)
-
-    params = %{
-      serial: Certificate.get_serial_number(otp_cert),
-      aki: Certificate.get_aki(otp_cert),
-      ski: Certificate.get_ski(otp_cert),
-      not_before: not_before,
-      not_after: not_after,
-      der: X509.Certificate.to_der(otp_cert),
-      description: description
-    }
-
-    create_ca_certificate(org, params)
-  end
-
-  def get_ca_certificates(%Org{id: org_id}) do
-    from(ca in CACertificate, where: ca.org_id == ^org_id, preload: [jitp: :product])
-    |> Repo.all()
-  end
-
-  @spec get_ca_certificate_by_aki(binary) :: {:ok, CACertificate.t()} | {:error, any()}
-  def get_ca_certificate_by_aki(aki) do
-    from(CACertificate, where: [aki: ^aki], preload: [jitp: :product])
-    |> Repo.fetch()
-  end
-
-  @spec known_ca_ski?(binary) :: boolean()
-  def known_ca_ski?(ski) do
-    CACertificate
-    |> where(ski: ^ski)
-    |> Repo.exists?()
-  end
-
-  @spec get_ca_certificate_by_ski(binary) :: {:ok, CACertificate.t()} | {:error, any()}
-  def get_ca_certificate_by_ski(ski) do
-    CACertificate
-    |> join(:left, [cac], jitp in assoc(cac, :jitp))
-    |> join(:left, [_cac, jitp], p in assoc(jitp, :product))
-    |> where([cac], cac.ski == ^ski)
-    |> preload([_cac, jitp, p], jitp: {jitp, product: p})
-    |> Repo.fetch()
-  end
-
-  @spec get_ca_certificate_by_serial(binary) :: {:ok, CACertificate.t()} | {:error, any()}
-  def get_ca_certificate_by_serial(serial) do
-    from(CACertificate, where: [serial: ^serial], preload: [jitp: :product])
-    |> Repo.fetch()
-  end
-
-  @spec get_ca_certificate_by_org_and_serial(Org.t(), binary) ::
-          {:ok, CACertificate.t()} | {:error, any()}
-  def get_ca_certificate_by_org_and_serial(%Org{id: org_id}, serial) do
-    from(
-      ca in CACertificate,
-      where: ca.serial == ^serial and ca.org_id == ^org_id,
-      preload: [jitp: :product]
-    )
-    |> Repo.fetch()
-  end
-
-  def update_ca_certificate(%CACertificate{} = certificate, params) do
-    certificate
-    |> CACertificate.update_changeset(params)
-    |> Repo.update()
-  end
-
-  def delete_ca_certificate(%CACertificate{} = ca_certificate) do
-    Repo.delete(ca_certificate)
   end
 
   def clean_up_soft_deleted_devices() do

--- a/lib/nerves_hub/devices/ca_certificates.ex
+++ b/lib/nerves_hub/devices/ca_certificates.ex
@@ -1,0 +1,106 @@
+defmodule NervesHub.Devices.CACertificates do
+  @moduledoc """
+  Context for managing CA (certificate authority) certificates.
+
+  CA certificates are registered per organization and used to authenticate
+  devices (and to support just-in-time provisioning) during the TLS handshake.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias NervesHub.Accounts.Org
+  alias NervesHub.Certificate
+  alias NervesHub.Devices.CACertificate
+  alias NervesHub.Repo
+
+  @spec create_ca_certificate(Org.t(), map()) ::
+          {:ok, CACertificate.t()}
+          | {:error, Changeset.t()}
+  def create_ca_certificate(%Org{} = org, params) do
+    org
+    |> Ecto.build_assoc(:ca_certificates)
+    |> CACertificate.changeset(params)
+    |> Repo.insert()
+    |> case do
+      {:ok, ca_certificate} ->
+        {:ok, Repo.preload(ca_certificate, jitp: :product)}
+
+      err ->
+        err
+    end
+  end
+
+  @spec create_ca_certificate_from_x509(Org.t(), X509.Certificate.t(), binary() | nil) ::
+          {:ok, CACertificate.t()} | {:error, Ecto.Changeset.t()}
+  def create_ca_certificate_from_x509(%Org{} = org, otp_cert, description \\ nil) when is_tuple(otp_cert) do
+    {not_before, not_after} = Certificate.get_validity(otp_cert)
+
+    params = %{
+      serial: Certificate.get_serial_number(otp_cert),
+      aki: Certificate.get_aki(otp_cert),
+      ski: Certificate.get_ski(otp_cert),
+      not_before: not_before,
+      not_after: not_after,
+      der: X509.Certificate.to_der(otp_cert),
+      description: description
+    }
+
+    create_ca_certificate(org, params)
+  end
+
+  def get_ca_certificates(%Org{id: org_id}) do
+    from(ca in CACertificate, where: ca.org_id == ^org_id, preload: [jitp: :product])
+    |> Repo.all()
+  end
+
+  @spec get_ca_certificate_by_aki(binary) :: {:ok, CACertificate.t()} | {:error, any()}
+  def get_ca_certificate_by_aki(aki) do
+    from(CACertificate, where: [aki: ^aki], preload: [jitp: :product])
+    |> Repo.fetch()
+  end
+
+  @spec known_ca_ski?(binary) :: boolean()
+  def known_ca_ski?(ski) do
+    CACertificate
+    |> where(ski: ^ski)
+    |> Repo.exists?()
+  end
+
+  @spec get_ca_certificate_by_ski(binary) :: {:ok, CACertificate.t()} | {:error, any()}
+  def get_ca_certificate_by_ski(ski) do
+    CACertificate
+    |> join(:left, [cac], jitp in assoc(cac, :jitp))
+    |> join(:left, [_cac, jitp], p in assoc(jitp, :product))
+    |> where([cac], cac.ski == ^ski)
+    |> preload([_cac, jitp, p], jitp: {jitp, product: p})
+    |> Repo.fetch()
+  end
+
+  @spec get_ca_certificate_by_serial(binary) :: {:ok, CACertificate.t()} | {:error, any()}
+  def get_ca_certificate_by_serial(serial) do
+    from(CACertificate, where: [serial: ^serial], preload: [jitp: :product])
+    |> Repo.fetch()
+  end
+
+  @spec get_ca_certificate_by_org_and_serial(Org.t(), binary) ::
+          {:ok, CACertificate.t()} | {:error, any()}
+  def get_ca_certificate_by_org_and_serial(%Org{id: org_id}, serial) do
+    from(
+      ca in CACertificate,
+      where: ca.serial == ^serial and ca.org_id == ^org_id,
+      preload: [jitp: :product]
+    )
+    |> Repo.fetch()
+  end
+
+  def update_ca_certificate(%CACertificate{} = certificate, params) do
+    certificate
+    |> CACertificate.update_changeset(params)
+    |> Repo.update()
+  end
+
+  def delete_ca_certificate(%CACertificate{} = ca_certificate) do
+    Repo.delete(ca_certificate)
+  end
+end

--- a/lib/nerves_hub/devices/device_certificate.ex
+++ b/lib/nerves_hub/devices/device_certificate.ex
@@ -6,7 +6,7 @@ defmodule NervesHub.Devices.DeviceCertificate do
 
   alias NervesHub.Accounts.Org
   alias NervesHub.Certificate
-  alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Repo
@@ -107,7 +107,7 @@ defmodule NervesHub.Devices.DeviceCertificate do
   defp validate_aki(%{changes: %{aki: aki}} = changeset) do
     org_id = get_field(changeset, :org_id)
 
-    case Devices.get_ca_certificate_by_ski(aki) do
+    case CACertificates.get_ca_certificate_by_ski(aki) do
       {:ok, %{org_id: ^org_id}} ->
         changeset
 

--- a/lib/nerves_hub/ssl.ex
+++ b/lib/nerves_hub/ssl.ex
@@ -6,6 +6,7 @@ defmodule NervesHub.SSL do
   alias NervesHub.Certificate
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate.JITP
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Device
   alias X509.Certificate.Extension
 
@@ -58,7 +59,7 @@ defmodule NervesHub.SSL do
         # registration
         {:valid, state}
 
-      is_binary(ski) and Devices.known_ca_ski?(ski) ->
+      is_binary(ski) and CACertificates.known_ca_ski?(ski) ->
         # Signer CA sent with the device certificate, but is an intermediary
         # so the chain is incomplete labeling it as unknown_ca.
         #
@@ -193,11 +194,11 @@ defmodule NervesHub.SSL do
 
   defp check_known_ca(otp_cert) do
     Certificate.get_aki(otp_cert)
-    |> Devices.get_ca_certificate_by_ski()
+    |> CACertificates.get_ca_certificate_by_ski()
     |> case do
       {:ok, db_ca} ->
         # Mark that this CA cert was used
-        Devices.update_ca_certificate(db_ca, %{last_used: DateTime.utc_now()})
+        CACertificates.update_ca_certificate(db_ca, %{last_used: DateTime.utc_now()})
 
       _ ->
         :unknown_ca

--- a/lib/nerves_hub_web/controllers/api/ca_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/ca_certificate_controller.ex
@@ -3,8 +3,8 @@ defmodule NervesHubWeb.API.CACertificateController do
   use OpenApiSpex.ControllerSpecs
 
   alias NervesHub.Certificate
-  alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate.CSR
+  alias NervesHub.Devices.CACertificates
   alias NervesHubWeb.API.OpenAPI.SchemaHelpers
   alias NervesHubWeb.API.Schemas.CACertificateSchemas
   alias NervesHubWeb.API.Schemas.ErrorSchemas
@@ -34,7 +34,7 @@ defmodule NervesHubWeb.API.CACertificateController do
   )
 
   def index(%{assigns: %{current_scope: %{org: org}}} = conn, _params) do
-    ca_certificates = Devices.get_ca_certificates(org)
+    ca_certificates = CACertificates.get_ca_certificates(org)
     render(conn, :index, ca_certificates: ca_certificates)
   end
 
@@ -62,7 +62,7 @@ defmodule NervesHubWeb.API.CACertificateController do
   )
 
   def show(%{assigns: %{current_scope: %{org: org}}} = conn, %{"serial" => serial}) do
-    with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_org_and_serial(org, serial) do
+    with {:ok, ca_certificate} <- CACertificates.get_ca_certificate_by_org_and_serial(org, serial) do
       render(conn, :show, ca_certificate: ca_certificate)
     end
   end
@@ -136,7 +136,7 @@ defmodule NervesHubWeb.API.CACertificateController do
            description: Map.get(params, "description"),
            jitp: params["jitp"]
          },
-         {:ok, ca_cert} <- Devices.create_ca_certificate(org, params) do
+         {:ok, ca_cert} <- CACertificates.create_ca_certificate(org, params) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", ~p"/api/orgs/#{org.name}/ca_certificates/#{ca_cert.serial}")
@@ -181,8 +181,8 @@ defmodule NervesHubWeb.API.CACertificateController do
   )
 
   def delete(%{assigns: %{current_scope: %{org: org}}} = conn, %{"serial" => serial}) do
-    with {:ok, ca_certificate} <- Devices.get_ca_certificate_by_org_and_serial(org, serial),
-         {:ok, _ca_certificate} <- Devices.delete_ca_certificate(ca_certificate) do
+    with {:ok, ca_certificate} <- CACertificates.get_ca_certificate_by_org_and_serial(org, serial),
+         {:ok, _ca_certificate} <- CACertificates.delete_ca_certificate(ca_certificate) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/lib/nerves_hub_web/live/org/certificate_authorities.ex
+++ b/lib/nerves_hub_web/live/org/certificate_authorities.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.CACertificate.CSR
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Products
   alias NervesHubWeb.Components.CAHelpers
   alias NervesHubWeb.Components.Utils
@@ -51,7 +52,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
   defp apply_action(%{assigns: %{current_scope: scope}} = socket, :edit, %{"serial" => serial}) do
     products = Products.get_products(scope)
 
-    case Devices.get_ca_certificate_by_serial(serial) do
+    case CACertificates.get_ca_certificate_by_serial(serial) do
       {:ok, cert} ->
         changeset = Devices.CACertificate.changeset(cert, %{})
 
@@ -76,8 +77,8 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
     authorized!(:"certificate_authority:delete", socket.assigns.current_scope)
 
     with {:ok, ca_certificate} <-
-           Devices.get_ca_certificate_by_org_and_serial(socket.assigns.org, serial),
-         {:ok, _ca_certificate} <- Devices.delete_ca_certificate(ca_certificate) do
+           CACertificates.get_ca_certificate_by_org_and_serial(socket.assigns.org, serial),
+         {:ok, _ca_certificate} <- CACertificates.delete_ca_certificate(ca_certificate) do
       socket
       |> put_flash(:info, "Certificate successfully deleted")
       |> list_certificates()
@@ -96,9 +97,9 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
   def handle_event("update_certificate_authority", %{"ca_certificate" => ca_certificate}, socket) do
     authorized!(:"certificate_authority:update", socket.assigns.current_scope)
 
-    with {:ok, cert} <- Devices.get_ca_certificate_by_serial(socket.assigns.serial),
+    with {:ok, cert} <- CACertificates.get_ca_certificate_by_serial(socket.assigns.serial),
          {:ok, params} <- maybe_delete_jitp(ca_certificate),
-         {:ok, _cert} <- Devices.update_ca_certificate(cert, params) do
+         {:ok, _cert} <- CACertificates.update_ca_certificate(cert, params) do
       socket
       |> put_flash(:info, "Certificate Authority updated")
       |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
@@ -150,7 +151,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
            description: params["description"],
            jitp: params["jitp"]
          },
-         {:ok, _ca_certificate} <- Devices.create_ca_certificate(socket.assigns.org, params) do
+         {:ok, _ca_certificate} <- CACertificates.create_ca_certificate(socket.assigns.org, params) do
       socket
       |> put_flash(:info, "Certificate Authority created")
       |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
@@ -182,7 +183,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
   end
 
   defp list_certificates(socket) do
-    certificates = Devices.get_ca_certificates(socket.assigns.org)
+    certificates = CACertificates.get_ca_certificates(socket.assigns.org)
     assign(socket, :certificates, certificates)
   end
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -12,6 +12,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.CACertificate
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceConnection
@@ -822,7 +823,7 @@ defmodule NervesHub.DevicesTest do
       der: X509.Certificate.to_der(ca)
     }
 
-    assert {:ok, %CACertificate{org_id: ^org_id}} = Devices.create_ca_certificate(org, params)
+    assert {:ok, %CACertificate{org_id: ^org_id}} = CACertificates.create_ca_certificate(org, params)
   end
 
   test "cannot create ca certificates with duplicate serial numbers", %{org: org} do
@@ -842,8 +843,8 @@ defmodule NervesHub.DevicesTest do
       der: X509.Certificate.to_der(ca)
     }
 
-    assert {:ok, %CACertificate{org_id: ^org_id}} = Devices.create_ca_certificate(org, params)
-    assert {:error, %Changeset{}} = Devices.create_ca_certificate(org, params)
+    assert {:ok, %CACertificate{org_id: ^org_id}} = CACertificates.create_ca_certificate(org, params)
+    assert {:error, %Changeset{}} = CACertificates.create_ca_certificate(org, params)
   end
 
   test "can get certificate by aki", %{org: org} do
@@ -866,8 +867,8 @@ defmodule NervesHub.DevicesTest do
       der: X509.Certificate.to_der(ca)
     }
 
-    assert {:ok, %CACertificate{org_id: ^org_id}} = Devices.create_ca_certificate(org, params)
-    assert {:ok, %CACertificate{serial: ^serial}} = Devices.get_ca_certificate_by_aki(aki)
+    assert {:ok, %CACertificate{org_id: ^org_id}} = CACertificates.create_ca_certificate(org, params)
+    assert {:ok, %CACertificate{serial: ^serial}} = CACertificates.get_ca_certificate_by_aki(aki)
   end
 
   test "get_device_by_identifier with existing device", %{user: user, org: org, device: target_device} do

--- a/test/nerves_hub/ssl_test.exs
+++ b/test/nerves_hub/ssl_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHub.SSLTest do
   alias NervesHub.Certificate
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate.JITP
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Fixtures
   alias X509.Certificate.Validity
 
@@ -51,7 +52,7 @@ defmodule NervesHub.SSLTest do
 
     test "verifies when signer CA is expired", context do
       expired_ca = do_corruption(context.unknown_signer, :expired)
-      {:ok, _db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
+      {:ok, _db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
 
       %{db_cert: _db_cert} =
         Fixtures.device_certificate_fixture(context.device, context.unknown_cert)
@@ -127,7 +128,7 @@ defmodule NervesHub.SSLTest do
       assert {:fail, _state} = run_verify(intermediary_ca, {:bad_cert, :unknown_ca})
 
       # Register the intermediary signer CA
-      {:ok, _db_ca} = Devices.create_ca_certificate_from_x509(context.org, intermediary_ca)
+      {:ok, _db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, intermediary_ca)
 
       assert {:valid, _state} = run_verify(intermediary_ca, {:bad_cert, :unknown_ca})
     end
@@ -161,15 +162,15 @@ defmodule NervesHub.SSLTest do
     end
 
     test "rejects unknown Signer CA", context do
-      {:ok, _} = Devices.delete_ca_certificate(context.ca_db_cert)
+      {:ok, _} = CACertificates.delete_ca_certificate(context.ca_db_cert)
 
       assert {:fail, :unknown_ca} = run_verify(context.cert2)
     end
 
     test "rejects Signer CA from another org", context do
-      {:ok, _} = Devices.delete_ca_certificate(context.ca_db_cert)
+      {:ok, _} = CACertificates.delete_ca_certificate(context.ca_db_cert)
       new_org = Fixtures.org_fixture(context.user, %{name: "New-Org"})
-      {:ok, _db_ca} = Devices.create_ca_certificate_from_x509(new_org, context.ca_cert)
+      {:ok, _db_ca} = CACertificates.create_ca_certificate_from_x509(new_org, context.ca_cert)
 
       assert {:fail, :mismatched_org} = run_verify(context.cert2)
     end
@@ -186,10 +187,10 @@ defmodule NervesHub.SSLTest do
     end
 
     test "rejects registering when signer CA expired", context do
-      {:ok, _} = Devices.delete_ca_certificate(context.ca_db_cert)
+      {:ok, _} = CACertificates.delete_ca_certificate(context.ca_db_cert)
       expired_ca = do_corruption(context.ca_cert, :expired)
-      {:ok, db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
-      {:ok, db_ca} = Devices.update_ca_certificate(db_ca, %{check_expiration: true})
+      {:ok, db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
+      {:ok, db_ca} = CACertificates.update_ca_certificate(db_ca, %{check_expiration: true})
       assert is_nil(db_ca.last_used)
       assert {:fail, :cert_expired} = run_verify(context.cert2)
       refute is_nil(Fixtures.reload(db_ca).last_used)
@@ -202,10 +203,10 @@ defmodule NervesHub.SSLTest do
     end
 
     test "allows registering when signer CA expired and validity not enforced", context do
-      {:ok, _} = Devices.delete_ca_certificate(context.ca_db_cert)
+      {:ok, _} = CACertificates.delete_ca_certificate(context.ca_db_cert)
       expired_ca = do_corruption(context.ca_cert, :expired)
       # Validity not enforced by default
-      {:ok, db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
+      {:ok, db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
       assert is_nil(db_ca.last_used)
       assert {:valid, _} = run_verify(context.cert2)
       assert {:ok, _db_cert} = Devices.get_device_certificate_by_x509(context.cert2)
@@ -245,8 +246,8 @@ defmodule NervesHub.SSLTest do
 
     test "rejects registering when signer CA expired and validity enforced", context do
       expired_ca = do_corruption(context.unknown_signer, :expired)
-      {:ok, db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
-      {:ok, db_ca} = Devices.update_ca_certificate(db_ca, %{check_expiration: true})
+      {:ok, db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
+      {:ok, db_ca} = CACertificates.update_ca_certificate(db_ca, %{check_expiration: true})
       assert is_nil(db_ca.last_used)
       assert {:fail, :cert_expired} = run_verify(context.unknown_cert)
       refute is_nil(Fixtures.reload(db_ca).last_used)
@@ -255,7 +256,7 @@ defmodule NervesHub.SSLTest do
     test "allows registering when signer CA expired and validity not enforced", context do
       expired_ca = do_corruption(context.unknown_signer, :expired)
       # Validity not enforced by default
-      {:ok, db_ca} = Devices.create_ca_certificate_from_x509(context.org, expired_ca)
+      {:ok, db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
       assert is_nil(db_ca.last_used)
       assert {:valid, _} = run_verify(context.unknown_cert)
       assert {:ok, _db_cert} = Devices.get_device_certificate_by_x509(context.unknown_cert)
@@ -285,7 +286,7 @@ defmodule NervesHub.SSLTest do
       %{db_cert: _} = Fixtures.device_certificate_fixture(context.device, context.cert)
 
       # Make new CA known
-      {:ok, _db_ca} = Devices.create_ca_certificate_from_x509(context.org, context.unknown_signer)
+      {:ok, _db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, context.unknown_signer)
 
       # Use known CA which is a different public key
       assert {:fail, :unexpected_pubkey} = run_verify(context.unknown_cert)

--- a/test/nerves_hub_web/channels/websocket_test.exs
+++ b/test/nerves_hub_web/channels/websocket_test.exs
@@ -10,6 +10,7 @@ defmodule NervesHubWeb.WebsocketTest do
   alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
@@ -182,7 +183,7 @@ defmodule NervesHubWeb.WebsocketTest do
       serial = NervesHub.Certificate.get_serial_number(ca)
 
       # Ensure this signer CA does not exist in the DB
-      assert {:error, :not_found} = Devices.get_ca_certificate_by_serial(serial)
+      assert {:error, :not_found} = CACertificates.get_ca_certificate_by_serial(serial)
 
       key = X509.PrivateKey.new_ec(:secp256r1)
 
@@ -260,7 +261,7 @@ defmodule NervesHubWeb.WebsocketTest do
       serial = NervesHub.Certificate.get_serial_number(ca)
 
       # Ensure this signer CA does not exist in the DB
-      assert {:error, :not_found} = Devices.get_ca_certificate_by_serial(serial)
+      assert {:error, :not_found} = CACertificates.get_ca_certificate_by_serial(serial)
 
       key = X509.PrivateKey.new_ec(:secp256r1)
 
@@ -1209,7 +1210,7 @@ defmodule NervesHubWeb.WebsocketTest do
 
       assert_online_and_available(device)
 
-      [%{last_used: updated_last_used}] = Devices.get_ca_certificates(org)
+      [%{last_used: updated_last_used}] = CACertificates.get_ca_certificates(org)
 
       assert last_used != updated_last_used
 

--- a/test/nerves_hub_web/controllers/api/ca_certificate_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/ca_certificate_controller_test.exs
@@ -2,7 +2,7 @@ defmodule NervesHubWeb.API.CACertificateControllerTest do
   use NervesHubWeb.APIConnCase, async: true
 
   alias NervesHub.Certificate
-  alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
   alias X509.Certificate.Extension
 
   describe "index" do
@@ -200,7 +200,7 @@ defmodule NervesHubWeb.API.CACertificateControllerTest do
       }
       |> Map.merge(params)
 
-    {:ok, ca_certificate} = Devices.create_ca_certificate(org, params)
+    {:ok, ca_certificate} = CACertificates.create_ca_certificate(org, params)
     {:ok, %{ca_certificate: ca_certificate}}
   end
 end

--- a/test/nerves_hub_web/live/org/certificate_authorities_test.exs
+++ b/test/nerves_hub_web/live/org/certificate_authorities_test.exs
@@ -2,8 +2,8 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
   alias NervesHub.Certificate
-  alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate.CSR
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Fixtures
   alias NervesHubWeb.Components.Utils
 
@@ -58,7 +58,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       serial = Certificate.get_serial_number(ca)
 
       assert {:ok, %{description: ^description, serial: ^serial}} =
-               Devices.get_ca_certificate_by_serial(serial)
+               CACertificates.get_ca_certificate_by_serial(serial)
     end
 
     test "renders errors when cert is invalid", %{conn: conn, org: org, tmp_dir: tmp_dir} do
@@ -90,7 +90,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_path("/org/#{org.name}/settings/certificates/new")
       |> assert_has("div", text: "Certificate Authority pem file is empty or invalid")
 
-      assert [] = Devices.get_ca_certificates(org)
+      assert [] = CACertificates.get_ca_certificates(org)
     end
 
     test "renders errors when csr is invalid", %{conn: conn, org: org, tmp_dir: tmp_dir} do
@@ -118,7 +118,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
         text: "Error validating certificate signing request. Please check if the right registration code was used."
       )
 
-      assert [] = Devices.get_ca_certificates(org)
+      assert [] = CACertificates.get_ca_certificates(org)
     end
 
     @tag timeout: :infinity
@@ -169,7 +169,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
                 description: ^description,
                 serial: ^serial,
                 jitp: %{tags: ["prod"], description: "a jitp description"}
-              }} = Devices.get_ca_certificate_by_serial(serial)
+              }} = CACertificates.get_ca_certificate_by_serial(serial)
     end
   end
 
@@ -185,7 +185,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_has("div", text: "Certificate successfully deleted")
       |> refute_has("code", text: Utils.format_serial(ca.serial))
 
-      assert {:error, :not_found} = Devices.get_ca_certificate_by_serial(ca.serial)
+      assert {:error, :not_found} = CACertificates.get_ca_certificate_by_serial(ca.serial)
     end
   end
 
@@ -202,7 +202,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_has("div", text: "Certificate Authority updated")
 
       assert {:ok, %{description: "a new description", serial: ^serial}} =
-               Devices.get_ca_certificate_by_serial(serial)
+               CACertificates.get_ca_certificate_by_serial(serial)
     end
 
     test "update fails when description is blank", %{conn: conn, user: user, org: org} do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -8,6 +8,7 @@ defmodule NervesHub.Fixtures do
   alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.Certificate
   alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Firmwares
@@ -140,7 +141,7 @@ defmodule NervesHub.Fixtures do
       der: X509.Certificate.to_der(ca)
     }
 
-    {:ok, db_cert} = Devices.create_ca_certificate(org, params)
+    {:ok, db_cert} = CACertificates.create_ca_certificate(org, params)
     %{cert: ca, key: ca_key, db_cert: db_cert}
   end
 


### PR DESCRIPTION
First step of **Phase 4** — splitting the `Devices` god-module (129 public functions, ~1,900 lines) into focused sub-contexts. **Stacked on Phase 3** (`cleanup/phase-3-encapsulation`, #2876). Phase 4 ships as several small sub-PRs, one sub-context each, so review stays manageable.

### What moved
The 10 CA-certificate functions move out of `NervesHub.Devices` into a new, documented **`NervesHub.Devices.CACertificates`**:
`create_ca_certificate/2`, `create_ca_certificate_from_x509/3`, `get_ca_certificates/1`, `get_ca_certificate_by_aki/1`, `get_ca_certificate_by_ski/1`, `get_ca_certificate_by_serial/1`, `get_ca_certificate_by_org_and_serial/2`, `update_ca_certificate/2`, `delete_ca_certificate/1`, `known_ca_ski?/1`.

These operate on `Org`/`CACertificate` with **no `Device` involvement**, making them the most self-contained sub-domain to extract first.

### Approach
- **Function names unchanged** — only the module qualifier moved (`Devices.X` → `CACertificates.X`). This keeps the diff a pure move, not a rename.
- All **46 call sites** across `lib/` and `test/` repointed to the new module; now-unused `Devices` aliases dropped where applicable.
- New module carries a `@moduledoc`.

### Verification
- `mix format` ✓, credo (new module clean) ✓, dialyzer (0 unskipped) ✓
- **Full test suite: 1396 passing, 0 failures.**

### Next in Phase 4
`Devices.Health`, `Devices.Pinning`, `Devices.Certificates` (device certs), then the `Accounts` splits (OrgKeys / Invites / UserTokens / CLISessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)