### PR TITLE
Context cleanup — Phase 4b: extract Devices.Pinning sub-context

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -15,8 +15,8 @@ defmodule NervesHub.Accounts do
   alias NervesHub.Accounts.UserNotifier
   alias NervesHub.Accounts.UserToken
   alias NervesHub.CLISessionCache
-  alias NervesHub.Devices
   alias NervesHub.Devices.Device
+  alias NervesHub.Devices.Pinning
   alias NervesHub.Products.Product
   alias NervesHub.Repo
 
@@ -213,7 +213,7 @@ defmodule NervesHub.Accounts do
   def soft_delete_org_user(org_user) do
     with {:ok, %{org_id: org_id, user_id: user_id}} <-
            Repo.soft_delete(org_user),
-         {_, nil} <- Devices.unpin_org_devices(user_id, org_id) do
+         {_, nil} <- Pinning.unpin_org_devices(user_id, org_id) do
       :ok
     end
   end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -1599,63 +1599,6 @@ defmodule NervesHub.Devices do
     end)
   end
 
-  @spec get_pinned_devices(Scope.t()) :: [Device.t()]
-  def get_pinned_devices(%Scope{user: user}) when not is_nil(user) do
-    query =
-      PinnedDevice
-      |> where(user_id: ^user.id)
-      |> select([:device_id])
-
-    Device
-    |> where([d], d.id in subquery(query))
-    |> join(:left, [d], o in assoc(d, :org))
-    |> join(:left, [d, o], p in assoc(d, :product))
-    |> join(:left, [d, o, lc], lc in assoc(d, :latest_connection))
-    |> join(:left, [d, o, lc, lh], lh in assoc(d, :latest_health))
-    |> preload([d, o, p, lc, lh], org: o, product: p, latest_connection: lc, latest_health: lh)
-    |> Repo.all()
-  end
-
-  @spec pin_device(non_neg_integer(), non_neg_integer()) ::
-          {:ok, PinnedDevice.t()} | {:error, Ecto.Changeset.t()}
-  def pin_device(user_id, device_id) do
-    %{user_id: user_id, device_id: device_id}
-    |> PinnedDevice.create()
-    |> Repo.insert()
-  end
-
-  @spec unpin_device(neg_integer(), non_neg_integer()) ::
-          {:ok, PinnedDevice.t()} | {:error, Ecto.Changeset.t()}
-  def unpin_device(user_id, device_id) do
-    PinnedDevice
-    |> Repo.get_by!(user_id: user_id, device_id: device_id)
-    |> Repo.delete()
-  end
-
-  def device_pinned?(user_id, device_id) do
-    PinnedDevice
-    |> where([p], p.user_id == ^user_id)
-    |> where([p], p.device_id == ^device_id)
-    |> Repo.exists?()
-  end
-
-  @doc """
-  Unpins all devices belonging to user and org.
-  """
-  @spec unpin_org_devices(non_neg_integer(), non_neg_integer()) ::
-          {non_neg_integer(), nil | [term()]}
-  def unpin_org_devices(user_id, org_id) do
-    sub =
-      Device
-      |> where(org_id: ^org_id)
-      |> select([:id])
-
-    PinnedDevice
-    |> where([p], p.user_id == ^user_id)
-    |> where([p], p.device_id in subquery(sub))
-    |> Repo.delete_all()
-  end
-
   @doc """
   Get firmware or delta.
   """

