### PR TITLE
Context cleanup — Phase 4d: extract Devices.Certificates sub-context

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -11,7 +11,6 @@ defmodule NervesHub.Devices do
   alias NervesHub.Accounts.User
   alias NervesHub.AuditLogs
   alias NervesHub.AuditLogs.DeviceTemplates
-  alias NervesHub.Certificate
   alias NervesHub.DeploymentOrchestratorEvents
   alias NervesHub.DeviceEvents
   alias NervesHub.DeviceLink.DeviceInfo
@@ -278,13 +277,6 @@ defmodule NervesHub.Devices do
     |> Repo.one!()
   end
 
-  @doc """
-  Preloads a device's certificates. Pass `force: true` to reload them.
-  """
-  def preload_device_certificates(%Device{} = device, opts \\ []) do
-    Repo.preload(device, :device_certificates, opts)
-  end
-
   defp join_and_preload_deployment_group_and_current_release(query) do
     query
     |> join(:left, [d], dp in assoc(d, :deployment_group), as: :deployment_group)
@@ -329,17 +321,6 @@ defmodule NervesHub.Devices do
     query
     |> join(:left, [d], p in assoc(d, :product), as: :product)
     |> preload([product: p], product: p)
-  end
-
-  def get_device_by_x509(cert) do
-    fingerprint = NervesHub.Certificate.fingerprint(cert)
-
-    Device
-    |> join(:inner, [d], p in assoc(d, :product))
-    |> join(:inner, [d], dc in assoc(d, :device_certificates))
-    |> where([_, _, dc], dc.fingerprint == ^fingerprint)
-    |> preload([_d, p], product: p)
-    |> Repo.fetch()
   end
 
   @spec get_shared_secret_auth(String.t()) ::
@@ -420,113 +401,6 @@ defmodule NervesHub.Devices do
 
   def destroy_device(%Device{} = device) do
     Repo.delete(device)
-  end
-
-  @spec create_device_certificate(Device.t(), map() | X509.Certificate.t()) ::
-          {:ok, DeviceCertificate.t()}
-          | {:error, Changeset.t()}
-  def create_device_certificate(%Device{} = device, otp_cert) when is_tuple(otp_cert) do
-    {nb, na} = Certificate.get_validity(otp_cert)
-
-    params = %{
-      aki: Certificate.get_aki(otp_cert),
-      der: Certificate.to_der(otp_cert),
-      not_after: na,
-      not_before: nb,
-      serial: Certificate.get_serial_number(otp_cert),
-      ski: Certificate.get_ski(otp_cert)
-    }
-
-    create_device_certificate(device, params)
-  end
-
-  def create_device_certificate(%Device{} = device, params) do
-    params = Map.put(params, :org_id, device.org_id)
-
-    changeset =
-      device
-      |> Ecto.build_assoc(:device_certificates)
-      |> DeviceCertificate.changeset(params)
-
-    case Repo.insert(changeset) do
-      {:ok, device_certificate} ->
-        :telemetry.execute([:nerves_hub, :device_certificates, :created], %{count: 1})
-
-        {:ok, device_certificate}
-
-      {:error, error} ->
-        {:error, error}
-    end
-  end
-
-  def has_device_certificates?(%Device{} = device) do
-    DeviceCertificate
-    |> join(:inner, [dc], d in assoc(dc, :device))
-    |> where([_dc, d], d.id == ^device.id)
-    |> Repo.exists?()
-  end
-
-  def get_device_certificates(%Device{} = device) do
-    DeviceCertificate
-    |> join(:inner, [dc], d in assoc(dc, :device))
-    |> where([_dc, d], d.id == ^device.id)
-    |> Repo.all()
-  end
-
-  @spec get_device_by_certificate(DeviceCertificate.t()) ::
-          {:ok, Device.t()} | {:error, :not_found}
-  def get_device_by_certificate(%DeviceCertificate{device: %Ecto.Association.NotLoaded{}} = cert) do
-    Repo.preload(cert, :device)
-    |> get_device_by_certificate()
-  end
-
-  def get_device_by_certificate(%DeviceCertificate{device: %Device{} = device}), do: {:ok, Repo.preload(device, :org)}
-
-  def get_device_by_certificate(_), do: {:error, :not_found}
-
-  def get_device_certificate_by_x509(cert) do
-    fingerprint = NervesHub.Certificate.fingerprint(cert)
-
-    DeviceCertificate
-    |> where(fingerprint: ^fingerprint)
-    |> join(:inner, [dc], d in assoc(dc, :device))
-    |> preload([_dc, d], device: d)
-    |> Repo.fetch()
-  end
-
-  def get_device_by_public_key(otp_cert) do
-    pk_fingerprint = NervesHub.Certificate.public_key_fingerprint(otp_cert)
-
-    Device
-    |> join(:inner, [d], dc in assoc(d, :device_certificates))
-    |> where([_d, dc], dc.public_key_fingerprint == ^pk_fingerprint)
-    |> Repo.one()
-  end
-
-  @spec get_device_certificate_by_device_and_serial(Device.t(), binary) ::
-          {:ok, DeviceCertificate.t()} | {:error, any()}
-  def get_device_certificate_by_device_and_serial(%Device{id: device_id}, serial) do
-    query =
-      from(
-        dc in DeviceCertificate,
-        where: dc.serial == ^serial and dc.device_id == ^device_id
-      )
-
-    query
-    |> Repo.fetch()
-  end
-
-  def update_device_certificate(%DeviceCertificate{} = certificate, params) do
-    certificate
-    |> DeviceCertificate.update_changeset(params)
-    |> Repo.update()
-  end
-
-  @spec delete_device_certificate(DeviceCertificate.t()) ::
-          {:ok, DeviceCertificate.t()}
-          | {:error, Changeset.t()}
-  def delete_device_certificate(%DeviceCertificate{} = device_certificate) do
-    Repo.delete(device_certificate)
   end
 
   def clean_up_soft_deleted_devices() do

