### PR TITLE
Reject firmware uploaded to the wrong product

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -303,19 +303,32 @@ defmodule NervesHub.Firmwares do
     |> where([f, p], p.id == ^product_id)
   end
 
+  @doc """
+  Store an uploaded firmware file.
+
+  Pass `:product` to require that the archive's own declared product name
+  matches the product the upload was addressed to. Without it the declared name
+  alone decides where the firmware lands, which is how this behaved before the
+  option existed.
+  """
   @spec create_firmware(
           org :: Org.t(),
           filepath :: Path.t(),
-          opts :: [{:upload_file_2, upload_file_2()}]
+          opts :: [{:upload_file_2, upload_file_2()} | {:product, Product.t()}]
         ) ::
           {:ok, Firmware.t()}
-          | {:error, Changeset.t() | :no_public_keys | :invalid_signature | any}
+          | {:error,
+             Changeset.t()
+             | :no_public_keys
+             | :invalid_signature
+             | {:product_mismatch, declared :: String.t(), expected :: String.t()}
+             | any}
   def create_firmware(org, filepath, opts \\ []) do
     upload_file_2 = opts[:upload_file_2] || (&firmware_upload_config().upload_file(&1, &2))
 
     Repo.transact(
       fn ->
-        with {:ok, params} <- build_firmware_params(org, filepath),
+        with {:ok, params} <- build_firmware_params(org, filepath, opts[:product]),
              {:ok, firmware} <- insert_firmware(params),
              :ok <- upload_file_2.(filepath, firmware.upload_metadata) do
           {:ok, firmware}
@@ -866,13 +879,14 @@ defmodule NervesHub.Firmwares do
     :ok
   end
 
-  @spec build_firmware_params(Org.t(), Path.t()) :: {:ok, map()} | {:error, any()}
-  defp build_firmware_params(%{id: org_id} = org, filepath) do
+  @spec build_firmware_params(Org.t(), Path.t(), Product.t() | nil) :: {:ok, map()} | {:error, any()}
+  defp build_firmware_params(%{id: org_id} = org, filepath, expected_product) do
     org = NervesHub.Repo.preload(org, :org_keys)
 
     with {:ok, %{id: org_key_id}} <- verify_signature(filepath, org.org_keys),
          {:ok, %{path: conf_path, firmware_metadata: fm, tool_metadata: tm} = m} <-
-           update_tool().get_firmware_metadata_from_file(filepath) do
+           update_tool().get_firmware_metadata_from_file(filepath),
+         :ok <- check_expected_product(fm.product, expected_product) do
       filename = fm.uuid <> ".fw"
 
       params =
@@ -899,7 +913,7 @@ defmodule NervesHub.Firmwares do
           tool_metadata: tm
         }
         |> calculate_checksums()
-        |> resolve_product()
+        |> resolve_product(expected_product)
 
       {:ok, params}
     end
@@ -930,7 +944,17 @@ defmodule NervesHub.Firmwares do
     |> Enum.to_list()
   end
 
-  defp resolve_product(params) do
+  # The archive declares which product it belongs to. When the upload was
+  # addressed to a particular product, that has already been checked to match
+  # (see `check_expected_product/2`), so it can be used directly rather than
+  # looked up a second time.
+  defp resolve_product(params, %Product{} = product) do
+    params
+    |> Map.put(:product_id, product.id)
+    |> Map.put(:require_unique_firmware_version, product.require_unique_firmware_version)
+  end
+
+  defp resolve_product(params, nil) do
     case Products.get_product_by_org_id_and_name(params.org_id, params.product_name) do
       {:ok, product} ->
         params
@@ -940,6 +964,17 @@ defmodule NervesHub.Firmwares do
       _ ->
         params
     end
+  end
+
+  # Uploading to `/products/a/firmware` an archive that declares product "b"
+  # used to file the firmware under "b" and hand back a `location` header
+  # pointing at "a" — a link to something that is not there. The upload target
+  # wins, and a mismatch is refused rather than silently rerouted.
+  defp check_expected_product(_declared, nil), do: :ok
+  defp check_expected_product(declared, %Product{name: declared}), do: :ok
+
+  defp check_expected_product(declared, %Product{name: expected}) do
+    {:error, {:product_mismatch, declared, expected}}
   end
 
   defp update_tool() do

--- a/lib/nerves_hub_web/controllers/api/fallback_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/fallback_controller.ex
@@ -16,6 +16,15 @@ defmodule NervesHubWeb.API.FallbackController do
     |> render(:error, changeset: changeset)
   end
 