--- a/lib/nerves_hub/devices/pinning.ex
+++ b/lib/nerves_hub/devices/pinning.ex
@@ -1,0 +1,72 @@
+defmodule NervesHub.Devices.Pinning do
+  @moduledoc """
+  Context for pinning devices to a user.
+
+  Pinned devices are surfaced to the user (e.g. on their orgs dashboard)
+  independently of the product they belong to.
+  """
+
+  import Ecto.Query
+
+  alias NervesHub.Accounts.Scope
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.PinnedDevice
+  alias NervesHub.Repo
+
+  @spec get_pinned_devices(Scope.t()) :: [Device.t()]
+  def get_pinned_devices(%Scope{user: user}) when not is_nil(user) do
+    query =
+      PinnedDevice
+      |> where(user_id: ^user.id)
+      |> select([:device_id])
+
+    Device
+    |> where([d], d.id in subquery(query))
+    |> join(:left, [d], o in assoc(d, :org))
+    |> join(:left, [d, o], p in assoc(d, :product))
+    |> join(:left, [d, o, lc], lc in assoc(d, :latest_connection))
+    |> join(:left, [d, o, lc, lh], lh in assoc(d, :latest_health))
+    |> preload([d, o, p, lc, lh], org: o, product: p, latest_connection: lc, latest_health: lh)
+    |> Repo.all()
+  end
+
+  @spec pin_device(non_neg_integer(), non_neg_integer()) ::
+          {:ok, PinnedDevice.t()} | {:error, Ecto.Changeset.t()}
+  def pin_device(user_id, device_id) do
+    %{user_id: user_id, device_id: device_id}
+    |> PinnedDevice.create()
+    |> Repo.insert()
+  end
+
+  @spec unpin_device(neg_integer(), non_neg_integer()) ::
+          {:ok, PinnedDevice.t()} | {:error, Ecto.Changeset.t()}
+  def unpin_device(user_id, device_id) do
+    PinnedDevice
+    |> Repo.get_by!(user_id: user_id, device_id: device_id)
+    |> Repo.delete()
+  end
+
+  def device_pinned?(user_id, device_id) do
+    PinnedDevice
+    |> where([p], p.user_id == ^user_id)
+    |> where([p], p.device_id == ^device_id)
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Unpins all devices belonging to user and org.
+  """
+  @spec unpin_org_devices(non_neg_integer(), non_neg_integer()) ::
+          {non_neg_integer(), nil | [term()]}
+  def unpin_org_devices(user_id, org_id) do
+    sub =
+      Device
+      |> where(org_id: ^org_id)
+      |> select([:id])
+
+    PinnedDevice
+    |> where([p], p.user_id == ^user_id)
+    |> where([p], p.device_id in subquery(sub))
+    |> Repo.delete_all()
+  end
+end

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Pinning
   alias NervesHub.Extensions.Health
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Tracker
@@ -57,7 +58,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> general_assigns(device)
     |> schedule_health_check_timer()
     |> load_inprogress_firmware_update()
-    |> assign(:pinned?, Devices.device_pinned?(user.id, device.id))
+    |> assign(:pinned?, Pinning.device_pinned?(user.id, device.id))
     |> setup_presence_tracking()
     |> setup_tab_components(@tab_components)
     |> ok()
@@ -192,7 +193,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   def handle_info(_unknown, socket), do: {:noreply, socket}
 
   def handle_event("pin", _value, %{assigns: %{user: user, device: device}} = socket) do
-    case Devices.pin_device(user.id, device.id) do
+    case Pinning.pin_device(user.id, device.id) do
       {:ok, _} ->
         socket
         |> assign(:pinned?, true)
@@ -208,7 +209,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   end
 
   def handle_event("unpin", _value, %{assigns: %{user: user, device: device}} = socket) do
-    case Devices.unpin_device(user.id, device.id) do
+    case Pinning.unpin_device(user.id, device.id) do
       {:ok, _} ->
         socket
         |> assign(:pinned?, false)

--- a/lib/nerves_hub_web/live/orgs/index.ex
+++ b/lib/nerves_hub_web/live/orgs/index.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWeb.Live.Orgs.Index do
   import Number.Delimit, only: [number_to_delimited: 2]
 
   alias NervesHub.Accounts
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Pinning
   alias NervesHub.Products
   alias NervesHub.Tracker
   alias NervesHubWeb.Components.PinnedDevices
@@ -14,7 +14,7 @@ defmodule NervesHubWeb.Live.Orgs.Index do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, %{assigns: %{current_scope: scope}} = socket) do
-    pinned_devices = Devices.get_pinned_devices(scope)
+    pinned_devices = Pinning.get_pinned_devices(scope)
 
     statuses =
       Map.new(pinned_devices, fn device ->

--- a/test/nerves_hub/devices/pinned_devices_test.exs
+++ b/test/nerves_hub/devices/pinned_devices_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
   alias NervesHub.Accounts.Scope
   alias NervesHub.Devices
   alias NervesHub.Devices.PinnedDevice
+  alias NervesHub.Devices.Pinning
   alias NervesHub.Fixtures
 
   setup %{tmp_dir: tmp_dir} do
@@ -32,7 +33,7 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
 
   test "Pin device", %{device: device, user: user} do
     assert {:ok, pinned} =
-             Devices.pin_device(user.id, device.id)
+             Pinning.pin_device(user.id, device.id)
 
     assert pinned.device_id == device.id
     assert pinned.user_id == user.id
@@ -40,28 +41,28 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
 
   test "Constraint on device and user", %{device: device, user: user} do
     assert {:error, _changeset} =
-             Devices.pin_device(user.id, 17)
+             Pinning.pin_device(user.id, 17)
 
     assert {:error, _changeset} =
-             Devices.pin_device(2, device.id)
+             Pinning.pin_device(2, device.id)
   end
 
   test "Get pinned devices for user", %{user: user, device: device} do
     {:ok, _} =
-      Devices.pin_device(user.id, device.id)
+      Pinning.pin_device(user.id, device.id)
 
     devices =
       Scope.for_user(user)
-      |> Devices.get_pinned_devices()
+      |> Pinning.get_pinned_devices()
 
     assert length(devices) == 1
   end
 
   test "Unpin device", %{device: device, user: user} do
     assert {:ok, _} =
-             Devices.pin_device(user.id, device.id)
+             Pinning.pin_device(user.id, device.id)
 
-    {:ok, %PinnedDevice{}} = Devices.unpin_device(user.id, device.id)
+    {:ok, %PinnedDevice{}} = Pinning.unpin_device(user.id, device.id)
   end
 
   test "Move device to new org - unpin if user has no access to new org", %{
@@ -70,11 +71,11 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
     product2: product2
   } do
     assert {:ok, _} =
-             Devices.pin_device(user.id, device.id)
+             Pinning.pin_device(user.id, device.id)
 
     pinned_devices =
       Scope.for_user(user)
-      |> Devices.get_pinned_devices()
+      |> Pinning.get_pinned_devices()
 
     assert length(pinned_devices) == 1
 
@@ -84,7 +85,7 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
     # Assert device is unpinned for unauthorized user
     assert [] ==
              Scope.for_user(user)
-             |> Devices.get_pinned_devices()
+             |> Pinning.get_pinned_devices()
   end
 
   test "Unpin devices when org access for user is revoked", %{
@@ -96,11 +97,11 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
     Accounts.add_org_user(org, user2, %{role: :view})
 
     assert {:ok, _} =
-             Devices.pin_device(user2.id, device.id)
+             Pinning.pin_device(user2.id, device.id)
 
     pinned_devices =
       Scope.for_user(user2)
-      |> Devices.get_pinned_devices()
+      |> Pinning.get_pinned_devices()
 
     assert length(pinned_devices) == 1
 
@@ -110,16 +111,16 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
     # Assert user has no pinned devices
     assert [] =
              Scope.for_user(user2)
-             |> Devices.get_pinned_devices()
+             |> Pinning.get_pinned_devices()
   end
 
   test "Remove entries when user is soft-deleted", %{user: user, device: device} do
     assert {:ok, _} =
-             Devices.pin_device(user.id, device.id)
+             Pinning.pin_device(user.id, device.id)
 
     pinned_devices =
       Scope.for_user(user)
-      |> Devices.get_pinned_devices()
+      |> Pinning.get_pinned_devices()
 
     assert length(pinned_devices) == 1
 
@@ -128,17 +129,17 @@ defmodule NervesHub.Devices.PinnedDevicesTest do
 
     assert [] =
              Scope.for_user(user)
-             |> Devices.get_pinned_devices()
+             |> Pinning.get_pinned_devices()
   end
 
   test "Remove entries when device is (soft)deleted", %{user: user, device: device} do
     assert {:ok, _} =
-             Devices.pin_device(user.id, device.id)
+             Pinning.pin_device(user.id, device.id)
 
     Devices.delete_device(device)
 
     assert [] =
              Scope.for_user(user)
-             |> Devices.get_pinned_devices()
+             |> Pinning.get_pinned_devices()
   end
 end


### PR DESCRIPTION
Second step of **Phase 4** (splitting the `Devices` god-module). **Stacked on Phase 4a** (`cleanup/phase-4a-devices-cacertificates`, #2877).

### What moved
The five user-facing device-pinning functions move out of `NervesHub.Devices` into a new, documented **`NervesHub.Devices.Pinning`**:
`get_pinned_devices/1`, `pin_device/2`, `unpin_device/2`, `device_pinned?/2`, `unpin_org_devices/2`.

The `PinnedDevice` schema stays referenced by `Devices` (for the non-pinning pinned-status join and device cleanup), so only the dedicated pinning **operations** moved.

### Approach
- Function names unchanged; **23 call sites** across `lib/` and `test/` repointed.
- Dropped the now-unused `Devices` alias from `Accounts` and the orgs-index LiveView.

### Verification
- `mix format` ✓, credo (new module clean) ✓, dialyzer (0 unskipped) ✓
- **Full test suite: 1396 passing, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)