### PR TITLE
API endpoints for iroh endpoint ids

### DIFF
--- a/lib/nerves_hub/devices/external_identities.ex
+++ b/lib/nerves_hub/devices/external_identities.ex
@@ -38,11 +38,20 @@ defmodule NervesHub.Devices.ExternalIdentities do
 
   @doc """
   All identities recorded for a device, ordered by service then instance.
+
+  `opts` narrows the list:
+
+    * `:service` — only this protocol, as an atom. Cast a name that arrived from
+      outside with `cast_service/1` first; an unsupported one should be an error
+      to its caller rather than quietly the whole list.
+    * `:instance` — only this endpoint of it, matched exactly.
   """
-  @spec list_for_device(pos_integer()) :: [ExternalIdentity.t()]
-  def list_for_device(device_id) do
+  @spec list_for_device(pos_integer(), keyword()) :: [ExternalIdentity.t()]
+  def list_for_device(device_id, opts \\ []) do
     ExternalIdentity
     |> where(device_id: ^device_id)
+    |> filter_by_service(opts[:service])
+    |> filter_by_instance(opts[:instance])
     |> order_by(asc: :service, asc: :instance)
     |> Repo.all()
   end
@@ -93,6 +102,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
 
   defp filter_by_service(query, nil), do: query
   defp filter_by_service(query, service), do: where(query, service: ^service)
+
+  defp filter_by_instance(query, nil), do: query
+  defp filter_by_instance(query, instance), do: where(query, instance: ^instance)
 
   defp filter_by_owner(query, nil), do: query
   defp filter_by_owner(query, :device), do: where(query, [ei], not is_nil(ei.device_id))
@@ -211,6 +223,29 @@ defmodule NervesHub.Devices.ExternalIdentities do
     ExternalIdentity
     |> where(service: ^service)
     |> where(identifier: ^identifier)
