### PR TITLE
Make device-reported metadata and update progress tool-agnostic

### DIFF
--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -76,7 +76,13 @@ defmodule NervesHub.DeviceLink do
     {session, []}
   end
 
-  def device_message(session, "fwup_progress", %{"value" => percent} = params) do
+  # `fwup_progress` is what every deployed nerves_hub_link sends, and devices in
+  # the field cannot be made to send anything else, so it can never be retired.
+  # `update_progress` is the same message under a name that does not presume
+  # fwup, and is what a non-Nerves agent should send. Both carry the same
+  # payload: a `value` percentage and an optional `stage`.
+  def device_message(session, event, %{"value" => percent} = params)
+      when event in ["fwup_progress", "update_progress"] do
     {stage, percent} =
       case {params["stage"], percent} do
         {nil, 100} -> {"completed", nil}
@@ -629,32 +635,37 @@ defmodule NervesHub.DeviceLink do
     :ok
   end
 
-  # The reported firmware is the same as what we already know about
-  defp update_firmware_metadata(
-         %Device{firmware_metadata: %{uuid: uuid}} = device,
-         %{"nerves_fw_uuid" => uuid} = params
-       ) do
-    validation_status = fetch_validation_status(params)
-    auto_revert_detected? = firmware_auto_revert_detected?(params)
-
-    Devices.update_firmware_metadata(device, nil, validation_status, auto_revert_detected?)
-  end
-
-  # A new UUID is being reported from an update
+  # Whether the device is reporting the firmware we already have on record has
+  # to be decided *after* its metadata is resolved, not from a raw parameter.
+  # This used to match on `nerves_fw_uuid`, which only a Nerves device sends —
+  # so any other device took the "this is a new firmware" path on every single
+  # join, and `firmware_update_successful/2` recorded an audit entry, telemetry
+  # and an update stat each time it merely reconnected.
   defp update_firmware_metadata(%{firmware_metadata: previous_metadata} = device, params) do
-    with {:ok, metadata} <- Firmwares.metadata_from_device(params, device.product_id),
-         validation_status = fetch_validation_status(params),
-         auto_revert_detected? = firmware_auto_revert_detected?(params),
-         {:ok, device} <-
-           Devices.update_firmware_metadata(
-             device,
-             metadata,
-             validation_status,
-             auto_revert_detected?
-           ) do
-      FirmwareUpdates.firmware_update_successful(device, previous_metadata)
+    with {:ok, metadata} <- Firmwares.metadata_from_device(params, device.product_id) do
+      validation_status = fetch_validation_status(params)
+      auto_revert_detected? = firmware_auto_revert_detected?(params)
+
+      if same_firmware?(previous_metadata, metadata) do
+        Devices.update_firmware_metadata(device, nil, validation_status, auto_revert_detected?)
+      else
+        with {:ok, device} <-
+               Devices.update_firmware_metadata(
+                 device,
+                 metadata,
+                 validation_status,
+                 auto_revert_detected?
+               ) do
+          FirmwareUpdates.firmware_update_successful(device, previous_metadata)
+        end
+      end
     end
   end
+
+  # A device with no resolvable firmware, or one we have nothing on record for,
+  # is never "the same" — the first report has to be written.
+  defp same_firmware?(%{uuid: uuid}, %{uuid: uuid}) when not is_nil(uuid), do: true
+  defp same_firmware?(_previous, _reported), do: false
 
   defp fetch_validation_status(params) do
     params

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -438,21 +438,28 @@ defmodule NervesHub.Firmwares do
     {:ok, metadata}
   end
 
+  @doc """
+  Translate the firmware metadata a device reported on join.
+
+  Which keys are read depends on the device: a Nerves device reports
+  `nerves_fw_*`, an ESP-IDF device reports `esp_idf_*`. The update tool owns
+  that translation — see `NervesHub.Firmwares.UpdateTool.for_device_metadata/2`
+  for how one is chosen.
+
+  If the result is not a complete `FirmwareMetadata`, the reported UUID is
+  looked up instead, so a device that reports little still resolves to the
+  firmware NervesHub already holds.
+  """
+  # Returns the plain map shape (`FirmwareMetadata.metadata()`), not the struct —
+  # callers feed it to `FirmwareMetadata.changeset/2`. The spec previously said
+  # `FirmwareMetadata.t()`, which no code path has ever produced.
   @spec metadata_from_device(metadata :: map(), product_id :: pos_integer()) ::
