### PR TITLE
Improve device health metadata display

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -12,6 +12,7 @@ import BarChart from "./hooks/barChart.js"
 import Chart from "./hooks/chart.js"
 import CommandPalette from "./hooks/commandPalette.js"
 import Console from "./hooks/console.js"
+import CopyToClipboard from "./hooks/copyToClipboard.js"
 import CrossFadeOnUpdate from "./hooks/crossFadeOnUpdate.js"
 import DeviceLocationMap from "./hooks/deviceLocationMap.js"
 import DeviceLocationMapWithGeocoder from "./hooks/deviceLocationMapWithGeocoder.js"
@@ -61,6 +62,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     Chart,
     CommandPalette,
     Console,
+    CopyToClipboard,
     CrossFadeOnUpdate,
     DeviceLocationMap,
     DeviceLocationMapWithGeocoder,

--- a/assets/js/hooks/copyToClipboard.js
+++ b/assets/js/hooks/copyToClipboard.js
@@ -1,0 +1,49 @@
+// Generic "copy to clipboard" hook.
+//
+// Copies the string in the element's `data-copy-value` attribute to the
+// clipboard when clicked. If the button contains icons tagged with
+// `data-icon="copy"` and `data-icon="check"`, it briefly swaps the copy icon
+// for the check icon to confirm the copy.
+export default {
+  mounted() {
+    this.handleClick = () => this.copy(this.el.dataset.copyValue ?? "")
+    this.el.addEventListener("click", this.handleClick)
+  },
+
+  destroyed() {
+    this.el.removeEventListener("click", this.handleClick)
+    clearTimeout(this.resetTimeout)
+  },
+
+  copy(text) {
+    const confirmCopied = () => this.flash()
+
+    if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+      // NOTE: Safari locks down the clipboard API to only work when triggered
+      //   by a direct user interaction and won't allow it inside an async
+      //   promise. Wrapping the value in a ClipboardItem works around this.
+      const type = "text/plain"
+      const blob = new Blob([text], { type })
+      const data = [new window.ClipboardItem({ [type]: blob })]
+      navigator.clipboard.write(data).then(confirmCopied, () => {})
+    } else if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).then(confirmCopied, () => {})
+    }
+  },
+
+  flash() {
+    const copyIcon = this.el.querySelector("[data-icon='copy']")
+    const checkIcon = this.el.querySelector("[data-icon='check']")
+
+    if (!copyIcon || !checkIcon) return
+
+    copyIcon.classList.add("hidden")
+    checkIcon.classList.remove("hidden")
+
+    clearTimeout(this.resetTimeout)
+    this.resetTimeout = setTimeout(() => {
+      copyIcon.classList.remove("hidden")
+      checkIcon.classList.add("hidden")
+    }, 1500)
+  },
+}

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -56,8 +56,26 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     metadata =
       if device.latest_health, do: device.latest_health.data["metadata"] || %{}, else: %{}
 
-    assign(socket, :metadata, Map.drop(metadata, standard_keys(device)))
+    entries =
+      metadata
+      |> Map.drop(standard_keys(device))
+      |> Enum.reject(fn {_key, value} -> value in ["", nil] end)
+      |> Enum.map(fn {key, value} -> {key, metadata_value(value)} end)
+      |> Enum.sort_by(fn {key, _value} -> key end)
+
+    assign(socket, :metadata_entries, entries)
   end
+
+  # Metadata values arrive as decoded JSON, so they can be strings, numbers,
+  # booleans, or nested structures. Render everything as a string so it can be
+  # both displayed and copied to the clipboard.
+  defp metadata_value(value) when is_binary(value), do: value
+  defp metadata_value(value), do: inspect(value)
+
+  # Values wider than the truncation cap get a hover tooltip revealing the full
+  # value. The threshold roughly matches the value column's max width so short
+  # values that already fit don't get a redundant tooltip.
+  defp long_value?(value), do: String.length(value) > 32
 
   defp assign_support_scripts(%{assigns: %{product: product}} = socket) do
     scripts = Scripts.all_by_product(product)
