### PR TITLE
Version connection history rows at microsecond resolution

### DIFF
--- a/lib/nerves_hub/devices/device_connection_history.ex
+++ b/lib/nerves_hub/devices/device_connection_history.ex
@@ -43,8 +43,18 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
     |> put_change(:lib, connection.lib)
     |> put_change(:lib_version, connection.lib_version)
     |> put_change(:network_interface, to_string(connection.network_interface))
-    |> put_change(:version, DateTime.utc_now() |> DateTime.to_unix())
+    |> put_change(:version, current_version())
   end
+
+  # The `ReplacingMergeTree` dedupes on (org_id, product_id, device_id,
+  # established_at), which every row for a single connection shares, and keeps
+  # the row with the highest `version`. A connection's rows (connecting,
+  # connected, heartbeats, disconnected) are usually written within the same
+  # second, so a second-resolution version leaves them tied and ClickHouse picks
+  # between them arbitrarily - the merged view could report an already
+  # disconnected connection as still open. Microseconds keep the writes strictly
+  # ordered, so the most recent one always wins.
+  defp current_version(), do: DateTime.to_unix(DateTime.utc_now(), :microsecond)
 
   @doc """
   Builds a new history row from an existing one.
@@ -61,6 +71,6 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
     |> change()
     |> put_change(:disconnected_at, now)
     |> put_change(:disconnected_reason, "Stale connection")
-    |> put_change(:version, DateTime.to_unix(now))
+    |> put_change(:version, DateTime.to_unix(now, :microsecond))
   end
 end

--- a/test/nerves_hub/devices/connection_history_test.exs
+++ b/test/nerves_hub/devices/connection_history_test.exs
@@ -48,9 +48,9 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
 
       :ok = Connections.device_connected(connection.id)
 
-      # connecting + connected share the same ref/established_at, so the
-      # ReplacingMergeTree may keep both rows until merged; both are present.
-      assert_eventually(history_for(connection.id) != [])
+      # connecting + connected share the same ref/established_at, so the merged
+      # view collapses them to a single row
+      assert_eventually([%DeviceConnectionHistory{}] = history_for(connection.id))
     end
 
     test "device_disconnected/2 records a history row with the disconnect details", %{
@@ -60,11 +60,15 @@ defmodule NervesHub.Devices.ConnectionHistoryTest do
       :ok = Connections.device_connected(connection.id)
       :ok = Connections.device_disconnected(connection.id, "Stale connection")
 
+      # all three rows share the merge tree's sorting key, and the disconnect is
+      # written last, so the merged view collapses to it
       assert_eventually(
-        Enum.any?(history_for(connection.id), fn h ->
-          not is_nil(h.disconnected_at) and h.disconnected_reason == "Stale connection"
-        end)
+        [%DeviceConnectionHistory{disconnected_reason: "Stale connection"} = history] =
+          history_for(connection.id)
       )
+
+      assert history.device_id == device.id
+      refute is_nil(history.disconnected_at)
     end
 
     test "device_heartbeat/1 records a history row", %{device: device} do

--- a/test/nerves_hub/devices/device_connection_history_test.exs
+++ b/test/nerves_hub/devices/device_connection_history_test.exs
@@ -71,13 +71,35 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         last_seen_at: ~U[2020-01-01 00:05:00.000000Z]
       }
 
-      before = DateTime.utc_now() |> DateTime.to_unix()
+      before = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
       changes = DeviceConnectionHistory.from_device_connection_changeset(connection).changes
-      later = DateTime.utc_now() |> DateTime.to_unix()
+      later = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
 
       # version tracks the current time at insert, independent of last_seen_at
       assert changes.version >= before
       assert changes.version <= later
+    end
+
+    test "successive rows for the same connection get strictly increasing versions" do
+      connection = %DeviceConnection{
+        id: UUIDv7.generate(),
+        org_id: 1,
+        product_id: 2,
+        device_id: 3,
+        established_at: DateTime.utc_now(),
+        last_seen_at: DateTime.utc_now()
+      }
+
+      # every row for a connection shares the ReplacingMergeTree's sorting key,
+      # so the versions have to break the tie - ties are resolved arbitrarily by
+      # ClickHouse and the disconnect could lose to an earlier row
+      versions =
+        Enum.map(1..25, fn _ ->
+          DeviceConnectionHistory.from_device_connection_changeset(connection).changes.version
+        end)
+
+      assert versions == Enum.sort(versions)
+      assert versions == Enum.uniq(versions)
     end
 
     test "the version does not depend on last_seen_at" do
@@ -89,7 +111,8 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         established_at: ~U[2026-06-20 10:00:00.000000Z]
       }
 
-      now = DateTime.utc_now() |> DateTime.to_unix()
+      now = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+      one_second = 1_000_000
 
       old_last_seen =
         DeviceConnectionHistory.from_device_connection_changeset(%{base | last_seen_at: ~U[2020-01-01 00:00:00Z]})
@@ -98,8 +121,25 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         DeviceConnectionHistory.from_device_connection_changeset(%{base | last_seen_at: ~U[2026-06-20 10:05:00Z]})
 
       # both are versioned by insert time, not by their (very different) last_seen_at
-      assert_in_delta old_last_seen.changes.version, now, 2
-      assert_in_delta new_last_seen.changes.version, now, 2
+      assert_in_delta old_last_seen.changes.version, now, 2 * one_second
+      assert_in_delta new_last_seen.changes.version, now, 2 * one_second
+    end
+
+    test "mark_as_stale_and_disconnected_changeset bumps the version past the row it carries forward" do
+      history = %DeviceConnectionHistory{
+        org_id: 1,
+        product_id: 2,
+        device_id: 3,
+        ref: UUIDv7.generate(),
+        established_at: ~U[2026-06-20 10:00:00.000000Z],
+        last_seen_at: ~U[2026-06-20 10:05:00.000000Z],
+        version: DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+      }
+
+      changes = DeviceConnectionHistory.mark_as_stale_and_disconnected_changeset(history).changes
+
+      assert changes.disconnected_reason == "Stale connection"
+      assert changes.version > history.version
     end
   end
 end


### PR DESCRIPTION
## The problem

`device_connection_history` is a `ReplacingMergeTree(version)` sorted by `(org_id, product_id, device_id, established_at)`. Every history row for a single connection — connecting, connected, heartbeats, disconnected — shares all four of those values, so `version` is the only thing deciding which row the merged (`FINAL`) view keeps.

`version` was `DateTime.to_unix(now)`: whole seconds. A connect/disconnect cycle usually completes well inside one second, so the rows come out tied, and ClickHouse resolves version ties arbitrarily.

Probe of a real run, 1.5s after the writes, all three rows present:

```
=== RAW (3) ===
  version=1787015348 last_seen=...858927Z disc_at=nil    reason=""
  version=1787015348 last_seen=...861415Z disc_at=nil    reason=""
  version=1787015348 last_seen=...862130Z disc_at=...    reason="Stale connection"
=== FINAL (1) ===
  version=1787015348 disc_at=nil reason=""
```

The merged view reports a closed connection as still open. That matters in production, not just in tests: `Connections.clean_stale_connections_from_analytics/0` reads with `final: 1` looking for rows with a nil `disconnected_at`, so a cleanly closed connection can be picked up and written back as a spurious stale disconnect. The same merged view backs the product insights queries.

It also made `test "device_disconnected/2 records a history row with the disconnect details"` flaky — 3 failures in 6 runs on an unmodified `main`. Waiting longer never helped; the disconnect row had already landed.

## The fix

Version rows at microsecond resolution. A connection's rows are built sequentially in the caller, so versions strictly increase and the most recent write always wins the merge.

No migration needed — the column is already `UInt64`, and a microsecond version (~1.8e15) outranks every existing second-scale one (~1.8e9), which is the correct outcome since those rows are older.

One caveat: during a rolling deploy, an old node writing a seconds-scale version for a connection whose earlier rows came from a new node will lose the merge. That is one deploy window, affecting only connections straddling it, and is unavoidable for any change of version scale.

## Tests

- The disconnect test now asserts the merged view collapses to exactly one row carrying the disconnect — that is the deterministic guarantee, and it fails loudly if the tie-break regresses.
- Corrected a stale comment on the `device_connected` test claiming `FINAL` may keep both rows.
- Added unit tests for strictly increasing versions across successive rows, and for `mark_as_stale_and_disconnected_changeset/1` bumping past the row it carries forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)