### PR TITLE
Context cleanup — Phase 4c: extract Devices.Health sub-context

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -8,6 +8,7 @@
   {"lib/nerves_hub/accounts.ex", :call_without_opaque},
   {"lib/nerves_hub/accounts/remove_account.ex", :call_without_opaque},
   {"lib/nerves_hub/devices.ex", :call_without_opaque},
+  {"lib/nerves_hub/devices/health.ex", :call_without_opaque},
   {"lib/nerves_hub_web/components/layouts.ex", :call},
   {"lib/nerves_hub_web/components/layouts.ex", :no_return}
 ]

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -20,7 +20,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Devices.DeviceFirmwares
-  alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Devices.PinnedDevice
   alias NervesHub.Devices.SharedSecretAuth
@@ -1440,57 +1439,6 @@ defmodule NervesHub.Devices do
     end
   end
 
-  @spec save_device_health(health_report :: map()) ::
-          {:ok, DeviceHealth.t()} | {:error, Ecto.Changeset.t()}
-  def save_device_health(device_status) do
-    Multi.new()
-    |> Multi.insert(:insert_health, DeviceHealth.save(device_status))
-    |> Ecto.Multi.update_all(:update_device, &update_health_on_device/1, [])
-    |> Repo.transact()
-    |> case do
-      {:ok, %{insert_health: health}} ->
-        {:ok, health}
-
-      {:error, _, changeset, _} ->
-        {:error, changeset}
-    end
-  end
-
-  defp update_health_on_device(%{insert_health: health}) do
-    Device
-    |> where(id: ^health.device_id)
-    |> update(set: [latest_health_id: ^health.id])
-  end
-
-  def truncate_device_health() do
-    interval =
-      Application.get_env(:nerves_hub, :device_health_days_to_retain)
-
-    delete_limit = Application.get_env(:nerves_hub, :device_health_delete_limit)
-    time_ago = DateTime.shift(DateTime.utc_now(), day: -interval)
-
-    query =
-      DeviceHealth
-      |> join(:inner, [dh], d in Device, on: dh.device_id == d.id)
-      |> where([dh, _d], dh.inserted_at < ^time_ago)
-      |> where([dh, d], dh.id != d.latest_health_id)
-      |> select([dh], dh.id)
-      |> limit(^delete_limit)
-
-    {delete_count, _} =
-      DeviceHealth
-      |> where([dh], dh.id in subquery(query))
-      |> Repo.delete_all(timeout: 30_000)
-
-    if delete_count == 0 do
-      :ok
-    else
-      # relax stress on Ecto pool and go again
-      Process.sleep(2000)
-      truncate_device_health()
-    end
-  end
-
   defp version_match?(_vsn, ""), do: true
 
   defp version_match?(version, requirement) do
@@ -1706,15 +1654,6 @@ defmodule NervesHub.Devices do
   def total_count(product) do
     Device
     |> where(product_id: ^product.id)
-    |> Repo.exclude_deleted()
-    |> Repo.aggregate(:count)
-  end
-
-  def health_status_count(product, status) do
-    Device
-    |> join(:inner, [d], lh in assoc(d, :latest_health))
-    |> where(product_id: ^product.id)
-    |> where([_, lh], lh.status == ^status)
     |> Repo.exclude_deleted()
     |> Repo.aggregate(:count)
   end