@@ -394,13 +412,34 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
               </div>
             </div>
 
-            <div :if={!Enum.empty?(@metadata)} class="flex min-h-7 gap-4 px-4">
-              <span class="text-base-500 pt-1 text-sm">Metadata:</span>
-              <span class="flex flex-col gap-1">
-                <span :for={{key, value} <- Map.filter(@metadata, fn {_key, val} -> val != "" end)} class="bg-base-800 border-base-800 text-base-300 rounded border px-2 py-1 text-sm">
-                  <span>{key |> String.replace("_", " ") |> String.capitalize()}: {value}</span>
-                </span>
-              </span>
+            <div :if={@metadata_entries != []} class="flex flex-col gap-2 px-4">
+              <span class="text-base-500 text-sm">Metadata:</span>
+              <div class="flex flex-col gap-1.5">
+                <div :for={{key, value} <- @metadata_entries} class="group/meta flex w-full min-w-0 items-center gap-1.5">
+                  <div id={"metadata-#{key}"} class="relative flex min-w-0" phx-hook={long_value?(value) && "ToolTip"} data-placement="top">
+                    <div class="border-base-700 flex min-w-0 items-stretch overflow-hidden rounded border text-xs">
+                      <span class="bg-base-700 text-base-300 shrink-0 px-2 py-0.5 tracking-wide">{key |> String.replace("_", " ") |> String.capitalize()}</span>
+                      <span class="bg-base-800 text-base-200 min-w-0 truncate px-2 py-0.5 font-mono">{value}</span>
+                    </div>
+                    <div :if={long_value?(value)} role="tooltip" class="bg-surface-overlay border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden max-w-md rounded border px-2 py-1.5 shadow-lg">
+                      <span class="text-base-200 font-mono text-xs break-all">{value}</span>
+                      <div class="bg-surface-overlay border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
+                    </div>
+                  </div>
+                  <button
+                    id={"copy-metadata-#{key}"}
+                    type="button"
+                    phx-hook="CopyToClipboard"
+                    data-copy-value={value}
+                    aria-label={"Copy #{key} value"}
+                    title="Copy value"
+                    class="hover:text-base-200 text-base-500 shrink-0 cursor-pointer opacity-0 transition-opacity group-hover/meta:opacity-100 focus:opacity-100"
+                  >
+                    <span data-icon="copy" class="lucide-copy--light size-4"></span>
+                    <span data-icon="check" class="lucide-check--light text-success hidden size-4"></span>
+                  </button>
+                </div>
+              </div>
             </div>
 
             <div :if={@extension_overrides != []} class="flex min-h-7 items-center gap-4 px-4">


### PR DESCRIPTION
Long metadata values from a device's health report previously overflowed the **General Info** card (and the page) on the device details tab, because the value was neither truncated nor wrapped.

<img width="620" height="297" alt="Screenshot 2026-08-15 at 12 57 39 PM" src="https://github.com/user-attachments/assets/02b7e7c4-ea28-411a-af7e-cb892384c23d" />

This reworks the Metadata section of the device details tab:

- **Compact two-tone pills** — each metadata key/value pair renders on a single line as a pill with distinct key and value backgrounds, sized to its content, so short values stay compact rather than stretching full width.
- **CSS truncation to the section width** — long values truncate with an ellipsis at the available width of the General Info section instead of overflowing, via a flexbox `min-w-0` shrink chain (no fixed width cap), so a value can use the full section width if needed.
- **Full value on hover** — values long enough to truncate get a tooltip (reusing the existing `ToolTip` hook) revealing the full value.
- **Copy button** — a copy button appears on hover to copy the full, untruncated value, backed by a new reusable `CopyToClipboard` LiveView hook.

<img width="615" height="384" alt="Screenshot 2026-08-15 at 12 50 29 PM" src="https://github.com/user-attachments/assets/972cd08a-88a2-4822-b185-6bc424994bb7" />

<img width="616" height="389" alt="Screenshot 2026-08-15 at 12 50 36 PM" src="https://github.com/user-attachments/assets/b1ee0de3-e613-4c5c-a4dd-a5840e3bf09b" />