+  def call(conn, {:error, {:product_mismatch, declared, expected}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorJSON)
+    |> render(:"422", %{
+      reason: "This firmware is built for the product #{inspect(declared)}, but was uploaded to #{inspect(expected)}."
+    })
+  end
+
   def call(conn, {:error, {_key, message}}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/nerves_hub_web/controllers/api/firmware_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/firmware_controller.ex
@@ -52,7 +52,7 @@ defmodule NervesHubWeb.API.FirmwareController do
     Logger.info("System Memory:" <> inspect(:memsup.get_system_memory_data()))
 
     with {%{path: filepath}, _params} <- Map.pop(params, "firmware"),
-         {:ok, firmware} <- Firmwares.create_firmware(org, filepath) do
+         {:ok, firmware} <- Firmwares.create_firmware(org, filepath, product: product) do
       firmware = Firmwares.preload_product(firmware)
 
       conn

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -263,51 +263,50 @@ defmodule NervesHubWeb.Live.Firmware do
   end
 
   defp create_firmware(socket, filepath) do
-    case Firmwares.create_firmware(socket.assigns.current_scope.org, filepath) do
+    %{org: org, product: product} = socket.assigns.current_scope
+
+    case Firmwares.create_firmware(org, filepath, product: product) do
       {:ok, _firmware} ->
         socket
         |> put_flash(:info, "Firmware uploaded successfully")
-        |> push_patch(to: ~p"/org/#{socket.assigns.current_scope.org}/#{socket.assigns.product}/firmware")
+        |> push_patch(to: ~p"/org/#{org}/#{product}/firmware")
 
-      {:error, :no_public_keys} ->
-        error_feedback(
-          socket,
-          "Please register public keys for verifying firmware signatures first"
-        )
+      {:error, error} ->
+        error_feedback(socket, upload_error(error))
+    end
+  end
 
-      {:error, :invalid_signature} ->
-        error_feedback(socket, "Firmware corrupt, signature invalid, or missing public key")
+  # Turns whatever `create_firmware/3` failed with into something a user can act
+  # on. A changeset is passed through untouched — `error_feedback/3` renders it.
+  defp upload_error(:no_public_keys) do
+    "Please register public keys for verifying firmware signatures first"
+  end
 
-      {:error,
-       %Ecto.Changeset{
-         errors: [product_id: {"can't be blank", [validation: :required]}]
-       }} ->
-        error_feedback(
-          socket,
-          "No matching product could be found. Please check that your Nerves application product name (`:app` or `:name` in `mix.exs`) matches your #{Application.get_env(:nerves_hub, :web_title_suffix)} product name."
-        )
+  defp upload_error(:invalid_signature) do
+    "Firmware corrupt, signature invalid, or missing public key"
+  end
 
-      {:error,
-       %Ecto.Changeset{
+  defp upload_error({:product_mismatch, declared, expected}) do
+    "This firmware is built for the product #{inspect(declared)}, but was uploaded to " <>
+      "#{inspect(expected)}. Check the product name in your firmware build."
+  end
+
+  defp upload_error(%Ecto.Changeset{errors: [product_id: {"can't be blank", [validation: :required]}]}) do
+    "No matching product could be found. Please check that your Nerves application product name " <>
+      "(`:app` or `:name` in `mix.exs`) matches your #{Application.get_env(:nerves_hub, :web_title_suffix)} product name."
+  end
+
+  defp upload_error(%Ecto.Changeset{
          errors: [
            uuid: {"has already been taken", [constraint: :unique, constraint_name: "firmwares_product_id_uuid_index"]}
          ]
-       } = _changeset} ->
-        error_feedback(
-          socket,
-          "Firmware UUID has already been taken, has this version been uploaded already?"
-        )
-
-      {:error, error} when is_binary(error) ->
-        error_feedback(socket, error)
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        error_feedback(socket, changeset)
-
-      _ ->
-        error_feedback(socket, "Unknown error uploading firmware. Please contact support.")
-    end
+       }) do
+    "Firmware UUID has already been taken, has this version been uploaded already?"
   end
+
+  defp upload_error(%Ecto.Changeset{} = changeset), do: changeset
+  defp upload_error(error) when is_binary(error), do: error
+  defp upload_error(_error), do: "Unknown error uploading firmware. Please contact support."
 
   defp error_feedback(socket, changeset_or_message, opts \\ [])
 

--- a/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
@@ -2,6 +2,7 @@ defmodule NervesHubWeb.API.FirmwareControllerTest do
   use NervesHubWeb.APIConnCase, async: true
 
   alias NervesHub.Accounts
+  alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Upload
   alias NervesHub.Fixtures
   alias NervesHub.Support.Fwup
@@ -64,6 +65,60 @@ defmodule NervesHubWeb.API.FirmwareControllerTest do
     test "renders errors when data is invalid", %{conn: conn, org: org, product: product} do
       conn = post(conn, Routes.api_firmware_path(conn, :create, org.name, product.name))
       assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "create firmware addressed to the wrong product" do
+    test "is rejected rather than filed under the declared product", %{
+      conn: conn,
+      user: user,
+      org: org,
+      product: product
+    } do
+      org_key = Fixtures.org_key_fixture(org, user)
+      other_product = Fixtures.product_fixture(user, org)
+
+      # Built for `other_product`, uploaded to `product`.
+      {:ok, signed_firmware_path} =
+        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{
+          product: other_product.name
+        })
+
+      {boundary, body} = multipart_file(File.read!(signed_firmware_path))
+
+      conn =
+        conn
+        |> put_req_header("content-type", "multipart/form-data; boundary=#{boundary}")
+        |> post(Routes.api_firmware_path(conn, :create, org.name, product.name), body)
+
+      assert response = json_response(conn, 422)
+      assert response["errors"]["detail"] =~ other_product.name
+      assert response["errors"]["detail"] =~ product.name
+
+      # And nothing was stored anywhere.
+      assert Firmwares.get_firmwares_by_product(other_product.id) == []
+      assert Firmwares.get_firmwares_by_product(product.id) == []
+    end
+
+    test "an archive declaring the addressed product still uploads", %{
+      conn: conn,
+      user: user,
+      org: org,
+      product: product
+    } do
+      org_key = Fixtures.org_key_fixture(org, user)
+
+      {:ok, signed_firmware_path} =
+        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{product: product.name})
+
+      {boundary, body} = multipart_file(File.read!(signed_firmware_path))
+
+      conn =
+        conn
+        |> put_req_header("content-type", "multipart/form-data; boundary=#{boundary}")
+        |> post(Routes.api_firmware_path(conn, :create, org.name, product.name), body)
+
+      assert json_response(conn, 201)["data"]
     end
   end
 