--- a/lib/nerves_hub/devices/health.ex
+++ b/lib/nerves_hub/devices/health.ex
@@ -1,0 +1,76 @@
+defmodule NervesHub.Devices.Health do
+  @moduledoc """
+  Context for recording and querying device health.
+
+  Health reports are stored as `DeviceHealth` rows; the most recent report is
+  denormalized onto the device as `latest_health`. Old reports are periodically
+  truncated.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.DeviceHealth
+  alias NervesHub.Repo
+
+  @spec save_device_health(health_report :: map()) ::
+          {:ok, DeviceHealth.t()} | {:error, Ecto.Changeset.t()}
+  def save_device_health(device_status) do
+    Multi.new()
+    |> Multi.insert(:insert_health, DeviceHealth.save(device_status))
+    |> Ecto.Multi.update_all(:update_device, &update_health_on_device/1, [])
+    |> Repo.transact()
+    |> case do
+      {:ok, %{insert_health: health}} ->
+        {:ok, health}
+
+      {:error, _, changeset, _} ->
+        {:error, changeset}
+    end
+  end
+
+  defp update_health_on_device(%{insert_health: health}) do
+    Device
+    |> where(id: ^health.device_id)
+    |> update(set: [latest_health_id: ^health.id])
+  end
+
+  def truncate_device_health() do
+    interval =
+      Application.get_env(:nerves_hub, :device_health_days_to_retain)
+
+    delete_limit = Application.get_env(:nerves_hub, :device_health_delete_limit)
+    time_ago = DateTime.shift(DateTime.utc_now(), day: -interval)
+
+    query =
+      DeviceHealth
+      |> join(:inner, [dh], d in Device, on: dh.device_id == d.id)
+      |> where([dh, _d], dh.inserted_at < ^time_ago)
+      |> where([dh, d], dh.id != d.latest_health_id)
+      |> select([dh], dh.id)
+      |> limit(^delete_limit)
+
+    {delete_count, _} =
+      DeviceHealth
+      |> where([dh], dh.id in subquery(query))
+      |> Repo.delete_all(timeout: 30_000)
+
+    if delete_count == 0 do
+      :ok
+    else
+      # relax stress on Ecto pool and go again
+      Process.sleep(2000)
+      truncate_device_health()
+    end
+  end
+
+  def health_status_count(product, status) do
+    Device
+    |> join(:inner, [d], lh in assoc(d, :latest_health))
+    |> where(product_id: ^product.id)
+    |> where([_, lh], lh.status == ^status)
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+end

--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -2,7 +2,7 @@ defmodule NervesHub.Extensions.Health do
   @behaviour NervesHub.Extensions
 
   alias NervesHub.DeviceLink.DeviceInfo
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Health
   alias NervesHub.Devices.HealthStatus
   alias NervesHub.Devices.Metrics
   alias NervesHub.Helpers.Logging
@@ -73,7 +73,7 @@ defmodule NervesHub.Extensions.Health do
     }
 
     with {:health_report, {:ok, _}} <-
-           {:health_report, Devices.save_device_health(device_health)},
+           {:health_report, Health.save_device_health(device_health)},
          {:metrics_report, {:ok, _}} <-
            {:metrics_report, Metrics.save_metrics(socket.assigns.device_info.device_id, metrics)} do
       :ok = device_internal_broadcast!(socket.assigns.device_info, "health_check_report", %{})

--- a/lib/nerves_hub/workers/device_health_truncation.ex
+++ b/lib/nerves_hub/workers/device_health_truncation.ex
@@ -10,12 +10,12 @@ defmodule NervesHub.Workers.DeviceHealthTruncation do
     queue: :cleanup,
     max_attempts: 1
 
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Health
   alias NervesHub.Devices.Metrics
 
   @impl Oban.Worker
   def perform(_) do
-    :ok = Devices.truncate_device_health()
+    :ok = Health.truncate_device_health()
     {:ok, _} = Metrics.truncate_device_metrics()
 
     :ok

--- a/lib/nerves_hub_web/live/product/insights.ex
+++ b/lib/nerves_hub_web/live/product/insights.ex
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.Live.Product.Insights do
 
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Health
   alias NervesHub.ProductNotifications
   alias NervesHub.Products
 
@@ -145,10 +146,10 @@ defmodule NervesHubWeb.Live.Product.Insights do
 
   defp fleet_health_information(%{assigns: %{current_scope: scope}} = socket) do
     socket
-    |> assign(:healthy_count, Devices.health_status_count(scope.product, :healthy))
-    |> assign(:warning_count, Devices.health_status_count(scope.product, :warning))
-    |> assign(:unhealthy_count, Devices.health_status_count(scope.product, :unhealthy))
-    |> assign(:unknown_count, Devices.health_status_count(scope.product, :unknown))
+    |> assign(:healthy_count, Health.health_status_count(scope.product, :healthy))
+    |> assign(:warning_count, Health.health_status_count(scope.product, :warning))
+    |> assign(:unhealthy_count, Health.health_status_count(scope.product, :unhealthy))
+    |> assign(:unknown_count, Health.health_status_count(scope.product, :unknown))
     |> then(fn %{assigns: assigns} = socket ->
       total = assigns.healthy_count + assigns.warning_count + assigns.unhealthy_count + assigns.unknown_count
       assign(socket, :total_health_count, total)

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -18,6 +18,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Devices.DeviceHealth
+  alias NervesHub.Devices.Health
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Firmware
@@ -361,7 +362,7 @@ defmodule NervesHub.DevicesTest do
 
   test "destroy_device", %{device: device} do
     {:ok, _} =
-      Devices.save_device_health(%{
+      Health.save_device_health(%{
         "device_id" => device.id,
         "data" => %{},
         "status" => :healthy,
@@ -1222,7 +1223,7 @@ defmodule NervesHub.DevicesTest do
       device_health = %{"device_id" => device.id, "data" => %{"literally_any_map" => "values"}}
 
       assert {:ok, %Devices.DeviceHealth{id: health_id}} =
-               Devices.save_device_health(device_health)
+               Health.save_device_health(device_health)
 
       # Assert device is updated with latest health
       assert %{latest_health_id: ^health_id} = Devices.get_device(device.id)

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -10,6 +10,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.Health
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
@@ -398,7 +399,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       device2 = Fixtures.device_fixture(org, product, firmware)
 
       {:ok, _} =
-        Devices.save_device_health(%{
+        Health.save_device_health(%{
           "device_id" => device2.id,
           "data" => %{},
           "status" => :healthy,
@@ -649,7 +650,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       device2 = Fixtures.device_fixture(org, product, firmware)
 
       device_health = %{"device_id" => device.id, "data" => %{"alarms" => %{"SomeAlarm" => []}}}
-      assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
+      assert {:ok, _} = Health.save_device_health(device_health)
 
       conn
       |> visit(device_index_path(fixture))
@@ -669,7 +670,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       device2 = Fixtures.device_fixture(org, product, firmware)
 
       device_health = %{"device_id" => device.id, "data" => %{"alarms" => %{"SomeAlarm" => []}}}
-      assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
+      assert {:ok, _} = Health.save_device_health(device_health)
 
       conn
       |> visit(device_index_path(fixture))
@@ -690,7 +691,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
 
       alarm = "SomeAlarm"
       device_health = %{"device_id" => device.id, "data" => %{"alarms" => %{alarm => []}}}
-      assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
+      assert {:ok, _} = Health.save_device_health(device_health)
 
       conn
       |> visit(device_index_path(fixture))

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -13,6 +13,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.Health
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Devices.Metrics
   alias NervesHub.Firmwares
@@ -609,7 +610,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         "data" => %{"alarms" => %{"SomeAlarm" => "Some description"}}
       }
 
-      assert {:ok, _} = NervesHub.Devices.save_device_health(device_health)
+      assert {:ok, _} = Health.save_device_health(device_health)
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -632,7 +633,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> assert_has("div", text: "No Alarms Received")
 
       assert {:ok, _} =
-               NervesHub.Devices.save_device_health(%{
+               Health.save_device_health(%{
                  "device_id" => device.id,
                  "data" => %{"alarms" => %{}}
                })

--- a/test/nerves_hub_web/live/new_ui/devices/index_test.exs
+++ b/test/nerves_hub_web/live/new_ui/devices/index_test.exs
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
 
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
+  alias NervesHub.Devices.Health
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHub.Repo
@@ -181,7 +182,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       device2 = Fixtures.device_fixture(org, product, firmware)
 
       {:ok, _} =
-        Devices.save_device_health(%{
+        Health.save_device_health(%{
           "device_id" => device2.id,
           "data" => %{},
           "status" => :healthy,
@@ -212,7 +213,7 @@ defmodule NervesHubWeb.Live.NewUI.Devices.IndexTest do
       device2 = Fixtures.device_fixture(org, product, firmware, %{tags: ["foo", "bar"]})
 
       {:ok, _} =
-        Devices.save_device_health(%{
+        Health.save_device_health(%{
           "device_id" => device2.id,
           "data" => %{},
           "status" => :healthy,

--- a/test/nerves_hub_web/live/product/insights_test.exs
+++ b/test/nerves_hub_web/live/product/insights_test.exs
@@ -3,7 +3,7 @@ defmodule NervesHubWeb.Live.Product.InsightsTest do
 
   import Phoenix.LiveViewTest
 
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Health
   alias NervesHub.Fixtures
   alias NervesHub.ProductNotifications
 
@@ -24,7 +24,7 @@ defmodule NervesHubWeb.Live.Product.InsightsTest do
 
   defp set_health(device, status) do
     {:ok, _} =
-      Devices.save_device_health(%{
+      Health.save_device_health(%{
         "device_id" => device.id,
         "data" => %{},
         "status" => status,

--- a/test/support/advanced_query_fixtures.ex
+++ b/test/support/advanced_query_fixtures.ex
@@ -17,8 +17,8 @@ defmodule NervesHub.AdvancedQueryFixtures do
   test name.
   """
 
