### PR TITLE
Context cleanup — Phase 4h: extract Devices.Deployments sub-context

### DIFF
--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -8,6 +8,7 @@ defmodule NervesHub.DeviceLink do
   alias NervesHub.AuditLogs.DeviceTemplates
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.Updates
@@ -196,7 +197,7 @@ defmodule NervesHub.DeviceLink do
     # Update the connection to say that we are fully up and running
     Connections.device_connected(device_info.connection_ref)
     # tell the orchestrator that we are online
-    Devices.deployment_device_online(device_info)
+    Deployments.deployment_device_online(device_info)
   end
 
   defp refresh_deployment_group(device) do

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -10,22 +10,16 @@ defmodule NervesHub.Devices do
   alias NervesHub.Accounts.User
   alias NervesHub.AuditLogs
   alias NervesHub.AuditLogs.DeviceTemplates
-  alias NervesHub.DeploymentOrchestratorEvents
   alias NervesHub.DeviceEvents
-  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.DeviceFirmwares
-  alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Devices.PinnedDevice
   alias NervesHub.Devices.SharedSecretAuth
   alias NervesHub.Extensions
   alias NervesHub.Filtering, as: CommonFiltering
-  alias NervesHub.Firmwares.Firmware
   alias NervesHub.Firmwares.FirmwareMetadata
-  alias NervesHub.ManagedDeployments
-  alias NervesHub.ManagedDeployments.DeploymentGroup
   alias NervesHub.ProductNotifications
   alias NervesHub.Products
   alias NervesHub.Products.Product
@@ -412,25 +406,6 @@ defmodule NervesHub.Devices do
     end)
   end
 