--- a/lib/nerves_hub/devices/bulk_actions.ex
+++ b/lib/nerves_hub/devices/bulk_actions.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Devices.BulkActions do
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkImport
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.Device
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
@@ -62,7 +63,7 @@ defmodule NervesHub.Devices.BulkActions do
         with {:ok, device} <- Repo.insert(changeset),
              {:ok, pem} <- details.pem,
              {:ok, otp_cert} <- Certificate.from_pem_or_der(pem),
-             {:ok, _db_cert} <- Devices.create_device_certificate(device, otp_cert) do
+             {:ok, _db_cert} <- Certificates.create_device_certificate(device, otp_cert) do
           {:ok, device}
         end
       end)

--- a/lib/nerves_hub/devices/certificates.ex
+++ b/lib/nerves_hub/devices/certificates.ex
@@ -1,0 +1,141 @@
+defmodule NervesHub.Devices.Certificates do
+  @moduledoc """
+  Context for managing device certificates.
+
+  Device certificates are used to authenticate a device during the TLS
+  handshake and to look a device up from a presented X.509 certificate.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias NervesHub.Certificate
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.DeviceCertificate
+  alias NervesHub.Repo
+
+  @spec create_device_certificate(Device.t(), map() | X509.Certificate.t()) ::
+          {:ok, DeviceCertificate.t()}
+          | {:error, Changeset.t()}
+  def create_device_certificate(%Device{} = device, otp_cert) when is_tuple(otp_cert) do
+    {nb, na} = Certificate.get_validity(otp_cert)
+
+    params = %{
+      aki: Certificate.get_aki(otp_cert),
+      der: Certificate.to_der(otp_cert),
+      not_after: na,
+      not_before: nb,
+      serial: Certificate.get_serial_number(otp_cert),
+      ski: Certificate.get_ski(otp_cert)
+    }
+
+    create_device_certificate(device, params)
+  end
+
+  def create_device_certificate(%Device{} = device, params) do
+    params = Map.put(params, :org_id, device.org_id)
+
+    changeset =
+      device
+      |> Ecto.build_assoc(:device_certificates)
+      |> DeviceCertificate.changeset(params)
+
+    case Repo.insert(changeset) do
+      {:ok, device_certificate} ->
+        :telemetry.execute([:nerves_hub, :device_certificates, :created], %{count: 1})
+
+        {:ok, device_certificate}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  def has_device_certificates?(%Device{} = device) do
+    DeviceCertificate
+    |> join(:inner, [dc], d in assoc(dc, :device))
+    |> where([_dc, d], d.id == ^device.id)
+    |> Repo.exists?()
+  end
+
+  def get_device_certificates(%Device{} = device) do
+    DeviceCertificate
+    |> join(:inner, [dc], d in assoc(dc, :device))
+    |> where([_dc, d], d.id == ^device.id)
+    |> Repo.all()
+  end
+
+  @doc """
+  Preloads a device's certificates. Pass `force: true` to reload them.
+  """
+  def preload_device_certificates(%Device{} = device, opts \\ []) do
+    Repo.preload(device, :device_certificates, opts)
+  end
+
+  @spec get_device_by_certificate(DeviceCertificate.t()) ::
+          {:ok, Device.t()} | {:error, :not_found}
+  def get_device_by_certificate(%DeviceCertificate{device: %Ecto.Association.NotLoaded{}} = cert) do
+    Repo.preload(cert, :device)
+    |> get_device_by_certificate()
+  end
+
+  def get_device_by_certificate(%DeviceCertificate{device: %Device{} = device}), do: {:ok, Repo.preload(device, :org)}
+
+  def get_device_by_certificate(_), do: {:error, :not_found}
+
+  def get_device_by_x509(cert) do
+    fingerprint = Certificate.fingerprint(cert)
+
+    Device
+    |> join(:inner, [d], p in assoc(d, :product))
+    |> join(:inner, [d], dc in assoc(d, :device_certificates))
+    |> where([_, _, dc], dc.fingerprint == ^fingerprint)
+    |> preload([_d, p], product: p)
+    |> Repo.fetch()
+  end
+
+  def get_device_certificate_by_x509(cert) do
+    fingerprint = Certificate.fingerprint(cert)
+
+    DeviceCertificate
+    |> where(fingerprint: ^fingerprint)
+    |> join(:inner, [dc], d in assoc(dc, :device))
+    |> preload([_dc, d], device: d)
+    |> Repo.fetch()
+  end
+
+  def get_device_by_public_key(otp_cert) do
+    pk_fingerprint = Certificate.public_key_fingerprint(otp_cert)
+
+    Device
+    |> join(:inner, [d], dc in assoc(d, :device_certificates))
+    |> where([_d, dc], dc.public_key_fingerprint == ^pk_fingerprint)
+    |> Repo.one()
+  end
+
+  @spec get_device_certificate_by_device_and_serial(Device.t(), binary) ::
+          {:ok, DeviceCertificate.t()} | {:error, any()}
+  def get_device_certificate_by_device_and_serial(%Device{id: device_id}, serial) do
+    query =
+      from(
+        dc in DeviceCertificate,
+        where: dc.serial == ^serial and dc.device_id == ^device_id
+      )
+
+    query
+    |> Repo.fetch()
+  end
+
+  def update_device_certificate(%DeviceCertificate{} = certificate, params) do
+    certificate
+    |> DeviceCertificate.update_changeset(params)
+    |> Repo.update()
+  end
+
+  @spec delete_device_certificate(DeviceCertificate.t()) ::
+          {:ok, DeviceCertificate.t()}
+          | {:error, Changeset.t()}
+  def delete_device_certificate(%DeviceCertificate{} = device_certificate) do
+    Repo.delete(device_certificate)
+  end
+end

--- a/lib/nerves_hub/ssl.ex
+++ b/lib/nerves_hub/ssl.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.SSL do
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate.JITP
   alias NervesHub.Devices.CACertificates
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.Device
   alias X509.Certificate.Extension
 
@@ -107,9 +108,9 @@ defmodule NervesHub.SSL do
     # We have always been ignoring expiration if we already have
     # the certificate stored, but in the future there might be reasons
     # to consider expirations for existing
-    case Devices.get_device_certificate_by_x509(otp_cert) do
+    case Certificates.get_device_certificate_by_x509(otp_cert) do
       {:ok, %{device: %{deleted_at: nil}} = db_cert} ->
-        Devices.update_device_certificate(db_cert, %{last_used: DateTime.utc_now()})
+        Certificates.update_device_certificate(db_cert, %{last_used: DateTime.utc_now()})
 
       {:ok, _db_cert} ->
         :ignore_deleted_device
@@ -120,7 +121,7 @@ defmodule NervesHub.SSL do
   end
 
   defp maybe_register(otp_cert) do
-    case Devices.get_device_by_public_key(otp_cert) do
+    case Certificates.get_device_by_public_key(otp_cert) do
       nil ->
         maybe_register_from_new_public_key(otp_cert)
 
@@ -143,7 +144,7 @@ defmodule NervesHub.SSL do
          {:ok, device} <- maybe_jitp_device(cn, db_ca),
          :ok <- check_new_public_key_allowed(device) do
       params = params_from_otp_cert(otp_cert)
-      Devices.create_device_certificate(device, params)
+      Certificates.create_device_certificate(device, params)
     end
   end
 
@@ -160,7 +161,7 @@ defmodule NervesHub.SSL do
          {:ok, _} <-
            :public_key.pkix_path_validation(db_ca.der, [der], verify_fun: {&path_verify/3, verify_state}) do
       params = params_from_otp_cert(otp_cert)
-      Devices.create_device_certificate(device, params)
+      Certificates.create_device_certificate(device, params)
     end
   end
 
@@ -248,7 +249,7 @@ defmodule NervesHub.SSL do
   end
 
   defp check_new_public_key_allowed(device) do
-    case Devices.has_device_certificates?(device) do
+    case Certificates.has_device_certificates?(device) do
       true ->
         # TODO: Support device allowing multiple public keys?
         #

--- a/lib/nerves_hub_web/channels/device_socket.ex
+++ b/lib/nerves_hub_web/channels/device_socket.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.DeviceSocket do
 
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.ProductNotifications
@@ -99,7 +100,7 @@ defmodule NervesHubWeb.DeviceSocket do
   @decorate with_span("Channels.DeviceSocket.connect:cert_auth")
   def connect(_params, socket, %{peer_data: %{ssl_cert: ssl_cert}}) when not is_nil(ssl_cert) do
     X509.Certificate.from_der!(ssl_cert)
-    |> Devices.get_device_by_x509()
+    |> Certificates.get_device_by_x509()
     |> case do
       {:ok, device} ->
         socket_and_assigns(socket, device)

--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
 
   alias NervesHub.Certificate
   alias NervesHub.Devices
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.Device
   alias NervesHub.Extensions
   alias NervesHubWeb.Components.Utils
@@ -24,7 +25,7 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   end
 
   def render(assigns) do
-    device = Devices.preload_device_certificates(assigns.device, force: true)
+    device = Certificates.preload_device_certificates(assigns.device, force: true)
 
     assigns = Map.put(assigns, :device, device)
 
@@ -368,11 +369,11 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   def hooked_event("validate-cert", _, socket), do: {:halt, socket}
 
   def hooked_event("delete-certificate", %{"serial" => serial}, %{assigns: %{device: device}} = socket) do
-    device = %{device_certificates: certs} = Devices.preload_device_certificates(device)
+    device = %{device_certificates: certs} = Certificates.preload_device_certificates(device)
 
     db_cert = Enum.find(certs, &(&1.serial == serial))
 
-    case Devices.delete_device_certificate(db_cert) do
+    case Certificates.delete_device_certificate(db_cert) do
       {:ok, _db_cert} ->
         updated_certs = Enum.reject(certs, &(&1.serial == serial))
 
@@ -438,8 +439,8 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   defp import_cert(%{assigns: %{device: device}} = socket, path) do
     with {:ok, pem_or_der} <- File.read(path),
          {:ok, otp_cert} <- Certificate.from_pem_or_der(pem_or_der),
-         {:ok, _db_cert} <- Devices.create_device_certificate(device, otp_cert) do
-      updated = Devices.preload_device_certificates(device)
+         {:ok, _db_cert} <- Certificates.create_device_certificate(device, otp_cert) do
+      updated = Certificates.preload_device_certificates(device)
 
       assign(socket, :device, updated)
       |> put_flash(:info, "Certificate Upload Successful")

--- a/lib/nerves_hub_web/controllers/api/device_certificate_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_certificate_controller.ex
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
 
   alias NervesHub.Certificate
   alias NervesHub.Devices
+  alias NervesHub.Devices.Certificates
   alias NervesHubWeb.API.OpenAPI.SchemaHelpers
   alias NervesHubWeb.API.Schemas.DeviceCertificateSchemas
   alias NervesHubWeb.API.Schemas.ErrorSchemas
@@ -48,7 +49,7 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
 
   def index(%{assigns: %{current_scope: scope}} = conn, %{"identifier" => identifier}) do
     with {:ok, device} <- Devices.get_by_identifier(scope, identifier) do
-      device_certificates = Devices.get_device_certificates(device)
+      device_certificates = Certificates.get_device_certificates(device)
       render(conn, :index, device_certificates: device_certificates)
     end
   end
@@ -92,7 +93,7 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
 
   def show(%{assigns: %{device: device}} = conn, %{"serial" => serial}) do
     with {:ok, device_certificate} <-
-           Devices.get_device_certificate_by_device_and_serial(device, serial) do
+           Certificates.get_device_certificate_by_device_and_serial(device, serial) do
       render(conn, :show, device_certificate: device_certificate)
     end
   end
@@ -148,7 +149,7 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
            not_after: not_after,
            der: X509.Certificate.to_der(cert)
          },
-         {:ok, device_certificate} <- Devices.create_device_certificate(device, params) do
+         {:ok, device_certificate} <- Certificates.create_device_certificate(device, params) do
       conn
       |> put_status(:created)
       |> put_resp_header(
@@ -209,8 +210,8 @@ defmodule NervesHubWeb.API.DeviceCertificateController do
 
   def delete(%{assigns: %{device: device}} = conn, %{"serial" => serial}) do
     with {:ok, device_certificate} <-
-           Devices.get_device_certificate_by_device_and_serial(device, serial),
-         {:ok, _device_certificate} <- Devices.delete_device_certificate(device_certificate) do
+           Certificates.get_device_certificate_by_device_and_serial(device, serial),
+         {:ok, _device_certificate} <- Certificates.delete_device_certificate(device_certificate) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.API.DeviceController do
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Firmwares
   alias NervesHub.Products
@@ -117,7 +118,7 @@ defmodule NervesHubWeb.API.DeviceController do
     with {:ok, cert_pem} <- Base.decode64(cert64),
          {:ok, cert} <- X509.Certificate.from_pem(cert_pem),
          {:ok, %DeviceCertificate{device_id: device_id}} <-
-           Devices.get_device_certificate_by_x509(cert),
+           Certificates.get_device_certificate_by_x509(cert),
          {:ok, device} <- Devices.get_device_by_org(org, device_id) do
       device = Devices.get_by_identifier_with_deployment_and_release!(device.identifier)
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -13,6 +13,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.CACertificates
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceConnection
@@ -684,10 +685,10 @@ defmodule NervesHub.DevicesTest do
   end
 
   test "delete_device deletes its certificates", %{device: device} do
-    [_cert] = Devices.get_device_certificates(device)
+    [_cert] = Certificates.get_device_certificates(device)
 
     {:ok, _device} = Devices.delete_device(device)
-    assert [] = Devices.get_device_certificates(device)
+    assert [] = Certificates.get_device_certificates(device)
   end
 
   test "create_device with invalid parameters", %{firmware: firmware} do
@@ -733,7 +734,7 @@ defmodule NervesHub.DevicesTest do
     }
 
     assert {:ok, %DeviceCertificate{device_id: ^device_id}} =
-             Devices.create_device_certificate(device, params)
+             Certificates.create_device_certificate(device, params)
   end
 
   test "create device certificate without subject key id", %{device: device, cert: cert} do
@@ -750,7 +751,7 @@ defmodule NervesHub.DevicesTest do
     }
 
     assert {:ok, %DeviceCertificate{device_id: ^device_id}} =
-             Devices.create_device_certificate(device, params)
+             Certificates.create_device_certificate(device, params)
   end
 
   test "select one device when it has two certificates", %{
@@ -772,10 +773,10 @@ defmodule NervesHub.DevicesTest do
     expected_id = device.id
 
     assert {:ok, %DeviceCertificate{} = db_cert2} =
-             Devices.create_device_certificate(device, params)
+             Certificates.create_device_certificate(device, params)
 
-    assert {:ok, %{id: ^expected_id}} = Devices.get_device_by_certificate(db_cert2)
-    assert {:ok, %{id: ^expected_id}} = Devices.get_device_by_certificate(db_cert)
+    assert {:ok, %{id: ^expected_id}} = Certificates.get_device_by_certificate(db_cert2)
+    assert {:ok, %{id: ^expected_id}} = Certificates.get_device_by_certificate(db_cert)
   end
 
   test "cannot create device certificates with duplicate serial numbers", %{
@@ -794,8 +795,8 @@ defmodule NervesHub.DevicesTest do
       der: X509.Certificate.to_der(cert)
     }
 
-    assert {:ok, %DeviceCertificate{}} = Devices.create_device_certificate(device, params)
-    assert {:error, %Changeset{}} = Devices.create_device_certificate(device, params)
+    assert {:ok, %DeviceCertificate{}} = Certificates.create_device_certificate(device, params)
+    assert {:error, %Changeset{}} = Certificates.create_device_certificate(device, params)
   end
 
   test "cannot create device certificates with invalid parameters", %{device: device} do
@@ -804,7 +805,7 @@ defmodule NervesHub.DevicesTest do
       device_id: device.id
     }
 
-    assert {:error, %Changeset{}} = Devices.create_device_certificate(device, params)
+    assert {:error, %Changeset{}} = Certificates.create_device_certificate(device, params)
   end
 
   test "create ca certificate with valid params", %{org: org} do

--- a/test/nerves_hub/ssl_test.exs
+++ b/test/nerves_hub/ssl_test.exs
@@ -6,6 +6,7 @@ defmodule NervesHub.SSLTest do
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificate.JITP
   alias NervesHub.Devices.CACertificates
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Fixtures
   alias X509.Certificate.Validity
 
@@ -209,13 +210,13 @@ defmodule NervesHub.SSLTest do
       {:ok, db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
       assert is_nil(db_ca.last_used)
       assert {:valid, _} = run_verify(context.cert2)
-      assert {:ok, _db_cert} = Devices.get_device_certificate_by_x509(context.cert2)
+      assert {:ok, _db_cert} = Certificates.get_device_certificate_by_x509(context.cert2)
     end
 
     test "registers a valid certificate", context do
-      assert {:error, :not_found} = Devices.get_device_certificate_by_x509(context.cert2)
+      assert {:error, :not_found} = Certificates.get_device_certificate_by_x509(context.cert2)
       assert {:valid, _} = run_verify(context.cert2)
-      assert {:ok, _db_cert} = Devices.get_device_certificate_by_x509(context.cert2)
+      assert {:ok, _db_cert} = Certificates.get_device_certificate_by_x509(context.cert2)
     end
   end
 
@@ -259,7 +260,7 @@ defmodule NervesHub.SSLTest do
       {:ok, db_ca} = CACertificates.create_ca_certificate_from_x509(context.org, expired_ca)
       assert is_nil(db_ca.last_used)
       assert {:valid, _} = run_verify(context.unknown_cert)
-      assert {:ok, _db_cert} = Devices.get_device_certificate_by_x509(context.unknown_cert)
+      assert {:ok, _db_cert} = Certificates.get_device_certificate_by_x509(context.unknown_cert)
     end
 
     test "rejects registering when signature bad", context do
@@ -321,9 +322,9 @@ defmodule NervesHub.SSLTest do
     end
 
     test "registers a valid certificate", context do
-      assert {:error, :not_found} = Devices.get_device_certificate_by_x509(context.cert)
+      assert {:error, :not_found} = Certificates.get_device_certificate_by_x509(context.cert)
       assert {:valid, _} = run_verify(context.cert)
-      assert {:ok, _db_cert} = Devices.get_device_certificate_by_x509(context.cert)
+      assert {:ok, _db_cert} = Certificates.get_device_certificate_by_x509(context.cert)
     end
   end
 

--- a/test/nerves_hub_web/controllers/api/device_certificate_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/device_certificate_controller_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.API.DeviceCertificateControllerTest do
 
   alias NervesHub.Certificate
   alias NervesHub.Devices
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Fixtures
 
   setup %{org: org, product: product} do
@@ -80,7 +81,7 @@ defmodule NervesHubWeb.API.DeviceCertificateControllerTest do
       assert json_response(conn, 200)["data"]["serial"] == serial
 
       otp_certificate = X509.Certificate.from_pem!(pem)
-      {:ok, db_cert} = Devices.get_device_certificate_by_x509(otp_certificate)
+      {:ok, db_cert} = Certificates.get_device_certificate_by_x509(otp_certificate)
 
       assert db_cert.der == Certificate.to_der(otp_certificate)
       assert db_cert.fingerprint == Certificate.fingerprint(otp_certificate)

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.DeviceControllerTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Fixtures
 
   setup %{user: user, org: org} do
@@ -14,7 +15,7 @@ defmodule NervesHubWeb.DeviceControllerTest do
       product: product,
       device: device
     } do
-      [cert | _] = NervesHub.Devices.Certificates.get_device_certificates(device)
+      [cert | _] = Certificates.get_device_certificates(device)
 
       conn = get(conn, ~p"/org/#{org}/#{product}/devices/#{device}/certificate/#{cert.serial}/download")
 

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -14,7 +14,7 @@ defmodule NervesHubWeb.DeviceControllerTest do
       product: product,
       device: device
     } do
-      [cert | _] = NervesHub.Devices.get_device_certificates(device)
+      [cert | _] = NervesHub.Devices.Certificates.get_device_certificates(device)
 
       conn = get(conn, ~p"/org/#{org}/#{product}/devices/#{device}/certificate/#{cert.serial}/download")
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -9,6 +9,7 @@ defmodule NervesHub.Fixtures do
   alias NervesHub.Certificate
   alias NervesHub.Devices
   alias NervesHub.Devices.CACertificates
+  alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Firmwares
@@ -403,7 +404,7 @@ defmodule NervesHub.Fixtures do
       der: der
     }
 
-    {:ok, device_cert} = Devices.create_device_certificate(device, params)
+    {:ok, device_cert} = Certificates.create_device_certificate(device, params)
     %{db_cert: device_cert, cert: cert}
   end
 


### PR DESCRIPTION
Final step of **Phase 4** (splitting the `Devices` god-module). **Stacked on Phase 4c** (`cleanup/phase-4c-devices-health`, #2879).

### What moved
The 11 device-certificate functions move out of `NervesHub.Devices` into a new, documented **`NervesHub.Devices.Certificates`**:
`create_device_certificate/2`, `has_device_certificates?/1`, `get_device_certificates/1`, `preload_device_certificates/2`, `get_device_by_certificate/1`, `get_device_by_x509/1`, `get_device_certificate_by_x509/1`, `get_device_by_public_key/1`, `get_device_certificate_by_device_and_serial/2`, `update_device_certificate/2`, `delete_device_certificate/1`.

### Approach
- Function names unchanged; **37 call sites** across 11 `lib/`+`test/` files repointed.
- `DeviceCertificate` schema stays referenced by `Devices` (soft-delete cleanup query); the now-unused `Certificate` alias is dropped from `Devices`.

### Milestone
With this, the four `Devices` sub-domains — **CACertificates** (4a), **Pinning** (4b), **Health** (4c), **Certificates** (4d) — are each in their own module.

### Verification
- `mix format` ✓, credo (new module clean) ✓, dialyzer (0 unskipped) ✓
- **Full test suite: 1396 passing, 0 failures.**

### Next (paused for review)
The `Accounts` splits (`OrgKeys` / `Invites` / `UserTokens` / `CLISessions`) remain — paused here so the Devices split can be reviewed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)