### PR TITLE
Context cleanup — Phase 4f: move firmware signing-key logic to Accounts

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -17,6 +17,7 @@ defmodule NervesHub.Accounts do
   alias NervesHub.CLISessionCache
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.Pinning
+  alias NervesHub.Firmwares.Firmware
   alias NervesHub.Products.Product
   alias NervesHub.Repo
 
@@ -532,6 +533,41 @@ defmodule NervesHub.Accounts do
     |> change_org_key(attrs)
     |> Repo.insert()
   end
+
+  @doc """
+  Fetch the org's firmware signing keys for the given device.
+  """
+  def fetch_firmware_signing_keys(device_id) do
+    OrgKey
+    |> join(:inner, [ok], d in assoc(ok, :org))
+    |> join(:inner, [ok, o], d in assoc(o, :devices))
+    |> where([ok, o, d], d.id == ^device_id)
+    |> Repo.all()
+  end
+
+  @doc """
+  When a device moves orgs, copy the signing keys for its current firmware into
+  the target org if they are not already present.
+  """
+  def maybe_copy_firmware_keys(%{firmware_metadata: %{uuid: uuid}, org_id: source}, %Org{id: target}) do
+    existing_target_keys = from(k in OrgKey, where: [org_id: ^target], select: k.key)
+
+    from(
+      k in OrgKey,
+      join: f in Firmware,
+      on: [org_key_id: k.id],
+      where: f.uuid == ^uuid and k.org_id == ^source,
+      where: k.key not in subquery(existing_target_keys),
+      select: %{name: k.name, key: k.key, org_id: type(^target, :integer)}
+    )
+    |> Repo.one()
+    |> case do
+      %{} = attrs -> create_org_key(attrs)
+      _ -> :ignore
+    end
+  end
+
+  def maybe_copy_firmware_keys(_old, _updated), do: :ignore
 
   @spec list_org_keys(Scope.t() | pos_integer(), boolean()) :: [OrgKey.t()]
   def list_org_keys(scope_or_org_id, load_created_by \\ true)

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -3,6 +3,7 @@ defmodule NervesHub.DeviceLink do
   Encapsulation of device connection workflow logic
   """
 
+  alias NervesHub.Accounts
   alias NervesHub.Archives
   alias NervesHub.AuditLogs.DeviceTemplates
   alias NervesHub.Devices
@@ -207,7 +208,7 @@ defmodule NervesHub.DeviceLink do
   defp maybe_send_public_keys(device_info, params) do
     signing_keys =
       if Enum.any?(@public_key_types, fn type -> params[type] == "on_connect" end) do
-        Devices.fetch_firmware_signing_keys(device_info.device_id)
+        Accounts.fetch_firmware_signing_keys(device_info.device_id)
       else
         []
       end

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -5,7 +5,6 @@ defmodule NervesHub.Devices do
   alias Ecto.Multi
   alias NervesHub.Accounts
   alias NervesHub.Accounts.Org
-  alias NervesHub.Accounts.OrgKey
   alias NervesHub.Accounts.OrgUser
   alias NervesHub.Accounts.Scope
   alias NervesHub.Accounts.User
@@ -1042,7 +1041,7 @@ defmodule NervesHub.Devices do
       deployment_id: nil
     }
 
-    _ = maybe_copy_firmware_keys(device, product.org)
+    _ = Accounts.maybe_copy_firmware_keys(device, product.org)
 
     description =
       "User #{user.name} moved device #{device.identifier} to #{product.org.name} : #{product.name}"
@@ -1277,34 +1276,6 @@ defmodule NervesHub.Devices do
   defp tags_match?(device_tags, deployment_group_tags) do
     Enum.all?(deployment_group_tags, fn tag -> tag in device_tags end)
   end
-
-  def fetch_firmware_signing_keys(device_id) do
-    OrgKey
-    |> join(:inner, [ok], d in assoc(ok, :org))
-    |> join(:inner, [ok, o], d in assoc(o, :devices))
-    |> where([ok, o, d], d.id == ^device_id)
-    |> Repo.all()
-  end
-
-  def maybe_copy_firmware_keys(%{firmware_metadata: %{uuid: uuid}, org_id: source}, %Org{id: target}) do
-    existing_target_keys = from(k in OrgKey, where: [org_id: ^target], select: k.key)
-
-    from(
-      k in OrgKey,
-      join: f in Firmware,
-      on: [org_key_id: k.id],
-      where: f.uuid == ^uuid and k.org_id == ^source,
-      where: k.key not in subquery(existing_target_keys),
-      select: %{name: k.name, key: k.key, org_id: type(^target, :integer)}
-    )
-    |> Repo.one()
-    |> case do
-      %{} = attrs -> Accounts.create_org_key(attrs)
-      _ -> :ignore
-    end
-  end
-
-  def maybe_copy_firmware_keys(_old, _updated), do: :ignore
 
   @doc """
   Get distinct device platforms based on the product


### PR DESCRIPTION
Continues relocating non-device logic out of Devices. **Stacked on Phase 4e** (`cleanup/phase-4e-firmware-delta-resolution`, #2881).

### What moved (Devices → Accounts)
The two org-key functions move into `NervesHub.Accounts`, which owns the `OrgKey` schema:
- `fetch_firmware_signing_keys/1` — the org's signing keys for a device
- `maybe_copy_firmware_keys/2` — copies a firmware's signing keys into the target org when a device moves orgs (now calls the local `create_org_key/1`)

Both operated purely on `OrgKey`/`Org`; nothing device-specific. The now-unused `OrgKey` alias is dropped from `Devices`. Callers repointed: `Devices.move` (internal) and `DeviceLink` now call `Accounts`.

### Verification
- `mix format` ✓, credo (no new issues) ✓, dialyzer (0 unskipped) ✓
- Full suite: **1396 passing, 0 failures.**

### Next in this batch
4g `Devices.Updates` (the update-orchestration engine), 4h `Devices.Deployments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)