-          {:ok, FirmwareMetadata.t() | nil}
-  def metadata_from_device(metadata, product_id) do
-    metadata = %{
-      uuid: Map.get(metadata, "nerves_fw_uuid"),
-      architecture: Map.get(metadata, "nerves_fw_architecture"),
-      platform: Map.get(metadata, "nerves_fw_platform"),
-      product: Map.get(metadata, "nerves_fw_product"),
-      version: Map.get(metadata, "nerves_fw_version"),
-      author: Map.get(metadata, "nerves_fw_author"),
-      description: Map.get(metadata, "nerves_fw_description"),
-      fwup_version: Map.get(metadata, "fwup_version"),
-      vcs_identifier: Map.get(metadata, "nerves_fw_vcs_identifier"),
-      misc: Map.get(metadata, "nerves_fw_misc")
-    }
+          {:ok, FirmwareMetadata.metadata() | nil}
+  def metadata_from_device(reported, product_id) do
+    metadata =
+      reported
+      |> UpdateTool.for_device_metadata()
+      |> then(& &1.metadata_from_device(reported))
 
     case FirmwareMetadata.changeset(%FirmwareMetadata{}, metadata).valid? do
       true ->

--- a/lib/nerves_hub/firmwares/update_tool.ex
+++ b/lib/nerves_hub/firmwares/update_tool.ex
@@ -182,6 +182,27 @@ defmodule NervesHub.Firmwares.UpdateTool do
   @callback device_update_type(device :: Device.t(), Firmware.t()) :: :delta | :full
 
   @doc """
+  Whether this tool recognises the firmware metadata a device reported on join.
+
+  Devices predate the tool registry and mostly cannot be upgraded in the field,
+  so a device is not required to say which format it speaks. A tool identifies
+  its own metadata by the keys present — `nerves_fw_uuid` for fwup, for example.
+
+  A device that *can* say so should send `"update_tool"` in its join params,
+  which takes precedence over this.
+  """
+  @callback recognises_device_metadata?(params :: map()) :: boolean()
+
+  @doc """
+  Translate the firmware metadata a device reported into NervesHub's shape.
+
+  Returns a plain map for `NervesHub.Firmwares.FirmwareMetadata.changeset/2`.
+  Values that cannot be derived should be `nil` rather than omitted — a device
+  reporting partial metadata falls back to a database lookup by UUID.
+  """
+  @callback metadata_from_device(params :: map()) :: map()
+
+  @doc """
   Every tool this instance is configured to use, keyed by `tool_name/0`.
   """
   @spec all() :: %{String.t() => module()}
@@ -229,6 +250,33 @@ defmodule NervesHub.Firmwares.UpdateTool do
       nil -> {:error, :unrecognised_firmware_format}
       module -> {:ok, module}
     end
+  end
+
+  @doc """
+  The tool that handles the firmware metadata a device reported.
+
+  Prefers an explicit `"update_tool"` in the params, then asks each tool whether
+  it recognises the keys, and finally falls back to `fallback` — which exists so
+  that a device reporting nothing recognisable is still read the way it was
+  before this seam existed, rather than losing its metadata.
+  """
+  @spec for_device_metadata(map(), module()) :: module()
+  def for_device_metadata(params, fallback \\ __MODULE__.Fwup) do
+    declared = params["update_tool"]
+
+    with true <- is_binary(declared),
+         {:ok, module} <- fetch(declared) do
+      module
+    else
+      _ -> sniff_device_metadata(params, fallback)
+    end
+  end
+
+  defp sniff_device_metadata(params, fallback) do
+    all()
+    |> Map.values()
+    |> Enum.find(& &1.recognises_device_metadata?(params))
+    |> Kernel.||(fallback)
   end
 
   @spec fetch(String.t() | nil) :: {:ok, module()} | {:error, {:unknown_update_tool, String.t()}}

--- a/lib/nerves_hub/firmwares/update_tool/fwup.ex
+++ b/lib/nerves_hub/firmwares/update_tool/fwup.ex
@@ -68,6 +68,25 @@ defmodule NervesHub.Firmwares.UpdateTool.Fwup do
   end
 
   @impl UpdateTool
+  def recognises_device_metadata?(params), do: Map.has_key?(params, "nerves_fw_uuid")
+
+  @impl UpdateTool
+  def metadata_from_device(params) do
+    %{
+      uuid: params["nerves_fw_uuid"],
+      architecture: params["nerves_fw_architecture"],
+      platform: params["nerves_fw_platform"],
+      product: params["nerves_fw_product"],
+      version: params["nerves_fw_version"],
+      author: params["nerves_fw_author"],
+      description: params["nerves_fw_description"],
+      fwup_version: params["fwup_version"],
+      vcs_identifier: params["nerves_fw_vcs_identifier"],
+      misc: params["nerves_fw_misc"]
+    }
+  end
+
+  @impl UpdateTool
   def get_firmware_metadata_from_file(filepath) do
     with {:ok, firmware_metadata} <- FwupUtil.metadata(filepath),
          {:ok, meta_conf_path} <- extract_meta_conf_locally(filepath),

