### PR TITLE
Fix device events stream never forwarding update progress

### DIFF
--- a/lib/nerves_hub_web/channels/device_events_stream_channel.ex
+++ b/lib/nerves_hub_web/channels/device_events_stream_channel.ex
@@ -28,10 +28,14 @@ defmodule NervesHubWeb.DeviceEventsStreamChannel do
     end
   end
 
+  # `NervesHub.FirmwareUpdates` broadcasts `firmware_update_progress` with string
+  # keys. This previously matched on `fwup_progress` with a `:percent` atom key —
+  # neither of which is ever broadcast — so nothing was forwarded to external
+  # subscribers.
   @impl Phoenix.Channel
-  def handle_info(%Broadcast{event: "fwup_progress", payload: %{percent: percent}}, socket) do
+  def handle_info(%Broadcast{event: "firmware_update_progress", payload: payload}, socket) do
     # Forward the firmware update progress to the connected client
-    push(socket, "firmware_update", %{percent: percent})
+    push(socket, "firmware_update", %{percent: payload["progress"], stage: payload["stage"]})
 
     {:noreply, socket}
   end

--- a/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_events_stream_channel_test.exs
@@ -2,12 +2,13 @@ defmodule NervesHubWeb.DeviceEventsStreamChannelTest do
   use NervesHubWeb.ChannelCase
 
   alias NervesHub.Accounts
+  alias NervesHub.FirmwareUpdates
   alias NervesHub.Fixtures
   alias NervesHubWeb.DeviceEventsStreamChannel
   alias NervesHubWeb.EventStreamSocket
 
   describe "handle_info/2" do
-    test "handles fwup_progress messages", %{tmp_dir: tmp_dir} do
+    test "forwards firmware update progress to subscribers", %{tmp_dir: tmp_dir} do
       user = Fixtures.user_fixture()
 
       device = device_fixture(user, %{identifier: "test-device-123"}, tmp_dir)
@@ -19,11 +20,12 @@ defmodule NervesHubWeb.DeviceEventsStreamChannelTest do
       {:ok, _join_reply, _channel} =
         subscribe_and_join(socket, DeviceEventsStreamChannel, "device:#{device.identifier}")
 
-      NervesHubWeb.Endpoint.broadcast("internal:device:#{device.id}", "fwup_progress", %{
-        percent: 50
-      })
+      # Go through the real broadcast path rather than hand-rolling the message,
+      # so that a mismatch between what is broadcast and what is handled fails
+      # this test instead of hiding behind it.
+      :ok = FirmwareUpdates.update_inflight_update(device.id, "downloading", 50, false)
 
-      assert_push("firmware_update", %{percent: 50})
+      assert_push("firmware_update", %{percent: 50, stage: "downloading"})
     end
   end
 


### PR DESCRIPTION
`DeviceEventsStreamChannel` matched on a broadcast that is never sent: event `"fwup_progress"` with a `:percent` atom key. What `NervesHub.FirmwareUpdates` actually broadcasts is `"firmware_update_progress"` with string keys.

The handler wasn't fixed when some recent changes were merged in.

The existing test hid this by hand-broadcasting the fake message rather than going through the real path. It now calls `FirmwareUpdates.update_inflight_update/4`, so a mismatch between what is broadcast and what is handled fails the test instead of passing under it.

The pushed payload gains `stage` alongside `percent`, which is additive for existing consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)