-  @type firmware_id :: binary()
-  @type source_firmware_id() :: firmware_id()
-  @type target_firmware_id() :: firmware_id()
-
-  @spec get_device_firmware_for_delta_generation_by_deployment_group(binary()) ::
-          list({source_firmware_id(), target_firmware_id()})
-  def get_device_firmware_for_delta_generation_by_deployment_group(deployment_id) do
-    DeploymentGroup
-    |> where([dep], dep.id == ^deployment_id)
-    |> join(:inner, [dep], dev in Device, on: dev.deployment_id == dep.id)
-    |> join(:inner, [dep], cr in assoc(dep, :current_release))
-    |> join(:inner, [_, dev], f in Firmware, on: f.uuid == fragment("?.firmware_metadata->>'uuid'", dev))
-    # Exclude the current firmware, we don't need to generate that one
-    |> where([_, _, cr, f], f.id != cr.firmware_id)
-    |> select([_, _, cr, f], {f.id, cr.firmware_id})
-    |> distinct(true)
-    |> Repo.all()
-  end
-
   @spec update_firmware_metadata(
           device :: Device.t(),
           connecting_metadata :: FirmwareMetadata.t() | nil,
@@ -523,136 +498,6 @@ defmodule NervesHub.Devices do
       {:error, changeset} ->
         {:error, changeset}
     end
-  end
-
-  @doc """
-  Returns true if Version.match? and all deployment tags are in device tags.
-  """
-  def matches_deployment_group?(
-        %Device{tags: tags, firmware_metadata: %FirmwareMetadata{version: version}},
-        %DeploymentGroup{conditions: %{version: requirement, tags: dep_tags}}
-      ) do
-    if version_match?(version, requirement) and tags_match?(tags, dep_tags) do
-      true
-    else
-      false
-    end
-  end
-
-  def matches_deployment_group?(_, _), do: false
-
-  @spec update_deployment_group(Device.t(), DeploymentGroup.t()) :: Device.t()
-  # No-op if the deployment group ID matches the current deployment ID
-  def update_deployment_group(%{deployment_id: deployment_id} = device, %{id: deployment_id}) do
-    device
-  end
-
-  def update_deployment_group(device, deployment_group) do
-    # Use a transaction to ensure device update and delta generation happen atomically
-    # This prevents race condition: when the transaction commits, both the device's new
-    # deployment_id and any firmware_delta rows (with :processing status) become visible
-    # simultaneously, preventing the orchestrator from scheduling a full update when a delta
-    # is being prepared
-    {:ok, device} =
-      Repo.transact(fn ->
-        # Update the device's deployment group first
-        updated_device =
-          device
-          |> Device.update_deployment_group(deployment_group)
-          |> Repo.update!()
-
-        # Then queue delta generation for any new device firmware combinations
-        # This will pick up the newly added device's firmware
-        _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
-
-        {:ok, updated_device}
-      end)
-
-    # notify the device about its assigned deployment group changing
-    DeviceEvents.deployment_assigned(device)
-
-    # let the orchestrator know that a device has been added to the deployment group
-    DeploymentOrchestratorEvents.device_added(device)
-
-    Map.put(device, :deployment_group, deployment_group)
-  end
-
-  @spec clear_deployment_group(Device.t()) :: Device.t()
-  def clear_deployment_group(device) do
-    device =
-      device
-      |> Device.clear_deployment_group()
-      |> Repo.update!()
-
-    DeviceEvents.deployment_cleared(device)
-
-    Map.put(device, :deployment_group, nil)
-  end
-
-  def deployment_device_online(%DeviceInfo{deployment_id: nil}) do
-    :ok
-  end
-
-  def deployment_device_online(device_info) do
-    firmware_uuid = if(device_info.firmware_metadata, do: device_info.firmware_metadata.uuid)
-
-    payload = %{
-      updates_enabled: device_info.device_updates_enabled,
-      updates_blocked_until: device_info.device_updates_blocked_until,
-      firmware_uuid: firmware_uuid
-    }
-
-    DeploymentOrchestratorEvents.device_online(device_info, payload)
-
-    :ok
-  end
-
-  def up_to_date_count(%DeploymentGroup{} = deployment_group) do
-    Device
-    |> where([d], d.deployment_id == ^deployment_group.id)
-    |> where([d], d.updates_enabled == true)
-    |> where([d], d.firmware_metadata["uuid"] == ^deployment_group.current_release.firmware.uuid)
-    |> Repo.exclude_deleted()
-    |> Repo.aggregate(:count)
-  end
-
-  @spec updating_count(DeploymentGroup.t()) :: term() | nil
-  def updating_count(%DeploymentGroup{id: id}) do
-    InflightUpdate
-    |> where([ifu], ifu.deployment_id == ^id)
-    |> Repo.aggregate(:count)
-  end
-
-  @spec waiting_for_update_count(DeploymentGroup.t()) :: term() | nil
-  def waiting_for_update_count(%DeploymentGroup{} = deployment_group) do
-    Device
-    |> where([d], d.deployment_id == ^deployment_group.id)
-    |> where([d], d.updates_enabled == true)
-    |> where(
-      [d],
-      is_nil(d.firmware_metadata) or
-        d.firmware_metadata["uuid"] != ^deployment_group.current_release.firmware.uuid
-    )
-    |> Repo.exclude_deleted()
-    |> Repo.aggregate(:count)
-  end
-
-  @spec updates_disabled_count(DeploymentGroup.t()) :: non_neg_integer()
-  def updates_disabled_count(%DeploymentGroup{id: id}) do
-    Device
-    |> where([d], d.deployment_id == ^id)
-    |> where([d], d.updates_enabled == false)
-    |> Repo.exclude_deleted()
-    |> Repo.aggregate(:count)
-  end
-
-  @spec in_penalty_box_count(DeploymentGroup.t(), DateTime.t()) :: non_neg_integer()
-  def in_penalty_box_count(%DeploymentGroup{id: id}, now \\ DateTime.utc_now()) do
-    Device
-    |> where([d], d.deployment_id == ^id)
-    |> where([d], not is_nil(d.updates_blocked_until) and d.updates_blocked_until > ^now)
-    |> Repo.exclude_deleted()
-    |> Repo.aggregate(:count)
   end
 
   def restore_device(%Device{} = device) do
@@ -799,39 +644,6 @@ defmodule NervesHub.Devices do
     end
   end
 
-  @doc """
-  Removes unmatched devices from deployment group. The given device ids are
-  assumed to be ids of devices that "match" a deployment group's conditions,
-  e.g. devices from ManagedDeployments.matched_device_ids/2. Devices are
-  fetched by their id and also filtered by the deployment group's id and
-  product id.
-
-  `Repo.update_all()` is used to update the rows. The return informs how
-  many rows were updated and how many were ignored because of a problem.
-
-  remove_unmatched_devices_from_deployment_group([1, 2, 3], deployment_group)
-  > {:ok, %{updated: 3, ignored: 0}}
-  """
-  @spec remove_unmatched_devices_from_deployment_group([non_neg_integer()], DeploymentGroup.t()) ::
-          {:ok, %{updated: non_neg_integer(), ignored: non_neg_integer()}}
-  def remove_unmatched_devices_from_deployment_group(matched_device_ids, deployment_group) do
-    {devices_updated_count, _} =
-      Device
-      |> Repo.exclude_deleted()
-      |> where([d], d.deployment_id == ^deployment_group.id)
-      |> where([d], d.product_id == ^deployment_group.product_id)
-      |> where([d], d.id not in ^matched_device_ids)
-      |> Repo.update_all([set: [deployment_id: nil]], timeout: to_timeout(minute: 2))
-
-    :ok = Enum.each(matched_device_ids, &DeviceEvents.updated(%Device{id: &1}))
-
-    {:ok,
-     %{
-       updated: devices_updated_count,
-       ignored: length(matched_device_ids) - devices_updated_count
-     }}
-  end
-
   @spec get_devices_by_id(Scope.t(), [non_neg_integer()]) :: [Device.t()]
   def get_devices_by_id(%Scope{user: user}, ids) when is_list(ids) do
     Device
@@ -848,19 +660,6 @@ defmodule NervesHub.Devices do
     else
       :ok
     end
-  end
-
-  defp version_match?(_vsn, ""), do: true
-
-  defp version_match?(version, requirement) do
-    Version.match?(version, requirement)
-  end
-
-  defp tags_match?(nil, deployment_group_tags), do: tags_match?([], deployment_group_tags)
-  defp tags_match?(device_tags, nil), do: tags_match?(device_tags, [])
-
-  defp tags_match?(device_tags, deployment_group_tags) do
-    Enum.all?(deployment_group_tags, fn tag -> tag in device_tags end)
   end
 
   @doc """

--- a/lib/nerves_hub/devices/deployments.ex
+++ b/lib/nerves_hub/devices/deployments.ex
@@ -1,0 +1,218 @@
+defmodule NervesHub.Devices.Deployments do
+  @moduledoc """
+  Context for a device's relationship to its deployment group.
+
+  Covers deployment group membership matching (does a device satisfy a
+  deployment group's version and tag conditions?), assigning and clearing a
+  device's deployment group, and the per-deployment device counts used to
+  summarize a deployment group's rollout progress.
+  """
+
+  import Ecto.Query
+
+  alias NervesHub.DeploymentOrchestratorEvents
+  alias NervesHub.DeviceEvents
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Firmwares.FirmwareMetadata
+  alias NervesHub.ManagedDeployments
+  alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.Repo
+
+  @type firmware_id :: binary()
+  @type source_firmware_id() :: firmware_id()
+  @type target_firmware_id() :: firmware_id()
+
+  @spec get_device_firmware_for_delta_generation_by_deployment_group(binary()) ::
+          list({source_firmware_id(), target_firmware_id()})
+  def get_device_firmware_for_delta_generation_by_deployment_group(deployment_id) do
+    DeploymentGroup
+    |> where([dep], dep.id == ^deployment_id)
+    |> join(:inner, [dep], dev in Device, on: dev.deployment_id == dep.id)
+    |> join(:inner, [dep], cr in assoc(dep, :current_release))
+    |> join(:inner, [_, dev], f in Firmware, on: f.uuid == fragment("?.firmware_metadata->>'uuid'", dev))
+    # Exclude the current firmware, we don't need to generate that one
+    |> where([_, _, cr, f], f.id != cr.firmware_id)
+    |> select([_, _, cr, f], {f.id, cr.firmware_id})
+    |> distinct(true)
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns true if Version.match? and all deployment tags are in device tags.
+  """
+  def matches_deployment_group?(
+        %Device{tags: tags, firmware_metadata: %FirmwareMetadata{version: version}},
+        %DeploymentGroup{conditions: %{version: requirement, tags: dep_tags}}
+      ) do
+    if version_match?(version, requirement) and tags_match?(tags, dep_tags) do
+      true
+    else
+      false
+    end
+  end
+
+  def matches_deployment_group?(_, _), do: false
+
+  @spec update_deployment_group(Device.t(), DeploymentGroup.t()) :: Device.t()
+  # No-op if the deployment group ID matches the current deployment ID
+  def update_deployment_group(%{deployment_id: deployment_id} = device, %{id: deployment_id}) do
+    device
+  end
+
+  def update_deployment_group(device, deployment_group) do
+    # Use a transaction to ensure device update and delta generation happen atomically
+    # This prevents race condition: when the transaction commits, both the device's new
+    # deployment_id and any firmware_delta rows (with :processing status) become visible
+    # simultaneously, preventing the orchestrator from scheduling a full update when a delta
+    # is being prepared
+    {:ok, device} =
+      Repo.transact(fn ->
+        # Update the device's deployment group first
+        updated_device =
+          device
+          |> Device.update_deployment_group(deployment_group)
+          |> Repo.update!()
+
+        # Then queue delta generation for any new device firmware combinations
+        # This will pick up the newly added device's firmware
+        _ = ManagedDeployments.trigger_delta_generation_for_deployment_group(deployment_group)
+
+        {:ok, updated_device}
+      end)
+
+    # notify the device about its assigned deployment group changing
+    DeviceEvents.deployment_assigned(device)
+
+    # let the orchestrator know that a device has been added to the deployment group
+    DeploymentOrchestratorEvents.device_added(device)
+
+    Map.put(device, :deployment_group, deployment_group)
+  end
+
+  @spec clear_deployment_group(Device.t()) :: Device.t()
+  def clear_deployment_group(device) do
+    device =
+      device
+      |> Device.clear_deployment_group()
+      |> Repo.update!()
+
+    DeviceEvents.deployment_cleared(device)
+
+    Map.put(device, :deployment_group, nil)
+  end
+
+  def deployment_device_online(%DeviceInfo{deployment_id: nil}) do
+    :ok
+  end
+
+  def deployment_device_online(device_info) do
+    firmware_uuid = if(device_info.firmware_metadata, do: device_info.firmware_metadata.uuid)
+
+    payload = %{
+      updates_enabled: device_info.device_updates_enabled,
+      updates_blocked_until: device_info.device_updates_blocked_until,
+      firmware_uuid: firmware_uuid
+    }
+
+    DeploymentOrchestratorEvents.device_online(device_info, payload)
+
+    :ok
+  end
+
+  def up_to_date_count(%DeploymentGroup{} = deployment_group) do
+    Device
+    |> where([d], d.deployment_id == ^deployment_group.id)
+    |> where([d], d.updates_enabled == true)
+    |> where([d], d.firmware_metadata["uuid"] == ^deployment_group.current_release.firmware.uuid)
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+
+  @spec updating_count(DeploymentGroup.t()) :: term() | nil
+  def updating_count(%DeploymentGroup{id: id}) do
+    InflightUpdate
+    |> where([ifu], ifu.deployment_id == ^id)
+    |> Repo.aggregate(:count)
+  end
+
+  @spec waiting_for_update_count(DeploymentGroup.t()) :: term() | nil
+  def waiting_for_update_count(%DeploymentGroup{} = deployment_group) do
+    Device
+    |> where([d], d.deployment_id == ^deployment_group.id)
+    |> where([d], d.updates_enabled == true)
+    |> where(
+      [d],
+      is_nil(d.firmware_metadata) or
+        d.firmware_metadata["uuid"] != ^deployment_group.current_release.firmware.uuid
+    )
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+
+  @spec updates_disabled_count(DeploymentGroup.t()) :: non_neg_integer()
+  def updates_disabled_count(%DeploymentGroup{id: id}) do
+    Device
+    |> where([d], d.deployment_id == ^id)
+    |> where([d], d.updates_enabled == false)
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+
+  @spec in_penalty_box_count(DeploymentGroup.t(), DateTime.t()) :: non_neg_integer()
+  def in_penalty_box_count(%DeploymentGroup{id: id}, now \\ DateTime.utc_now()) do
+    Device
+    |> where([d], d.deployment_id == ^id)
+    |> where([d], not is_nil(d.updates_blocked_until) and d.updates_blocked_until > ^now)
+    |> Repo.exclude_deleted()
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Removes unmatched devices from deployment group. The given device ids are
+  assumed to be ids of devices that "match" a deployment group's conditions,
+  e.g. devices from ManagedDeployments.matched_device_ids/2. Devices are
+  fetched by their id and also filtered by the deployment group's id and
+  product id.
+
+  `Repo.update_all()` is used to update the rows. The return informs how
+  many rows were updated and how many were ignored because of a problem.
+
+  remove_unmatched_devices_from_deployment_group([1, 2, 3], deployment_group)
+  > {:ok, %{updated: 3, ignored: 0}}
+  """
+  @spec remove_unmatched_devices_from_deployment_group([non_neg_integer()], DeploymentGroup.t()) ::
+          {:ok, %{updated: non_neg_integer(), ignored: non_neg_integer()}}
+  def remove_unmatched_devices_from_deployment_group(matched_device_ids, deployment_group) do
+    {devices_updated_count, _} =
+      Device
+      |> Repo.exclude_deleted()
+      |> where([d], d.deployment_id == ^deployment_group.id)
+      |> where([d], d.product_id == ^deployment_group.product_id)
+      |> where([d], d.id not in ^matched_device_ids)
+      |> Repo.update_all([set: [deployment_id: nil]], timeout: to_timeout(minute: 2))
+
+    :ok = Enum.each(matched_device_ids, &DeviceEvents.updated(%Device{id: &1}))
+
+    {:ok,
+     %{
+       updated: devices_updated_count,
+       ignored: length(matched_device_ids) - devices_updated_count
+     }}
+  end
+
+  defp version_match?(_vsn, ""), do: true
+
+  defp version_match?(version, requirement) do
+    Version.match?(version, requirement)
+  end
+
+  defp tags_match?(nil, deployment_group_tags), do: tags_match?([], deployment_group_tags)
+  defp tags_match?(device_tags, nil), do: tags_match?(device_tags, [])
+
+  defp tags_match?(device_tags, deployment_group_tags) do
+    Enum.all?(deployment_group_tags, fn tag -> tag in device_tags end)
+  end
+end

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -5,7 +5,7 @@ defmodule NervesHub.ManagedDeployments do
   alias NervesHub.Accounts.User
   alias NervesHub.AuditLogs.DeploymentGroupTemplates
   alias NervesHub.AuditLogs.DeviceTemplates
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Filtering, as: CommonFiltering
   alias NervesHub.Firmwares
@@ -364,7 +364,7 @@ defmodule NervesHub.ManagedDeployments do
   def recalculate_deployment_group_status(deployment_group) do
     source_ids =
       deployment_group.id
-      |> Devices.get_device_firmware_for_delta_generation_by_deployment_group()
+      |> Deployments.get_device_firmware_for_delta_generation_by_deployment_group()
       |> Enum.map(fn {source_id, _target_id} -> source_id end)
 
     if Enum.any?(source_ids) do
@@ -453,7 +453,7 @@ defmodule NervesHub.ManagedDeployments do
   end
 
   def trigger_delta_generation_for_deployment_group(deployment_group) do
-    Devices.get_device_firmware_for_delta_generation_by_deployment_group(deployment_group.id)
+    Deployments.get_device_firmware_for_delta_generation_by_deployment_group(deployment_group.id)
     |> Enum.map(fn {source_id, target_id} ->
       Firmwares.attempt_firmware_delta(source_id, target_id, false)
     end)
@@ -586,14 +586,14 @@ defmodule NervesHub.ManagedDeployments do
 
         DeviceTemplates.audit_set_deployment(device, deployment, :one_found)
 
-        Devices.update_deployment_group(device, deployment)
+        Deployments.update_deployment_group(device, deployment)
 
       [deployment | _] ->
         set_deployment_group_telemetry(:multiple_found, device, deployment)
 
         DeviceTemplates.audit_set_deployment(device, deployment, :multiple_found)
 
-        Devices.update_deployment_group(device, deployment)
+        Deployments.update_deployment_group(device, deployment)
     end
   end
 

--- a/lib/nerves_hub_web/components/deployment_group_page/summary.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/summary.ex
@@ -4,7 +4,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
   import NervesHubWeb.LayoutView,
     only: [humanize_size: 1]
 
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.UpdateStats
   alias NervesHub.Firmwares
   alias NervesHub.FirmwareUpdates
@@ -25,11 +25,11 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
 
     socket
     |> assign(:inflight_updates, inflight_updates)
-    |> assign(:up_to_date_count, Devices.up_to_date_count(deployment_group))
-    |> assign(:waiting_for_update_count, Devices.waiting_for_update_count(deployment_group))
-    |> assign(:updating_count, Devices.updating_count(deployment_group))
-    |> assign(:updates_disabled_count, Devices.updates_disabled_count(deployment_group))
-    |> assign(:in_penalty_box_count, Devices.in_penalty_box_count(deployment_group))
+    |> assign(:up_to_date_count, Deployments.up_to_date_count(deployment_group))
+    |> assign(:waiting_for_update_count, Deployments.waiting_for_update_count(deployment_group))
+    |> assign(:updating_count, Deployments.updating_count(deployment_group))
+    |> assign(:updates_disabled_count, Deployments.updates_disabled_count(deployment_group))
+    |> assign(:in_penalty_box_count, Deployments.in_penalty_box_count(deployment_group))
     |> assign(:deltas, Firmwares.get_deltas_by_target_firmware(deployment_group.current_release.firmware))
     |> ok()
   end
@@ -62,7 +62,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     %{deployment_group: deployment_group} = assigns
 
     inflight_updates = FirmwareUpdates.inflight_updates_for(deployment_group)
-    updating_count = Devices.updating_count(deployment_group)
+    updating_count = Deployments.updating_count(deployment_group)
 
     socket
     |> assign(assigns)
@@ -72,11 +72,11 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Summary do
     )
     |> assign_update_stats(deployment_group)
     |> assign_deltas_and_stats()
-    |> assign(:up_to_date_count, Devices.up_to_date_count(deployment_group))
-    |> assign(:waiting_for_update_count, Devices.waiting_for_update_count(deployment_group))
+    |> assign(:up_to_date_count, Deployments.up_to_date_count(deployment_group))
+    |> assign(:waiting_for_update_count, Deployments.waiting_for_update_count(deployment_group))
     |> assign(:updating_count, updating_count)
-    |> assign(:updates_disabled_count, Devices.updates_disabled_count(deployment_group))
-    |> assign(:in_penalty_box_count, Devices.in_penalty_box_count(deployment_group))
+    |> assign(:updates_disabled_count, Deployments.updates_disabled_count(deployment_group))
+    |> assign(:in_penalty_box_count, Deployments.in_penalty_box_count(deployment_group))
     |> assign(:inflight_updates, inflight_updates)
     |> assign(:firmware, deployment_group.current_release.firmware)
     |> assign(:deltas, Firmwares.get_deltas_by_target_firmware(deployment_group.current_release.firmware))

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -7,6 +7,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.Metrics
   alias NervesHub.Devices.Updates
@@ -733,7 +734,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     authorized!(:"device:set-deployment-group", socket.assigns.current_scope)
 
     deployment = Enum.find(deployment_groups, &(&1.id == String.to_integer(deployment_id)))
-    device = Devices.update_deployment_group(device, deployment)
+    device = Deployments.update_deployment_group(device, deployment)
     _ = DeviceTemplates.audit_device_deployment_group_update(user, device, deployment)
 
     send(self(), :reload_device)
@@ -857,7 +858,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   end
 
   def hooked_event("remove-from-deployment-group", _, %{assigns: %{device: device}} = socket) do
-    device = Devices.clear_deployment_group(device)
+    device = Deployments.clear_deployment_group(device)
 
     send(self(), :reload_device)
 

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -2,8 +2,8 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
   use NervesHubWeb, :live_view
 
   alias NervesHub.AuditLogs.DeploymentGroupTemplates
-  alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
+  alias NervesHub.Devices.Deployments
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Helpers.Logging
   alias NervesHub.ManagedDeployments
@@ -118,7 +118,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
 
     remove_devices = fn ->
       {:ok, %{updated: updated, ignored: ignored}} =
-        Devices.remove_unmatched_devices_from_deployment_group(
+        Deployments.remove_unmatched_devices_from_deployment_group(
           matched_device_ids,
           deployment_group
         )
@@ -252,9 +252,9 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
 
     socket
     |> assign(:inflight_updates, inflight_updates)
-    |> assign(:up_to_date_count, Devices.up_to_date_count(deployment_group))
-    |> assign(:waiting_for_update_count, Devices.waiting_for_update_count(deployment_group))
-    |> assign(:updating_count, Devices.updating_count(deployment_group))
+    |> assign(:up_to_date_count, Deployments.up_to_date_count(deployment_group))
+    |> assign(:waiting_for_update_count, Deployments.waiting_for_update_count(deployment_group))
+    |> assign(:updating_count, Deployments.updating_count(deployment_group))
     |> noreply()
   end
 

--- a/test/nerves_hub/devices/update_stats_test.exs
+++ b/test/nerves_hub/devices/update_stats_test.exs
@@ -2,6 +2,7 @@ defmodule NervesHub.Devices.UpdateStatsTest do
   use NervesHub.DataCase, async: true
 
   alias NervesHub.Devices
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.UpdateStat
   alias NervesHub.Devices.UpdateStats
   alias NervesHub.Firmwares
@@ -58,7 +59,7 @@ defmodule NervesHub.Devices.UpdateStatsTest do
       deployment_group: deployment_group
     } do
       {:ok, metadata} = Firmwares.metadata_from_firmware(source_firmware)
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       assert :ok = UpdateStats.log_update(device, metadata)
 
       stats = Repo.all(UpdateStat)
@@ -113,7 +114,7 @@ defmodule NervesHub.Devices.UpdateStatsTest do
       deployment_group: deployment_group,
       other_firmware: other_firmware
     } do
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       assert device.deployment_id
 
       {:ok, metadata} = Firmwares.metadata_from_firmware(other_firmware)
@@ -186,8 +187,8 @@ defmodule NervesHub.Devices.UpdateStatsTest do
       source_firmware_metadata: source_firmware_metadata,
       user: user
     } do
-      device = Devices.update_deployment_group(device, deployment_group)
-      device2 = Devices.update_deployment_group(device2, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
+      device2 = Deployments.update_deployment_group(device2, deployment_group)
 
       :ok = UpdateStats.log_update(device, source_firmware_metadata)
       _ = Fixtures.firmware_delta_fixture(source_firmware, target_firmware)
@@ -230,7 +231,7 @@ defmodule NervesHub.Devices.UpdateStatsTest do
       source_firmware_metadata: source_firmware_metadata,
       tmp_dir: tmp_dir
     } do
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       :ok = UpdateStats.log_update(device, source_firmware_metadata)
 
       # create firmware from different product with same uuid

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -14,6 +14,7 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.CACertificate
   alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Certificates
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceConnection
@@ -626,7 +627,7 @@ defmodule NervesHub.DevicesTest do
 
       _no_deployment = Fixtures.device_fixture(org, product, current, %{})
 
-      assert Devices.up_to_date_count(dg) == 1
+      assert Deployments.up_to_date_count(dg) == 1
     end
 
     test "waiting_for_update_count/1 only counts eligible devices not on the current firmware",
@@ -645,7 +646,7 @@ defmodule NervesHub.DevicesTest do
 
       _no_deployment = Fixtures.device_fixture(org, product, other, %{})
 
-      assert Devices.waiting_for_update_count(dg) == 1
+      assert Deployments.waiting_for_update_count(dg) == 1
     end
 
     test "updates_disabled_count/1 counts deployment devices with updates_enabled = false",
@@ -661,7 +662,7 @@ defmodule NervesHub.DevicesTest do
       _disabled_no_deployment =
         Fixtures.device_fixture(org, product, current, %{updates_enabled: false})
 
-      assert Devices.updates_disabled_count(dg) == 2
+      assert Deployments.updates_disabled_count(dg) == 2
     end
 
     test "in_penalty_box_count/2 only counts deployment devices with a future block timestamp",
@@ -681,7 +682,7 @@ defmodule NervesHub.DevicesTest do
       _blocked_no_deployment =
         Fixtures.device_fixture(org, product, current, %{updates_blocked_until: future})
 
-      assert Devices.in_penalty_box_count(dg, now) == 1
+      assert Deployments.in_penalty_box_count(dg, now) == 1
     end
   end
 
@@ -900,9 +901,9 @@ defmodule NervesHub.DevicesTest do
 
     nil_tags_deployment_group = put_in(deployment_group.conditions.tags, nil)
 
-    refute Devices.matches_deployment_group?(%{device | tags: nil}, deployment_group)
-    assert Devices.matches_deployment_group?(%{device | tags: nil}, nil_tags_deployment_group)
-    assert Devices.matches_deployment_group?(device, nil_tags_deployment_group)
+    refute Deployments.matches_deployment_group?(%{device | tags: nil}, deployment_group)
+    assert Deployments.matches_deployment_group?(%{device | tags: nil}, nil_tags_deployment_group)
+    assert Deployments.matches_deployment_group?(device, nil_tags_deployment_group)
   end
 
   test "create shared secret auth with associated product shared secret auth", context do
@@ -1240,7 +1241,7 @@ defmodule NervesHub.DevicesTest do
       refute device.deployment_id
 
       NervesHubWeb.Endpoint.subscribe("device:#{device.id}")
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
 
       assert device.deployment_id == deployment_group.id
       assert_receive %{event: "deployment_updated"}
@@ -1277,7 +1278,7 @@ defmodule NervesHub.DevicesTest do
       deployment_topic = "orchestrator:deployment:#{deployment_group.id}"
       Phoenix.PubSub.subscribe(NervesHub.PubSub, deployment_topic)
 
-      _device = Devices.update_deployment_group(device, deployment_group)
+      _device = Deployments.update_deployment_group(device, deployment_group)
 
       # Assert that the device-added event was broadcast
       assert_receive %Broadcast{topic: ^deployment_topic, event: "device-added"}, 500
@@ -1311,7 +1312,7 @@ defmodule NervesHub.DevicesTest do
       {:ok, {_release, deployment_group}} =
         ManagedDeployments.create_deployment_release(deployment_group, target_firmware, nil, user, %{})
 
-      _device = Devices.update_deployment_group(device, deployment_group)
+      _device = Deployments.update_deployment_group(device, deployment_group)
 
       # Delta generation happens inline in the transaction
       # Assert that delta generation job was enqueued for the new firmware pair
@@ -1482,10 +1483,10 @@ defmodule NervesHub.DevicesTest do
       device: device,
       deployment_group: deployment_group
     } do
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
 
       NervesHubWeb.Endpoint.subscribe("device:#{device.id}")
-      device = Devices.clear_deployment_group(device)
+      device = Deployments.clear_deployment_group(device)
 
       refute device.deployment_id
       assert_receive %{event: "deployment_updated"}
@@ -2409,26 +2410,26 @@ defmodule NervesHub.DevicesTest do
 
       _ =
         Fixtures.device_fixture(org, product, firmware2)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware2)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware3)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware3)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware4)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       pairs =
-        Devices.get_device_firmware_for_delta_generation_by_deployment_group(deployment_group.id)
+        Deployments.get_device_firmware_for_delta_generation_by_deployment_group(deployment_group.id)
 
       assert length(pairs) == 3
       assert Enum.member?(pairs, {firmware2.id, firmware.id})

--- a/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
+++ b/test/nerves_hub/managed_deployments/distributed/orchestrator_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
   alias NervesHub.Devices
   alias NervesHub.Devices.BulkActions
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Devices.Updates
   alias NervesHub.Firmwares
@@ -79,10 +80,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     topic1 = "device:#{device1.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic1)
 
-    device1 = Devices.update_deployment_group(device1, deployment_group)
+    device1 = Deployments.update_deployment_group(device1, deployment_group)
     {:ok, connection} = Connections.device_connecting(device1.org_id, device1.product_id, device1.id)
     :ok = Connections.device_connected(connection.id)
-    to_device_info(device1) |> Devices.deployment_device_online()
+    to_device_info(device1) |> Deployments.deployment_device_online()
 
     # sent when a device is a assigned a deployment group
     assert_receive %Broadcast{topic: ^topic1, event: "deployment_updated"}, 500
@@ -94,10 +95,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     topic2 = "device:#{device2.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic2)
 
-    device2 = Devices.update_deployment_group(device2, deployment_group)
+    device2 = Deployments.update_deployment_group(device2, deployment_group)
     {:ok, connection} = Connections.device_connecting(device2.org_id, device2.product_id, device2.id)
     :ok = Connections.device_connected(connection.id)
-    to_device_info(device2) |> Devices.deployment_device_online()
+    to_device_info(device2) |> Deployments.deployment_device_online()
 
     # and check that device2 was told to update
     assert_receive %Broadcast{topic: ^topic2, event: "update"}, 500
@@ -106,10 +107,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     topic3 = "device:#{device3.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, topic3)
 
-    device3 = Devices.update_deployment_group(device3, deployment_group)
+    device3 = Deployments.update_deployment_group(device3, deployment_group)
     {:ok, connection} = Connections.device_connecting(device3.org_id, device3.product_id, device3.id)
     :ok = Connections.device_connected(connection.id)
-    to_device_info(device3) |> Devices.deployment_device_online()
+    to_device_info(device3) |> Deployments.deployment_device_online()
 
     # and check that device3 isn't told to update as the concurrent limit has been reached
     refute_receive %Broadcast{topic: ^topic3, event: "update"}, 500
@@ -130,11 +131,11 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     deployment_group = Repo.preload(deployment_group, current_release: :firmware)
 
-    device = Devices.update_deployment_group(device, deployment_group)
+    device = Deployments.update_deployment_group(device, deployment_group)
     {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
     :ok = Connections.device_connected(connection.id)
 
-    device2 = Devices.update_deployment_group(device2, deployment_group)
+    device2 = Deployments.update_deployment_group(device2, deployment_group)
     {:ok, connection} = Connections.device_connecting(device2.org_id, device2.product_id, device2.id)
     :ok = Connections.device_connected(connection.id)
 
@@ -194,7 +195,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     {:ok, deployment_group} =
       ManagedDeployments.update_deployment_group(deployment_group, %{concurrent_updates: 1}, user)
 
-    device = Devices.update_deployment_group(device, deployment_group)
+    device = Deployments.update_deployment_group(device, deployment_group)
     {:ok, device} = Devices.update_device(device, %{firmware_validation_status: "not_validated"})
     {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
     :ok = Connections.device_connected(connection.id)
@@ -280,14 +281,14 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     device1_topic = "device:#{device1.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, device1_topic)
 
-    device1 = Devices.update_deployment_group(device1, deployment_group)
+    device1 = Deployments.update_deployment_group(device1, deployment_group)
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-added"}, 500
 
     {:ok, connection} = Connections.device_connecting(device1.org_id, device1.product_id, device1.id)
     :ok = Connections.device_connected(connection.id)
 
-    to_device_info(device1) |> Devices.deployment_device_online()
+    to_device_info(device1) |> Deployments.deployment_device_online()
 
     # sent when a device is assigned a deployment group
     assert_receive %Broadcast{topic: ^device1_topic, event: "deployment_updated"},
@@ -308,7 +309,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     {:ok, device2} =
       Devices.update_device(device2, %{firmware_metadata: %{"uuid" => firmware.uuid}})
 
-    device2 = Devices.update_deployment_group(device2, deployment_group)
+    device2 = Deployments.update_deployment_group(device2, deployment_group)
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-added"}, 500
 
@@ -317,7 +318,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     {:ok, connection} = Connections.device_connecting(device2.org_id, device2.product_id, device2.id)
     :ok = Connections.device_connected(connection.id)
 
-    to_device_info(device2) |> Devices.deployment_device_online()
+    to_device_info(device2) |> Deployments.deployment_device_online()
 
     assert_receive %Broadcast{topic: ^deployment_group_topic, event: "device-online"}, 500
     refute_receive %Broadcast{topic: ^device2_topic, event: "update"}, 500
@@ -414,13 +415,13 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
     device1_topic = "device:#{device1.id}"
     Phoenix.PubSub.subscribe(NervesHub.PubSub, device1_topic)
 
-    device1 = Devices.update_deployment_group(device1, deployment_group)
+    device1 = Deployments.update_deployment_group(device1, deployment_group)
     {:ok, device1} = Devices.update_device(device1, %{updates_enabled: false})
 
     {:ok, connection} = Connections.device_connecting(device1.org_id, device1.product_id, device1.id)
     :ok = Connections.device_connected(connection.id)
 
-    to_device_info(device1) |> Devices.deployment_device_online()
+    to_device_info(device1) |> Deployments.deployment_device_online()
 
     # sent when a device is assigned a deployment group
     assert_receive %Broadcast{topic: ^device1_topic, event: "deployment_updated"},
@@ -488,7 +489,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     allow(Updates, self(), pid)
 
-    _device1 = Devices.update_deployment_group(device1, deployment_group)
+    _device1 = Deployments.update_deployment_group(device1, deployment_group)
 
     # the orchestrator is told that a device has just been assigned to it
     assert_receive %Broadcast{topic: ^deployment_topic, event: "device-added"}, 500
@@ -592,7 +593,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
 
     device =
       Fixtures.device_fixture(org, product, other_firmware)
-      |> Devices.update_deployment_group(deployment_group)
+      |> Deployments.update_deployment_group(deployment_group)
 
     {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
     :ok = Connections.device_connected(connection.id)
@@ -706,9 +707,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
-      new_device = Devices.update_deployment_group(new_device, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      old_device2 = Deployments.update_deployment_group(old_device2, deployment_group)
+      new_device = Deployments.update_deployment_group(new_device, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
@@ -775,7 +776,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       :ok = Connections.device_connected(conn1.id)
@@ -828,8 +829,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      new_device = Devices.update_deployment_group(new_device, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      new_device = Deployments.update_deployment_group(new_device, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       {:ok, conn2} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
@@ -866,7 +867,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
 
       {:ok, conn} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(conn.id)
@@ -905,7 +906,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      new_device = Devices.update_deployment_group(new_device, deployment_group)
+      new_device = Deployments.update_deployment_group(new_device, deployment_group)
 
       {:ok, conn} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
       :ok = Connections.device_connected(conn.id)
@@ -953,8 +954,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      old_device2 = Deployments.update_deployment_group(old_device2, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
@@ -1008,8 +1009,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      eligible = Devices.update_deployment_group(eligible, deployment_group)
-      bad = Devices.update_deployment_group(bad, deployment_group)
+      eligible = Deployments.update_deployment_group(eligible, deployment_group)
+      bad = Deployments.update_deployment_group(bad, deployment_group)
 
       for device <- [eligible, bad] do
         {:ok, conn} = Connections.device_connecting(device.org_id, device.product_id, device.id)
@@ -1074,9 +1075,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
-      new_device = Devices.update_deployment_group(new_device, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      old_device2 = Deployments.update_deployment_group(old_device2, deployment_group)
+      new_device = Deployments.update_deployment_group(new_device, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
@@ -1139,8 +1140,8 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      new_device = Devices.update_deployment_group(new_device, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      new_device = Deployments.update_deployment_group(new_device, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       {:ok, conn2} = Connections.device_connecting(new_device.org_id, new_device.product_id, new_device.id)
@@ -1178,7 +1179,7 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
 
       {:ok, conn} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(conn.id)
@@ -1252,10 +1253,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      device_1_10 = Devices.update_deployment_group(device_1_10, deployment_group)
-      device_1_9 = Devices.update_deployment_group(device_1_9, deployment_group)
-      device_2_0 = Devices.update_deployment_group(device_2_0, deployment_group)
-      device_1_1 = Devices.update_deployment_group(device_1_1, deployment_group)
+      device_1_10 = Deployments.update_deployment_group(device_1_10, deployment_group)
+      device_1_9 = Deployments.update_deployment_group(device_1_9, deployment_group)
+      device_2_0 = Deployments.update_deployment_group(device_2_0, deployment_group)
+      device_1_1 = Deployments.update_deployment_group(device_1_1, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(device_1_10.org_id, device_1_10.product_id, device_1_10.id)
       {:ok, conn2} = Connections.device_connecting(device_1_9.org_id, device_1_9.product_id, device_1_9.id)
@@ -1333,9 +1334,9 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
-      new_device = Devices.update_deployment_group(new_device, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      old_device2 = Deployments.update_deployment_group(old_device2, deployment_group)
+      new_device = Deployments.update_deployment_group(new_device, deployment_group)
 
       {:ok, conn1} = Connections.device_connecting(old_device1.org_id, old_device1.product_id, old_device1.id)
       {:ok, conn2} = Connections.device_connecting(old_device2.org_id, old_device2.product_id, old_device2.id)
@@ -1429,10 +1430,10 @@ defmodule NervesHub.ManagedDeployments.Distributed.OrchestratorTest do
           false
         )
 
-      old_device1 = Devices.update_deployment_group(old_device1, deployment_group)
-      old_device2 = Devices.update_deployment_group(old_device2, deployment_group)
-      old_device3 = Devices.update_deployment_group(old_device3, deployment_group)
-      old_device4 = Devices.update_deployment_group(old_device4, deployment_group)
+      old_device1 = Deployments.update_deployment_group(old_device1, deployment_group)
+      old_device2 = Deployments.update_deployment_group(old_device2, deployment_group)
+      old_device3 = Deployments.update_deployment_group(old_device3, deployment_group)
+      old_device4 = Deployments.update_deployment_group(old_device4, deployment_group)
 
       # Create connections with specific timestamps to ensure FIFO ordering
       # Device 1 should be first (oldest connection - 4 minutes ago)

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -7,6 +7,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
   alias Ecto.Changeset
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Firmwares.FirmwareDelta
   alias NervesHub.Fixtures
@@ -229,7 +230,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       device =
         Fixtures.device_fixture(org, product, firmware, %{tags: ["beta", "rpi"]})
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       assert device.deployment_id == deployment_group.id
 
@@ -261,7 +262,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       device =
         Fixtures.device_fixture(org, product, firmware, %{tags: ["beta", "rpi"]})
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       assert device.deployment_id == deployment_group.id
 
@@ -284,7 +285,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       device =
         Fixtures.device_fixture(org, product, firmware, %{tags: ["beta", "rpi"]})
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       assert device.deployment_id == deployment_group.id
 
@@ -310,23 +311,23 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       _ =
         Fixtures.device_fixture(org, product, firmware2)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware2)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware3)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware3)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       _ =
         Fixtures.device_fixture(org, product, firmware4)
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
 
       {:ok, _deployment_group} =
         ManagedDeployments.update_deployment_group(deployment_group, %{delta_updatable: true}, user)
@@ -1066,7 +1067,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
       device: device,
       deployment_group: deployment_group
     } do
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       assert device.deployment_id
 
       device = ManagedDeployments.verify_deployment_group_membership(device)
@@ -1080,7 +1081,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
          } do
       {:ok, device} =
         device
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
         |> Devices.update_firmware_metadata(%{"platform" => "foobar"}, :unknown, false)
 
       device = ManagedDeployments.verify_deployment_group_membership(device)
@@ -1097,7 +1098,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
          } do
       {:ok, device} =
         device
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
         |> Devices.update_firmware_metadata(%{"architecture" => "foobar"}, :unknown, false)
 
       device = ManagedDeployments.verify_deployment_group_membership(device)
@@ -1114,7 +1115,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
          } do
       {:ok, device} =
         device
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
         |> Devices.update_firmware_metadata(%{"version" => "1.0.1"}, :unknown, false)
 
       device = ManagedDeployments.verify_deployment_group_membership(device)
@@ -1137,7 +1138,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       deployment_group = Repo.reload(deployment_group)
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
 
       device = ManagedDeployments.verify_deployment_group_membership(device)
       refute device.deployment_id
@@ -1158,7 +1159,7 @@ defmodule NervesHub.ManagedDeploymentsTest do
 
       {:ok, device} =
         device
-        |> Devices.update_deployment_group(deployment_group)
+        |> Deployments.update_deployment_group(deployment_group)
         |> Devices.update_firmware_metadata(%{"platform" => "foobar"}, :unknown, false)
 
       device = ManagedDeployments.verify_deployment_group_membership(device)

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -7,8 +7,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   alias NervesHub.AuditLogs
   alias NervesHub.DeviceEvents
-  alias NervesHub.Devices
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments
@@ -434,7 +434,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
   test "deployment information is updated when the deployment is cleared", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
-    Devices.update_deployment_group(device, deployment_group)
+    Deployments.update_deployment_group(device, deployment_group)
 
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
@@ -449,7 +449,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     refute is_nil(device_channel.assigns.device_info.deployment_id)
     refute is_nil(device_channel.assigns.deployment_channel)
 
-    Devices.clear_deployment_group(device)
+    Deployments.clear_deployment_group(device)
 
     # we need to let the channel process all messages before we can
     # check the state of the device's connection types
@@ -464,7 +464,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
   test "deployment information is updated when the device joins a new deployment", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, firmware, deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
-    Devices.update_deployment_group(device, deployment_group)
+    Deployments.update_deployment_group(device, deployment_group)
 
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
 
@@ -482,7 +482,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
     new_deployment_group =
       Fixtures.deployment_group_fixture(firmware, %{name: "Super Deployment", user: user})
 
-    Devices.update_deployment_group(device, new_deployment_group)
+    Deployments.update_deployment_group(device, new_deployment_group)
 
     # we need to let the channel process all messages before we can
     # check the state of the device's connection types
@@ -518,7 +518,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
   test "deployment group is removed on join when conditions no longer match", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
-    Devices.update_deployment_group(device, deployment_group)
+    Deployments.update_deployment_group(device, deployment_group)
 
     {:ok, _deployment_group} =
       ManagedDeployments.update_deployment_group(
@@ -545,7 +545,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
   test "deployment group is not removed when matching conditions are met", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
-    device = Devices.update_deployment_group(device, deployment_group)
+    device = Deployments.update_deployment_group(device, deployment_group)
     assert device.deployment_id == deployment_group.id
 
     %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)

--- a/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
@@ -2,7 +2,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
   alias NervesHub.AuditLogs
-  alias NervesHub.Devices
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.ManagedDeployments
   alias NervesHub.ManagedDeployments.DeploymentGroup
@@ -204,7 +204,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
     deployment_group: deployment_group,
     device: device
   } do
-    device = Devices.update_deployment_group(device, deployment_group)
+    device = Deployments.update_deployment_group(device, deployment_group)
 
     assert Enum.count(Repo.all_by(Device, deployment_id: deployment_group.id)) == 1
 

--- a/test/nerves_hub_web/live/deployment_groups/show/summary_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/summary_tab_test.exs
@@ -4,6 +4,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SummaryTabTest do
 
   alias NervesHub.AuditLogs
   alias NervesHub.Devices
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.UpdateStats
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.UpdateTool.Fwup
@@ -37,7 +38,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SummaryTabTest do
 
     device =
       Fixtures.device_fixture(org, product, source_firmware, %{status: :provisioned})
-      |> Devices.update_deployment_group(deployment_group)
+      |> Deployments.update_deployment_group(deployment_group)
 
     # Ensure device firmware metadata reflects the target firmware because
     # update stats are logged after a successful firmware update
@@ -291,11 +292,11 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SummaryTabTest do
     deployment_group: deployment_group,
     device: device
   } do
-    Devices.update_deployment_group(device, deployment_group)
+    Deployments.update_deployment_group(device, deployment_group)
 
     # deleted devices shouldn't be included in the count
     Fixtures.device_fixture(org, product, firmware, %{deleted_at: DateTime.utc_now()})
-    |> Devices.update_deployment_group(deployment_group)
+    |> Deployments.update_deployment_group(deployment_group)
 
     assert_has(conn, "span", text: "1")
   end

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -11,6 +11,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.Health
@@ -262,7 +263,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
         {:ok, device} =
           Devices.update_firmware_metadata(device, restored_firmware_metadata, :unknown, false)
 
-        device = Devices.update_deployment_group(device, deployment_group)
+        device = Deployments.update_deployment_group(device, deployment_group)
 
         {:ok, _} = Metrics.save_metrics(device.id, %{"cpu_usage_percent" => 22})
 
@@ -1100,7 +1101,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     } do
       assert device.updates_enabled
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
@@ -1134,7 +1135,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     } do
       assert device.updates_enabled
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
@@ -1187,7 +1188,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       assert device.updates_enabled
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)
@@ -1237,7 +1238,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       metadata = Map.put(device.firmware_metadata, :fwup_version, "1.13.0") |> Map.from_struct()
       Devices.update_device(device, %{firmware_metadata: metadata})
 
-      device = Devices.update_deployment_group(device, deployment_group)
+      device = Deployments.update_deployment_group(device, deployment_group)
       {:ok, connection} = Connections.device_connecting(device.org_id, device.product_id, device.id)
       :ok = Connections.device_connected(connection.id)
       device = Devices.set_as_provisioned!(device)


### PR DESCRIPTION
Final step of the Devices cleanup. Extracts the **device↔deployment-group** functions into a new **`NervesHub.Devices.Deployments`**. **Stacked on Phase 4g** (`cleanup/phase-4g-devices-updates`, #2883).

### What moved
A device's relationship to its deployment group + per-deployment device counts:
`get_device_firmware_for_delta_generation_by_deployment_group`, `matches_deployment_group?`, `update_deployment_group`, `clear_deployment_group`, `deployment_device_online`, `up_to_date_count`, `updating_count`, `waiting_for_update_count`, `updates_disabled_count`, `in_penalty_box_count`, `remove_unmatched_devices_from_deployment_group` — plus private `version_match?`/`tags_match?` and the delta-gen `@type`s.

The cluster is self-contained (no back-calls into core `Devices`), so no qualification was needed; six now-unused aliases were dropped from `devices.ex`. Call sites repointed across lib and test (including `ManagedDeployments` itself, which called four of these). No dynamic-dispatch/Mimic wiring for this cluster (verified).

### The big picture
`devices.ex` is now **783 lines, down from 1,927** at the start. The Devices god-module has been split into six focused sub-modules — `CACertificates`, `Pinning`, `Health`, `Certificates`, `Updates`, `Deployments` — with **delta resolution moved to `Firmwares`** and **signing keys moved to `Accounts`**.

### Verification
- `mix format` (bare, exit 0) ✓, credo ✓, dialyzer (0 unskipped) ✓
- **Full test suite: 1396 passing, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)