--- a/lib/nerves_hub_web/components/update_progress.ex
+++ b/lib/nerves_hub_web/components/update_progress.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubWeb.Components.FwupProgress do
+defmodule NervesHubWeb.Components.UpdateProgress do
   use NervesHubWeb, :component
 
   attr(:progress, :any)

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -19,7 +19,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
   alias NervesHubWeb.Components.DevicePage.LogsTab
   alias NervesHubWeb.Components.DevicePage.SettingsTab
   alias NervesHubWeb.Components.DeviceUpdateStatus
-  alias NervesHubWeb.Components.FwupProgress
+  alias NervesHubWeb.Components.UpdateProgress
   alias NervesHubWeb.Presence
   alias Phoenix.LiveView.AsyncResult
   alias Phoenix.Socket.Broadcast

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -42,7 +42,7 @@
   </:top_bar>
 
   <:big_header>
-    <FwupProgress.render :if={@firmware_update_stage} stage={@firmware_update_stage} progress={@firmware_update_progress} />
+    <UpdateProgress.render :if={@firmware_update_stage} stage={@firmware_update_stage} progress={@firmware_update_progress} />
 
     <div class="group/identifier flex shrink-0 items-center gap-3">
       <svg

--- a/test/nerves_hub/device_link_test.exs
+++ b/test/nerves_hub/device_link_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHub.DeviceLinkTest do
   alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.DeviceLink
   alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.DeviceLink.Session
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.InflightUpdate
@@ -366,6 +367,56 @@ defmodule NervesHub.DeviceLinkTest do
 
       :ok =
         DeviceLink.status_update(to_device_info(device), %{"status" => "started", "downloader_network_interface" => nil})
+    end
+  end
+
+  describe "device_message/3 progress events" do
+    setup %{device: device, firmware: firmware} do
+      {:ok, inflight_update} = Fixtures.inflight_update(device, firmware)
+      session = %Session{device_info: to_device_info(device)}
+
+      {:ok, %{inflight_update: inflight_update, session: session}}
+    end
+
+    # Every deployed nerves_hub_link sends this name and cannot be changed.
+    test "fwup_progress records progress", %{inflight_update: inflight_update, session: session} do
+      assert {_session, []} =
+               DeviceLink.device_message(session, "fwup_progress", %{"value" => 42, "stage" => "downloading"})
+
+      inflight_update = Repo.reload!(inflight_update)
+      assert inflight_update.progress == 42
+      assert inflight_update.status == :downloading
+    end
+
+    # The tool-neutral name a non-Nerves agent should send.
+    test "update_progress records progress identically", %{inflight_update: inflight_update, session: session} do
+      assert {_session, []} =
+               DeviceLink.device_message(session, "update_progress", %{"value" => 42, "stage" => "downloading"})
+
+      inflight_update = Repo.reload!(inflight_update)
+      assert inflight_update.progress == 42
+      assert inflight_update.status == :downloading
+    end
+
+    test "update_progress without a stage is treated as updating", %{
+      inflight_update: inflight_update,
+      session: session
+    } do
+      assert {_session, []} = DeviceLink.device_message(session, "update_progress", %{"value" => 30})
+
+      assert Repo.reload!(inflight_update).status == :updating
+    end
+
+    test "update_progress at 100 with no stage completes", %{inflight_update: inflight_update, session: session} do
+      assert {_session, []} = DeviceLink.device_message(session, "update_progress", %{"value" => 100})
+
+      assert Repo.reload!(inflight_update).status == :completed
+    end
+
+    # The catch-all clause must swallow a malformed message rather than crash
+    # the link and take the device's connection with it.
+    test "a progress message with no value is ignored", %{session: session} do
+      assert {_session, []} = DeviceLink.device_message(session, "update_progress", %{})
     end
   end
 

