### PR TITLE
Rename external identities to network identities

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -8,7 +8,7 @@
   {"lib/nerves_hub/accounts.ex", :call_without_opaque},
   {"lib/nerves_hub/accounts/remove_account.ex", :call_without_opaque},
   {"lib/nerves_hub/devices.ex", :call_without_opaque},
-  {"lib/nerves_hub/devices/external_identities.ex", :call_without_opaque},
+  {"lib/nerves_hub/devices/network_identities.ex", :call_without_opaque},
   {"lib/nerves_hub/devices/health.ex", :call_without_opaque},
   {"lib/nerves_hub/devices/updates.ex", :call_without_opaque},
   {"lib/nerves_hub_web/components/layouts.ex", :call},

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ docs/                 Design docs
 
 - `accounts.ex` / `accounts/` — users, orgs, org-users, tokens, scopes.
 - `devices.ex` / `devices/` — device lifecycle, connections, health status,
-  metrics, and external identities (a device's identity on networks NervesHub
+  metrics, and network identities (a device's identity on networks NervesHub
   doesn't run, such as iroh or NetBird).
 - `managed_deployments.ex` / `managed_deployments/` — deployment groups and the
   `Distributed.Orchestrator` (one per deployment).
@@ -68,7 +68,7 @@ docs/                 Design docs
   archive artifacts, uploads, and firmware **delta** building.
 - `products.ex` / `products/` — products and product settings.
 - `extensions.ex` / `extensions/` — the device **extension framework**
-  (`health`, `geo`, `local_shell`, `logging`, `external_identity`); extensions
+  (`health`, `geo`, `local_shell`, `logging`, `network_identity`); extensions
   attach per-device and exchange messages over the extensions channel.
 - `scripts.ex` / `scripts/` — support scripts run against a device console.
 - `workers/` — Oban workers (e.g. firmware delta building, firmware deletion).

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -15,7 +15,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.DeviceFirmwares
-  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHub.Devices.NetworkIdentity
   alias NervesHub.Devices.PinnedDevice
   alias NervesHub.Devices.SharedSecretAuth
   alias NervesHub.Extensions
@@ -289,10 +289,10 @@ defmodule NervesHub.Devices do
     |> preload([d, device_certificates: dc], device_certificates: dc)
   end
 
-  defp join_and_preload(query, :external_identities) do
+  defp join_and_preload(query, :network_identities) do
     query
-    |> join(:left, [d], ei in assoc(d, :external_identities), as: :external_identities)
-    |> preload([external_identities: ei], external_identities: ei)
+    |> join(:left, [d], ei in assoc(d, :network_identities), as: :network_identities)
+    |> preload([network_identities: ei], network_identities: ei)
   end
 
   defp join_and_preload(query, :latest_connection) do
@@ -380,14 +380,14 @@ defmodule NervesHub.Devices do
     # A device is only soft deleted, so these have to go explicitly: otherwise
     # they keep holding the (service, identifier) unique index and reprovisioning
     # the same hardware collides with the identity of the device just deleted.
-    external_identities_query = from(ei in ExternalIdentity, where: ei.device_id == ^device.id)
+    network_identities_query = from(ei in NetworkIdentity, where: ei.device_id == ^device.id)
 
     changeset = Repo.soft_delete_changeset(device)
 
     Multi.new()
     |> Multi.delete_all(:device_certificates, device_certificates_query)
     |> Multi.delete_all(:pinned_devices, pinned_devices_query)
-    |> Multi.delete_all(:external_identities, external_identities_query)
+    |> Multi.delete_all(:network_identities, network_identities_query)
     |> Multi.update(:device, changeset)
     |> Repo.transact()
     |> case do
@@ -560,8 +560,8 @@ defmodule NervesHub.Devices do
     # placed on that organisation's network by anything using them. Same
     # transaction as the move, so there is no window where the two disagree.
     |> Multi.update_all(
-      :external_identities,
-      from(ei in ExternalIdentity, where: ei.device_id == ^device.id),
+      :network_identities,
+      from(ei in NetworkIdentity, where: ei.device_id == ^device.id),
       set: [org_id: product.org_id, updated_at: DateTime.utc_now(:second)]
     )
     |> Multi.run(:audit_device, fn _, _ ->

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -10,8 +10,8 @@ defmodule NervesHub.Devices.Device do
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Devices.DeviceMetric
-  alias NervesHub.Devices.ExternalIdentity
   alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.Devices.NetworkIdentity
   alias NervesHub.Devices.UpdateStat
   alias NervesHub.Extensions.DeviceExtensionsSetting
   alias NervesHub.Firmwares.FirmwareMetadata
@@ -58,7 +58,7 @@ defmodule NervesHub.Devices.Device do
     has_many(:device_connections, DeviceConnection, on_delete: :delete_all)
     has_many(:device_metrics, DeviceMetric, on_delete: :delete_all)
     has_many(:device_health, DeviceHealth, on_delete: :delete_all)
-    has_many(:external_identities, ExternalIdentity, on_delete: :delete_all)
+    has_many(:network_identities, NetworkIdentity, on_delete: :delete_all)
     has_many(:update_stats, UpdateStat, on_delete: :delete_all)
 
     field(:identifier, :string)

--- a/lib/nerves_hub/devices/network_identities.ex
+++ b/lib/nerves_hub/devices/network_identities.ex
@@ -1,8 +1,8 @@
-defmodule NervesHub.Devices.ExternalIdentities do
+defmodule NervesHub.Devices.NetworkIdentities do
   @moduledoc """
   Context for identities held on networks NervesHub does not run.
 
-  See `NervesHub.Devices.ExternalIdentity` for what is stored and why, including
+  See `NervesHub.Devices.NetworkIdentity` for what is stored and why, including
   who can hold one: a device, a membership, or nobody in particular.
 
   Writes arrive from two places with very different trust. A device announcing
@@ -30,7 +30,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
   alias NervesHub.Accounts.OrgUser
   alias NervesHub.Accounts.User
   alias NervesHub.Devices.Device
-  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHub.Devices.NetworkIdentity
   alias NervesHub.Repo
   alias Phoenix.Channel.Server, as: ChannelServer
 
@@ -46,9 +46,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
       to its caller rather than quietly the whole list.
     * `:instance` — only this endpoint of it, matched exactly.
   """
-  @spec list_for_device(pos_integer(), keyword()) :: [ExternalIdentity.t()]
+  @spec list_for_device(pos_integer(), keyword()) :: [NetworkIdentity.t()]
   def list_for_device(device_id, opts \\ []) do
-    ExternalIdentity
+    NetworkIdentity
     |> where(device_id: ^device_id)
     |> filter_by_service(opts[:service])
     |> filter_by_instance(opts[:instance])
@@ -64,9 +64,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
   the default.
   """
   @spec get(pos_integer(), atom(), String.t()) ::
-          {:ok, ExternalIdentity.t()} | {:error, :not_found}
-  def get(device_id, service, instance \\ ExternalIdentity.default_instance()) do
-    ExternalIdentity
+          {:ok, NetworkIdentity.t()} | {:error, :not_found}
+  def get(device_id, service, instance \\ NetworkIdentity.default_instance()) do
+    NetworkIdentity
     |> where(device_id: ^device_id)
     |> where(service: ^service)
     |> where(instance: ^instance)
@@ -88,9 +88,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
   Owners are preloaded, since a list of keys without whose they are is not much
   of a list.
   """
-  @spec list_for_org(pos_integer(), keyword()) :: [ExternalIdentity.t()]
+  @spec list_for_org(pos_integer(), keyword()) :: [NetworkIdentity.t()]
   def list_for_org(org_id, opts \\ []) do
-    ExternalIdentity
+    NetworkIdentity
     |> where(org_id: ^org_id)
     |> filter_by_service(opts[:service])
     |> filter_by_owner(opts[:owner])
@@ -163,7 +163,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
   somebody outside the organisation doing the registering.
   """
   @spec register(pos_integer(), atom() | String.t(), map()) ::
-          {:ok, ExternalIdentity.t()}
+          {:ok, NetworkIdentity.t()}
           | {:error, :unsupported_service | :claimed_elsewhere | :invalid_member | Ecto.Changeset.t()}
   def register(org_id, service, attrs) do
     with {:ok, service} <- cast_service_result(service),
@@ -173,8 +173,8 @@ defmodule NervesHub.Devices.ExternalIdentities do
       if is_binary(identifier) and Repo.exists?(claimed_query(service, identifier)) do
         {:error, :claimed_elsewhere}
       else
-        %ExternalIdentity{}
-        |> ExternalIdentity.changeset(%{
+        %NetworkIdentity{}
+        |> NetworkIdentity.changeset(%{
           org_id: org_id,
           org_user_id: org_user_id,
           service: service,
@@ -220,7 +220,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
   end
 
   defp claimed_query(service, identifier) do
-    ExternalIdentity
+    NetworkIdentity
     |> where(service: ^service)
     |> where(identifier: ^identifier)
   end
@@ -236,10 +236,10 @@ defmodule NervesHub.Devices.ExternalIdentities do
   about it.
   """
   @spec get_for_org(pos_integer(), atom() | String.t(), String.t()) ::
-          {:ok, ExternalIdentity.t()} | {:error, :not_found | :unsupported_service}
+          {:ok, NetworkIdentity.t()} | {:error, :not_found | :unsupported_service}
   def get_for_org(org_id, service, identifier) when is_binary(identifier) do
     with {:ok, service} <- cast_service_result(service) do
-      ExternalIdentity
+      NetworkIdentity
       |> where(org_id: ^org_id)
       |> where(service: ^service)
       |> where(identifier: ^identifier)
@@ -254,9 +254,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
   Scoped to an organisation so a caller cannot delete one belonging to another
   by guessing an id.
   """
-  @spec delete(pos_integer(), pos_integer()) :: {:ok, ExternalIdentity.t()} | {:error, :not_found}
+  @spec delete(pos_integer(), pos_integer()) :: {:ok, NetworkIdentity.t()} | {:error, :not_found}
   def delete(org_id, id) do
-    ExternalIdentity
+    NetworkIdentity
     |> where(id: ^id)
     |> where(org_id: ^org_id)
     |> Repo.fetch()
@@ -320,7 +320,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
   end
 
   defp owner_by_identifier(service, identifier) do
-    ExternalIdentity
+    NetworkIdentity
     |> where(service: ^service)
     |> where(identifier: ^identifier)
     |> join(:left, [ei], d in Device, on: d.id == ei.device_id)
@@ -387,7 +387,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
   under its own instance; anything that omits one is the service's only endpoint.
   """
   @spec report(pos_integer(), atom() | String.t(), map()) ::
-          {:ok, ExternalIdentity.t()}
+          {:ok, NetworkIdentity.t()}
           | {:error,
              :unsupported_service
              | :operator_managed
@@ -437,34 +437,34 @@ defmodule NervesHub.Devices.ExternalIdentities do
     # Who, if anyone, already holds this key. Checked before the device's own row
     # so that a conflict is reported as a conflict, rather than arriving later as
     # a unique violation that repeats on every reconnect.
-    case Repo.get_by(ExternalIdentity, service: service, identifier: identifier) do
+    case Repo.get_by(NetworkIdentity, service: service, identifier: identifier) do
       nil ->
         record_for_instance(device, service, instance, identifier, details)
 
-      %ExternalIdentity{device_id: device_id, instance: ^instance} = existing
+      %NetworkIdentity{device_id: device_id, instance: ^instance} = existing
       when device_id == :erlang.map_get(:id, device) ->
         # The device's own row for this endpoint. Ordinary re-report, or a
         # detail change.
         update_own(existing, identifier, details, device)
 
-      %ExternalIdentity{device_id: device_id} when device_id == :erlang.map_get(:id, device) ->
+      %NetworkIdentity{device_id: device_id} when device_id == :erlang.map_get(:id, device) ->
         # The device already holds this key under a different endpoint. One key
         # names one endpoint, so this is the device misreporting rather than a
         # rotation, and quietly moving the other row would lose an endpoint.
         Logger.warning(
-          "[ExternalIdentities] device #{device.id} reported a #{service} key it already holds " <>
+          "[NetworkIdentities] device #{device.id} reported a #{service} key it already holds " <>
             "under another instance; leaving both alone"
         )
 
         {:error, :claimed_elsewhere}
 
-      %ExternalIdentity{device_id: nil, org_user_id: nil, org_id: org_id} = unclaimed
+      %NetworkIdentity{device_id: nil, org_user_id: nil, org_id: org_id} = unclaimed
       when org_id == :erlang.map_get(:org_id, device) ->
         claim(unclaimed, device, instance, details)
 
       other ->
         Logger.warning(
-          "[ExternalIdentities] device #{device.id} reported a #{service} key already held by " <>
+          "[NetworkIdentities] device #{device.id} reported a #{service} key already held by " <>
             "#{describe_owner(other)}; leaving it alone"
         )
 
@@ -477,8 +477,8 @@ defmodule NervesHub.Devices.ExternalIdentities do
   defp record_for_instance(device, service, instance, identifier, details) do
     case get(device.id, service, instance) do
       {:error, :not_found} ->
-        %ExternalIdentity{}
-        |> ExternalIdentity.changeset(%{
+        %NetworkIdentity{}
+        |> NetworkIdentity.changeset(%{
           org_id: device.org_id,
           device_id: device.id,
           service: service,
@@ -491,9 +491,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
         |> Repo.insert()
         |> broadcast_if_ok(device.id)
 
-      {:ok, %ExternalIdentity{source: :operator} = existing} ->
+      {:ok, %NetworkIdentity{source: :operator} = existing} ->
         Logger.warning(
-          "[ExternalIdentities] device #{device.id} reported a #{service}/#{instance} identity " <>
+          "[NetworkIdentities] device #{device.id} reported a #{service}/#{instance} identity " <>
             "that differs from the operator-recorded one; ignoring the device's value"
         )
 
@@ -511,7 +511,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
   # endpoint and the partial unique index would refuse the second.
   defp claim(unclaimed, device, instance, details) do
     superseded =
-      ExternalIdentity
+      NetworkIdentity
       |> where(device_id: ^device.id)
       |> where(service: ^unclaimed.service)
       |> where(instance: ^instance)
@@ -520,7 +520,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
     |> Multi.delete_all(:superseded, superseded)
     |> Multi.update(
       :claimed,
-      ExternalIdentity.changeset(unclaimed, %{
+      NetworkIdentity.changeset(unclaimed, %{
         device_id: device.id,
         instance: instance,
         details: details,
@@ -532,7 +532,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
     |> case do
       {:ok, %{claimed: claimed}} ->
         Logger.info(
-          "[ExternalIdentities] device #{device.id} claimed a #{unclaimed.service} key " <>
+          "[NetworkIdentities] device #{device.id} claimed a #{unclaimed.service} key " <>
             "that had been registered by hand"
         )
 
@@ -543,14 +543,14 @@ defmodule NervesHub.Devices.ExternalIdentities do
     end
   end
 
-  defp update_own(%ExternalIdentity{source: :operator} = existing, identifier, _details, device) do
+  defp update_own(%NetworkIdentity{source: :operator} = existing, identifier, _details, device) do
     if existing.identifier == identifier do
       # The device agrees with what the operator recorded, so record that we
       # heard from it and leave the row otherwise untouched.
       touch(existing)
     else
       Logger.warning(
-        "[ExternalIdentities] device #{device.id} reported a #{existing.service} identity " <>
+        "[NetworkIdentities] device #{device.id} reported a #{existing.service} identity " <>
           "that differs from the operator-recorded one; ignoring the device's value"
       )
 
@@ -562,30 +562,30 @@ defmodule NervesHub.Devices.ExternalIdentities do
     update(existing, identifier, details, device.id)
   end
 
-  defp describe_owner(%ExternalIdentity{device_id: id}) when not is_nil(id), do: "device #{id}"
+  defp describe_owner(%NetworkIdentity{device_id: id}) when not is_nil(id), do: "device #{id}"
 
-  defp describe_owner(%ExternalIdentity{org_user_id: id}) when not is_nil(id), do: "membership #{id}"
+  defp describe_owner(%NetworkIdentity{org_user_id: id}) when not is_nil(id), do: "membership #{id}"
 
-  defp describe_owner(%ExternalIdentity{org_id: id}), do: "organisation #{id} by hand"
+  defp describe_owner(%NetworkIdentity{org_id: id}), do: "organisation #{id} by hand"
 
   # An absent or unusable instance means "this service's only endpoint". Devices
   # that run one of something shouldn't have to say so.
   defp cast_instance(instance) when is_binary(instance) do
     case String.trim(instance) do
-      "" -> ExternalIdentity.default_instance()
+      "" -> NetworkIdentity.default_instance()
       trimmed -> trimmed
     end
   end
 
   defp cast_instance(instance) when is_atom(instance) and not is_nil(instance), do: Atom.to_string(instance)
 
-  defp cast_instance(_instance), do: ExternalIdentity.default_instance()
+  defp cast_instance(_instance), do: NetworkIdentity.default_instance()
 
   defp update(existing, identifier, details, device_id) do
     changed? = existing.identifier != identifier or existing.details != details
 
     existing
-    |> ExternalIdentity.changeset(%{
+    |> NetworkIdentity.changeset(%{
       identifier: identifier,
       details: details,
       last_reported_at: DateTime.utc_now()
@@ -599,9 +599,9 @@ defmodule NervesHub.Devices.ExternalIdentities do
     end)
   end
 
-  defp touch(%ExternalIdentity{} = identity) do
+  defp touch(%NetworkIdentity{} = identity) do
     identity
-    |> ExternalIdentity.changeset(%{last_reported_at: DateTime.utc_now()})
+    |> NetworkIdentity.changeset(%{last_reported_at: DateTime.utc_now()})
     |> Repo.update()
   end
 
@@ -610,7 +610,7 @@ defmodule NervesHub.Devices.ExternalIdentities do
       ChannelServer.broadcast(
         NervesHub.PubSub,
         "internal:device:#{device_id}",
-        "external_identities:updated",
+        "network_identities:updated",
         %{service: identity.service}
       )
 
@@ -631,13 +631,13 @@ defmodule NervesHub.Devices.ExternalIdentities do
   def cast_service(service)
 
   def cast_service(service) when is_atom(service) do
-    if service in ExternalIdentity.services(), do: {:ok, service}, else: :error
+    if service in NetworkIdentity.services(), do: {:ok, service}, else: :error
   end
 
   def cast_service(service) when is_binary(service) do
     # String.to_existing_atom/1 is not enough on its own — every service name is
     # already an existing atom, so it would happily return one we do not support.
-    Enum.find_value(ExternalIdentity.services(), :error, fn known ->
+    Enum.find_value(NetworkIdentity.services(), :error, fn known ->
       if Atom.to_string(known) == service, do: {:ok, known}
     end)
   end

--- a/lib/nerves_hub/devices/network_identity.ex
+++ b/lib/nerves_hub/devices/network_identity.ex
@@ -1,4 +1,4 @@
-defmodule NervesHub.Devices.ExternalIdentity do
+defmodule NervesHub.Devices.NetworkIdentity do
   @moduledoc """
   An identity held on a network that NervesHub does not operate.
 
@@ -121,7 +121,7 @@ defmodule NervesHub.Devices.ExternalIdentity do
   # URLs is well under a kilobyte.
   @max_details_bytes 4_096
 
-  schema "external_identities" do
+  schema "network_identities" do
     belongs_to(:org, Org)
     belongs_to(:device, Device)
     belongs_to(:org_user, OrgUser)
@@ -142,7 +142,7 @@ defmodule NervesHub.Devices.ExternalIdentity do
   end
 
   @doc """
-  Build a changeset for an external identity.
+  Build a changeset for an network identity.
 
   Every constraint the database holds is declared, so a violation comes back as
   a changeset error rather than a raised `Postgrex.Error`. A duplicated key is a
@@ -162,16 +162,16 @@ defmodule NervesHub.Devices.ExternalIdentity do
     |> foreign_key_constraint(:device_id)
     |> foreign_key_constraint(:org_user_id)
     |> unique_constraint([:service, :identifier],
-      name: :external_identities_service_identifier_index
+      name: :network_identities_service_identifier_index
     )
     |> unique_constraint([:device_id, :service, :instance],
-      name: :external_identities_device_service_instance_index
+      name: :network_identities_device_service_instance_index
     )
     |> unique_constraint([:org_user_id, :service, :instance],
-      name: :external_identities_org_user_service_instance_index
+      name: :network_identities_org_user_service_instance_index
     )
     |> check_constraint(:device_id,
-      name: :external_identities_one_owner,
+      name: :network_identities_one_owner,
       message: "an identity belongs to a device or a membership, not both"
     )
   end

--- a/lib/nerves_hub/extensions.ex
+++ b/lib/nerves_hub/extensions.ex
@@ -16,11 +16,11 @@ defmodule NervesHub.Extensions do
   """
 
   alias NervesHub.Devices.Device
-  alias NervesHub.Extensions.ExternalIdentity
   alias NervesHub.Extensions.Geo
   alias NervesHub.Extensions.Health
   alias NervesHub.Extensions.LocalShell
   alias NervesHub.Extensions.Logging
+  alias NervesHub.Extensions.NetworkIdentity
   alias NervesHub.Extensions.State
   alias NervesHub.Extensions.Unsupported
   alias NervesHub.Products.Product
@@ -44,17 +44,17 @@ defmodule NervesHub.Extensions do
   @callback description() :: String.t()
   @callback enabled?() :: boolean()
 
-  @supported_extensions [:health, :geo, :local_shell, :logging, :external_identity]
-  @type extension() :: :health | :geo | :local_shell | :logging | :external_identity
+  @supported_extensions [:health, :geo, :local_shell, :logging, :network_identity]
+  @type extension() :: :health | :geo | :local_shell | :logging | :network_identity
 
   @doc """
   Get list of supported extensions as atoms with descriptive text.
   """
-  @spec list() :: [:external_identity | :geo | :health | :local_shell | :logging, ...]
+  @spec list() :: [:network_identity | :geo | :health | :local_shell | :logging, ...]
   def list(), do: @supported_extensions
 
   @spec module(extension()) ::
-          ExternalIdentity
+          NetworkIdentity
           | Geo
           | Health
           | LocalShell
@@ -63,7 +63,7 @@ defmodule NervesHub.Extensions do
   def module(:health), do: Health
   def module(:local_shell), do: LocalShell
   def module(:logging), do: Logging
-  def module(:external_identity), do: ExternalIdentity
+  def module(:network_identity), do: NetworkIdentity
 
   @spec module(extension(), Version.t()) :: module() | Unsupported
   def module(:health, ver) do
@@ -98,9 +98,9 @@ defmodule NervesHub.Extensions do
     end
   end
 
-  def module(:external_identity, ver) do
+  def module(:network_identity, ver) do
     if Version.match?(ver, "~> 0.0.1") do
-      ExternalIdentity
+      NetworkIdentity
     else
       Unsupported
     end

--- a/lib/nerves_hub/extensions/device_extensions_setting.ex
+++ b/lib/nerves_hub/extensions/device_extensions_setting.ex
@@ -11,12 +11,12 @@ defmodule NervesHub.Extensions.DeviceExtensionsSetting do
     field(:geo, :boolean, default: true)
     field(:local_shell, :boolean, default: true)
     field(:logging, :boolean, default: true)
-    field(:external_identity, :boolean, default: true)
+    field(:network_identity, :boolean, default: true)
   end
 
   def changeset(setting, params) do
     setting
-    |> cast(params, [:health, :geo, :local_shell, :logging, :external_identity])
+    |> cast(params, [:health, :geo, :local_shell, :logging, :network_identity])
   end
 
   @impl Access

--- a/lib/nerves_hub/extensions/network_identity.ex
+++ b/lib/nerves_hub/extensions/network_identity.ex
@@ -1,10 +1,10 @@
-defmodule NervesHub.Extensions.ExternalIdentity do
+defmodule NervesHub.Extensions.NetworkIdentity do
   @moduledoc """
   Lets a device announce the identities it holds on other networks.
 
   On attach the server asks once, and the device answers with everything it
   knows about itself — an iroh endpoint id, a NetBird or Tailscale peer key. See
-  `NervesHub.Devices.ExternalIdentity` for what is kept and why.
+  `NervesHub.Devices.NetworkIdentity` for what is kept and why.
 
   There is no interval here, unlike `geo` and `health`. An identity is
   long-lived by construction, so polling for it would be noise. A device whose
@@ -14,7 +14,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
 
   @behaviour NervesHub.Extensions
 
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
 
   require Logger
 
@@ -58,7 +58,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
     # A device on an older or simply wrong version of the client shouldn't take
     # its own connection down over this, so log it and carry on.
     Logger.warning(
-      "[ExternalIdentity] device #{state.device_info.device_id} sent an unusable report: " <>
+      "[NetworkIdentity] device #{state.device_info.device_id} sent an unusable report: " <>
         inspect(payload, limit: 5)
     )
 
@@ -67,7 +67,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
 
   @impl NervesHub.Extensions
   def handle_info(:request, state) do
-    {state, [{:push, "external_identity:request", %{}}]}
+    {state, [{:push, "network_identity:request", %{}}]}
   end
 
   defp record(%{"service" => service, "identifier" => identifier} = entry, device_id)
@@ -75,7 +75,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
     details = Map.get(entry, "details", %{})
 
     device_id
-    |> ExternalIdentities.report(service, %{
+    |> NetworkIdentities.report(service, %{
       identifier: identifier,
       # Names which endpoint of the service this is, for a device running
       # more than one. The context defaults it when absent.
@@ -87,7 +87,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
 
   defp record(entry, device_id) do
     Logger.warning(
-      "[ExternalIdentity] skipping malformed identity from device #{device_id}: " <>
+      "[NetworkIdentity] skipping malformed identity from device #{device_id}: " <>
         inspect(entry, limit: 5)
     )
   end
@@ -100,7 +100,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
   defp handled({:error, :unsupported_service}, service, device_id) do
     # Expected: a device may legitimately run something we have no schema for.
     Logger.debug(
-      "[ExternalIdentity] ignoring unsupported service #{inspect(service)} " <>
+      "[NetworkIdentity] ignoring unsupported service #{inspect(service)} " <>
         "from device #{device_id}"
     )
   end
@@ -116,7 +116,7 @@ defmodule NervesHub.Extensions.ExternalIdentity do
 
   defp handled({:error, changeset}, service, device_id) do
     Logger.warning(
-      "[ExternalIdentity] could not record #{service} identity for device " <>
+      "[NetworkIdentity] could not record #{service} identity for device " <>
         "#{device_id}: #{inspect(changeset.errors)}"
     )
   end

--- a/lib/nerves_hub/extensions/product_extensions_setting.ex
+++ b/lib/nerves_hub/extensions/product_extensions_setting.ex
@@ -11,12 +11,12 @@ defmodule NervesHub.Extensions.ProductExtensionsSetting do
     field(:geo, :boolean, default: false)
     field(:local_shell, :boolean, default: false)
     field(:logging, :boolean, default: false)
-    field(:external_identity, :boolean, default: false)
+    field(:network_identity, :boolean, default: false)
   end
 
   def changeset(setting, params) do
     setting
-    |> cast(params, [:health, :geo, :local_shell, :logging, :external_identity])
+    |> cast(params, [:health, :geo, :local_shell, :logging, :network_identity])
   end
 
   @impl Access

--- a/lib/nerves_hub_web/api_spec.ex
+++ b/lib/nerves_hub_web/api_spec.ex
@@ -79,7 +79,7 @@ defmodule NervesHubWeb.ApiSpec do
           description: "Device Certificate management"
         },
         %Tag{
-          name: "External Identities",
+          name: "Network Identities",
           description: "Identities a Device holds on networks NervesHub does not run"
         },
         %Tag{

--- a/lib/nerves_hub_web/components/device_network_identities.ex
+++ b/lib/nerves_hub_web/components/device_network_identities.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Components.DeviceExternalIdentities do
+defmodule NervesHubWeb.Components.DeviceNetworkIdentities do
   @moduledoc """
   Shows the identities a device holds on networks NervesHub does not run.
 
@@ -13,7 +13,7 @@ defmodule NervesHubWeb.Components.DeviceExternalIdentities do
 
   use NervesHubWeb, :component
 
-  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHub.Devices.NetworkIdentity
 
   attr(:identities, :list, default: [])
   attr(:enabled_device, :any, default: true)
@@ -46,7 +46,7 @@ defmodule NervesHubWeb.Components.DeviceExternalIdentities do
     ~H"""
     <.frame>
       <div class="text-base-500 flex items-center gap-2 px-4 pt-2 pb-4">
-        This device hasn't reported any external identities.
+        This device hasn't reported any network identities.
       </div>
     </.frame>
     """
@@ -105,7 +105,7 @@ defmodule NervesHubWeb.Components.DeviceExternalIdentities do
   defp frame(assigns) do
     ~H"""
     <div class="text-base-50 flex h-14 items-center pr-3 pl-4 leading-6 font-medium">
-      External Identities
+      Network Identities
     </div>
     {render_slot(@inner_block)}
     """
@@ -149,7 +149,7 @@ defmodule NervesHubWeb.Components.DeviceExternalIdentities do
 
   defp long_value?(value), do: String.length(value) > 32
 
-  defp named_instance?(identity), do: identity.instance != ExternalIdentity.default_instance()
+  defp named_instance?(identity), do: identity.instance != NetworkIdentity.default_instance()
 
   # Brand capitalisation, which no generic humanising of the atom gets right.
   defp service_name(:iroh), do: "iroh"

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -14,8 +14,8 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   alias NervesHub.Firmwares
   alias NervesHub.ManagedDeployments
   alias NervesHub.Scripts
-  alias NervesHubWeb.Components.DeviceExternalIdentities
   alias NervesHubWeb.Components.DeviceLocation
+  alias NervesHubWeb.Components.DeviceNetworkIdentities
   alias NervesHubWeb.Components.HealthStatus
   alias Phoenix.Socket.Broadcast
 
@@ -582,10 +582,10 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
         </div>
 
         <div class="bg-surface-raised border-base-700 shadow-device-details-content flex flex-col rounded border">
-          <DeviceExternalIdentities.render
-            enabled_product={@product.extensions.external_identity}
-            enabled_device={@device.extensions.external_identity}
-            identities={@device.external_identities}
+          <DeviceNetworkIdentities.render
+            enabled_product={@product.extensions.network_identity}
+            enabled_device={@device.extensions.network_identity}
+            identities={@device.network_identities}
           />
         </div>
 

--- a/lib/nerves_hub_web/components/navigation.ex
+++ b/lib/nerves_hub_web/components/navigation.ex
@@ -87,7 +87,7 @@ defmodule NervesHubWeb.Components.Navigation do
         :if={org_iroh_endpoints_ui_enabled?()}
         label="Iroh Endpoints"
         path={~p"/org/#{@scope.org}/settings/iroh-endpoints"}
-        selected={:external_identities == @selected_tab}
+        selected={:network_identities == @selected_tab}
         icon="data-[selected=false]:lucide-waypoints--light data-[selected=true]:lucide-waypoints"
       />
       <.nav_link

--- a/lib/nerves_hub_web/components/navigation.ex
+++ b/lib/nerves_hub_web/components/navigation.ex
@@ -87,7 +87,7 @@ defmodule NervesHubWeb.Components.Navigation do
         :if={org_iroh_endpoints_ui_enabled?()}
         label="Iroh Endpoints"
         path={~p"/org/#{@scope.org}/settings/iroh-endpoints"}
-        selected={:network_identities == @selected_tab}
+        selected={:iroh_endpoints == @selected_tab}
         icon="data-[selected=false]:lucide-waypoints--light data-[selected=true]:lucide-waypoints"
       />
       <.nav_link

--- a/lib/nerves_hub_web/controllers/api/iroh_endpoint_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/iroh_endpoint_controller.ex
@@ -6,7 +6,7 @@ defmodule NervesHubWeb.API.IrohEndpointController do
   itself rather than by a row id: the key is what a caller has, it is unique
   per service, and an id would mean listing before you could act.
 
-  Fixed to iroh, like the page. `ExternalIdentityController` is the generic view
+  Fixed to iroh, like the page. `NetworkIdentityController` is the generic view
   of the same table, for reading what a device has reported about itself.
   """
 
@@ -14,7 +14,7 @@ defmodule NervesHubWeb.API.IrohEndpointController do
   use OpenApiSpex.ControllerSpecs
 
   alias NervesHub.Accounts
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHubWeb.API.OpenAPI.SchemaHelpers
   alias NervesHubWeb.API.Schemas.ErrorSchemas
   alias NervesHubWeb.API.Schemas.IrohEndpointSchemas
@@ -81,7 +81,7 @@ defmodule NervesHubWeb.API.IrohEndpointController do
   def index(%{assigns: %{current_scope: %{org: org}}} = conn, params) do
     with {:ok, owner} <- filter_owner(params["owner"]) do
       endpoints =
-        ExternalIdentities.list_for_org(org.id,
+        NetworkIdentities.list_for_org(org.id,
           service: @service,
           owner: owner,
           # Passed through as it arrives. The context trims it, treats a blank
@@ -136,12 +136,12 @@ defmodule NervesHubWeb.API.IrohEndpointController do
   def create(%{assigns: %{current_scope: %{org: org}}} = conn, params) do
     with {:ok, org_user_id} <- resolve_member(org, params["user_email"]),
          attrs = registration_attrs(params, org_user_id),
-         {:ok, registered} <- ExternalIdentities.register(org.id, @service, attrs),
+         {:ok, registered} <- NetworkIdentities.register(org.id, @service, attrs),
          # Read it back rather than render what register/3 returned. That struct
          # has no owner loaded, so an endpoint just attached to a person would
          # render as belonging to nobody — and create would disagree with show
          # about the same row.
-         {:ok, endpoint} <- ExternalIdentities.get_for_org(org.id, @service, registered.identifier) do
+         {:ok, endpoint} <- NetworkIdentities.get_for_org(org.id, @service, registered.identifier) do
       conn
       |> put_status(:created)
       |> put_resp_header(
@@ -163,7 +163,7 @@ defmodule NervesHubWeb.API.IrohEndpointController do
   )
 
   def show(%{assigns: %{current_scope: %{org: org}}} = conn, %{"identifier" => identifier}) do
-    with {:ok, endpoint} <- ExternalIdentities.get_for_org(org.id, @service, identifier) do
+    with {:ok, endpoint} <- NetworkIdentities.get_for_org(org.id, @service, identifier) do
       render(conn, :show, iroh_endpoint: endpoint)
     end
   end
@@ -184,8 +184,8 @@ defmodule NervesHubWeb.API.IrohEndpointController do
   )
 
   def delete(%{assigns: %{current_scope: %{org: org}}} = conn, %{"identifier" => identifier}) do
-    with {:ok, endpoint} <- ExternalIdentities.get_for_org(org.id, @service, identifier),
-         {:ok, _endpoint} <- ExternalIdentities.delete(org.id, endpoint.id) do
+    with {:ok, endpoint} <- NetworkIdentities.get_for_org(org.id, @service, identifier),
+         {:ok, _endpoint} <- NetworkIdentities.delete(org.id, endpoint.id) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/lib/nerves_hub_web/controllers/api/iroh_endpoint_json.ex
+++ b/lib/nerves_hub_web/controllers/api/iroh_endpoint_json.ex
@@ -1,8 +1,8 @@
 defmodule NervesHubWeb.API.IrohEndpointJSON do
   @moduledoc false
 
-  alias NervesHub.Devices.ExternalIdentity
-  alias NervesHubWeb.API.ExternalIdentityJSON
+  alias NervesHub.Devices.NetworkIdentity
+  alias NervesHubWeb.API.NetworkIdentityJSON
 
   def index(%{iroh_endpoints: iroh_endpoints}) do
     %{data: for(endpoint <- iroh_endpoints, do: iroh_endpoint(endpoint))}
@@ -12,24 +12,24 @@ defmodule NervesHubWeb.API.IrohEndpointJSON do
     %{data: iroh_endpoint(iroh_endpoint)}
   end
 
-  defp iroh_endpoint(%ExternalIdentity{} = endpoint) do
+  defp iroh_endpoint(%NetworkIdentity{} = endpoint) do
     endpoint
-    |> ExternalIdentityJSON.external_identity()
+    |> NetworkIdentityJSON.network_identity()
     |> Map.put(:owner, owner(endpoint))
   end
 
   # An organization's list is mostly a question of whose each key is, so the
   # owner is spelled out rather than left as an id to look up. `type` is what a
   # caller should branch on; the rest is nil for the kinds that do not have it.
-  defp owner(%ExternalIdentity{device: %{identifier: identifier}}) do
+  defp owner(%NetworkIdentity{device: %{identifier: identifier}}) do
     %{type: "device", device_identifier: identifier, user_name: nil, user_email: nil}
   end
 
-  defp owner(%ExternalIdentity{org_user: %{user: %{name: name, email: email}}}) do
+  defp owner(%NetworkIdentity{org_user: %{user: %{name: name, email: email}}}) do
     %{type: "user", device_identifier: nil, user_name: name, user_email: email}
   end
 
-  defp owner(%ExternalIdentity{}) do
+  defp owner(%NetworkIdentity{}) do
     %{type: "none", device_identifier: nil, user_name: nil, user_email: nil}
   end
 end

--- a/lib/nerves_hub_web/controllers/api/network_identity_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/network_identity_controller.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.API.ExternalIdentityController do
+defmodule NervesHubWeb.API.NetworkIdentityController do
   @moduledoc """
   What a device holds on networks NervesHub does not run.
 
@@ -11,20 +11,20 @@ defmodule NervesHubWeb.API.ExternalIdentityController do
   use NervesHubWeb, :api_controller
   use OpenApiSpex.ControllerSpecs
 
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHubWeb.API.OpenAPI.SchemaHelpers
   alias NervesHubWeb.API.Schemas.ErrorSchemas
-  alias NervesHubWeb.API.Schemas.ExternalIdentitySchemas
+  alias NervesHubWeb.API.Schemas.NetworkIdentitySchemas
 
   security([%{"bearer_auth" => []}])
-  tags(["External Identities"])
+  tags(["Network Identities"])
 
   @auth_error_responses SchemaHelpers.auth_error_responses()
 
   plug(:validate_role, [org: :view] when action in [:index])
 
   operation(:index,
-    summary: "List the External Identities a Device holds",
+    summary: "List the Network Identities a Device holds",
     description: """
     The keys this device has reported holding on other networks — an iroh
     endpoint id, a NetBird, Tailscale or WireGuard public key.
@@ -54,8 +54,7 @@ defmodule NervesHubWeb.API.ExternalIdentityController do
     ],
     responses:
       [
-        ok:
-          {"External Identity list response", "application/json", ExternalIdentitySchemas.ExternalIdentityListResponse},
+        ok: {"Network Identity list response", "application/json", NetworkIdentitySchemas.NetworkIdentityListResponse},
         unprocessable_entity: {"Unknown service", "application/json", ErrorSchemas.ChangesetErrorResponse}
       ] ++ @auth_error_responses
   )
@@ -63,12 +62,12 @@ defmodule NervesHubWeb.API.ExternalIdentityController do
   def index(%{assigns: %{device: device}} = conn, params) do
     with {:ok, service} <- filter_service(params["service"]) do
       identities =
-        ExternalIdentities.list_for_device(device.id,
+        NetworkIdentities.list_for_device(device.id,
           service: service,
           instance: filter_instance(params["instance"])
         )
 
-      render(conn, :index, external_identities: identities)
+      render(conn, :index, network_identities: identities)
     end
   end
 
@@ -79,7 +78,7 @@ defmodule NervesHubWeb.API.ExternalIdentityController do
   defp filter_service(""), do: {:ok, nil}
 
   defp filter_service(service) do
-    case ExternalIdentities.cast_service(service) do
+    case NetworkIdentities.cast_service(service) do
       {:ok, service} -> {:ok, service}
       :error -> {:error, :unsupported_service}
     end

--- a/lib/nerves_hub_web/controllers/api/network_identity_json.ex
+++ b/lib/nerves_hub_web/controllers/api/network_identity_json.ex
@@ -1,14 +1,14 @@
-defmodule NervesHubWeb.API.ExternalIdentityJSON do
+defmodule NervesHubWeb.API.NetworkIdentityJSON do
   @moduledoc false
 
-  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHub.Devices.NetworkIdentity
 
-  def index(%{external_identities: external_identities}) do
-    %{data: for(identity <- external_identities, do: external_identity(identity))}
+  def index(%{network_identities: network_identities}) do
+    %{data: for(identity <- network_identities, do: network_identity(identity))}
   end
 
-  def show(%{external_identity: external_identity}) do
-    %{data: external_identity(external_identity)}
+  def show(%{network_identity: network_identity}) do
+    %{data: network_identity(network_identity)}
   end
 
   @doc """
@@ -18,7 +18,7 @@ defmodule NervesHubWeb.API.ExternalIdentityJSON do
   add an owner to it — the two endpoints show the same rows and should not
   disagree about what one looks like.
   """
-  def external_identity(%ExternalIdentity{} = identity) do
+  def network_identity(%NetworkIdentity{} = identity) do
     %{
       identifier: identity.identifier,
       service: identity.service,

--- a/lib/nerves_hub_web/controllers/api/schemas/network_identity_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/network_identity_schemas.ex
@@ -1,9 +1,9 @@
-defmodule NervesHubWeb.API.Schemas.ExternalIdentitySchemas do
+defmodule NervesHubWeb.API.Schemas.NetworkIdentitySchemas do
   alias OpenApiSpex.Schema
 
   require OpenApiSpex
 
-  defmodule ExternalIdentity do
+  defmodule NetworkIdentity do
     require OpenApiSpex
 
     OpenApiSpex.schema(%{
@@ -51,12 +51,12 @@ defmodule NervesHubWeb.API.Schemas.ExternalIdentitySchemas do
     })
   end
 
-  defmodule ExternalIdentityListResponse do
+  defmodule NetworkIdentityListResponse do
     OpenApiSpex.schema(%{
-      description: "External Identity list response",
+      description: "Network Identity list response",
       type: :object,
       properties: %{
-        data: %Schema{description: "The identities this device holds", type: :array, items: ExternalIdentity}
+        data: %Schema{description: "The identities this device holds", type: :array, items: NetworkIdentity}
       },
       example: %{
         "data" => [

--- a/lib/nerves_hub_web/helpers/authorization.ex
+++ b/lib/nerves_hub_web/helpers/authorization.ex
@@ -22,9 +22,9 @@ defmodule NervesHubWeb.Helpers.Authorization do
   # Registering a key nobody has proven is a privileged act: it decides which
   # organisation that key answers for, and a key belonging to someone else would
   # place their machine on this organisation's network.
-  def authorized?(:"external_identity:view", role), do: role_check(:view, role)
-  def authorized?(:"external_identity:create", role), do: role_check(:manage, role)
-  def authorized?(:"external_identity:delete", role), do: role_check(:manage, role)
+  def authorized?(:"network_identity:view", role), do: role_check(:view, role)
+  def authorized?(:"network_identity:create", role), do: role_check(:manage, role)
+  def authorized?(:"network_identity:delete", role), do: role_check(:manage, role)
 
   def authorized?(:"certificate_authority:create", role), do: role_check(:admin, role)
   def authorized?(:"certificate_authority:update", role), do: role_check(:admin, role)

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -179,7 +179,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     {:noreply, assign(socket, :device, device)}
   end
 
-  def handle_info(%Broadcast{event: "external_identities:updated"}, socket) do
+  def handle_info(%Broadcast{event: "network_identities:updated"}, socket) do
     %{device: device, current_scope: scope} = socket.assigns
 
     device = load_device(scope, device.identifier)
@@ -342,7 +342,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
       :product,
       :latest_connection,
       :latest_health,
-      :external_identities
+      :network_identities
     ])
   end
 

--- a/lib/nerves_hub_web/live/org/iroh_endpoints.ex
+++ b/lib/nerves_hub_web/live/org/iroh_endpoints.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Live.Org.NetworkIdentities do
+defmodule NervesHubWeb.Live.Org.IrohEndpoints do
   @moduledoc """
   The keys an organisation's devices and people hold on networks NervesHub does
   not run.
@@ -60,7 +60,7 @@ defmodule NervesHubWeb.Live.Org.NetworkIdentities do
     {:noreply,
      socket
      |> page_title("Iroh Endpoints - #{socket.assigns.org.name}")
-     |> sidebar_tab(:network_identities)}
+     |> sidebar_tab(:iroh_endpoints)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/nerves_hub_web/live/org/iroh_endpoints.html.heex
+++ b/lib/nerves_hub_web/live/org/iroh_endpoints.html.heex
@@ -135,7 +135,7 @@
           </div>
 
           <div class="text-base-400 mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-            <% {kind, who} = NervesHubWeb.Live.Org.NetworkIdentities.owner_label(identity) %>
+            <% {kind, who} = NervesHubWeb.Live.Org.IrohEndpoints.owner_label(identity) %>
             <span><span class="text-base-500">{kind}:</span> {who}</span>
             <span :if={identity.instance != "default"}>
               <span class="text-base-500">Instance:</span> {identity.instance}

--- a/lib/nerves_hub_web/live/org/network_identities.ex
+++ b/lib/nerves_hub_web/live/org/network_identities.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Live.Org.ExternalIdentities do
+defmodule NervesHubWeb.Live.Org.NetworkIdentities do
   @moduledoc """
   The keys an organisation's devices and people hold on networks NervesHub does
   not run.
@@ -17,8 +17,8 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
   use NervesHubWeb, :live_view
 
   alias NervesHub.Accounts
-  alias NervesHub.Devices.ExternalIdentities
-  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHub.Devices.NetworkIdentities
+  alias NervesHub.Devices.NetworkIdentity
 
   # The page is named for iroh because that is what the keys are used for today.
   # The table underneath is not iroh-specific, so this is the one place that
@@ -60,7 +60,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
     {:noreply,
      socket
      |> page_title("Iroh Endpoints - #{socket.assigns.org.name}")
-     |> sidebar_tab(:external_identities)}
+     |> sidebar_tab(:network_identities)}
   end
 
   @impl Phoenix.LiveView
@@ -80,9 +80,9 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
   end
 
   def handle_event("register", %{"identity" => params}, %{assigns: %{current_scope: scope}} = socket) do
-    authorized!(:"external_identity:create", scope)
+    authorized!(:"network_identity:create", scope)
 
-    case ExternalIdentities.register(scope.org.id, @service, params) do
+    case NetworkIdentities.register(scope.org.id, @service, params) do
       {:ok, _identity} ->
         {:noreply,
          socket
@@ -113,9 +113,9 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
   end
 
   def handle_event("delete", %{"id" => id}, %{assigns: %{current_scope: scope}} = socket) do
-    authorized!(:"external_identity:delete", scope)
+    authorized!(:"network_identity:delete", scope)
 
-    case ExternalIdentities.delete(scope.org.id, String.to_integer(id)) do
+    case NetworkIdentities.delete(scope.org.id, String.to_integer(id)) do
       {:ok, _identity} ->
         {:noreply,
          socket
@@ -129,7 +129,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
 
   defp load_identities(socket) do
     identities =
-      ExternalIdentities.list_for_org(socket.assigns.org.id,
+      NetworkIdentities.list_for_org(socket.assigns.org.id,
         service: @service,
         owner: socket.assigns.owner_filter,
         search: socket.assigns.search
@@ -139,7 +139,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
   end
 
   defp registration_form() do
-    to_form(ExternalIdentity.changeset(%ExternalIdentity{}, %{}), as: :identity)
+    to_form(NetworkIdentity.changeset(%NetworkIdentity{}, %{}), as: :identity)
   end
 
   # Memberships rather than users, since that is what an identity attaches to:
@@ -182,9 +182,9 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentities do
   @doc false
   # What holds this key, for the table. A device and a membership are the two
   # owners; anything else was recorded by hand and belongs to the organisation.
-  def owner_label(%ExternalIdentity{device: %{identifier: identifier}}), do: {"Device", identifier}
+  def owner_label(%NetworkIdentity{device: %{identifier: identifier}}), do: {"Device", identifier}
 
-  def owner_label(%ExternalIdentity{org_user: %{user: %{name: name}}}), do: {"User", name}
+  def owner_label(%NetworkIdentity{org_user: %{user: %{name: name}}}), do: {"User", name}
 
-  def owner_label(%ExternalIdentity{}), do: {"Unassigned", "registered by hand"}
+  def owner_label(%NetworkIdentity{}), do: {"Unassigned", "registered by hand"}
 end

--- a/lib/nerves_hub_web/live/org/network_identities.html.heex
+++ b/lib/nerves_hub_web/live/org/network_identities.html.heex
@@ -3,7 +3,7 @@
     <h1 class="text-base-50 text-xl leading-[30px] font-semibold">Iroh Endpoints</h1>
     <div class="mr-auto"></div>
     <.button
-      :if={authorized?(:"external_identity:create", @current_scope)}
+      :if={authorized?(:"network_identity:create", @current_scope)}
       type="button"
       phx-click="toggle-registration"
       aria-label="Register an endpoint"
@@ -135,7 +135,7 @@
           </div>
 
           <div class="text-base-400 mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-            <% {kind, who} = NervesHubWeb.Live.Org.ExternalIdentities.owner_label(identity) %>
+            <% {kind, who} = NervesHubWeb.Live.Org.NetworkIdentities.owner_label(identity) %>
             <span><span class="text-base-500">{kind}:</span> {who}</span>
             <span :if={identity.instance != "default"}>
               <span class="text-base-500">Instance:</span> {identity.instance}
@@ -154,7 +154,7 @@
         </div>
 
         <button
-          :if={authorized?(:"external_identity:delete", @current_scope)}
+          :if={authorized?(:"network_identity:delete", @current_scope)}
           class="bg-base-800 border-base-700 hover:bg-base-700 text-base-300 rounded border px-3 py-1.5 text-sm font-medium"
           phx-click="delete"
           phx-value-id={identity.id}

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -7,7 +7,7 @@ defmodule NervesHubWeb.Router do
 
   alias Live.Org.CertificateAuthorities
   alias Live.Org.Delete
-  alias Live.Org.ExternalIdentities
+  alias Live.Org.NetworkIdentities
   alias Live.Org.Settings
   alias Live.Org.Show
   alias Live.Org.SigningKeys
@@ -172,8 +172,8 @@ defmodule NervesHubWeb.Router do
                     post("/:name_or_id", ScriptController, :send)
                   end
 
-                  scope "/external_identities" do
-                    get("/", ExternalIdentityController, :index)
+                  scope "/network_identities" do
+                    get("/", NetworkIdentityController, :index)
                   end
 
                   scope "/certificates" do
@@ -315,7 +315,7 @@ defmodule NervesHubWeb.Router do
       live("/org/:org_name/settings/users/:user_id/edit", Users, :edit)
       # Gated as well as hidden from the sidebar: a hidden link still leaves the
       # URL typeable, so the LiveView refuses to mount when the flag is off.
-      live("/org/:org_name/settings/iroh-endpoints", ExternalIdentities)
+      live("/org/:org_name/settings/iroh-endpoints", NetworkIdentities)
 
       live("/org/:org_name/settings/certificates", CertificateAuthorities, :index)
       live("/org/:org_name/settings/certificates/new", CertificateAuthorities, :new)

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -7,7 +7,7 @@ defmodule NervesHubWeb.Router do
 
   alias Live.Org.CertificateAuthorities
   alias Live.Org.Delete
-  alias Live.Org.NetworkIdentities
+  alias Live.Org.IrohEndpoints
   alias Live.Org.Settings
   alias Live.Org.Show
   alias Live.Org.SigningKeys
@@ -315,7 +315,7 @@ defmodule NervesHubWeb.Router do
       live("/org/:org_name/settings/users/:user_id/edit", Users, :edit)
       # Gated as well as hidden from the sidebar: a hidden link still leaves the
       # URL typeable, so the LiveView refuses to mount when the flag is off.
-      live("/org/:org_name/settings/iroh-endpoints", NetworkIdentities)
+      live("/org/:org_name/settings/iroh-endpoints", IrohEndpoints)
 
       live("/org/:org_name/settings/certificates", CertificateAuthorities, :index)
       live("/org/:org_name/settings/certificates/new", CertificateAuthorities, :new)

--- a/priv/repo/migrations/20260815064345_create_network_identities.exs
+++ b/priv/repo/migrations/20260815064345_create_network_identities.exs
@@ -1,8 +1,8 @@
-defmodule NervesHub.Repo.Migrations.CreateExternalIdentities do
+defmodule NervesHub.Repo.Migrations.CreateNetworkIdentities do
   use Ecto.Migration
 
   def change() do
-    create table(:external_identities) do
+    create table(:network_identities) do
       # The organisation this identity speaks for. Not derived from the owner at
       # read time, because the relay authorization path resolves a key straight
       # to an organisation and the identities page lists an organisation's keys —
@@ -47,41 +47,41 @@ defmodule NervesHub.Repo.Migrations.CreateExternalIdentities do
     #
     # It also surfaces a cloned SD card, where a whole batch boots holding the
     # identity of the device that was imaged.
-    create(unique_index(:external_identities, [:service, :identifier]))
+    create(unique_index(:network_identities, [:service, :identifier]))
 
     # One identity per endpoint per owner. Partial, because the owner columns are
     # nullable and a plain composite index would let every operator-recorded row
     # collide silently — the same NULL != NULL trap as `instance` above, which is
     # why that column is not nullable.
     create(
-      unique_index(:external_identities, [:device_id, :service, :instance],
+      unique_index(:network_identities, [:device_id, :service, :instance],
         where: "device_id IS NOT NULL",
-        name: :external_identities_device_service_instance_index
+        name: :network_identities_device_service_instance_index
       )
     )
 
     create(
-      unique_index(:external_identities, [:org_user_id, :service, :instance],
+      unique_index(:network_identities, [:org_user_id, :service, :instance],
         where: "org_user_id IS NOT NULL",
-        name: :external_identities_org_user_service_instance_index
+        name: :network_identities_org_user_service_instance_index
       )
     )
 
     # Listing an organisation's identities is the page this exists to serve.
-    create(index(:external_identities, [:org_id]))
+    create(index(:network_identities, [:org_id]))
 
     # Plain indexes on the owner columns as well as the partial unique ones
     # above. Postgres does not use a partial index to find rows for a cascading
     # delete, so without these, removing a device or a membership scans the
     # table. NervesHub.Database.IndexTest checks every foreign key has one.
-    create(index(:external_identities, [:device_id]))
-    create(index(:external_identities, [:org_user_id]))
+    create(index(:network_identities, [:device_id]))
+    create(index(:network_identities, [:org_user_id]))
 
     # An identity belongs to a device, or to a membership, or to neither. Never
     # both: the two owners could disagree about which organisation it belongs to,
     # and that answer has to be unambiguous.
     create(
-      constraint(:external_identities, :external_identities_one_owner,
+      constraint(:network_identities, :network_identities_one_owner,
         check: "NOT (device_id IS NOT NULL AND org_user_id IS NOT NULL)"
       )
     )

--- a/test/nerves_hub/device_link/serialization_test.exs
+++ b/test/nerves_hub/device_link/serialization_test.exs
@@ -15,11 +15,11 @@ defmodule NervesHub.DeviceLink.SerializationTest do
 
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.DeviceLink.Session
-  alias NervesHub.Extensions.ExternalIdentity
   alias NervesHub.Extensions.Geo
   alias NervesHub.Extensions.Health
   alias NervesHub.Extensions.LocalShell
   alias NervesHub.Extensions.Logging
+  alias NervesHub.Extensions.NetworkIdentity
   alias NervesHub.Extensions.State
   alias NervesHubWeb.Channels.Scrollback
 
@@ -87,7 +87,7 @@ defmodule NervesHub.DeviceLink.SerializationTest do
         Geo,
         Logging,
         LocalShell,
-        ExternalIdentity
+        NetworkIdentity
       ]
 
       for extension <- extensions do

--- a/test/nerves_hub/devices/network_identities_test.exs
+++ b/test/nerves_hub/devices/network_identities_test.exs
@@ -1,10 +1,10 @@
-defmodule NervesHub.Devices.ExternalIdentitiesTest do
+defmodule NervesHub.Devices.NetworkIdentitiesTest do
   use NervesHub.DataCase, async: true
 
   alias NervesHub.Accounts
   alias NervesHub.Devices
-  alias NervesHub.Devices.ExternalIdentities
-  alias NervesHub.Devices.ExternalIdentity
+  alias NervesHub.Devices.NetworkIdentities
+  alias NervesHub.Devices.NetworkIdentity
   alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias Phoenix.Socket.Broadcast
@@ -23,7 +23,7 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
   describe "report/3" do
     test "records an identity a device reports about itself", %{device: device} do
       assert {:ok, identity} =
-               ExternalIdentities.report(device.id, "iroh", %{
+               NetworkIdentities.report(device.id, "iroh", %{
                  identifier: "a1b2c3",
                  details: %{"ticket" => "some-ticket"}
                })
@@ -36,40 +36,40 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     end
 
     test "replaces the previous value rather than accumulating rows", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "first"})
-      {:ok, updated} = ExternalIdentities.report(device.id, "iroh", %{identifier: "second"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "first"})
+      {:ok, updated} = NetworkIdentities.report(device.id, "iroh", %{identifier: "second"})
 
       assert updated.identifier == "second"
-      assert [%ExternalIdentity{identifier: "second"}] = ExternalIdentities.list_for_device(device.id)
+      assert [%NetworkIdentity{identifier: "second"}] = NetworkIdentities.list_for_device(device.id)
     end
 
     test "a device can hold identities on several services at once", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "iroh-key"})
-      {:ok, _} = ExternalIdentities.report(device.id, "tailscale", %{identifier: "ts-key"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "iroh-key"})
+      {:ok, _} = NetworkIdentities.report(device.id, "tailscale", %{identifier: "ts-key"})
 
       assert [%{service: :iroh}, %{service: :tailscale}] =
-               ExternalIdentities.list_for_device(device.id)
+               NetworkIdentities.list_for_device(device.id)
     end
 
     test "accepts an atom service as well as a string", %{device: device} do
       assert {:ok, identity} =
-               ExternalIdentities.report(device.id, :netbird, %{identifier: "nb-key"})
+               NetworkIdentities.report(device.id, :netbird, %{identifier: "nb-key"})
 
       assert identity.service == :netbird
     end
 
     test "refuses a service this NervesHub doesn't know", %{device: device} do
       assert {:error, :unsupported_service} =
-               ExternalIdentities.report(device.id, "zerotier", %{identifier: "zt-key"})
+               NetworkIdentities.report(device.id, "zerotier", %{identifier: "zt-key"})
 
-      assert ExternalIdentities.list_for_device(device.id) == []
+      assert NetworkIdentities.list_for_device(device.id) == []
     end
 
     test "refuses a service name that is an atom but not a known one", %{device: device} do
       # :erlang is certainly an existing atom, which is exactly why casting can't
       # lean on String.to_existing_atom/1.
       assert {:error, :unsupported_service} =
-               ExternalIdentities.report(device.id, :erlang, %{identifier: "nope"})
+               NetworkIdentities.report(device.id, :erlang, %{identifier: "nope"})
     end
 
     test "two devices cannot claim the same key", %{device: device, org: org, product: product, firmware: firmware} do
@@ -77,27 +77,27 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # imaged. The second device to report is the one that fails.
       other = Fixtures.device_fixture(org, product, firmware, %{identifier: "cloned-sibling"})
 
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "shared-key"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "shared-key"})
 
       # Reported as a conflict rather than left to the unique index. A cloned
       # batch would otherwise fail this way on every reconnect, forever, looking
       # like a network fault instead of the duplication it is.
       assert {:error, :claimed_elsewhere} =
-               ExternalIdentities.report(other.id, "iroh", %{identifier: "shared-key"})
+               NetworkIdentities.report(other.id, "iroh", %{identifier: "shared-key"})
 
-      assert ExternalIdentities.list_for_device(other.id) == []
+      assert NetworkIdentities.list_for_device(other.id) == []
     end
 
     test "the same key on different services is fine", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "same-bytes"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "same-bytes"})
 
       assert {:ok, _} =
-               ExternalIdentities.report(device.id, "wireguard", %{identifier: "same-bytes"})
+               NetworkIdentities.report(device.id, "wireguard", %{identifier: "same-bytes"})
     end
 
     test "refuses an identifier longer than the column allows", %{device: device} do
       assert {:error, changeset} =
-               ExternalIdentities.report(device.id, "iroh", %{
+               NetworkIdentities.report(device.id, "iroh", %{
                  identifier: String.duplicate("a", 256)
                })
 
@@ -106,16 +106,16 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
 
     test "refuses an oversized details payload", %{device: device} do
       # `details` is written from a device-supplied map, so it needs a ceiling.
-      huge = %{"blob" => String.duplicate("x", ExternalIdentity.max_details_bytes() + 1)}
+      huge = %{"blob" => String.duplicate("x", NetworkIdentity.max_details_bytes() + 1)}
 
       assert {:error, changeset} =
-               ExternalIdentities.report(device.id, "iroh", %{identifier: "ok", details: huge})
+               NetworkIdentities.report(device.id, "iroh", %{identifier: "ok", details: huge})
 
       assert changeset.errors[:details]
     end
 
     test "requires an identifier", %{device: device} do
-      assert {:error, changeset} = ExternalIdentities.report(device.id, "iroh", %{details: %{}})
+      assert {:error, changeset} = NetworkIdentities.report(device.id, "iroh", %{details: %{}})
       assert "can't be blank" in errors_on(changeset).identifier
     end
   end
@@ -125,19 +125,19 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # A device can run an iroh console and an iroh application, each holding
       # its own key. Both are iroh; they are not the same identity.
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           instance: "iroh_console",
           identifier: "console-key"
         })
 
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           instance: "app_sync",
           identifier: "app-key"
         })
 
       assert [%{instance: "app_sync"}, %{instance: "iroh_console"}] =
-               ExternalIdentities.list_for_device(device.id)
+               NetworkIdentities.list_for_device(device.id)
     end
 
     test "a rotated key updates its row rather than accumulating a dead one", %{device: device} do
@@ -145,27 +145,27 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # identifier: keying on the value being tracked would leave the old key
       # behind forever with nothing marking it stale.
       {:ok, first} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           instance: "iroh_console",
           identifier: "key-before-rotation"
         })
 
       {:ok, second} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           instance: "iroh_console",
           identifier: "key-after-rotation"
         })
 
       assert first.id == second.id
-      assert [%{identifier: "key-after-rotation"}] = ExternalIdentities.list_for_device(device.id)
+      assert [%{identifier: "key-after-rotation"}] = NetworkIdentities.list_for_device(device.id)
     end
 
     test "one device cannot report the same key under two instances", %{device: device} do
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{instance: "one", identifier: "same-key"})
+        NetworkIdentities.report(device.id, "iroh", %{instance: "one", identifier: "same-key"})
 
       assert {:error, :claimed_elsewhere} =
-               ExternalIdentities.report(device.id, "iroh", %{
+               NetworkIdentities.report(device.id, "iroh", %{
                  instance: "two",
                  identifier: "same-key"
                })
@@ -173,18 +173,18 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # The endpoint it was already under keeps it, rather than the report
       # quietly moving the row and losing an endpoint.
       assert [%{instance: "one", identifier: "same-key"}] =
-               ExternalIdentities.list_for_device(device.id)
+               NetworkIdentities.list_for_device(device.id)
     end
 
     test "get/3 finds the endpoint asked for", %{device: device} do
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{instance: "console", identifier: "a"})
+        NetworkIdentities.report(device.id, "iroh", %{instance: "console", identifier: "a"})
 
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{instance: "sync", identifier: "b"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{instance: "sync", identifier: "b"})
 
-      assert {:ok, %{identifier: "a"}} = ExternalIdentities.get(device.id, :iroh, "console")
-      assert {:ok, %{identifier: "b"}} = ExternalIdentities.get(device.id, :iroh, "sync")
-      assert ExternalIdentities.get(device.id, :iroh) == {:error, :not_found}
+      assert {:ok, %{identifier: "a"}} = NetworkIdentities.get(device.id, :iroh, "console")
+      assert {:ok, %{identifier: "b"}} = NetworkIdentities.get(device.id, :iroh, "sync")
+      assert NetworkIdentities.get(device.id, :iroh) == {:error, :not_found}
     end
   end
 
@@ -192,10 +192,10 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     test "defaults when a device doesn't name one", %{device: device} do
       # Most services are singletons; a device running one of something
       # shouldn't have to say so.
-      assert {:ok, identity} = ExternalIdentities.report(device.id, "iroh", %{identifier: "solo"})
+      assert {:ok, identity} = NetworkIdentities.report(device.id, "iroh", %{identifier: "solo"})
 
-      assert identity.instance == ExternalIdentity.default_instance()
-      assert {:ok, ^identity} = ExternalIdentities.get(device.id, :iroh)
+      assert identity.instance == NetworkIdentity.default_instance()
+      assert {:ok, ^identity} = NetworkIdentities.get(device.id, :iroh)
     end
 
     test "blank and unusable values fall back to the default", %{device: device} do
@@ -203,21 +203,21 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # rather than colliding — which is the point.
       for {instance, label} <- [{"", "empty"}, {"   ", "whitespace"}, {nil, "nil"}, {123, "number"}] do
         assert {:ok, identity} =
-                 ExternalIdentities.report(device.id, "iroh", %{
+                 NetworkIdentities.report(device.id, "iroh", %{
                    instance: instance,
                    identifier: "key-#{label}"
                  })
 
-        assert identity.instance == ExternalIdentity.default_instance(),
+        assert identity.instance == NetworkIdentity.default_instance(),
                "a #{label} instance should have fallen back to the default"
       end
 
-      assert length(ExternalIdentities.list_for_device(device.id)) == 1
+      assert length(NetworkIdentities.list_for_device(device.id)) == 1
     end
 
     test "is trimmed", %{device: device} do
       assert {:ok, identity} =
-               ExternalIdentities.report(device.id, "iroh", %{
+               NetworkIdentities.report(device.id, "iroh", %{
                  instance: "  iroh_console  ",
                  identifier: "trimmed"
                })
@@ -227,7 +227,7 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
 
     test "an atom instance is accepted", %{device: device} do
       assert {:ok, identity} =
-               ExternalIdentities.report(device.id, "iroh", %{
+               NetworkIdentities.report(device.id, "iroh", %{
                  instance: :iroh_console,
                  identifier: "atom-instance"
                })
@@ -239,7 +239,7 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
   describe "report/3 against an operator-recorded identity" do
     setup %{device: device} do
       identity =
-        Fixtures.external_identity_fixture(device, %{
+        Fixtures.network_identity_fixture(device, %{
           service: :iroh,
           identifier: "operator-recorded",
           source: :operator
@@ -252,16 +252,16 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # This disagreement is the signal — a reflashed device, a wiped data
       # partition, or something claiming to be this device.
       assert {:error, :operator_managed} =
-               ExternalIdentities.report(device.id, "iroh", %{identifier: "device-claims-this"})
+               NetworkIdentities.report(device.id, "iroh", %{identifier: "device-claims-this"})
 
-      assert {:ok, unchanged} = ExternalIdentities.get(device.id, :iroh)
+      assert {:ok, unchanged} = NetworkIdentities.get(device.id, :iroh)
       assert unchanged.identifier == "operator-recorded"
       assert unchanged.source == :operator
     end
 
     test "a device agreeing is recorded as having been heard from", %{device: device, identity: identity} do
       assert {:ok, touched} =
-               ExternalIdentities.report(device.id, "iroh", %{identifier: "operator-recorded"})
+               NetworkIdentities.report(device.id, "iroh", %{identifier: "operator-recorded"})
 
       assert touched.source == :operator
       assert DateTime.compare(touched.last_reported_at, identity.last_reported_at) in [:gt, :eq]
@@ -270,29 +270,29 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
 
   describe "get/2 and list_for_device/1" do
     test "get/2 reports a missing identity rather than raising", %{device: device} do
-      assert ExternalIdentities.get(device.id, :iroh) == {:error, :not_found}
+      assert NetworkIdentities.get(device.id, :iroh) == {:error, :not_found}
     end
 
     test "list_for_device/1 is empty for a device that has reported nothing", %{device: device} do
-      assert ExternalIdentities.list_for_device(device.id) == []
+      assert NetworkIdentities.list_for_device(device.id) == []
     end
 
     test "identities are scoped to their own device", %{device: device, org: org, product: product, firmware: firmware} do
       other = Fixtures.device_fixture(org, product, firmware, %{identifier: "some-other-device"})
 
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "mine"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "mine"})
 
-      assert ExternalIdentities.list_for_device(other.id) == []
+      assert NetworkIdentities.list_for_device(other.id) == []
     end
   end
 
   describe "deleting a device" do
-    test "takes its external identities with it", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "goes-away"})
+    test "takes its network identities with it", %{device: device} do
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "goes-away"})
 
       {:ok, _device} = Devices.delete_device(device)
 
-      assert ExternalIdentities.list_for_device(device.id) == []
+      assert NetworkIdentities.list_for_device(device.id) == []
     end
 
     test "frees the key so the same hardware can be reprovisioned", %{
@@ -303,13 +303,13 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     } do
       # A device is only soft deleted, so without an explicit cleanup its rows
       # would keep holding the (service, identifier) index forever.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "reused-key"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "reused-key"})
       {:ok, _} = Devices.delete_device(device)
 
       replacement = Fixtures.device_fixture(org, product, firmware, %{identifier: "replacement"})
 
       assert {:ok, _} =
-               ExternalIdentities.report(replacement.id, "iroh", %{identifier: "reused-key"})
+               NetworkIdentities.report(replacement.id, "iroh", %{identifier: "reused-key"})
     end
   end
 
@@ -317,31 +317,31 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     test "tells the device page when an identity changes", %{device: device} do
       Phoenix.PubSub.subscribe(NervesHub.PubSub, "internal:device:#{device.id}")
 
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "first"})
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "first"})
+      assert_receive %Broadcast{event: "network_identities:updated"}
 
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "changed"})
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "changed"})
+      assert_receive %Broadcast{event: "network_identities:updated"}
     end
 
     test "stays quiet when a device re-reports what we already had", %{device: device} do
       # Devices report on every reconnect. Re-rendering every open device page
       # each time would be pure noise.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "steady"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "steady"})
 
       Phoenix.PubSub.subscribe(NervesHub.PubSub, "internal:device:#{device.id}")
 
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "steady"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "steady"})
 
-      refute_receive %Broadcast{event: "external_identities:updated"}, 100
+      refute_receive %Broadcast{event: "network_identities:updated"}, 100
     end
   end
 
   describe "get_owner_by_identifier/2" do
     test "finds the device that reported the key", %{device: device, org: org, product: product} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
-      assert {:ok, found} = ExternalIdentities.get_owner_by_identifier(:iroh, "abc123")
+      assert {:ok, found} = NetworkIdentities.get_owner_by_identifier(:iroh, "abc123")
 
       assert found.org_id == org.id
       assert found.owner == "device"
@@ -350,14 +350,14 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       assert found.org_user_id == nil
       assert found.user_id == nil
       assert found.service == :iroh
-      assert found.instance == ExternalIdentity.default_instance()
+      assert found.instance == NetworkIdentity.default_instance()
       assert found.identifier == "abc123"
     end
 
     test "accepts the service as a string, as an :erpc caller would send it", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
-      assert {:ok, found} = ExternalIdentities.get_owner_by_identifier("iroh", "abc123")
+      assert {:ok, found} = NetworkIdentities.get_owner_by_identifier("iroh", "abc123")
       assert found.device_id == device.id
     end
 
@@ -365,9 +365,9 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # The caller runs on a node with no NervesHub modules loaded, where a
       # struct is a map carrying a __struct__ key pointing at nothing. See the
       # cross-application contract note in AGENTS.md.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
-      assert {:ok, found} = ExternalIdentities.get_owner_by_identifier(:iroh, "abc123")
+      assert {:ok, found} = NetworkIdentities.get_owner_by_identifier(:iroh, "abc123")
 
       refute is_struct(found)
       refute Map.has_key?(found, :__struct__)
@@ -377,9 +377,9 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # Pins the shape for callers this repository cannot see and will not fail
       # to compile against. Adding a key here is safe; removing or renaming one
       # is a breaking change needing a coordinated release.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
-      assert {:ok, found} = ExternalIdentities.get_owner_by_identifier(:iroh, "abc123")
+      assert {:ok, found} = NetworkIdentities.get_owner_by_identifier(:iroh, "abc123")
 
       assert found |> Map.keys() |> Enum.sort() == [
                :device_id,
@@ -395,10 +395,10 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     end
 
     test "returns not_found for a key nobody registered", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
       assert {:error, :not_found} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "never-registered")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "never-registered")
     end
 
     test "deleting a device takes its identities with it", %{device: device} do
@@ -406,10 +406,10 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # outright, so the key stops resolving rather than resolving to a deleted
       # device. It has to: the rows hold the (service, identifier) unique index,
       # and reprovisioning the same hardware would otherwise collide.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
       {:ok, _} = Devices.delete_device(device)
 
-      assert {:error, :not_found} = ExternalIdentities.get_owner_by_identifier(:iroh, "abc123")
+      assert {:error, :not_found} = NetworkIdentities.get_owner_by_identifier(:iroh, "abc123")
     end
 
     test "refuses an identity whose device is soft deleted", %{device: device} do
@@ -417,54 +417,54 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # not supposed to outlive its device, but the join checks deleted_at
       # anyway: if a row ever did survive — a soft delete by some path that does
       # not clear identities — resolving it would admit a removed device.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
       device |> Repo.soft_delete_changeset() |> Repo.update!()
 
       assert {:error, :owner_deleted} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "abc123")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "abc123")
     end
 
     test "does not match the same key under a different service", %{device: device} do
       # (service, identifier) is unique together, not identifier alone, so the
       # service has to be part of the lookup.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
       assert {:error, :not_found} =
-               ExternalIdentities.get_owner_by_identifier(:wireguard, "abc123")
+               NetworkIdentities.get_owner_by_identifier(:wireguard, "abc123")
     end
 
     test "matches exactly, without normalising case", %{device: device} do
       # Case-folding cannot be done generically: iroh hex is case-insensitive in
       # practice, a WireGuard base64 key is not. Reporter and caller agree on a
       # form instead.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "abc123"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "abc123"})
 
-      assert {:error, :not_found} = ExternalIdentities.get_owner_by_identifier(:iroh, "ABC123")
+      assert {:error, :not_found} = NetworkIdentities.get_owner_by_identifier(:iroh, "ABC123")
     end
 
     test "finds each endpoint of a device separately", %{device: device} do
       # A device running an iroh console and an iroh application holds one key
       # per instance, and either may be the one asking to use a relay.
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{identifier: "console", instance: "console"})
+        NetworkIdentities.report(device.id, "iroh", %{identifier: "console", instance: "console"})
 
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{identifier: "app", instance: "app"})
+        NetworkIdentities.report(device.id, "iroh", %{identifier: "app", instance: "app"})
 
       assert {:ok, %{instance: "console"}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "console")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "console")
 
-      assert {:ok, %{instance: "app"}} = ExternalIdentities.get_owner_by_identifier(:iroh, "app")
+      assert {:ok, %{instance: "app"}} = NetworkIdentities.get_owner_by_identifier(:iroh, "app")
     end
 
     test "refuses a service NervesHub does not know" do
       assert {:error, :unsupported_service} =
-               ExternalIdentities.get_owner_by_identifier("zerotier", "abc123")
+               NetworkIdentities.get_owner_by_identifier("zerotier", "abc123")
     end
 
     test "returns not_found when nothing has been reported" do
-      assert {:error, :not_found} = ExternalIdentities.get_owner_by_identifier(:iroh, "abc123")
+      assert {:error, :not_found} = NetworkIdentities.get_owner_by_identifier(:iroh, "abc123")
     end
   end
 
@@ -474,8 +474,8 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       {:ok, org_user} = Accounts.add_org_user(org, member, %{role: :manage})
 
       identity =
-        %ExternalIdentity{}
-        |> ExternalIdentity.changeset(%{
+        %NetworkIdentity{}
+        |> NetworkIdentity.changeset(%{
           org_id: org.id,
           org_user_id: org_user.id,
           service: :iroh,
@@ -488,7 +488,7 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     end
 
     test "resolves to its organisation and its owner", %{org: org, org_user: org_user, member: member} do
-      assert {:ok, found} = ExternalIdentities.get_owner_by_identifier(:iroh, "laptop-key")
+      assert {:ok, found} = NetworkIdentities.get_owner_by_identifier(:iroh, "laptop-key")
 
       assert found.org_id == org.id
       assert found.owner == "org_user"
@@ -503,23 +503,23 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       :ok = Accounts.remove_org_user(org, member)
 
       assert {:error, :owner_deleted} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "laptop-key")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "laptop-key")
     end
 
     test "a device cannot take a key a person holds", %{device: device} do
       assert {:error, :claimed_elsewhere} =
-               ExternalIdentities.report(device.id, "iroh", %{identifier: "laptop-key"})
+               NetworkIdentities.report(device.id, "iroh", %{identifier: "laptop-key"})
 
       assert {:ok, %{owner: "org_user"}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "laptop-key")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "laptop-key")
     end
   end
 
   describe "an identity recorded by hand" do
     setup %{org: org} do
       identity =
-        %ExternalIdentity{}
-        |> ExternalIdentity.changeset(%{
+        %NetworkIdentity{}
+        |> NetworkIdentity.changeset(%{
           org_id: org.id,
           service: :iroh,
           identifier: "registered-ahead",
@@ -531,7 +531,7 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
     end
 
     test "resolves to its organisation with no owner", %{org: org} do
-      assert {:ok, found} = ExternalIdentities.get_owner_by_identifier(:iroh, "registered-ahead")
+      assert {:ok, found} = NetworkIdentities.get_owner_by_identifier(:iroh, "registered-ahead")
 
       assert found.org_id == org.id
       assert found.owner == "org"
@@ -543,26 +543,26 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       # The intended flow for registering a device before it appears: put the
       # key in, and the device claims it on its next connection.
       assert {:ok, claimed} =
-               ExternalIdentities.report(device.id, "iroh", %{identifier: "registered-ahead"})
+               NetworkIdentities.report(device.id, "iroh", %{identifier: "registered-ahead"})
 
       assert claimed.id == unowned.id
       assert claimed.device_id == device.id
       assert claimed.source == :device_reported
 
       assert {:ok, %{owner: "device"}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "registered-ahead")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "registered-ahead")
     end
 
     test "claiming replaces whatever the device held for that endpoint", %{device: device} do
       # One owner has one identity per endpoint, so the row the device was using
       # goes rather than colliding with the one it just claimed.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "key-before"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "key-before"})
 
       assert {:ok, _} =
-               ExternalIdentities.report(device.id, "iroh", %{identifier: "registered-ahead"})
+               NetworkIdentities.report(device.id, "iroh", %{identifier: "registered-ahead"})
 
-      assert [%{identifier: "registered-ahead"}] = ExternalIdentities.list_for_device(device.id)
-      assert {:error, :not_found} = ExternalIdentities.get_owner_by_identifier(:iroh, "key-before")
+      assert [%{identifier: "registered-ahead"}] = NetworkIdentities.list_for_device(device.id)
+      assert {:error, :not_found} = NetworkIdentities.get_owner_by_identifier(:iroh, "key-before")
     end
 
     test "a device in another organisation is refused", %{org: org, tmp_dir: tmp_dir} do
@@ -576,10 +576,10 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
       stranger = Fixtures.device_fixture(other_org, other_product, other_firmware)
 
       assert {:error, :claimed_elsewhere} =
-               ExternalIdentities.report(stranger.id, "iroh", %{identifier: "registered-ahead"})
+               NetworkIdentities.report(stranger.id, "iroh", %{identifier: "registered-ahead"})
 
       assert {:ok, %{org_id: resolved_org}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "registered-ahead")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "registered-ahead")
 
       assert resolved_org == org.id
     end
@@ -587,15 +587,15 @@ defmodule NervesHub.Devices.ExternalIdentitiesTest do
 
   describe "the schema" do
     test "services/0 lists what can be recorded" do
-      assert ExternalIdentity.services() == [:iroh, :netbird, :tailscale, :wireguard]
+      assert NetworkIdentity.services() == [:iroh, :netbird, :tailscale, :wireguard]
     end
 
     test "the device association loads through the standard preload path", %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "preloaded"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "preloaded"})
 
-      device = Repo.preload(device, :external_identities)
+      device = Repo.preload(device, :network_identities)
 
-      assert [%ExternalIdentity{identifier: "preloaded"}] = device.external_identities
+      assert [%NetworkIdentity{identifier: "preloaded"}] = device.network_identities
     end
   end
 end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -20,9 +20,9 @@ defmodule NervesHub.DevicesTest do
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceFirmware
   alias NervesHub.Devices.DeviceHealth
-  alias NervesHub.Devices.ExternalIdentities
   alias NervesHub.Devices.Health
   alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHub.Devices.Updates
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Firmware
@@ -1440,7 +1440,7 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
-  describe "move/3 and external identities" do
+  describe "move/3 and network identities" do
     test "an identity moves organisation with its device", %{device: device, user: user, tmp_dir: tmp_dir} do
       # The identity names an organisation of its own, and that is what other
       # networks resolve its key to. Left behind, this device would keep
@@ -1449,7 +1449,7 @@ defmodule NervesHub.DevicesTest do
       other_org = Fixtures.org_fixture(user, %{name: "receiving-org"})
       target_product = Fixtures.product_fixture(user, other_org)
 
-      identity = Fixtures.external_identity_fixture(device, %{identifier: "moves-with-me"})
+      identity = Fixtures.network_identity_fixture(device, %{identifier: "moves-with-me"})
       assert identity.org_id == device.org_id
 
       {:ok, moved} = Devices.move(device, target_product, user)
@@ -1458,7 +1458,7 @@ defmodule NervesHub.DevicesTest do
       assert Repo.reload!(identity).org_id == other_org.id
 
       assert {:ok, %{org_id: resolved}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, "moves-with-me")
+               NetworkIdentities.get_owner_by_identifier(:iroh, "moves-with-me")
 
       assert resolved == other_org.id
       _ = tmp_dir
@@ -1472,11 +1472,11 @@ defmodule NervesHub.DevicesTest do
       firmware: firmware
     } do
       untouched_device = Fixtures.device_fixture(org, product, firmware, %{identifier: "stays-put"})
-      untouched = Fixtures.external_identity_fixture(untouched_device, %{identifier: "not-moving"})
+      untouched = Fixtures.network_identity_fixture(untouched_device, %{identifier: "not-moving"})
 
       other_org = Fixtures.org_fixture(user, %{name: "receiving-org-2"})
       target_product = Fixtures.product_fixture(user, other_org)
-      _ = Fixtures.external_identity_fixture(device, %{identifier: "moving"})
+      _ = Fixtures.network_identity_fixture(device, %{identifier: "moving"})
 
       {:ok, _} = Devices.move(device, target_product, user)
 

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -4,7 +4,7 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
 
   alias NervesHub.Devices
   alias NervesHub.Devices.Device
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHub.Firmwares
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
@@ -413,7 +413,7 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     assert_push("attach", %{"extensions" => ["health"]})
   end
 
-  describe "the external identity extension" do
+  describe "the network identity extension" do
     setup %{tmp_dir: tmp_dir} do
       user = Fixtures.user_fixture()
       {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, dir: tmp_dir)
@@ -421,7 +421,7 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
 
       # Opt in at the product level, which is where every extension starts off.
       product = Products.get_product!(device.product_id)
-      {:ok, _product} = Products.enable_extension_setting(product, "external_identity")
+      {:ok, _product} = Products.enable_extension_setting(product, "network_identity")
 
       {:ok, socket} =
         connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
@@ -433,7 +433,7 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
       assert {:ok, attach_list, socket} =
                subscribe_and_join(socket, ExtensionsChannel, "extensions", %{
                  "device_api_version" => "2.2.0",
-                 "external_identity" => "0.0.1"
+                 "network_identity" => "0.0.1"
                })
 
       {attach_list, socket}
@@ -441,25 +441,25 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
 
     test "is offered to a device that supports it", %{socket: socket} do
       {attach_list, _socket} = join_extensions(socket)
-      assert "external_identity" in attach_list
+      assert "network_identity" in attach_list
     end
 
     test "asks the device for its identities once on attach", %{socket: socket} do
       {_attach_list, socket} = join_extensions(socket)
 
-      push(socket, "external_identity:attached")
-      assert_push("external_identity:request", %{})
+      push(socket, "network_identity:attached")
+      assert_push("network_identity:request", %{})
     end
 
     test "records what the device reports and tells the UI", %{device: device, socket: socket} do
       {_attach_list, socket} = join_extensions(socket)
 
-      push(socket, "external_identity:attached")
-      assert_push("external_identity:request", %{})
+      push(socket, "network_identity:attached")
+      assert_push("network_identity:request", %{})
 
       @endpoint.subscribe("internal:device:#{device.id}")
 
-      push(socket, "external_identity:report", %{
+      push(socket, "network_identity:report", %{
         "identities" => [
           %{
             "service" => "iroh",
@@ -469,9 +469,9 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
         ]
       })
 
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
 
-      assert [identity] = ExternalIdentities.list_for_device(device.id)
+      assert [identity] = NetworkIdentities.list_for_device(device.id)
       assert identity.service == :iroh
       assert identity.identifier == "abc123"
       assert identity.details == %{"ticket" => "a-connection-ticket"}
@@ -481,90 +481,90 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
       # A device running an iroh console and an iroh application reports both.
       # They are both iroh, and neither should overwrite the other.
       {_attach_list, socket} = join_extensions(socket)
-      push(socket, "external_identity:attached")
-      assert_push("external_identity:request", %{})
+      push(socket, "network_identity:attached")
+      assert_push("network_identity:request", %{})
 
       @endpoint.subscribe("internal:device:#{device.id}")
 
-      push(socket, "external_identity:report", %{
+      push(socket, "network_identity:report", %{
         "identities" => [
           %{"service" => "iroh", "instance" => "iroh_console", "identifier" => "console-key"},
           %{"service" => "iroh", "instance" => "kiosk_sync", "identifier" => "sync-key"}
         ]
       })
 
-      assert_receive %Broadcast{event: "external_identities:updated"}
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
 
       assert [%{instance: "iroh_console"}, %{instance: "kiosk_sync"}] =
-               ExternalIdentities.list_for_device(device.id)
+               NetworkIdentities.list_for_device(device.id)
     end
 
     test "records several identities from one report", %{device: device, socket: socket} do
       {_attach_list, socket} = join_extensions(socket)
-      push(socket, "external_identity:attached")
-      assert_push("external_identity:request", %{})
+      push(socket, "network_identity:attached")
+      assert_push("network_identity:request", %{})
 
       @endpoint.subscribe("internal:device:#{device.id}")
 
-      push(socket, "external_identity:report", %{
+      push(socket, "network_identity:report", %{
         "identities" => [
           %{"service" => "iroh", "identifier" => "iroh-key"},
           %{"service" => "netbird", "identifier" => "netbird-key"}
         ]
       })
 
-      assert_receive %Broadcast{event: "external_identities:updated"}
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
 
       assert [%{service: :iroh}, %{service: :netbird}] =
-               ExternalIdentities.list_for_device(device.id)
+               NetworkIdentities.list_for_device(device.id)
     end
 
     test "a service we don't support doesn't cost the device its other identities", %{device: device, socket: socket} do
       {_attach_list, socket} = join_extensions(socket)
-      push(socket, "external_identity:attached")
-      assert_push("external_identity:request", %{})
+      push(socket, "network_identity:attached")
+      assert_push("network_identity:request", %{})
 
       @endpoint.subscribe("internal:device:#{device.id}")
 
-      push(socket, "external_identity:report", %{
+      push(socket, "network_identity:report", %{
         "identities" => [
           %{"service" => "zerotier", "identifier" => "unsupported"},
           %{"service" => "iroh", "identifier" => "still-recorded"}
         ]
       })
 
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
 
       assert [%{service: :iroh, identifier: "still-recorded"}] =
-               ExternalIdentities.list_for_device(device.id)
+               NetworkIdentities.list_for_device(device.id)
     end
 
     test "a malformed report does not take the connection down", %{device: device, socket: socket} do
       {_attach_list, socket} = join_extensions(socket)
-      push(socket, "external_identity:attached")
-      assert_push("external_identity:request", %{})
+      push(socket, "network_identity:attached")
+      assert_push("network_identity:request", %{})
 
-      push(socket, "external_identity:report", %{"identities" => "not-a-list"})
-      push(socket, "external_identity:report", %{"identities" => [%{"nonsense" => true}]})
+      push(socket, "network_identity:report", %{"identities" => "not-a-list"})
+      push(socket, "network_identity:report", %{"identities" => [%{"nonsense" => true}]})
 
       @endpoint.subscribe("internal:device:#{device.id}")
 
       # The channel is still serving this device: a good report after the bad
       # ones still lands.
-      push(socket, "external_identity:report", %{
+      push(socket, "network_identity:report", %{
         "identities" => [%{"service" => "iroh", "identifier" => "after-the-garbage"}]
       })
 
-      assert_receive %Broadcast{event: "external_identities:updated"}
+      assert_receive %Broadcast{event: "network_identities:updated"}
 
-      assert [%{identifier: "after-the-garbage"}] = ExternalIdentities.list_for_device(device.id)
+      assert [%{identifier: "after-the-garbage"}] = NetworkIdentities.list_for_device(device.id)
     end
 
     test "is not offered to a device whose product has it switched off", %{device: device, certificate: certificate} do
       product = Products.get_product!(device.product_id)
-      {:ok, _product} = Products.disable_extension_setting(product, "external_identity")
+      {:ok, _product} = Products.disable_extension_setting(product, "network_identity")
 
       # The allowed set is worked out when the device authenticates, so this
       # needs a fresh connection rather than the one opened during setup.
@@ -573,7 +573,7 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
 
       {attach_list, _socket} = join_extensions(socket)
 
-      refute "external_identity" in attach_list
+      refute "network_identity" in attach_list
     end
   end
 

--- a/test/nerves_hub_web/controllers/api/iroh_endpoint_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/iroh_endpoint_controller_test.exs
@@ -3,7 +3,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
   alias NervesHub.Accounts.OrgUser
   alias NervesHub.Devices
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHub.Fixtures
 
   @endpoint_id "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302"
@@ -18,7 +18,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
     end
 
     test "lists an endpoint with what holds it", %{conn: conn, org: org} do
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
 
@@ -34,7 +34,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
     test "names the device holding one it reported", %{conn: conn, org: org, product: product} do
       device = device_fixture(org, product)
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
 
       conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
 
@@ -50,7 +50,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
     test "does not list another organization's endpoints", %{conn: conn, org: org, user: user} do
       other_org = Fixtures.org_fixture(user, %{name: "SomeoneElse"})
-      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
 
@@ -59,8 +59,8 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
     test "lists only iroh, not every service the table holds", %{conn: conn, org: org, product: product} do
       device = device_fixture(org, product)
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
-      {:ok, _} = ExternalIdentities.report(device.id, "tailscale", %{identifier: @other_id})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.report(device.id, "tailscale", %{identifier: @other_id})
 
       conn = get(conn, Routes.api_iroh_endpoint_path(conn, :index, org.name))
 
@@ -71,7 +71,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
   describe "index filters" do
     setup %{conn: conn, org: org, product: product, user: user} do
       device = device_fixture(org, product)
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
 
       {:ok, _} =
         post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{
@@ -81,7 +81,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
         |> json_response(201)
         |> then(&{:ok, &1})
 
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @unowned_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @unowned_id})
 
       [device: device]
     end
@@ -186,7 +186,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
       assert endpoint["owner"]["type"] == "none"
 
       assert {:ok, %{org_id: org_id, owner: "org"}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+               NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
 
       assert org_id == org.id
     end
@@ -214,7 +214,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
       assert owner["user_name"] == user.name
 
       assert {:ok, %{owner: "org_user", user_id: user_id}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+               NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
 
       assert user_id == user.id
     end
@@ -231,7 +231,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
     test "refuses a key registered elsewhere, without saying where", %{conn: conn, org: org, user: user} do
       other_org = Fixtures.org_fixture(user, %{name: "AlreadyHasIt"})
-      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = post(conn, Routes.api_iroh_endpoint_path(conn, :create, org.name), %{"identifier" => @endpoint_id})
 
@@ -275,7 +275,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
   describe "show" do
     test "finds one by its key", %{conn: conn, org: org} do
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = get(conn, Routes.api_iroh_endpoint_path(conn, :show, org.name, @endpoint_id))
 
@@ -292,7 +292,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
       # A key is not a secret — it is the one thing an outsider is most likely
       # to have — so knowing one must not read another organization's record.
       other_org = Fixtures.org_fixture(user, %{name: "NotYours"})
-      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = get(conn, Routes.api_iroh_endpoint_path(conn, :show, org.name, @endpoint_id))
 
@@ -302,12 +302,12 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
   describe "delete" do
     test "removes one, and then it is gone", %{conn: conn, org: org} do
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
       assert response(conn, 204)
 
-      assert {:error, :not_found} = ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+      assert {:error, :not_found} = NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
     end
 
     test "404s for a key nobody holds", %{conn: conn, org: org} do
@@ -318,12 +318,12 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
 
     test "will not remove another organization's", %{conn: conn, org: org, user: user} do
       other_org = Fixtures.org_fixture(user, %{name: "StillNotYours"})
-      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
 
       conn = delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
 
       assert json_response(conn, 404)
-      assert {:ok, _} = ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+      assert {:ok, _} = NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
     end
   end
 
@@ -340,7 +340,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
     end
 
     test "a view-only member may not delete", %{conn: conn, org: org, user: user} do
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
       org_user = NervesHub.Repo.get_by!(OrgUser, org_id: org.id, user_id: user.id)
       {:ok, _} = NervesHub.Accounts.change_org_user_role(org_user, :view)
 
@@ -348,7 +348,7 @@ defmodule NervesHubWeb.API.IrohEndpointControllerTest do
         delete(conn, Routes.api_iroh_endpoint_path(conn, :delete, org.name, @endpoint_id))
       end)
 
-      assert {:ok, _} = ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+      assert {:ok, _} = NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
     end
   end
 

--- a/test/nerves_hub_web/controllers/api/network_identity_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/network_identity_controller_test.exs
@@ -1,8 +1,8 @@
-defmodule NervesHubWeb.API.ExternalIdentityControllerTest do
+defmodule NervesHubWeb.API.NetworkIdentityControllerTest do
   use NervesHubWeb.APIConnCase, async: true
 
   alias NervesHub.Devices
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
 
   @iroh_console "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302"
   @iroh_app "5f691e39f55415be337b2e4cc0dd7291586ab7c4356bf32bab60f46fc78f95d5"
@@ -22,7 +22,7 @@ defmodule NervesHubWeb.API.ExternalIdentityControllerTest do
   end
 
   defp path(conn, org, product, device, params \\ []) do
-    Routes.api_external_identity_path(conn, :index, org.name, product.name, device.identifier, params)
+    Routes.api_network_identity_path(conn, :index, org.name, product.name, device.identifier, params)
   end
 
   describe "index" do
@@ -34,7 +34,7 @@ defmodule NervesHubWeb.API.ExternalIdentityControllerTest do
 
     test "lists what the device reported", %{conn: conn, org: org, product: product, device: device} do
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           identifier: @iroh_console,
           details: %{"relay" => "https://relay.example.com"}
         })
@@ -54,7 +54,7 @@ defmodule NervesHubWeb.API.ExternalIdentityControllerTest do
       {:ok, other} =
         Devices.create_device(%{identifier: "device-5678", org_id: org.id, product_id: product.id})
 
-      {:ok, _} = ExternalIdentities.report(other.id, "iroh", %{identifier: @iroh_console})
+      {:ok, _} = NetworkIdentities.report(other.id, "iroh", %{identifier: @iroh_console})
 
       conn = get(conn, path(conn, org, product, device))
 
@@ -64,9 +64,9 @@ defmodule NervesHubWeb.API.ExternalIdentityControllerTest do
 
   describe "filtering" do
     setup %{device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @iroh_console, instance: "console"})
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @iroh_app, instance: "application"})
-      {:ok, _} = ExternalIdentities.report(device.id, "tailscale", %{identifier: @tailscale})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @iroh_console, instance: "console"})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @iroh_app, instance: "application"})
+      {:ok, _} = NetworkIdentities.report(device.id, "tailscale", %{identifier: @tailscale})
       :ok
     end
 

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -14,10 +14,10 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   alias NervesHub.Devices.Deployments
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
-  alias NervesHub.Devices.ExternalIdentities
   alias NervesHub.Devices.Health
   alias NervesHub.Devices.InflightUpdate
   alias NervesHub.Devices.Metrics
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHub.Devices.Updates
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Firmware
@@ -1710,7 +1710,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     end
   end
 
-  describe "external identities" do
+  describe "network identities" do
     test "explains an empty panel when the product hasn't enabled reporting", %{
       conn: conn,
       org: org,
@@ -1719,7 +1719,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     } do
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
-      |> assert_has("div", text: "External Identities")
+      |> assert_has("div", text: "Network Identities")
       |> assert_has("div", text: "External identity reporting is not enabled for your product.")
     end
 
@@ -1729,11 +1729,11 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, _product} = Products.enable_extension_setting(product, "external_identity")
+      {:ok, _product} = Products.enable_extension_setting(product, "network_identity")
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
-      |> assert_has("div", text: "This device hasn't reported any external identities.")
+      |> assert_has("div", text: "This device hasn't reported any network identities.")
     end
 
     test "shows a reported identity with its service and label", %{
@@ -1743,7 +1743,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       device: device
     } do
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           identifier: "e13b8a4c9f2d",
           details: %{"relay_url" => "https://iroh.nervescloud.com"}
         })
@@ -1763,7 +1763,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       product: product,
       device: device
     } do
-      {:ok, _} = ExternalIdentities.report(device.id, "tailscale", %{identifier: "nodekey-abc"})
+      {:ok, _} = NetworkIdentities.report(device.id, "tailscale", %{identifier: "nodekey-abc"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -1777,7 +1777,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       ticket = String.duplicate("a", 170)
 
       {:ok, identity} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           identifier: "short-id",
           details: %{"ticket" => ticket}
         })
@@ -1795,8 +1795,8 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     } do
       # Turning reporting off stops new reports; it doesn't make what was already
       # recorded untrue, and hiding it would just look like data loss.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: "recorded-earlier"})
-      {:ok, _product} = Products.disable_extension_setting(product, "external_identity")
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: "recorded-earlier"})
+      {:ok, _product} = Products.disable_extension_setting(product, "network_identity")
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -1810,13 +1810,13 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       device: device
     } do
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           instance: "iroh_console",
           identifier: "console-endpoint-key"
         })
 
       {:ok, _} =
