### PR TITLE
Context cleanup — Phase 4e: move firmware/delta resolution to Firmwares

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -29,11 +29,9 @@ defmodule NervesHub.Devices do
   alias NervesHub.Firmwares.Firmware
   alias NervesHub.Firmwares.FirmwareDelta
   alias NervesHub.Firmwares.FirmwareMetadata
-  alias NervesHub.Firmwares.UpdateTool.Fwup
   alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
-  alias NervesHub.ManagedDeployments.DeploymentRelease
   alias NervesHub.ProductNotifications
   alias NervesHub.Products
   alias NervesHub.Products.Product
@@ -726,7 +724,7 @@ defmodule NervesHub.Devices do
   def resolve_update(device, deployment_group, opts) do
     case verify_update_eligibility(device, deployment_group) do
       {:ok, _device} ->
-        case get_delta_or_firmware(device, deployment_group) do
+        case Firmwares.get_delta_or_firmware(device, deployment_group) do
           {:ok, firmware_or_delta} ->
             {:ok, meta} = Firmwares.metadata_from_firmware(deployment_group.current_release.firmware)
 
@@ -760,52 +758,6 @@ defmodule NervesHub.Devices do
       {:error, :updates_blocked, _device} ->
         %UpdatePayload{update_available: false}
     end