-  alias NervesHub.Devices
   alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Devices.Health
   alias NervesHub.Fixtures
   alias NervesHub.Repo
 
@@ -73,7 +73,7 @@ defmodule NervesHub.AdvancedQueryFixtures do
   @doc "Saves a health record (and updates the device's latest health)."
   def save_health(device, status, data \\ %{}) do
     {:ok, _} =
-      Devices.save_device_health(%{
+      Health.save_device_health(%{
         "device_id" => device.id,
         "data" => data,
         "status" => status,


### PR DESCRIPTION
Third step of **Phase 4** (splitting the `Devices` god-module). **Stacked on Phase 4b** (`cleanup/phase-4b-devices-pinning`, #2878).

### What moved
The device-health functions move out of `NervesHub.Devices` into a new, documented **`NervesHub.Devices.Health`**:
`save_device_health/1`, `truncate_device_health/0`, `health_status_count/2` (plus the private `update_health_on_device/1`). The now-unused `DeviceHealth` alias is dropped from `Devices`.

### Approach
- Function names unchanged; call sites across `lib/` and `test/` repointed, dropping now-unused `Devices` aliases where applicable.
- Adds a `.dialyzer_ignore.exs` entry for the new module path — `save_device_health` uses an `Ecto.Multi` chain, which triggers the same known false-positive `:call_without_opaque` warning already ignored for `devices.ex` (the ignore file is path-based).

### Verification
- `mix format` ✓, credo (new module clean) ✓, dialyzer (0 unskipped) ✓
- Full suite: **1396 passing** (2 unrelated `ConnectionHistoryTest` failures in the full run were a `DBConnection` sandbox-ownership flake — the file passes 19/19 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)