-        ExternalIdentities.report(device.id, "iroh", %{
+        NetworkIdentities.report(device.id, "iroh", %{
           instance: "kiosk_sync",
           identifier: "sync-endpoint-key"
         })
@@ -1836,7 +1836,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       device: device
     } do
       # Saying "default" on every row would be noise.
-      {:ok, _} = ExternalIdentities.report(device.id, "netbird", %{identifier: "the-only-one"})
+      {:ok, _} = NetworkIdentities.report(device.id, "netbird", %{identifier: "the-only-one"})
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
@@ -1846,7 +1846,7 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
     test "marks an operator-recorded identity as such", %{conn: conn, org: org, product: product, device: device} do
       _identity =
-        Fixtures.external_identity_fixture(device, %{
+        Fixtures.network_identity_fixture(device, %{
           identifier: "operator-set",
           source: :operator
         })
@@ -1857,14 +1857,14 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     end
 
     test "updates live when a device reports a new identity", %{conn: conn, org: org, product: product, device: device} do
-      {:ok, _product} = Products.enable_extension_setting(product, "external_identity")
+      {:ok, _product} = Products.enable_extension_setting(product, "network_identity")
 
       session =
         conn
         |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
-        |> assert_has("div", text: "This device hasn't reported any external identities.")
+        |> assert_has("div", text: "This device hasn't reported any network identities.")
 
-      {:ok, _} = ExternalIdentities.report(device.id, "netbird", %{identifier: "peer-key-9000"})
+      {:ok, _} = NetworkIdentities.report(device.id, "netbird", %{identifier: "peer-key-9000"})
 
       assert_has(session, "span", text: "peer-key-9000", timeout: 1_000)
     end

--- a/test/nerves_hub_web/live/org/iroh_endpoints_test.exs
+++ b/test/nerves_hub_web/live/org/iroh_endpoints_test.exs
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Live.Org.NetworkIdentitiesTest do
+defmodule NervesHubWeb.Live.Org.IrohEndpointsTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
   alias NervesHub.Accounts.OrgUser

--- a/test/nerves_hub_web/live/org/network_identities_test.exs
+++ b/test/nerves_hub_web/live/org/network_identities_test.exs
@@ -1,8 +1,8 @@
-defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
+defmodule NervesHubWeb.Live.Org.NetworkIdentitiesTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
   alias NervesHub.Accounts.OrgUser
-  alias NervesHub.Devices.ExternalIdentities
+  alias NervesHub.Devices.NetworkIdentities
   alias NervesHub.Fixtures
 
   @endpoint_id "c8924b6c9b7a8528b1365ebec4b2e43b6edebef684f8521f12b8caaf6e1b2302"
@@ -50,7 +50,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
     end
 
     test "shows a device's endpoint and which device it is", %{conn: conn, org: org, device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
 
       conn
       |> visit(path(org))
@@ -64,7 +64,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
     test "offers the whole endpoint id to the clipboard", %{conn: conn, org: org, device: device} do
       # Truncation is visual only. What gets copied is the key itself, since a
       # partial one is no use to whoever is being sent it.
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
 
       conn
       |> visit(path(org))
@@ -72,7 +72,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
     end
 
     test "shows an endpoint registered by hand as unassigned", %{conn: conn, org: org} do
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
 
       conn
       |> visit(path(org))
@@ -82,7 +82,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
 
     test "does not show another organisation's endpoints", %{conn: conn, org: org, user: user} do
       other_org = Fixtures.org_fixture(user, %{name: "SomeoneElse"})
-      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
 
       conn
       |> visit(path(org))
@@ -148,8 +148,8 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
 
   describe "search and filter" do
     setup %{org: org, device: device} do
-      {:ok, _} = ExternalIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: String.duplicate("ab", 32)})
+      {:ok, _} = NetworkIdentities.report(device.id, "iroh", %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: String.duplicate("ab", 32)})
       :ok
     end
 
@@ -190,14 +190,14 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
       |> assert_has("div", text: "Endpoint registered")
 
       assert {:ok, %{org_id: org_id, owner: "org"}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+               NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
 
       assert org_id == org.id
     end
 
     test "refuses one already registered, without saying where", %{conn: conn, org: org, user: user} do
       other_org = Fixtures.org_fixture(user, %{name: "AlreadyHasIt"})
-      {:ok, _} = ExternalIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(other_org.id, :iroh, %{identifier: @endpoint_id})
 
       # Whether another organisation holds a key is that organisation's
       # business, so the message says it is taken and nothing more.
@@ -225,7 +225,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
       |> assert_has("span", text: user.name)
 
       assert {:ok, %{owner: "org_user", user_id: user_id}} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+               NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
 
       assert user_id == user.id
     end
@@ -239,7 +239,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
         NervesHub.Repo.get_by!(OrgUser, org_id: other_org.id, user_id: user.id)
 
       assert {:error, :invalid_member} =
-               ExternalIdentities.register(org.id, :iroh, %{
+               NetworkIdentities.register(org.id, :iroh, %{
                  identifier: @endpoint_id,
                  org_user_id: other_member.id
                })
@@ -259,7 +259,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
 
   describe "removing" do
     test "removes an endpoint", %{conn: conn, org: org} do
-      {:ok, _} = ExternalIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
+      {:ok, _} = NetworkIdentities.register(org.id, :iroh, %{identifier: @endpoint_id})
 
       conn
       |> visit(path(org))
@@ -267,7 +267,7 @@ defmodule NervesHubWeb.Live.Org.ExternalIdentitiesTest do
       |> assert_has("div", text: "Endpoint removed")
 
       assert {:error, :not_found} =
-               ExternalIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
+               NetworkIdentities.get_owner_by_identifier(:iroh, @endpoint_id)
     end
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -11,8 +11,8 @@ defmodule NervesHub.Fixtures do
   alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.DeviceConnection
-  alias NervesHub.Devices.ExternalIdentity
   alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.Devices.NetworkIdentity
   alias NervesHub.Firmwares
   alias NervesHub.ManagedDeployments
   alias NervesHub.Products
@@ -489,9 +489,9 @@ defmodule NervesHub.Fixtures do
     |> Repo.insert!()
   end
 
-  def external_identity_fixture(%Devices.Device{} = device, params \\ %{}) do
-    %ExternalIdentity{}
-    |> ExternalIdentity.changeset(
+  def network_identity_fixture(%Devices.Device{} = device, params \\ %{}) do
+    %NetworkIdentity{}
+    |> NetworkIdentity.changeset(
       Map.merge(
         %{
           # Identities name an organisation of their own; for a device-owned one
@@ -499,7 +499,7 @@ defmodule NervesHub.Fixtures do
           org_id: device.org_id,
           device_id: device.id,
           service: :iroh,
-          instance: ExternalIdentity.default_instance(),
+          instance: NetworkIdentity.default_instance(),
           identifier: "endpoint-#{counter()}",
           details: %{},
           source: :device_reported,


### PR DESCRIPTION
This PR renames `ExternalIdentity` to `NetworkIdentity` as it better describes the feature and its intent.