--- a/test/nerves_hub/firmwares/device_metadata_test.exs
+++ b/test/nerves_hub/firmwares/device_metadata_test.exs
@@ -1,0 +1,104 @@
+defmodule NervesHub.Firmwares.DeviceMetadataTest do
+  @moduledoc """
+  Covers `Firmwares.metadata_from_device/2` resolving a device's dialect.
+
+  The compatibility cases matter most: devices in the field cannot be upgraded,
+  so a Nerves device reporting `nerves_fw_*` must keep resolving exactly as it
+  did before this seam existed.
+  """
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Firmwares
+  alias NervesHub.Firmwares.UpdateTool
+  alias NervesHub.Fixtures
+
+  defp nerves_params(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "nerves_fw_uuid" => Ecto.UUID.generate(),
+        "nerves_fw_product" => "my_product",
+        "nerves_fw_version" => "1.2.3",
+        "nerves_fw_platform" => "rpi4",
+        "nerves_fw_architecture" => "arm",
+        "nerves_fw_author" => "me",
+        "nerves_fw_description" => "a description",
+        "fwup_version" => "1.13.0",
+        "nerves_fw_vcs_identifier" => "abc123",
+        "nerves_fw_misc" => "misc"
+      },
+      overrides
+    )
+  end
+
+  describe "tool selection" do
+    test "an explicit update_tool wins" do
+      params = Map.put(nerves_params(), "update_tool", "fwup")
+      assert UpdateTool.for_device_metadata(params) == UpdateTool.Fwup
+    end
+
+    test "an unknown update_tool falls back to sniffing" do
+      params = Map.put(nerves_params(), "update_tool", "not-a-real-tool")
+      assert UpdateTool.for_device_metadata(params) == UpdateTool.Fwup
+    end
+
+    test "nerves_fw_uuid identifies a Nerves device" do
+      assert UpdateTool.for_device_metadata(nerves_params()) == UpdateTool.Fwup
+    end
+
+    # Devices that report nothing recognisable must keep being read as fwup,
+    # which is how every device was read before this seam existed.
+    test "unrecognisable params fall back to fwup" do
+      assert UpdateTool.for_device_metadata(%{"something" => "else"}) == UpdateTool.Fwup
+    end
+  end
+
+  describe "metadata_from_device/2 with a Nerves device" do
+    test "reads nerves_fw_* keys", %{} do
+      product = product_fixture()
+      params = nerves_params()
+
+      assert {:ok, metadata} = Firmwares.metadata_from_device(params, product.id)
+
+      assert metadata.uuid == params["nerves_fw_uuid"]
+      assert metadata.product == "my_product"
+      assert metadata.version == "1.2.3"
+      assert metadata.platform == "rpi4"
+      assert metadata.architecture == "arm"
+      assert metadata.author == "me"
+      assert metadata.fwup_version == "1.13.0"
+      assert metadata.vcs_identifier == "abc123"
+      assert metadata.misc == "misc"
+    end
+
+    test "falls back to a database lookup when the report is incomplete", %{} do
+      %{firmware: firmware, product: product} = firmware_fixture()
+
+      params = %{"nerves_fw_uuid" => firmware.uuid}
+
+      assert {:ok, metadata} = Firmwares.metadata_from_device(params, product.id)
+      assert metadata.uuid == firmware.uuid
+      assert metadata.version == firmware.version
+    end
+
+    test "returns nil when nothing identifies the firmware" do
+      product = product_fixture()
+      assert {:ok, nil} = Firmwares.metadata_from_device(%{}, product.id)
+    end
+  end
+
+  defp product_fixture() do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    Fixtures.product_fixture(user, org)
+  end
+
+  defp firmware_fixture() do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    %{firmware: firmware, product: product}
+  end
+end


### PR DESCRIPTION
Two places assumed every device is a Nerves device.

## Device-reported firmware metadata

`Firmwares.metadata_from_device/2` read `nerves_fw_*` keys directly. It now delegates to the update tool, chosen by an explicit `update_tool` join param, then by which keys are present, and finally falling back to fwup — so a device reporting nothing recognisable is read exactly as it was before.

## "Same firmware as last time"

`update_firmware_metadata/2` decided this by pattern matching `nerves_fw_uuid`. Any device that does not send that key took the "this is a new firmware" branch on **every** join, and `firmware_update_successful/2` recorded an audit entry, telemetry and an update stat each time it merely reconnected.

It now compares the resolved UUIDs, which is dialect-agnostic.

This is latent today — no non-Nerves device exists yet — so it is a correctness fix rather than a live bug.

## Progress event

`update_progress` is accepted as a tool-neutral name for `fwup_progress`. Both carry the same payload. `fwup_progress` is what every deployed `nerves_hub_link` sends and can never be retired.

`Components.FwupProgress` becomes `Components.UpdateProgress`; its messages were already format-neutral.

Also corrects `metadata_from_device/2`'s spec, which claimed a `FirmwareMetadata.t()` struct that no code path has ever produced.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)