+  end
+
+  @doc """
+  Fetch one of an organisation's identities by the key it names.
+
+  Scoped to the organisation, because a key is not a secret — it is the one
+  thing an outsider is most likely to have — so knowing one must not be enough
+  to read the record another organisation keeps of it.
+
+  Owners are preloaded, since whose a key is is most of what there is to say
+  about it.
+  """
+  @spec get_for_org(pos_integer(), atom() | String.t(), String.t()) ::
+          {:ok, ExternalIdentity.t()} | {:error, :not_found | :unsupported_service}
+  def get_for_org(org_id, service, identifier) when is_binary(identifier) do
+    with {:ok, service} <- cast_service_result(service) do
+      ExternalIdentity
+      |> where(org_id: ^org_id)
+      |> where(service: ^service)
+      |> where(identifier: ^identifier)
+      |> preload([:device, org_user: :user])
+      |> Repo.fetch()
+    end
   end
 
   @doc """
@@ -584,11 +619,22 @@ defmodule NervesHub.Devices.ExternalIdentities do
 
   defp broadcast_if_ok(result, _device_id), do: result
 
-  defp cast_service(service) when is_atom(service) do
+  @doc """
+  The atom this schema uses for a service name, or `:error`.
+
+  Public because a caller taking a service from a query string has to know
+  whether it names one before filtering on it. Ecto raises on an unknown value,
+  and treating one as "no filter" would answer a typo with everything — which
+  reads as a device holding identities it does not have.
+  """
+  @spec cast_service(atom() | String.t()) :: {:ok, atom()} | :error
+  def cast_service(service)
+
+  def cast_service(service) when is_atom(service) do
     if service in ExternalIdentity.services(), do: {:ok, service}, else: :error
   end
 
-  defp cast_service(service) when is_binary(service) do
+  def cast_service(service) when is_binary(service) do
     # String.to_existing_atom/1 is not enough on its own — every service name is
     # already an existing atom, so it would happily return one we do not support.
     Enum.find_value(ExternalIdentity.services(), :error, fn known ->
@@ -596,5 +642,5 @@ defmodule NervesHub.Devices.ExternalIdentities do
     end)
   end
 
-  defp cast_service(_service), do: :error
+  def cast_service(_service), do: :error
 end

--- a/lib/nerves_hub_web/api_spec.ex
+++ b/lib/nerves_hub_web/api_spec.ex
@@ -79,12 +79,20 @@ defmodule NervesHubWeb.ApiSpec do
           description: "Device Certificate management"
         },
         %Tag{
+          name: "External Identities",
+          description: "Identities a Device holds on networks NervesHub does not run"
+        },
+        %Tag{
           name: "Deployment Groups",
           description: "Deployment Group and release management"
         },
         %Tag{
           name: "Firmwares",
           description: "Firmware uploading and management"
+        },
+        %Tag{
+          name: "Iroh Endpoints",
+          description: "Organization iroh endpoint id registration"
         },
         %Tag{
           name: "Organizations",

--- a/lib/nerves_hub_web/controllers/api/error_json.ex
+++ b/lib/nerves_hub_web/controllers/api/error_json.ex
@@ -28,6 +28,10 @@ defmodule NervesHubWeb.API.ErrorJSON do
     %{errors: %{detail: message}}
   end
 
+  def render("409.json", %{reason: reason}) do
+    %{errors: %{detail: reason}}
+  end
+
   def render("422.json", %{reason: reason}) do
     %{errors: %{detail: reason}}
   end

--- a/lib/nerves_hub_web/controllers/api/external_identity_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/external_identity_controller.ex
@@ -1,0 +1,96 @@
+defmodule NervesHubWeb.API.ExternalIdentityController do
+  @moduledoc """
+  What a device holds on networks NervesHub does not run.
+
+  Read-only. A device reports its own identities over its own connection, and
+  that is the only way one becomes device-owned — writing one here would be
+  recording a claim nobody proved. Register unproven keys against the
+  organization instead, with `NervesHubWeb.API.IrohEndpointController`.
+  """
+
+  use NervesHubWeb, :api_controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHubWeb.API.OpenAPI.SchemaHelpers
+  alias NervesHubWeb.API.Schemas.ErrorSchemas
+  alias NervesHubWeb.API.Schemas.ExternalIdentitySchemas
+
+  security([%{"bearer_auth" => []}])
+  tags(["External Identities"])
+
+  @auth_error_responses SchemaHelpers.auth_error_responses()
+
+  plug(:validate_role, [org: :view] when action in [:index])
+
+  operation(:index,
+    summary: "List the External Identities a Device holds",
+    description: """
+    The keys this device has reported holding on other networks — an iroh
+    endpoint id, a NetBird, Tailscale or WireGuard public key.
+
+    `service` is the protocol. `instance` names which endpoint of it, for a
+    device running more than one — an iroh console and an iroh application, say.
+    Anything running a single endpoint of a service uses `default`.
+    """,
+    parameters: [
+      org_name: [in: :path, description: "Organization Name", type: :string, example: "example_org"],
+      product_name: [in: :path, description: "Product Name", type: :string, example: "example_product"],
+      identifier: [in: :path, description: "Device Identifier", type: :string, example: "example_device"],
+      service: [
+        in: :query,
+        description: "Only identities for this protocol",
+        type: :string,
+        required: false,
+        example: "iroh"
+      ],
+      instance: [
+        in: :query,
+        description: "Only this endpoint of the protocol",
+        type: :string,
+        required: false,
+        example: "default"
+      ]
+    ],
+    responses:
+      [
+        ok:
+          {"External Identity list response", "application/json", ExternalIdentitySchemas.ExternalIdentityListResponse},
+        unprocessable_entity: {"Unknown service", "application/json", ErrorSchemas.ChangesetErrorResponse}
+      ] ++ @auth_error_responses
+  )
+
+  def index(%{assigns: %{device: device}} = conn, params) do
+    with {:ok, service} <- filter_service(params["service"]) do
+      identities =
+        ExternalIdentities.list_for_device(device.id,
+          service: service,
+          instance: filter_instance(params["instance"])
+        )
+
+      render(conn, :index, external_identities: identities)
+    end
+  end
+
+  # An unknown service is refused rather than ignored. Ignoring it would answer
+  # a typo with every identity the device has, which reads as a device holding
+  # keys on a network it has never touched.
+  defp filter_service(nil), do: {:ok, nil}
+  defp filter_service(""), do: {:ok, nil}
+
+  defp filter_service(service) do
+    case ExternalIdentities.cast_service(service) do
+      {:ok, service} -> {:ok, service}
+      :error -> {:error, :unsupported_service}
+    end
+  end
+
+  defp filter_instance(instance) when is_binary(instance) do
+    case String.trim(instance) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp filter_instance(_instance), do: nil
+end

--- a/lib/nerves_hub_web/controllers/api/external_identity_json.ex
+++ b/lib/nerves_hub_web/controllers/api/external_identity_json.ex
@@ -1,0 +1,35 @@
+defmodule NervesHubWeb.API.ExternalIdentityJSON do
+  @moduledoc false
+
+  alias NervesHub.Devices.ExternalIdentity
+
+  def index(%{external_identities: external_identities}) do
+    %{data: for(identity <- external_identities, do: external_identity(identity))}
+  end
+
+  def show(%{external_identity: external_identity}) do
+    %{data: external_identity(external_identity)}
+  end
+
+  @doc """
+  The fields common to every view of an identity.
+
+  Public so `NervesHubWeb.API.IrohEndpointJSON` can render the same shape and
+  add an owner to it — the two endpoints show the same rows and should not
+  disagree about what one looks like.
+  """
+  def external_identity(%ExternalIdentity{} = identity) do
+    %{
+      identifier: identity.identifier,
+      service: identity.service,
+      instance: identity.instance,
+      # Whether anything has actually proven this key: `device_reported` means a
+      # device did, on its own connection. `operator` means somebody typed it in.
+      source: identity.source,
+      details: identity.details,
+      last_reported_at: identity.last_reported_at,
+      inserted_at: identity.inserted_at,
+      updated_at: identity.updated_at
+    }
+  end
+end

--- a/lib/nerves_hub_web/controllers/api/fallback_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/fallback_controller.ex
@@ -57,6 +57,41 @@ defmodule NervesHubWeb.API.FallbackController do
     })
   end
 
+  def call(conn, {:error, :claimed_elsewhere}) do
+    # Deliberately does not say where. Whether another organization holds a key
+    # is that organization's business, and this must not become a way to probe
+    # for which keys are in use.
+    conn
+    |> put_status(:conflict)
+    |> put_view(ErrorJSON)
+    |> render(:"409", %{
+      reason:
+        "That endpoint id is already registered. If it belongs to one of your devices, " <>
+          "it will be claimed the next time that device connects."
+    })
+  end
+
+  def call(conn, {:error, :invalid_member}) do
+    conn
+    |> put_status(422)
+    |> put_view(ErrorJSON)
+    |> render(:"422", %{reason: "That email address does not belong to a member of this organization."})
+  end
+
+  def call(conn, {:error, :unknown_owner}) do
+    conn
+    |> put_status(422)
+    |> put_view(ErrorJSON)
+    |> render(:"422", %{reason: "owner must be one of: device, user, none."})
+  end
+
+  def call(conn, {:error, :unsupported_service}) do
+    conn
+    |> put_status(422)
+    |> put_view(ErrorJSON)
+    |> render(:"422", %{reason: "That is not a service this NervesHub knows about."})
+  end
+
   def call(conn, {:error, :authentication_failed}) do
     conn
     |> put_status(401)

--- a/lib/nerves_hub_web/controllers/api/iroh_endpoint_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/iroh_endpoint_controller.ex
@@ -1,0 +1,220 @@
+defmodule NervesHubWeb.API.IrohEndpointController do
+  @moduledoc """
+  An organisation's iroh endpoint ids, over the API.
+
+  The same registry the Iroh Endpoints page manages, addressed by the key
+  itself rather than by a row id: the key is what a caller has, it is unique
+  per service, and an id would mean listing before you could act.
+
+  Fixed to iroh, like the page. `ExternalIdentityController` is the generic view
+  of the same table, for reading what a device has reported about itself.
+  """
+
+  use NervesHubWeb, :api_controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias NervesHub.Accounts
+  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHubWeb.API.OpenAPI.SchemaHelpers
+  alias NervesHubWeb.API.Schemas.ErrorSchemas
+  alias NervesHubWeb.API.Schemas.IrohEndpointSchemas
+  alias OpenApiSpex.Schema
+
+  security([%{"bearer_auth" => []}])
+  tags(["Iroh Endpoints"])
+
+  @auth_error_responses SchemaHelpers.auth_error_responses()
+
+  @service :iroh
+
+  plug(:validate_role, [org: :manage] when action in [:create, :delete])
+  plug(:validate_role, [org: :view] when action in [:index, :show])
+
+  @org_name_parameter [
+    in: :path,
+    description: "Organization Name",
+    type: :string,
+    example: "example_org"
+  ]
+
+  @identifier_parameter [
+    in: :path,
+    description: "The endpoint id — 64 hex characters",
+    type: :string,
+    example: "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302"
+  ]
+
+  operation(:index,
+    summary: "List all Iroh Endpoints for an Organization",
+    description: """
+    Newest first.
+
+    `search` matches the **start** of an endpoint id, and anywhere within a
+    device identifier or a member's name. Prefix rather than substring on the
+    key because that is the half a caller has: logs and tables show a key
+    truncated, so the beginning is what can be copied out of one.
+    """,
+    parameters: [
+      org_name: @org_name_parameter,
+      owner: [
+        in: :query,
+        description: "Only endpoints held by this kind of owner, matching the `owner.type` in the response",
+        type: %Schema{type: :string, enum: ["device", "user", "none"]},
+        required: false,
+        example: "user"
+      ],
+      search: [
+        in: :query,
+        description: "Match the start of an endpoint id, or part of a device identifier or member name",
+        type: :string,
+        required: false,
+        example: "c8924b6c"
+      ]
+    ],
+    responses:
+      [
+        ok: {"Iroh Endpoints", "application/json", IrohEndpointSchemas.IrohEndpointListResponse},
+        unprocessable_entity: {"Unknown owner", "application/json", ErrorSchemas.ErrorResponse}
+      ] ++ @auth_error_responses
+  )
+
+  def index(%{assigns: %{current_scope: %{org: org}}} = conn, params) do
+    with {:ok, owner} <- filter_owner(params["owner"]) do
+      endpoints =
+        ExternalIdentities.list_for_org(org.id,
+          service: @service,
+          owner: owner,
+          # Passed through as it arrives. The context trims it, treats a blank
+          # one as no filter, and escapes the LIKE wildcards, so a search for
+          # "abc_" looks for that rather than matching everything.
+          search: params["search"]
+        )
+
+      render(conn, :index, iroh_endpoints: endpoints)
+    end
+  end
+
+  # Named for what `owner.type` renders in the response rather than for the
+  # context's own values, so a caller reading "user" back can filter with
+  # "user" instead of learning a second vocabulary for the same three things.
+  #
+  # An unknown one is refused rather than ignored: ignoring it would answer a
+  # typo with the whole list, which looks like a filter that found everything.
+  defp filter_owner(owner) when owner in [nil, ""], do: {:ok, nil}
+  defp filter_owner("device"), do: {:ok, :device}
+  defp filter_owner("user"), do: {:ok, :org_user}
+  defp filter_owner("none"), do: {:ok, :unowned}
+  defp filter_owner(_owner), do: {:error, :unknown_owner}
+
+  operation(:create,
+    summary: "Register an Iroh Endpoint for an Organization",
+    description: """
+    Records an endpoint id nobody has proven yet, which is the point and also
+    the risk. A key already registered anywhere is refused, without saying
+    where — whether another organization holds one is that organization's
+    business.
+
+    A key registered here for a device in this organization is claimed by that
+    device the next time it connects and proves it, so registering ahead of
+    provisioning needs no cleanup.
+    """,
+    parameters: [org_name: @org_name_parameter],
+    request_body: {
+      "Iroh Endpoint registration request body",
+      "application/json",
+      IrohEndpointSchemas.IrohEndpointCreateRequest,
+      required: true
+    },
+    responses:
+      [
+        created: {"Iroh Endpoint", "application/json", IrohEndpointSchemas.IrohEndpointShowResponse},
+        conflict: {"Already registered", "application/json", ErrorSchemas.ErrorResponse},
+        unprocessable_entity: {"Unprocessable Entity", "application/json", ErrorSchemas.ChangesetErrorResponse}
+      ] ++ @auth_error_responses
+  )
+
+  def create(%{assigns: %{current_scope: %{org: org}}} = conn, params) do
+    with {:ok, org_user_id} <- resolve_member(org, params["user_email"]),
+         attrs = registration_attrs(params, org_user_id),
+         {:ok, registered} <- ExternalIdentities.register(org.id, @service, attrs),
+         # Read it back rather than render what register/3 returned. That struct
+         # has no owner loaded, so an endpoint just attached to a person would
+         # render as belonging to nobody — and create would disagree with show
+         # about the same row.
+         {:ok, endpoint} <- ExternalIdentities.get_for_org(org.id, @service, registered.identifier) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header(
+        "location",
+        Routes.api_iroh_endpoint_path(conn, :show, org.name, endpoint.identifier)
+      )
+      |> render(:show, iroh_endpoint: endpoint)
+    end
+  end
+
+  operation(:show,
+    summary: "Show an Iroh Endpoint for an Organization",
+    parameters: [org_name: @org_name_parameter, identifier: @identifier_parameter],
+    responses:
+      [
+        ok: {"Iroh Endpoint", "application/json", IrohEndpointSchemas.IrohEndpointShowResponse},
+        not_found: {"Not Found", "application/json", ErrorSchemas.ErrorResponse}
+      ] ++ @auth_error_responses
+  )
+
+  def show(%{assigns: %{current_scope: %{org: org}}} = conn, %{"identifier" => identifier}) do
+    with {:ok, endpoint} <- ExternalIdentities.get_for_org(org.id, @service, identifier) do
+      render(conn, :show, iroh_endpoint: endpoint)
+    end
+  end
+
+  operation(:delete,
+    summary: "Delete an Iroh Endpoint for an Organization",
+    description: """
+    An endpoint a device reported is removed too, but the device records it
+    again the next time it connects — deleting one is not a way to stop a device
+    holding a key it holds.
+    """,
+    parameters: [org_name: @org_name_parameter, identifier: @identifier_parameter],
+    responses:
+      [
+        no_content: "Empty response",
+        not_found: {"Not Found", "application/json", ErrorSchemas.ErrorResponse}
+      ] ++ @auth_error_responses
+  )
+
+  def delete(%{assigns: %{current_scope: %{org: org}}} = conn, %{"identifier" => identifier}) do
+    with {:ok, endpoint} <- ExternalIdentities.get_for_org(org.id, @service, identifier),
+         {:ok, _endpoint} <- ExternalIdentities.delete(org.id, endpoint.id) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp registration_attrs(params, org_user_id) do
+    %{
+      "identifier" => params["identifier"],
+      "instance" => params["instance"],
+      "details" => params["details"],
+      "org_user_id" => org_user_id
+    }
+  end
+
+  # Memberships are addressed by the member's email here, not by `org_user_id`.
+  # The organization members API exposes no ids, so one would be a value a
+  # caller has no way to look up.
+  defp resolve_member(_org, email) when email in [nil, ""], do: {:ok, nil}
+
+  defp resolve_member(org, email) when is_binary(email) do
+    with {:ok, user} <- Accounts.get_user_by_email(email),
+         {:ok, org_user} <- Accounts.get_org_user(org, user) do
+      {:ok, org_user.id}
+    else
+      # Deliberately the same answer for "no such user" and "not in this
+      # organization": the caller may not know either, and this endpoint is not
+      # a way to find out which addresses have accounts.
+      _other -> {:error, :invalid_member}
+    end
+  end
+
+  defp resolve_member(_org, _email), do: {:error, :invalid_member}
+end

--- a/lib/nerves_hub_web/controllers/api/iroh_endpoint_json.ex
+++ b/lib/nerves_hub_web/controllers/api/iroh_endpoint_json.ex
@@ -1,0 +1,35 @@
+defmodule NervesHubWeb.API.IrohEndpointJSON do
+  @moduledoc false
+
+  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHubWeb.API.ExternalIdentityJSON
+
+  def index(%{iroh_endpoints: iroh_endpoints}) do
+    %{data: for(endpoint <- iroh_endpoints, do: iroh_endpoint(endpoint))}
+  end
+
+  def show(%{iroh_endpoint: iroh_endpoint}) do
+    %{data: iroh_endpoint(iroh_endpoint)}
+  end
+
+  defp iroh_endpoint(%ExternalIdentity{} = endpoint) do
+    endpoint
+    |> ExternalIdentityJSON.external_identity()
+    |> Map.put(:owner, owner(endpoint))
+  end
+
+  # An organization's list is mostly a question of whose each key is, so the
+  # owner is spelled out rather than left as an id to look up. `type` is what a
+  # caller should branch on; the rest is nil for the kinds that do not have it.
+  defp owner(%ExternalIdentity{device: %{identifier: identifier}}) do
+    %{type: "device", device_identifier: identifier, user_name: nil, user_email: nil}
+  end
+
+  defp owner(%ExternalIdentity{org_user: %{user: %{name: name, email: email}}}) do
+    %{type: "user", device_identifier: nil, user_name: name, user_email: email}
+  end
+
+  defp owner(%ExternalIdentity{}) do
+    %{type: "none", device_identifier: nil, user_name: nil, user_email: nil}
+  end
+end

--- a/lib/nerves_hub_web/controllers/api/schemas/external_identity_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/external_identity_schemas.ex
@@ -1,0 +1,87 @@
+defmodule NervesHubWeb.API.Schemas.ExternalIdentitySchemas do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  defmodule ExternalIdentity do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      description: "A key a device holds on a network NervesHub does not run",
+      type: :object,
+      properties: %{
+        identifier: %Schema{
+          type: :string,
+          description: "The value possession of which is proven — a public key, not a handle that can be reassigned"
+        },
+        service: %Schema{
+          type: :string,
+          description: "The protocol",
+          enum: ["iroh", "netbird", "tailscale", "wireguard"]
+        },
+        instance: %Schema{
+          type: :string,
+          description: "Which endpoint of that protocol. `default` for anything running a single one"
+        },
+        source: %Schema{
+          type: :string,
+          description:
+            "Whether anything proved this key. `device_reported` means a device did; `operator` means it was typed in",
+          enum: ["device_reported", "operator"]
+        },
+        details: %Schema{
+          type: :object,
+          description: "Per-service and non-authoritative — relay urls, an assigned address. Never a secret",
+          additionalProperties: true
+        },
+        last_reported_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      },
+      example: %{
+        "identifier" => "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302",
+        "service" => "iroh",
+        "instance" => "default",
+        "source" => "device_reported",
+        "details" => %{"relay" => "https://relay.example.com"},
+        "last_reported_at" => "2026-08-16T09:14:00Z",
+        "inserted_at" => "2026-08-14T11:02:31Z",
+        "updated_at" => "2026-08-16T09:14:00Z"
+      }
+    })
+  end
+
+  defmodule ExternalIdentityListResponse do
+    OpenApiSpex.schema(%{
+      description: "External Identity list response",
+      type: :object,
+      properties: %{
+        data: %Schema{description: "The identities this device holds", type: :array, items: ExternalIdentity}
+      },
+      example: %{
+        "data" => [
+          %{
+            "identifier" => "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302",
+            "service" => "iroh",
+            "instance" => "default",
+            "source" => "device_reported",
+            "details" => %{"relay" => "https://relay.example.com"},
+            "last_reported_at" => "2026-08-16T09:14:00Z",
+            "inserted_at" => "2026-08-14T11:02:31Z",
+            "updated_at" => "2026-08-16T09:14:00Z"
+          },
+          %{
+            "identifier" => "5f691e39f55415be337b2e4cc0dd7291586ab7c4356bf32bab60f46fc78f95d5",
+            "service" => "iroh",
+            "instance" => "console",
+            "source" => "device_reported",
+            "details" => %{},
+            "last_reported_at" => "2026-08-16T09:14:00Z",
+            "inserted_at" => "2026-08-14T11:02:31Z",
+            "updated_at" => "2026-08-16T09:14:00Z"
+          }
+        ]
+      }
+    })
+  end
+end

--- a/lib/nerves_hub_web/controllers/api/schemas/iroh_endpoint_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/iroh_endpoint_schemas.ex
@@ -1,0 +1,181 @@
+defmodule NervesHubWeb.API.Schemas.IrohEndpointSchemas do
+  alias OpenApiSpex.Schema
+
+  require OpenApiSpex
+
+  defmodule IrohEndpointOwner do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      description: "What holds this endpoint id",
+      type: :object,
+      properties: %{
+        type: %Schema{
+          type: :string,
+          description:
+            "`device` for one a device proved, `user` for a member's own machine, `none` for one the organization holds directly",
+          enum: ["device", "user", "none"]
+        },
+        device_identifier: %Schema{type: :string, nullable: true, description: "Set when `type` is `device`"},
+        user_name: %Schema{type: :string, nullable: true, description: "Set when `type` is `user`"},
+        user_email: %Schema{type: :string, nullable: true, description: "Set when `type` is `user`"}
+      },
+      example: %{
+        "type" => "device",
+        "device_identifier" => "example_device",
+        "user_name" => nil,
+        "user_email" => nil
+      }
+    })
+  end
+
+  defmodule IrohEndpoint do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      description: "An iroh endpoint id registered to an organization",
+      type: :object,
+      properties: %{
+        identifier: %Schema{type: :string, description: "The endpoint id — 64 hex characters"},
+        service: %Schema{type: :string, enum: ["iroh"]},
+        instance: %Schema{
+          type: :string,
+          description: "Which endpoint of iroh this is. `default` for anything running a single one"
+        },
+        source: %Schema{
+          type: :string,
+          description: "`device_reported` means a device proved this key; `operator` means it was registered by hand",
+          enum: ["device_reported", "operator"]
+        },
+        details: %Schema{type: :object, additionalProperties: true},
+        last_reported_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"},
+        owner: IrohEndpointOwner
+      },
+      example: %{
+        "identifier" => "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302",
+        "service" => "iroh",
+        "instance" => "default",
+        "source" => "device_reported",
+        "details" => %{},
+        "last_reported_at" => "2026-08-16T09:14:00Z",
+        "inserted_at" => "2026-08-14T11:02:31Z",
+        "updated_at" => "2026-08-16T09:14:00Z",
+        "owner" => %{
+          "type" => "device",
+          "device_identifier" => "example_device",
+          "user_name" => nil,
+          "user_email" => nil
+        }
+      }
+    })
+  end
+
+  defmodule IrohEndpointCreateRequest do
+    OpenApiSpex.schema(%{
+      description: "POST body for registering an Iroh Endpoint against an Organization",
+      type: :object,
+      properties: %{
+        identifier: %Schema{
+          type: :string,
+          description: "The endpoint id — the public key the endpoint proves it holds, not a ticket or a relay url"
+        },
+        instance: %Schema{
+          type: :string,
+          description: "Names which endpoint this is, for something running more than one. Omit for a single one",
+          default: "default"
+        },
+        user_email: %Schema{
+          type: :string,
+          description:
+            "Attach the endpoint to this member of the organization — their laptop, say. Omit for one the organization holds directly, or for a device that will claim it on its next connection. The address must belong to a member",
+          nullable: true
+        },
+        details: %Schema{
+          type: :object,
+          description: "Anything worth recording alongside the key. Non-authoritative, and never a secret",
+          additionalProperties: true
+        }
+      },
+      required: [:identifier],
+      example: %{
+        "identifier" => "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302",
+        "instance" => "console",
+        "user_email" => "member@example.com"
+      }
+    })
+  end
+
+  defmodule IrohEndpointListResponse do
+    OpenApiSpex.schema(%{
+      description: "Iroh Endpoint list response",
+      type: :object,
+      properties: %{
+        data: %Schema{description: "The organization's iroh endpoint ids", type: :array, items: IrohEndpoint}
+      },
+      example: %{
+        "data" => [
+          %{
+            "identifier" => "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302",
+            "service" => "iroh",
+            "instance" => "default",
+            "source" => "device_reported",
+            "details" => %{},
+            "last_reported_at" => "2026-08-16T09:14:00Z",
+            "inserted_at" => "2026-08-14T11:02:31Z",
+            "updated_at" => "2026-08-16T09:14:00Z",
+            "owner" => %{
+              "type" => "device",
+              "device_identifier" => "example_device",
+              "user_name" => nil,
+              "user_email" => nil
+            }
+          },
+          %{
+            "identifier" => "5f691e39f55415be337b2e4cc0dd7291586ab7c4356bf32bab60f46fc78f95d5",
+            "service" => "iroh",
+            "instance" => "default",
+            "source" => "operator",
+            "details" => %{},
+            "last_reported_at" => nil,
+            "inserted_at" => "2026-08-15T08:41:12Z",
+            "updated_at" => "2026-08-15T08:41:12Z",
+            "owner" => %{
+              "type" => "user",
+              "device_identifier" => nil,
+              "user_name" => "Alex Doe",
+              "user_email" => "member@example.com"
+            }
+          }
+        ]
+      }
+    })
+  end
+
+  defmodule IrohEndpointShowResponse do
+    OpenApiSpex.schema(%{
+      description: "Iroh Endpoint show response",
+      type: :object,
+      properties: %{data: IrohEndpoint},
+      example: %{
+        "data" => %{
+          "identifier" => "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302",
+          "service" => "iroh",
+          "instance" => "default",
+          "source" => "device_reported",
+          "details" => %{},
+          "last_reported_at" => "2026-08-16T09:14:00Z",
+          "inserted_at" => "2026-08-14T11:02:31Z",
+          "updated_at" => "2026-08-16T09:14:00Z",
+          "owner" => %{
+            "type" => "device",
+            "device_identifier" => "example_device",
+            "user_name" => nil,
+            "user_email" => nil
+          }
+        }
+      }
+    })
+  end
+end

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -123,6 +123,13 @@ defmodule NervesHubWeb.Router do
             delete("/:name", KeyController, :delete)
           end
 
+          scope "/iroh_endpoints" do
+            get("/", IrohEndpointController, :index)
+            post("/", IrohEndpointController, :create)
+            get("/:identifier", IrohEndpointController, :show)
+            delete("/:identifier", IrohEndpointController, :delete)
+          end
+
           scope "/ca_certificates" do
             get("/", CACertificateController, :index)
             get("/verification_token", CACertificateController, :verification_token)
@@ -163,6 +170,10 @@ defmodule NervesHubWeb.Router do
 
                   scope "/scripts", as: :device do
                     post("/:name_or_id", ScriptController, :send)
+                  end
+
+                  scope "/external_identities" do
+                    get("/", ExternalIdentityController, :index)
                   end
 
                   scope "/certificates" do

--- a/test/nerves_hub_web/controllers/api/external_identity_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/external_identity_controller_test.exs
@@ -1,0 +1,117 @@
+defmodule NervesHubWeb.API.ExternalIdentityControllerTest do
+  use NervesHubWeb.APIConnCase, async: true
+
+  alias NervesHub.Devices
+  alias NervesHub.Devices.ExternalIdentities
+
+  @iroh_console "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302"
+  @iroh_app "5f691e39f55415be337b2e4cc0dd7291586ab7c4356bf32bab60f46fc78f95d5"
+  @tailscale String.duplicate("ab", 32)
+
+  setup %{org: org, product: product} do
+    {:ok, device} =
+      Devices.create_device(%{
+        identifier: "device-1234",
+        description: "test device",
+        tags: ["test"],
+        org_id: org.id,
+        product_id: product.id
+      })
+
+    [device: device]
+  end
+
+  defp path(conn, org, product, device, params \\ []) do
+    Routes.api_external_identity_path(conn, :index, org.name, product.name, device.identifier, params)
+  end
+
+  describe "index" do
+    test "is empty for a device that has reported nothing", %{conn: conn, org: org, product: product, device: device} do
+      conn = get(conn, path(conn, org, product, device))
+
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "lists what the device reported", %{conn: conn, org: org, product: product, device: device} do
+      {:ok, _} =
+        ExternalIdentities.report(device.id, "iroh", %{
+          identifier: @iroh_console,
+          details: %{"relay" => "https://relay.example.com"}
+        })
+
+      conn = get(conn, path(conn, org, product, device))
+
+      assert [identity] = json_response(conn, 200)["data"]
+      assert identity["identifier"] == @iroh_console
+      assert identity["service"] == "iroh"
+      assert identity["instance"] == "default"
+      assert identity["source"] == "device_reported"
+      assert identity["details"] == %{"relay" => "https://relay.example.com"}
+      assert identity["last_reported_at"]
+    end
+
+    test "does not list another device's", %{conn: conn, org: org, product: product, device: device} do
+      {:ok, other} =
+        Devices.create_device(%{identifier: "device-5678", org_id: org.id, product_id: product.id})
+
+      {:ok, _} = ExternalIdentities.report(other.id, "iroh", %{identifier: @iroh_console})
+
+      conn = get(conn, path(conn, org, product, device))
+
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "filtering" do
+    setup %{device: device} do
+      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @iroh_console, instance: "console"})
+      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @iroh_app, instance: "application"})
+      {:ok, _} = ExternalIdentities.report(device.id, "tailscale", %{identifier: @tailscale})
+      :ok
+    end
+
+    test "narrows to one service", %{conn: conn, org: org, product: product, device: device} do
+      conn = get(conn, path(conn, org, product, device, service: "iroh"))
+
+      identifiers = for i <- json_response(conn, 200)["data"], do: i["identifier"]
+      assert Enum.sort(identifiers) == Enum.sort([@iroh_console, @iroh_app])
+    end
+
+    test "narrows to one endpoint of a service", %{conn: conn, org: org, product: product, device: device} do
+      conn = get(conn, path(conn, org, product, device, service: "iroh", instance: "console"))
+
+      assert [%{"identifier" => @iroh_console}] = json_response(conn, 200)["data"]
+    end
+
+    test "an instance on its own still narrows", %{conn: conn, org: org, product: product, device: device} do
+      conn = get(conn, path(conn, org, product, device, instance: "application"))
+
+      assert [%{"identifier" => @iroh_app}] = json_response(conn, 200)["data"]
+    end
+
+    test "an instance nothing uses is empty rather than everything", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      conn = get(conn, path(conn, org, product, device, instance: "nope"))
+
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "refuses a service this NervesHub does not know", %{conn: conn, org: org, product: product, device: device} do
+      # Ignoring it would answer a typo with every identity the device holds,
+      # which reads as keys on a network it has never touched.
+      conn = get(conn, path(conn, org, product, device, service: "zerotier"))
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "not a service"
+    end
+
+    test "an empty filter is no filter", %{conn: conn, org: org, product: product, device: device} do
+      conn = get(conn, path(conn, org, product, device, service: "", instance: ""))
+
+      assert length(json_response(conn, 200)["data"]) == 3
+    end
+  end
+end

--- a/test/nerves_hub_web/controllers/api/iroh_endpoint_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/iroh_endpoint_controller_test.exs
@@ -1,0 +1,365 @@
+defmodule NervesHubWeb.API.IrohEndpointControllerTest do
+  use NervesHubWeb.APIConnCase, async: true
+
+  alias NervesHub.Accounts.OrgUser
+  alias NervesHub.Devices
+  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Fixtures
+
+  @endpoint_id "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302"
+  @other_id String.duplicate("ab", 32)
+  @unowned_id String.duplicate("cd", 32)
+
+  describe "index" do
+    test "is empty for an organization holding none", %{conn: conn, org: org} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
+
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "lists an endpoint with what holds it", %{conn: conn, org: org} do
+      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
+
+      assert [endpoint] = json_response(conn, 200)["data"]
+      assert endpoint["identifier"] == @endpoint_id
+      assert endpoint["service"] == "iroh"
+      assert endpoint["instance"] == "default"
+      # Registered by hand, so nothing has proven it and nobody in the
+      # organization holds it.
+      assert endpoint["source"] == "operator"
+      assert endpoint["owner"]["type"] == "none"
+    end
+
+    test "names the device holding one it reported", %{conn: conn, org: org, product: product} do
+      device = device_fixture(org, product)
+      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
+
+      assert [%{"owner" => owner, "source" => "device_reported"}] = json_response(conn, 200)["data"]
+
+      assert owner == %{
+               "type" => "device",
+               "device_identifier" => device.identifier,
+               "user_name" => nil,
+               "user_email" => nil
+             }
+    end
+
+    test "does not list another organization's endpoints", %{conn: conn, org: org, user: user} do
+      other_org = Fixtures.org_fixture(user, %{name: "SomeoneElse"})
+      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
+
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "lists only iroh, not every service the table holds", %{conn: conn, org: org, product: product} do
+      device = device_fixture(org, product)
+      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = ExternalIdentities.report(device.id, "tailscale", %{identifier: @other_id})
+
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
+
+      assert [%{"identifier" => @endpoint_id}] = json_response(conn, 200)["data"]
+    end
+  end
+
+  describe "index filters" do
+    setup %{conn: conn, org: org, product: product, user: user} do
+      device = device_fixture(org, product)
+      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+
+      {:ok, _} =
+        post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{
+          "identifier" => @other_id,
+          "user_email" => user.email
+        })
+        |> json_response(201)
+        |> then(&{:ok, &1})
+
+      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @unowned_id})
+
+      [device: device]
+    end
+
+    defp identifiers(conn), do: for(e <- json_response(conn, 200)["data"], do: e["identifier"])
+
+    test "unfiltered lists all three", %{conn: conn, org: org} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
+
+      assert length(identifiers(conn)) == 3
+    end
+
+    test "narrows to endpoints a device holds", %{conn: conn, org: org} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, owner: "device"))
+
+      assert identifiers(conn) == [@endpoint_id]
+    end
+
+    test "narrows to endpoints a person holds", %{conn: conn, org: org} do
+      # The filter value is the one `owner.type` renders, not the context's
+      # `org_user` — a caller should not need a second vocabulary.
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, owner: "user"))
+
+      assert identifiers(conn) == [@other_id]
+    end
+
+    test "narrows to endpoints nothing in the organization holds", %{conn: conn, org: org} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, owner: "none"))
+
+      assert identifiers(conn) == [@unowned_id]
+    end
+
+    test "refuses an owner that is not one of the three", %{conn: conn, org: org} do
+      # Ignoring it would answer a typo with the whole list, which reads as a
+      # filter that matched everything.
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, owner: "operator"))
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "device, user, none"
+    end
+
+    test "matches the start of an endpoint id", %{conn: conn, org: org} do
+      conn =
+        get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, search: String.slice(@endpoint_id, 0, 8)))
+
+      assert identifiers(conn) == [@endpoint_id]
+    end
+
+    test "does not match the middle of an endpoint id", %{conn: conn, org: org} do
+      # Prefix, not substring: what a caller has is the truncated front of a key.
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, search: String.slice(@endpoint_id, 20, 8)))
+
+      assert identifiers(conn) == []
+    end
+
+    test "matches a device identifier", %{conn: conn, org: org, device: device} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, search: device.identifier))
+
+      assert identifiers(conn) == [@endpoint_id]
+    end
+
+    test "matches a member's name", %{conn: conn, org: org, user: user} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, search: user.name))
+
+      assert identifiers(conn) == [@other_id]
+    end
+
+    test "combines owner and search", %{conn: conn, org: org} do
+      conn =
+        get(
+          conn,
+          Routes.api_iroh_endpoint_path(conn, :index, org.name,
+            owner: "device",
+            search: String.slice(@endpoint_id, 0, 8)
+          )
+        )
+
+      assert identifiers(conn) == [@endpoint_id]
+
+      conn =
+        get(
+          conn,
+          Routes.api_iroh_endpoint_path(conn, :index, org.name, owner: "user", search: String.slice(@endpoint_id, 0, 8))
+        )
+
+      assert identifiers(conn) == []
+    end
+
+    test "blank filters are no filters", %{conn: conn, org: org} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name, owner: "", search: ""))
+
+      assert length(identifiers(conn)) == 3
+    end
+  end
+
+  describe "create" do
+    test "registers an endpoint against the organization", %{conn: conn, org: org} do
+      conn = post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{"identifier" => @endpoint_id})
+
+      assert %{"data" => endpoint} = json_response(conn, 201)
+      assert endpoint["identifier"] == @endpoint_id
+      assert endpoint["source"] == "operator"
+      assert endpoint["owner"]["type"] == "none"
+
+      assert {:ok, %{org_id: org_id, owner: "org"}} =
+               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+
+      assert org_id == org.id
+    end
+
+    test "points location at the endpoint it made", %{conn: conn, org: org} do
+      conn = post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{"identifier" => @endpoint_id})
+
+      assert [location] = get_resp_header(conn, "location")
+      assert location == Routes.api_iroh_endpoint_path(conn, :show, org.name, @endpoint_id)
+    end
+
+    test "attaches it to a member by their email", %{conn: conn, org: org, user: user} do
+      conn =
+        post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{
+          "identifier" => @endpoint_id,
+          "user_email" => user.email
+        })
+
+      assert %{"data" => %{"owner" => owner}} = json_response(conn, 201)
+
+      # Read back from the association rather than from what register/3 returned,
+      # which is the bug this asserts against: an unloaded owner renders as none.
+      assert owner["type"] == "user"
+      assert owner["user_email"] == user.email
+      assert owner["user_name"] == user.name
+
+      assert {:ok, %{owner: "org_user", user_id: user_id}} =
+               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+
+      assert user_id == user.id
+    end
+
+    test "takes an instance for a second endpoint on one owner", %{conn: conn, org: org} do
+      conn =
+        post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{
+          "identifier" => @endpoint_id,
+          "instance" => "console"
+        })
+
+      assert json_response(conn, 201)["data"]["instance"] == "console"
+    end
+
+    test "refuses a key registered elsewhere, without saying where", %{conn: conn, org: org, user: user} do
+      other_org = Fixtures.org_fixture(user, %{name: "AlreadyHasIt"})
+      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{"identifier" => @endpoint_id})
+
+      # 409 rather than 422: the request is well formed, the key is taken.
+      detail = json_response(conn, 409)["errors"]["detail"]
+      assert detail =~ "already registered"
+      assert detail =~ "claimed the next time that device connects"
+      refute detail =~ "AlreadyHasIt"
+    end
+
+    test "refuses an email that is not a member of this organization", %{conn: conn, org: org} do
+      outsider = Fixtures.user_fixture(%{email: "outsider@example.com"})
+
+      conn =
+        post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{
+          "identifier" => @endpoint_id,
+          "user_email" => outsider.email
+        })
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "not belong to a member"
+    end
+
+    test "gives the same answer for an address with no account", %{conn: conn, org: org} do
+      # Otherwise this endpoint reports which addresses have accounts, to anyone
+      # who can register a key.
+      conn =
+        post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{
+          "identifier" => @endpoint_id,
+          "user_email" => "nobody@example.com"
+        })
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "not belong to a member"
+    end
+
+    test "rejects a missing identifier", %{conn: conn, org: org} do
+      conn = post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{})
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "show" do
+    test "finds one by its key", %{conn: conn, org: org} do
+      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :show, org.name, @endpoint_id))
+
+      assert json_response(conn, 200)["data"]["identifier"] == @endpoint_id
+    end
+
+    test "404s for a key nobody holds", %{conn: conn, org: org} do
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :show, org.name, @endpoint_id))
+
+      assert json_response(conn, 404)
+    end
+
+    test "404s for one held by another organization", %{conn: conn, org: org, user: user} do
+      # A key is not a secret — it is the one thing an outsider is most likely
+      # to have — so knowing one must not read another organization's record.
+      other_org = Fixtures.org_fixture(user, %{name: "NotYours"})
+      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = get(conn, Routes.api_iroh_endpoint_path(conn, :show, org.name, @endpoint_id))
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  describe "delete" do
+    test "removes one, and then it is gone", %{conn: conn, org: org} do
+      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
+      assert response(conn, 204)
+
+      assert {:error, :not_found} = ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+    end
+
+    test "404s for a key nobody holds", %{conn: conn, org: org} do
+      conn = delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
+
+      assert json_response(conn, 404)
+    end
+
+    test "will not remove another organization's", %{conn: conn, org: org, user: user} do
+      other_org = Fixtures.org_fixture(user, %{name: "StillNotYours"})
+      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+
+      conn = delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
+
+      assert json_response(conn, 404)
+      assert {:ok, _} = ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+    end
+  end
+
+  describe "roles" do
+    test "a view-only member may read but not register", %{conn: conn, org: org, user: user} do
+      org_user = NervesHub.Repo.get_by!(OrgUser, org_id: org.id, user_id: user.id)
+      {:ok, _} = NervesHub.Accounts.change_org_user_role(org_user, :view)
+
+      assert conn |> get(Routes.api_iroh_endpoint_path(conn, :index, org.name)) |> json_response(200)
+
+      assert_error_sent(401, fn ->
+        post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{"identifier" => @endpoint_id})
+      end)
+    end
+
+    test "a view-only member may not delete", %{conn: conn, org: org, user: user} do
+      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      org_user = NervesHub.Repo.get_by!(OrgUser, org_id: org.id, user_id: user.id)
+      {:ok, _} = NervesHub.Accounts.change_org_user_role(org_user, :view)
+
+      assert_error_sent(401, fn ->
+        delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
+      end)
+
+      assert {:ok, _} = ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+    end
+  end
+
+  defp device_fixture(org, product) do
+    {:ok, device} =
+      Devices.create_device(%{
+        identifier: "device-#{System.unique_integer([:positive])}",
+        org_id: org.id,
+        product_id: product.id
+      })
+
+    device
+  end
+end


### PR DESCRIPTION
This PR adds API endpoints for the previous two PRs in the stack.

## The endpoints

```
GET    /api/orgs/:org_name/iroh_endpoints
POST   /api/orgs/:org_name/iroh_endpoints
GET    /api/orgs/:org_name/iroh_endpoints/:identifier
DELETE /api/orgs/:org_name/iroh_endpoints/:identifier

GET    /api/orgs/:org/products/:product/devices/:identifier/external_identities
```

The first is the registry, fixed to iroh like the page it mirrors. The second is the generic read of the same table — what a device has reported about itself, narrowed by `service` and `instance`.

Roles match the other organization resources: `view` to read, `manage` to create or delete.

## Addressed by the key

`:identifier` in the path rather than a row id. The key is the thing a caller has; an id would mean listing before you could act on anything, and there is no other way to discover one. `keys` uses `:name` and certificates use `:serial` for the same reason.

## Registration takes an email, not an org_user_id

The context's `register/3` wants `org_user_id`, and this does not ask for one. `OrgUserJSON` renders name, email and role and no id anywhere, so `org_user_id` would have been a value no API caller could look up — attaching a key to a person would simply have been impossible over the API. The controller resolves an email to the membership instead, which is also how `OrgUserController` addresses members.

An address with no account and an address outside the organization get the same 422. Otherwise this endpoint reports which addresses have accounts to anyone who can register a key.

## The device read is read-only

A device proves its own keys on its own connection, and that is the only path that makes one device-owned. A write here would record a claim nobody made. Keys nothing has proven go to the organization endpoint, which is exactly what it is for.

## A filter we do not know is an error

`?service=zerotier` is a 422, not an empty list and not silence. Ignoring it answers a typo with every identity the device holds, which reads as a device holding keys on a network it has never touched. `?owner=operator` is refused for the matching reason — ignoring it answers with the whole list, which looks like a filter that matched everything.

Exposing the service filter meant making `cast_service/1` public on the context, since Ecto raises rather than returns on an unknown enum value.

The owner filter takes `device`, `user` or `none` — the values `owner.type` renders in the response, not the context's `:device` / `:org_user` / `:unowned`. A caller that reads `"type": "user"` back should be able to filter with `user` rather than learn a second vocabulary for the same three things.

`search` matches the **start** of an endpoint id, and anywhere within a device identifier or a member's name. Prefix on the key because the truncated front is what a log or a table gives someone to copy. That will surprise anyone expecting substring, so it is in the operation description and pinned by a test that searching the middle of a key finds nothing.

## Error mapping

Three fallback clauses for errors the context already returned and nothing had translated, each of which would otherwise have been a 500:

| | |
|---|---|
| `:claimed_elsewhere` | **409** — the request is well formed, the key is taken. Carries the same wording as the page, and names no other organization |
| `:invalid_member` | 422 |
| `:unsupported_service` / `:unknown_owner` | 422 |

409 needed a `409.json` renderer, which `ErrorJSON` did not have. Without it the reason was dropped for the generic "Conflict".

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