-  end
-
-  @doc """
-  Returns true if the device is delta updatable.
-
-  Checks update tool version information and similar metadata to determine if
-  the device is delta updatable.
-  """
-  @spec delta_updatable?(Device.t(), DeploymentGroup.t() | Firmware.t()) :: boolean()
-  def delta_updatable?(device, %DeploymentGroup{} = deployment_group) do
-    Logger.metadata(device_id: device.id, deployment_group_id: deployment_group.id)
-    # note that source delta does not need delta markers to be updatable
-    # Any advanced decision about whether to delta update or not are delegated
-    # to the specialized update tool implementation
-
-    deployment_group.delta_updatable and
-      not is_nil(deployment_group.current_release.firmware) and
-      delta_updatable?(device, deployment_group.current_release.firmware)
-  end
-
-  def delta_updatable?(%{firmware_metadata: fw_meta} = device, %Firmware{} = firmware) do
-    Logger.metadata(
-      device_id: device.id,
-      target_firmware_uuid: firmware.uuid,
-      source_firmware_uuid: Map.get(fw_meta, :uuid)
-    )
-
-    firmware.delta_updatable and
-      :delta == update_tool().device_update_type(device, firmware)
-  end
-
-  @spec delta_ready?(Device.t(), Firmware.t()) :: boolean()
-  def delta_ready?(%Device{firmware_metadata: %{uuid: source_uuid}}, %Firmware{id: target_id, product_id: product_id}) do
-    source_firmware_id_query =
-      Firmware
-      |> where(uuid: ^source_uuid)
-      |> where(product_id: ^product_id)
-      |> select([f], f.id)
-
-    query =
-      FirmwareDelta
-      |> where([fd], fd.source_id == subquery(source_firmware_id_query))
-      |> where([fd], fd.target_id == ^target_id)
-      |> where([fd], fd.status == :completed)
-
-    Repo.exists?(query)
   end
 
   @doc """
@@ -1424,65 +1376,6 @@ defmodule NervesHub.Devices do
   @doc """
   Get firmware or delta.
   """
-  @spec get_delta_or_firmware(Device.t(), DeploymentGroup.t()) ::
-          {:ok, Firmware.t()} | {:ok, FirmwareDelta.t()}
-  def get_delta_or_firmware(%Device{firmware_metadata: %{uuid: source_uuid}} = device, %DeploymentGroup{
-        delta_updatable: true,
-        current_release: %DeploymentRelease{firmware: %Firmware{delta_updatable: true} = target_firmware}
-      }) do
-    case Firmwares.get_firmware_by_product_id_and_uuid(device.product_id, source_uuid) do
-      {:ok, source_firmware} ->
-        case get_delta_if_ready(device, source_firmware, target_firmware) do
-          {:ok, delta} ->
-            {:ok, delta}
-
-          _ ->
-            {:ok, target_firmware}
-        end
-
-      {:error, :not_found} ->
-        {:ok, target_firmware}
-    end
-  end
-
-  def get_delta_or_firmware(%Device{}, %DeploymentGroup{current_release: %{firmware: target}}), do: {:ok, target}
-
-  @spec get_delta_if_ready(Device.t(), Firmware.t(), Firmware.t()) ::
-          {:ok, FirmwareDelta.t()}
-          | {:device_delta_updatable, false}
-          | {:delta, {:ok, FirmwareDelta.t()}}
-          | {:delta, {:error, :not_found}}
-  defp get_delta_if_ready(device, source_firmware, target_firmware) do
-    with {:device_delta_updatable, true} <-
-           {:device_delta_updatable, delta_updatable?(device, target_firmware)},
-         {:delta, {:ok, %{status: :completed} = delta}} <-
-           {:delta,
-            Firmwares.get_firmware_delta_by_source_and_target(
-              source_firmware.id,
-              target_firmware.id
-            )} do
-      {:ok, delta}
-    end
-  end
-
-  @spec get_delta_url(Device.t(), Firmware.t()) ::
-          {:ok, String.t()}
-          | {:error, :failure}
-  def get_delta_url(%Device{firmware_metadata: %{uuid: source_uuid}}, %Firmware{id: target_id, product_id: product_id}) do
-    source_firmware_id_query =
-      Firmware
-      |> where(uuid: ^source_uuid)
-      |> where(product_id: ^product_id)
-      |> select([f], f.id)
-
-    delta =
-      FirmwareDelta
-      |> where([fd], fd.source_id == subquery(source_firmware_id_query))
-      |> where([fd], fd.target_id == ^target_id)
-      |> Repo.one()
-
-    Firmwares.get_firmware_url(delta)
-  end
 
   @spec soft_deleted_devices_exist_for_product?(non_neg_integer()) :: boolean()
   def soft_deleted_devices_exist_for_product?(product_id) do
@@ -1530,14 +1423,5 @@ defmodule NervesHub.Devices do
     |> where(product_id: ^product.id)
     |> Repo.exclude_deleted()
     |> Repo.aggregate(:count)
-  end
-
-  defp update_tool() do
-    Application.get_env(
-      :nerves_hub,
-      :update_tool,
-      # Fall back to old config key
-      Application.get_env(:nerves_hub, :delta_updater, Fwup)
-    )
   end
 end

--- a/lib/nerves_hub/events/device_events.ex
+++ b/lib/nerves_hub/events/device_events.ex
@@ -102,7 +102,7 @@ defmodule NervesHub.DeviceEvents do
     Repo.transact(fn ->
       url =
         if opts[:delta] do
-          {:ok, url} = Devices.get_delta_url(device, firmware)
+          {:ok, url} = Firmwares.get_delta_url(device, firmware)
           url
         else
           {:ok, url} = Firmwares.get_firmware_url(firmware)

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -14,6 +14,7 @@ defmodule NervesHub.Firmwares do
   alias NervesHub.Helpers.Logging
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.ManagedDeployments.DeploymentRelease
   alias NervesHub.Products
   alias NervesHub.Products.Product
   alias NervesHub.Repo
@@ -517,6 +518,108 @@ defmodule NervesHub.Firmwares do
           | {:error, :failure}
   def get_firmware_url(fw_or_delta) do
     firmware_upload_config().download_file(fw_or_delta)
+  end
+
+  @doc """
+  Returns true if the device is delta updatable.
+
+  Checks update tool version information and similar metadata to determine if
+  the device is delta updatable.
+  """
+  @spec delta_updatable?(Device.t(), DeploymentGroup.t() | Firmware.t()) :: boolean()
+  def delta_updatable?(device, %DeploymentGroup{} = deployment_group) do
+    Logger.metadata(device_id: device.id, deployment_group_id: deployment_group.id)
+    # note that source delta does not need delta markers to be updatable
+    # Any advanced decision about whether to delta update or not are delegated
+    # to the specialized update tool implementation
+
+    deployment_group.delta_updatable and
+      not is_nil(deployment_group.current_release.firmware) and
+      delta_updatable?(device, deployment_group.current_release.firmware)
+  end
+
+  def delta_updatable?(%{firmware_metadata: fw_meta} = device, %Firmware{} = firmware) do
+    Logger.metadata(
+      device_id: device.id,
+      target_firmware_uuid: firmware.uuid,
+      source_firmware_uuid: Map.get(fw_meta, :uuid)
+    )
+
+    firmware.delta_updatable and
+      :delta == update_tool().device_update_type(device, firmware)
+  end
+
+  @spec delta_ready?(Device.t(), Firmware.t()) :: boolean()
+  def delta_ready?(%Device{firmware_metadata: %{uuid: source_uuid}}, %Firmware{id: target_id, product_id: product_id}) do
+    source_uuid
+    |> firmware_delta_query(product_id, target_id)
+    |> where([fd], fd.status == :completed)
+    |> Repo.exists?()
+  end
+
+  @spec get_delta_or_firmware(Device.t(), DeploymentGroup.t()) ::
+          {:ok, Firmware.t()} | {:ok, FirmwareDelta.t()}
+  def get_delta_or_firmware(%Device{firmware_metadata: %{uuid: source_uuid}} = device, %DeploymentGroup{
+        delta_updatable: true,
+        current_release: %DeploymentRelease{firmware: %Firmware{delta_updatable: true} = target_firmware}
+      }) do
+    case get_firmware_by_product_id_and_uuid(device.product_id, source_uuid) do
+      {:ok, source_firmware} ->
+        case get_delta_if_ready(device, source_firmware, target_firmware) do
+          {:ok, delta} ->
+            {:ok, delta}
+
+          _ ->
+            {:ok, target_firmware}
+        end
+
+      {:error, :not_found} ->
+        {:ok, target_firmware}
+    end
+  end
+
+  def get_delta_or_firmware(%Device{}, %DeploymentGroup{current_release: %{firmware: target}}), do: {:ok, target}
+
+  @spec get_delta_url(Device.t(), Firmware.t()) ::
+          {:ok, String.t()}
+          | {:error, :failure}
+  def get_delta_url(%Device{firmware_metadata: %{uuid: source_uuid}}, %Firmware{id: target_id, product_id: product_id}) do
+    source_uuid
+    |> firmware_delta_query(product_id, target_id)
+    |> Repo.one()
+    |> get_firmware_url()
+  end
+
+  @spec get_delta_if_ready(Device.t(), Firmware.t(), Firmware.t()) ::
+          {:ok, FirmwareDelta.t()}
+          | {:device_delta_updatable, false}
+          | {:delta, {:ok, FirmwareDelta.t()}}
+          | {:delta, {:error, :not_found}}
+  defp get_delta_if_ready(device, source_firmware, target_firmware) do
+    with {:device_delta_updatable, true} <-
+           {:device_delta_updatable, delta_updatable?(device, target_firmware)},
+         {:delta, {:ok, %{status: :completed} = delta}} <-
+           {:delta,
+            get_firmware_delta_by_source_and_target(
+              source_firmware.id,
+              target_firmware.id
+            )} do
+      {:ok, delta}
+    end
+  end
+
+  # Builds the FirmwareDelta query from the device's current (source) firmware
+  # UUID to the target firmware id. Shared by delta_ready?/2 and get_delta_url/2.
+  defp firmware_delta_query(source_uuid, product_id, target_id) do
+    source_firmware_id_query =
+      Firmware
+      |> where(uuid: ^source_uuid)
+      |> where(product_id: ^product_id)
+      |> select([f], f.id)
+
+    FirmwareDelta
+    |> where([fd], fd.source_id == subquery(source_firmware_id_query))
+    |> where([fd], fd.target_id == ^target_id)
   end
 
   @spec generate_firmware_delta(FirmwareDelta.t(), Firmware.t(), Firmware.t()) ::

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -778,8 +778,8 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
 
     {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(product, uuid)
 
-    firmware_delta_updatable? = Devices.delta_updatable?(device, firmware)
-    delta_complete? = Devices.delta_ready?(device, firmware)
+    firmware_delta_updatable? = Firmwares.delta_updatable?(device, firmware)
+    delta_complete? = Firmwares.delta_ready?(device, firmware)
 
     socket
     |> assign(:delta_available?, firmware_delta_updatable? && delta_complete?)

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -2447,7 +2447,7 @@ defmodule NervesHub.DevicesTest do
       firmware2 = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       _ = Fixtures.firmware_delta_fixture(firmware2, firmware)
 
-      refute Devices.delta_ready?(device, firmware2)
+      refute Firmwares.delta_ready?(device, firmware2)
     end
 
     test "returns false when no matching delta for target is found", %{
@@ -2461,7 +2461,7 @@ defmodule NervesHub.DevicesTest do
       firmware3 = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       _ = Fixtures.firmware_delta_fixture(firmware, firmware2)
 
-      refute Devices.delta_ready?(device, firmware3)
+      refute Firmwares.delta_ready?(device, firmware3)
     end
 
     test "returns false when no matching delta that's completed is found", %{
@@ -2474,7 +2474,7 @@ defmodule NervesHub.DevicesTest do
       firmware2 = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       _ = Fixtures.firmware_delta_fixture(firmware, firmware2, %{status: :processing})
 
-      refute Devices.delta_ready?(device, firmware2)
+      refute Firmwares.delta_ready?(device, firmware2)
     end
 
     test "returns true when no completed delta is found", %{
@@ -2487,7 +2487,7 @@ defmodule NervesHub.DevicesTest do
       firmware2 = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
       %{status: :completed} = Fixtures.firmware_delta_fixture(firmware, firmware2)
 
-      assert Devices.delta_ready?(device, firmware2)
+      assert Firmwares.delta_ready?(device, firmware2)
     end
   end
 
@@ -2509,7 +2509,7 @@ defmodule NervesHub.DevicesTest do
           current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
       }
 
-      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, firmware} = Firmwares.get_delta_or_firmware(device, deployment_group)
 
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 
@@ -2524,7 +2524,7 @@ defmodule NervesHub.DevicesTest do
       refute deployment_group.delta_updatable
       refute firmware.delta_updatable
 
-      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, firmware} = Firmwares.get_delta_or_firmware(device, deployment_group)
 
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 
@@ -2542,7 +2542,7 @@ defmodule NervesHub.DevicesTest do
           current_release: %DeploymentRelease{firmware: %{firmware | delta_updatable: true}}
       }
 
-      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, firmware} = Firmwares.get_delta_or_firmware(device, deployment_group)
 
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 
@@ -2562,7 +2562,7 @@ defmodule NervesHub.DevicesTest do
           }
       }
 
-      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, firmware} = Firmwares.get_delta_or_firmware(device, deployment_group)
 
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 
@@ -2585,7 +2585,7 @@ defmodule NervesHub.DevicesTest do
           current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
       }
 
-      assert {:ok, %Firmware{}} = Devices.get_delta_or_firmware(device, deployment_group)
+      assert {:ok, %Firmware{}} = Firmwares.get_delta_or_firmware(device, deployment_group)
     end
 
     test "returns the full firmware if delta isn't ready", %{
@@ -2610,7 +2610,7 @@ defmodule NervesHub.DevicesTest do
           current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
       }
 
-      assert {:ok, %Firmware{}} = Devices.get_delta_or_firmware(device, deployment_group)
+      assert {:ok, %Firmware{}} = Firmwares.get_delta_or_firmware(device, deployment_group)
     end
 
     test "returns full firmware url when source firmware can't be found", %{
@@ -2635,7 +2635,7 @@ defmodule NervesHub.DevicesTest do
           current_release: %{deployment_group.current_release | firmware: %{target_firmware | delta_updatable: true}}
       }
 
-      {:ok, firmware} = Devices.get_delta_or_firmware(device, deployment_group)
+      {:ok, firmware} = Firmwares.get_delta_or_firmware(device, deployment_group)
 
       {:ok, url} = Firmwares.get_firmware_url(firmware)
 


### PR DESCRIPTION
Continues the Devices cleanup by relocating logic that **isn't about devices**. **Stacked on Phase 4d** (`cleanup/phase-4d-devices-certificates`, #2880).

### What moved (Devices → Firmwares)
The firmware/delta-resolution functions move into `NervesHub.Firmwares`, which already owns the `Firmware`/`FirmwareDelta` schemas, the update-tool config, and the firmware getters these call:
- `get_delta_or_firmware/2`, `get_delta_if_ready/3` (private)
- `get_delta_url/2`, `delta_ready?/2`, `delta_updatable?/2`

They take a device only to read its `firmware_metadata`; everything else they touch is firmware-domain.

### Bonus cleanups this enables
- **Deletes the duplicate `update_tool/0`** from Devices — Firmwares already had a byte-identical private copy, now the single source.
- **Dedups** the source-firmware subquery that `delta_ready?/2` and `get_delta_url/2` each built inline, into a shared private `firmware_delta_query/3`.
- Drops the now-unused `Fwup` and `DeploymentRelease` aliases from Devices.

Call sites (`device_events`, `details_tab`, `resolve_update`, tests) repointed to `Firmwares`.

### Verification
- `mix format` ✓, credo (no new issues) ✓, dialyzer (0 unskipped) ✓
- Full suite: **1396 passing** (1 unrelated `ConnectionHistoryTest` DBConnection flake; passes in isolation).

### Next in this batch
4f signing-keys → Accounts, 4g `Devices.Updates`, 4h `Devices.Deployments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)