--- a/test/nerves_hub_web/live/firmware_test.exs
+++ b/test/nerves_hub_web/live/firmware_test.exs
@@ -322,6 +322,9 @@ defmodule NervesHubWeb.Live.FirmwareTest do
       |> assert_has("div", text: "Firmware corrupt, signature invalid, or missing public key")
     end
 
+    # Previously this reported "No matching product could be found", which
+    # pointed at the wrong thing: the problem is not that AnotherProduct is
+    # missing, it is that this firmware was uploaded to the wrong product.
     test "error if meta-product does not match product name", %{
       conn: conn,
       user: user,
@@ -341,7 +344,31 @@ defmodule NervesHubWeb.Live.FirmwareTest do
       |> visit("/org/#{org.name}/#{product.name}/firmware")
       |> upload("Upload Firmware", signed_firmware_path)
       |> assert_path("/org/#{org.name}/#{product.name}/firmware")
-      |> assert_has("div", text: "No matching product could be found.")
+      |> assert_has("div", text: "AnotherProduct")
+      |> assert_has("div", text: "CoolProduct")
+    end
+
+    # The same firmware uploaded to the product it was built for still works —
+    # the check must not reject a legitimate upload.
+    test "uploads firmware whose meta-product matches the product", %{
+      conn: conn,
+      user: user,
+      org: org,
+      tmp_dir: tmp_dir
+    } do
+      product = Fixtures.product_fixture(user, org, %{name: "CoolProduct"})
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      {:ok, signed_firmware_path} =
+        Fwup.create_signed_firmware(org_key.name, "unsigned", "signed", %{
+          product: "CoolProduct",
+          dir: tmp_dir
+        })
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/firmware")
+      |> upload("Upload Firmware", signed_firmware_path)
+      |> assert_has("div", text: "Firmware uploaded successfully")
     end
   end
 end


### PR DESCRIPTION
The product a firmware lands in comes entirely from the name declared **inside the archive** — `create_firmware/3` never received the product the upload was addressed to. Both callers had one and neither passed it.

So POSTing to `/products/a/firmware` an archive declaring product `b` succeeds, files the firmware under `b`, and returns a `location` header pointing at `a` — a link to something that isn't there.

## The change

`create_firmware/3` takes an optional `:product`. When given, the archive's declared name must match it, and a mismatch is refused rather than silently rerouted. Both callers now pass it — the API from the URL, the LiveView from the current scope — and `resolve_product/2` uses it directly instead of looking the product up a second time.

Omitting `:product` keeps the old declared-name-decides behaviour, which is why existing callers and tests are unaffected.

## ⚠️ Behaviour change

Anyone whose tooling relies on the declared name to route firmware will now get a 422 instead of the upload landing somewhere other than where it was addressed. That is the point of the change, but it is worth a changelog note.

## Test changes worth reviewing

The existing `"error if meta-product does not match product name"` test asserted on *"No matching product could be found."* — which pointed at the wrong thing. It implied the declared product doesn't exist, when the real problem is that the firmware was uploaded to the wrong place. It now asserts both product names appear in the error.

The positive case — an archive declaring the product it was actually uploaded to — was uncovered. Now tested on both the API and LiveView paths, so the check can't reject a legitimate upload.

## Notes

- Fixes the wrong `location` header as a side effect: the firmware's product must now equal the URL's product, so the header can no longer point somewhere the firmware isn't.
- `create_firmware/3`'s `@spec` previously allowed only `{:upload_file_2, ...}` in opts; widening it (including the new error tuple) resolved four dialyzer warnings that were all downstream of that one contract.
- `create_firmware/2` in the LiveView went over Credo's complexity limit with the new error clause, so the error-to-message mapping is extracted into `upload_error/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)