### PR TITLE
Let a product choose which firmware formats it accepts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.expert
 .elixir-tools
 .elixir-ls
 .env.*

--- a/docs/esp_idf_support.md
+++ b/docs/esp_idf_support.md
@@ -38,6 +38,27 @@ not the setting is on. See [Firmware signing](#firmware-signing).
 Turning acceptance back off leaves the unsigned setting untouched, so a product
 that is switched off and on again comes back configured as it was.
 
+### Over the API
+
+Both settings are on the product resource, and settable with `PUT` or `PATCH`
+(org role `manage`):
+
+```bash
+curl -X PATCH \
+  -H "Authorization: token $NH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"allowed_update_tools": ["fwup", "esp-idf"]}' \
+  https://<host>/api/orgs/<org>/products/<product>
+```
+
+Only `require_unique_firmware_version`, `allowed_update_tools`, and
+`allow_unsigned_esp_idf_firmware` can be set. Any other field is a 422 rather
+than being ignored, so a request that cannot do what it says fails loudly — a
+product cannot be renamed this way, since its name identifies it in every URL.
+
+Listing a tool the instance has not enabled is also a 422; the instance flag
+bounds the product setting rather than the other way around.
+
 ## What works
 
 Upload an ESP-IDF application image through the web UI or the API exactly as you

--- a/docs/esp_idf_support.md
+++ b/docs/esp_idf_support.md
@@ -5,11 +5,45 @@ NervesHub can ingest ESP-IDF application images (`.bin`) alongside fwup archives
 **incomplete** — read the [Not supported yet](#not-supported-yet) section before
 relying on it.
 
+## Enabling it
+
+Support is off by default and has to be turned on in two places — once for the
+instance, and once for each product that should accept the format.
+
+### 1. The instance
+
+Set `ESP_IDF_FIRMWARE_ENABLED=true`. Without it no product can opt in and no
+`.bin` is recognised, whatever a product's settings say. Accepting a second
+image format changes what an instance will ingest and serve, so it is a
+deployment decision rather than something a version bump hands you.
+
+### 2. The product
+
+Under **Product → Settings → Firmware**:
+
+| Setting | Column | Default |
+| --- | --- | --- |
+| Accept ESP-IDF application images | `products.allowed_update_tools` | `["fwup"]` |
+| Allow unsigned ESP-IDF images | `products.allow_unsigned_esp_idf_firmware` | `false` |
+
+A product accepts only the formats listed in `allowed_update_tools`; uploading a
+`.bin` to a product that has not opted in is rejected with a message naming the
+product, not silently ingested. fwup is always in the list.
+
+The second setting is narrow on purpose: it excuses a *missing* signature block,
+and nothing else. An image that carries a signature is always verified against
+the organization's registered keys, and a bad signature is refused whether or
+not the setting is on. See [Firmware signing](#firmware-signing).
+
+Turning acceptance back off leaves the unsigned setting untouched, so a product
+that is switched off and on again comes back configured as it was.
+
 ## What works
 
 Upload an ESP-IDF application image through the web UI or the API exactly as you
 would an fwup archive. NervesHub picks the handling tool by inspecting the file
-itself, so there is nothing to configure per product and no flag to pass.
+itself rather than by extension, then checks that tool against the product's
+`allowed_update_tools`.
 
 ### Where the metadata comes from
 
@@ -56,11 +90,10 @@ Anything else is rejected at upload with a message naming `PROJECT_VER`.
 `esp32h2`, `esp32p4`. An unrecognised chip ID still uploads, recorded as
 `esp32-<id>` with architecture `unknown`.
 
-## Not supported yet
-
 ### Firmware signing
 
-**ESP-IDF images must be signed**, exactly as fwup archives must be. Register
+**ESP-IDF images must be signed** by default, exactly as fwup archives must be.
+Register
 the public half of your signing key against the organization, choosing the
 **ESP-IDF Secure Boot v2 (RSA-3072)** scheme:
 
@@ -75,13 +108,25 @@ is rejected. NervesHub deliberately ignores the public key embedded in the
 signature block: verifying against that would prove only that *somebody* signed
 the image, and anyone can self-sign.
 
-**ECDSA signatures are not supported.** That block uses a different layout, and
-P-192/P-256/P-384 variants; such an image is refused rather than misread.
+A product may accept unsigned images by setting **Allow unsigned ESP-IDF
+images**, which is useful while bringing a board up and before Secure Boot has
+been provisioned. It applies only to images with no signature block at all —
+a present-but-unverifiable signature is still refused, so the setting cannot be
+used to smuggle in an image signed by an unregistered key. Firmware uploaded
+this way is recorded with no signing key, and only ESP-IDF images may be left
+unsigned: the database still requires an `org_key_id` for every other tool.
+
+**ECDSA signatures are not supported.**
+
+That block uses a different layout, and P-192/P-256/P-384 variants; such an
+image is refused rather than misread.
 
 Note that none of this affects the device. Secure Boot v2 is enforced by the
 ESP32 bootloader against a key digest burned into eFuse, so an image signed with
 the wrong key will not boot regardless of what NervesHub concluded. Verification
 here is early failure and defence in depth, not the primary control.
+
+## Not supported yet
 
 ### Delta updates
 
@@ -157,5 +202,13 @@ table is out of scope and would need a different mechanism.
   normalisation, signature block handling, xdelta3 deltas.
 - `NervesHub.Support.EspIdf` — builds synthetic images for tests.
 
-To restrict an instance to a single tool, set `config :nerves_hub, :update_tool,
-NervesHub.Firmwares.UpdateTool.Fwup`. Otherwise both tools are enabled.
+- `NervesHub.Products.Product.accepts_update_tool?/2` — the per-product gate.
+
+`UpdateTool.all/0` is the set of tools an instance will *accept*, which the
+`ESP_IDF_FIRMWARE_ENABLED` flag governs. `UpdateTool.known/0` is the set it can
+*read*, which the flag does not: firmware already uploaded stays interpretable
+after the format is turned off again, so disabling the flag stops new uploads
+rather than orphaning existing ones.
+
+The older `config :nerves_hub, :update_tool, NervesHub.Firmwares.UpdateTool.Fwup`
+still works and pins an instance to exactly that one tool.

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -886,7 +886,8 @@ defmodule NervesHub.Firmwares do
     org = NervesHub.Repo.preload(org, :org_keys)
 
     with {:ok, tool} <- UpdateTool.for_file(filepath),
-         {:ok, org_key} <- tool.verify_signature(filepath, org.org_keys),
+         :ok <- check_tool_allowed(tool, expected_product),
+         {:ok, org_key} <- verify_signature(tool, filepath, org.org_keys, expected_product),
          {:ok, %{firmware_metadata: fm, tool_metadata: tm} = m} <-
            tool.get_firmware_metadata_from_file(filepath),
          :ok <- check_expected_product(fm.product, expected_product) do
@@ -968,6 +969,43 @@ defmodule NervesHub.Firmwares do
         params
     end
   end
+
+  # A product accepts only the formats it opted into. Checked before the
+  # signature so that "this product does not take ESP-IDF images" is what the
+  # uploader hears, rather than a complaint about signing a format they were
+  # never going to be allowed to upload.
+  defp check_tool_allowed(_tool, nil), do: :ok
+
+  defp check_tool_allowed(tool, %Product{} = product) do
+    if Product.accepts_update_tool?(product, tool.tool_name()) do
+      :ok
+    else
+      {:error, {:update_tool_not_allowed, tool.tool_name(), product.name}}
+    end
+  end
+
+  # A product may accept unsigned ESP-IDF images, because most ESP-IDF builds
+  # are not signed. A *present but invalid* signature is still refused — the
+  # setting excuses the absence of a signature, never a bad one.
+  defp verify_signature(tool, filepath, org_keys, product) do
+    case tool.verify_signature(filepath, org_keys) do
+      {:error, :firmware_not_signed} ->
+        if unsigned_allowed?(tool, product) do
+          {:ok, nil}
+        else
+          {:error, :firmware_not_signed}
+        end
+
+      result ->
+        result
+    end
+  end
+
+  defp unsigned_allowed?(tool, %Product{allow_unsigned_esp_idf_firmware: true}) do
+    tool.tool_name() == "esp-idf"
+  end
+
+  defp unsigned_allowed?(_tool, _product), do: false
 
   # Uploading to `/products/a/firmware` an archive that declares product "b"
   # used to file the firmware under "b" and hand back a `location` header

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -10,6 +10,7 @@ defmodule NervesHub.Products.Product do
   alias NervesHub.Devices.UpdateStat
   alias NervesHub.Extensions.ProductExtensionsSetting
   alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Firmwares.UpdateTool
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias NervesHub.Products.CustomHealthMetricsLabel
   alias NervesHub.Products.Notification
@@ -41,6 +42,16 @@ defmodule NervesHub.Products.Product do
     # Defaults to `true` so new products require unique firmware versions; the DB
     # column defaults to `false`, so existing products keep the prior behaviour.
     field(:require_unique_firmware_version, :boolean, default: true)
+
+    # Which firmware formats this product accepts. Defaults to fwup alone, so a
+    # product never starts accepting a new format because the platform gained
+    # support for one.
+    field(:allowed_update_tools, {:array, :string}, default: ["fwup"])
+
+    # Most ESP-IDF builds are unsigned, and requiring a signature would rule out
+    # the common case. Deliberately not a general `allow_unsigned_firmware`:
+    # fwup archives are always verified and no setting changes that.
+    field(:allow_unsigned_esp_idf_firmware, :boolean, default: false)
     embeds_one(:extensions, ProductExtensionsSetting, on_replace: :update)
 
     field(:device_count, :integer, virtual: true)
@@ -59,11 +70,37 @@ defmodule NervesHub.Products.Product do
   @doc false
   def changeset(product, params) do
     product
-    |> cast(params, @required_params ++ [:require_unique_firmware_version])
+    |> cast(
+      params,
+      @required_params ++
+        [:require_unique_firmware_version, :allowed_update_tools, :allow_unsigned_esp_idf_firmware]
+    )
     |> cast_embed(:extensions)
     |> update_change(:name, &trim/1)
     |> validate_required(@required_params)
+    |> validate_allowed_update_tools()
     |> unique_constraint(:name, name: :products_org_id_name_index)
+  end
+
+  @doc """
+  Whether this product accepts firmware handled by `tool`.
+  """
+  @spec accepts_update_tool?(t(), String.t()) :: boolean()
+  def accepts_update_tool?(%__MODULE__{allowed_update_tools: tools}, tool) do
+    tool in (tools || ["fwup"])
+  end
+
+  # An unknown tool name would silently accept nothing, so it is rejected here
+  # rather than becoming a confusing upload failure later.
+  defp validate_allowed_update_tools(changeset) do
+    known = Map.keys(UpdateTool.known())
+
+    validate_change(changeset, :allowed_update_tools, fn :allowed_update_tools, tools ->
+      case Enum.reject(tools, &(&1 in known)) do
+        [] -> []
+        unknown -> [allowed_update_tools: "unknown update tool(s): #{Enum.join(unknown, ", ")}"]
+      end
+    end)
   end
 
   def delete_changeset(product, _params \\ %{}) do

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -91,14 +91,33 @@ defmodule NervesHub.Products.Product do
   end
 
   # An unknown tool name would silently accept nothing, so it is rejected here
-  # rather than becoming a confusing upload failure later.
+  # rather than becoming a confusing upload failure later. So is a tool this
+  # instance has not enabled: the UI hides such a toggle, but the API is a
+  # second door, and a product listing a format the instance will not sniff for
+  # is a setting that reads as on and behaves as off.
+  #
+  # `validate_change/3` only fires when the field is being changed, so an
+  # instance that turns a format off does not invalidate the products that had
+  # already opted into it.
   defp validate_allowed_update_tools(changeset) do
     known = Map.keys(UpdateTool.known())
+    enabled = Map.keys(UpdateTool.all())
 
     validate_change(changeset, :allowed_update_tools, fn :allowed_update_tools, tools ->
-      case Enum.reject(tools, &(&1 in known)) do
-        [] -> []
-        unknown -> [allowed_update_tools: "unknown update tool(s): #{Enum.join(unknown, ", ")}"]
+      unknown = Enum.reject(tools, &(&1 in known))
+      disabled = Enum.filter(tools, &(&1 in known and &1 not in enabled))
+
+      cond do
+        unknown != [] ->
+          [allowed_update_tools: "unknown update tool(s): #{Enum.join(unknown, ", ")}"]
+
+        disabled != [] ->
+          [
+            allowed_update_tools: "not enabled on this NervesHub instance: #{Enum.join(disabled, ", ")}"
+          ]
+
+        true ->
+          []
       end
     end)
   end

--- a/lib/nerves_hub_web/controllers/api/fallback_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/fallback_controller.ex
@@ -36,6 +36,17 @@ defmodule NervesHubWeb.API.FallbackController do
     })
   end
 
+  def call(conn, {:error, {:unsettable_product_params, params}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorJSON)
+    |> render(:"422", %{
+      reason:
+        "These fields cannot be set on a product: #{Enum.map_join(params, ", ", &inspect/1)}. " <>
+          "A product cannot be renamed; its name identifies it in every URL."
+    })
+  end
+
   def call(conn, {:error, :firmware_not_signed}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/nerves_hub_web/controllers/api/fallback_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/fallback_controller.ex
@@ -25,6 +25,17 @@ defmodule NervesHubWeb.API.FallbackController do
     })
   end
 
+  def call(conn, {:error, {:update_tool_not_allowed, tool, product}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorJSON)
+    |> render(:"422", %{
+      reason:
+        "The product #{inspect(product)} does not accept #{tool} firmware. " <>
+          "An organization owner can enable it in the product's settings."
+    })
+  end
+
   def call(conn, {:error, :firmware_not_signed}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/nerves_hub_web/controllers/api/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/product_controller.ex
@@ -14,6 +14,7 @@ defmodule NervesHubWeb.API.ProductController do
   @auth_error_responses SchemaHelpers.auth_error_responses()
 
   plug(:validate_role, [org: :admin] when action in [:create, :delete])
+  plug(:validate_role, [org: :manage] when action in [:update])
   plug(:validate_role, [org: :view] when action in [:show])
 
   operation(:index,
@@ -99,6 +100,58 @@ defmodule NervesHubWeb.API.ProductController do
 
   def show(%{assigns: %{product: product}} = conn, _params) do
     render(conn, :show, product: product)
+  end
+
+  @settable_params ~w(require_unique_firmware_version allowed_update_tools allow_unsigned_esp_idf_firmware)
+
+  operation(:update,
+    summary: "Update a Product's settings",
+    parameters: [
+      org_name: [
+        in: :path,
+        description: "Organization Name",
+        type: :string,
+        example: "example_org"
+      ],
+      product_name: [
+        in: :path,
+        description: "Product Name",
+        type: :string,
+        example: "example_product"
+      ]
+    ],
+    request_body: {
+      "Product update request body",
+      "application/json",
+      ProductSchemas.ProductUpdateRequest,
+      required: true
+    },
+    responses:
+      [
+        ok: {"Product response", "application/json", ProductSchemas.ProductShowResponse},
+        not_found: {"Not Found", "application/json", ErrorSchemas.ErrorResponse},
+        unprocessable_entity: {"Unprocessable Entity", "application/json", ErrorSchemas.ChangesetErrorResponse}
+      ] ++ @auth_error_responses
+  )
+
+  def update(%{assigns: %{product: product}} = conn, params) do
+    # A whitelist that silently drops what it does not recognise turns a typo,
+    # or an attempt to rename a product, into a 200 that changed nothing. Name
+    # the rejected fields instead.
+    with :ok <- reject_unsettable(params),
+         {:ok, product} <- Products.update_product(product, Map.take(params, @settable_params)) do
+      render(conn, :show, product: product)
+    end
+  end
+
+  defp reject_unsettable(params) do
+    params
+    |> Map.keys()
+    |> Enum.reject(&(&1 in @settable_params or &1 in ~w(org_name product_name)))
+    |> case do
+      [] -> :ok
+      unsettable -> {:error, {:unsettable_product_params, unsettable}}
+    end
   end
 
   operation(:delete,

--- a/lib/nerves_hub_web/controllers/api/product_json.ex
+++ b/lib/nerves_hub_web/controllers/api/product_json.ex
@@ -11,7 +11,10 @@ defmodule NervesHubWeb.API.ProductJSON do
 
   def product(product) do
     %{
-      name: product.name
+      name: product.name,
+      require_unique_firmware_version: product.require_unique_firmware_version,
+      allowed_update_tools: product.allowed_update_tools,
+      allow_unsigned_esp_idf_firmware: product.allow_unsigned_esp_idf_firmware
     }
   end
 end

--- a/lib/nerves_hub_web/controllers/api/schemas/firmware_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/firmware_schemas.ex
@@ -60,8 +60,9 @@ defmodule NervesHubWeb.API.Schemas.FirmwareSchemas do
       Upload failure.
 
       Changeset failures (a duplicate UUID, say) are keyed by field. Failures
-      raised before the changeset — an unrecognised format, an unsigned image,
-      a version that is not SemVer — carry a single `detail` message instead.
+      raised before the changeset — an unrecognised format, a format this
+      product does not accept, an unsigned image, a version that is not SemVer —
+      carry a single `detail` message instead.
       """,
       type: :object,
       oneOf: [

--- a/lib/nerves_hub_web/controllers/api/schemas/product_schemas.ex
+++ b/lib/nerves_hub_web/controllers/api/schemas/product_schemas.ex
@@ -12,10 +12,38 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
         name: %Schema{
           type: :string,
           pattern: ~r/[a-zA-Z][a-zA-Z0-9_]+/
+        },
+        require_unique_firmware_version: %Schema{
+          type: :boolean,
+          description:
+            "Reject uploaded firmware whose version already exists for this product's platform and architecture."
+        },
+        allowed_update_tools: %Schema{
+          type: :array,
+          items: %Schema{type: :string, enum: ["fwup", "esp-idf"]},
+          description: """
+          The firmware formats this product accepts. `fwup` is always present.
+
+          A format also has to be enabled for the instance before a product can
+          list it — see the ESP-IDF support documentation.
+          """
+        },
+        allow_unsigned_esp_idf_firmware: %Schema{
+          type: :boolean,
+          description: """
+          Accept ESP-IDF images that carry no Secure Boot v2 signature block.
+
+          This excuses a missing signature and nothing else: an image that does
+          carry a signature is always verified against the organization's
+          registered signing keys.
+          """
         }
       },
       example: %{
-        "name" => "Example Product"
+        "name" => "Example Product",
+        "require_unique_firmware_version" => true,
+        "allowed_update_tools" => ["fwup"],
+        "allow_unsigned_esp_idf_firmware" => false
       }
     })
   end
@@ -29,7 +57,10 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
       },
       example: %{
         "data" => %{
-          "name" => "Example Product"
+          "name" => "Example Product",
+          "require_unique_firmware_version" => true,
+          "allowed_update_tools" => ["fwup"],
+          "allow_unsigned_esp_idf_firmware" => false
         }
       }
     })
@@ -45,10 +76,16 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
       example: %{
         "data" => [
           %{
-            "name" => "Example Product"
+            "name" => "Example Product",
+            "require_unique_firmware_version" => true,
+            "allowed_update_tools" => ["fwup"],
+            "allow_unsigned_esp_idf_firmware" => false
           },
           %{
-            "name" => "Another Example Product"
+            "name" => "Another Example Product",
+            "require_unique_firmware_version" => true,
+            "allowed_update_tools" => ["fwup", "esp-idf"],
+            "allow_unsigned_esp_idf_firmware" => true
           }
         ]
       }
@@ -78,12 +115,25 @@ defmodule NervesHubWeb.API.Schemas.ProductSchemas do
 
   defmodule ProductUpdateRequest do
     OpenApiSpex.schema(%{
-      description: "POST body for updating a product",
+      description: """
+      PUT body for updating a product's settings.
+
+      Every field is optional; only the ones sent are changed. A product cannot
+      be renamed here — its name is its identifier in every URL — and sending
+      any field not listed below is an error rather than being ignored.
+      """,
       type: :object,
       properties: %{
-        product: %Schema{
-          properties: %{}
-        }
+        require_unique_firmware_version: %Schema{type: :boolean},
+        allowed_update_tools: %Schema{
+          type: :array,
+          items: %Schema{type: :string, enum: ["fwup", "esp-idf"]}
+        },
+        allow_unsigned_esp_idf_firmware: %Schema{type: :boolean}
+      },
+      example: %{
+        "allowed_update_tools" => ["fwup", "esp-idf"],
+        "allow_unsigned_esp_idf_firmware" => true
       }
     })
   end

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -291,6 +291,11 @@ defmodule NervesHubWeb.Live.Firmware do
       "#{inspect(expected)}. Check the product name in your firmware build."
   end
 
+  defp upload_error({:update_tool_not_allowed, tool, product}) do
+    "The product #{inspect(product)} does not accept #{tool} firmware. " <>
+      "An organization owner can enable it in the product's settings."
+  end
+
   defp upload_error(:firmware_not_signed) do
     "This ESP-IDF image is not signed. NervesHub requires firmware to be signed: sign it with `espsecure.py sign_data --version 2` and register the matching public key against your organization."
   end

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -3,7 +3,9 @@ defmodule NervesHubWeb.Live.Product.Settings do
 
   alias NervesHub.DeviceLink
   alias NervesHub.Extensions
+  alias NervesHub.Firmwares.UpdateTool
   alias NervesHub.Products
+  alias NervesHub.Products.Product
 
   def mount(_params, _session, socket) do
     product = Products.load_shared_secret_auth(socket.assigns.current_scope.product)
@@ -17,6 +19,7 @@ defmodule NervesHubWeb.Live.Product.Settings do
       |> assign(:shared_auth_enabled, DeviceLink.shared_secrets_enabled?())
       |> assign(:form, to_form(Ecto.Changeset.change(product)))
       |> assign(:available_extensions, extensions())
+      |> assign(:esp_idf_available, UpdateTool.esp_idf_enabled?())
 
     {:ok, socket}
   end
@@ -99,6 +102,30 @@ defmodule NervesHubWeb.Live.Product.Settings do
     {:noreply, socket}
   end
 
+  # Turning ESP-IDF off leaves `allow_unsigned_esp_idf_firmware` as it was. It
+  # has no effect while the format is refused, and keeping it means turning the
+  # format back on restores the setup the product had before.
+  def handle_event("update-allow-esp-idf-firmware", params, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    allow = params["value"] == "on"
+    tools = if allow, do: ["fwup", "esp-idf"], else: ["fwup"]
+
+    update_setting(socket, %{allowed_update_tools: tools}, fn ->
+      "ESP-IDF application images are now #{(allow && "accepted") || "refused"} for this product."
+    end)
+  end
+
+  def handle_event("update-allow-unsigned-esp-idf-firmware", params, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    allow = params["value"] == "on"
+
+    update_setting(socket, %{allow_unsigned_esp_idf_firmware: allow}, fn ->
+      "Unsigned ESP-IDF images are now #{(allow && "allowed") || "refused"} for this product."
+    end)
+  end
+
   def handle_event("update-extension", %{"extension" => extension} = params, socket) do
     value = params["value"]
     available = Extensions.list() |> Enum.map(&to_string/1)
@@ -130,6 +157,24 @@ defmodule NervesHubWeb.Live.Product.Settings do
       end
 
     {:noreply, socket}
+  end
+
+  defp update_setting(socket, attrs, message) do
+    case Products.update_product(socket.assigns.product, attrs) do
+      {:ok, product} ->
+        socket
+        |> assign(:product, product)
+        |> put_flash(:info, message.())
+        |> noreply()
+
+      {:error, _changeset} ->
+        socket
+        |> put_flash(
+          :error,
+          "Failed to update the setting. Please contact support if this problem persists."
+        )
+        |> noreply()
+    end
   end
 
   defp extensions() do

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -86,6 +86,50 @@
               </div>
             </div>
           </div>
+
+          <div :if={@esp_idf_available} class="flex h-16 items-center gap-6 p-2">
+            <div class="bg-base-800 border-base-700 flex h-8 items-center rounded-full border px-2 py-1">
+              <input
+                id="allow-esp-idf-firmware"
+                name="allow-esp-idf-firmware"
+                type="checkbox"
+                class="border-base-700 checked:bg-primary text-base-400 rounded focus:ring-0"
+                phx-click="update-allow-esp-idf-firmware"
+                checked={Product.accepts_update_tool?(@product, "esp-idf")}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+            </div>
+            <div class="flex flex-col">
+              <div class="text-base-300 font-medium">Accept ESP-IDF application images</div>
+              <div class="text-base-400 text-xs">
+                Allow <code>.bin</code> images built by ESP-IDF to be uploaded to this product, alongside fwup archives.
+              </div>
+            </div>
+          </div>
+
+          <div
+            :if={@esp_idf_available && Product.accepts_update_tool?(@product, "esp-idf")}
+            class="flex h-16 items-center gap-6 p-2"
+          >
+            <div class="bg-base-800 border-base-700 flex h-8 items-center rounded-full border px-2 py-1">
+              <input
+                id="allow-unsigned-esp-idf-firmware"
+                name="allow-unsigned-esp-idf-firmware"
+                type="checkbox"
+                class="border-base-700 checked:bg-primary text-base-400 rounded focus:ring-0"
+                phx-click="update-allow-unsigned-esp-idf-firmware"
+                checked={@product.allow_unsigned_esp_idf_firmware}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+            </div>
+            <div class="flex flex-col">
+              <div class="text-base-300 font-medium">Allow unsigned ESP-IDF images</div>
+              <div class="text-base-400 text-xs">
+                Accept ESP-IDF images that carry no Secure Boot v2 signature block. An image that is signed
+                is always verified against this organization's signing keys, whether or not this is set.
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -138,6 +138,8 @@ defmodule NervesHubWeb.Router do
               pipe_through([:api_product])
 
               get("/", ProductController, :show)
+              put("/", ProductController, :update)
+              patch("/", ProductController, :update)
               delete("/", ProductController, :delete)
 
               scope "/devices" do

--- a/priv/repo/migrations/20260819000002_add_update_tool_settings_to_products.exs
+++ b/priv/repo/migrations/20260819000002_add_update_tool_settings_to_products.exs
@@ -1,0 +1,45 @@
+defmodule NervesHub.Repo.Migrations.AddUpdateToolSettingsToProducts do
+  @moduledoc """
+  Let an organization decide, per product, which firmware formats it accepts.
+
+  `allowed_update_tools` defaults to `{fwup}`, so every existing product keeps
+  behaving exactly as it did and no product accepts a new format until someone
+  opts it in.
+
+  `allow_unsigned_esp_idf_firmware` is the escape hatch for the common case that
+  an ESP-IDF build is simply not signed. It is deliberately ESP-specific rather
+  than a general `allow_unsigned_firmware`: fwup archives are always verified,
+  and a general name would read as though that could be turned off.
+  """
+
+  use Ecto.Migration
+
+  def up() do
+    alter table(:products) do
+      add(:allowed_update_tools, {:array, :string}, null: false, default: ["fwup"])
+      add(:allow_unsigned_esp_idf_firmware, :boolean, null: false, default: false)
+    end
+
+    # Unsigned firmware is possible again, so `org_key_id` cannot be NOT NULL.
+    # The CHECK keeps the 2018 guarantee for fwup, which is never unsigned
+    # whatever a product setting says — the per-product rule lives in `products`
+    # and cannot be expressed here.
+    execute("ALTER TABLE firmwares ALTER COLUMN org_key_id DROP NOT NULL")
+
+    execute("""
+    ALTER TABLE firmwares
+      ADD CONSTRAINT firmwares_signed_unless_esp_idf
+      CHECK (org_key_id IS NOT NULL OR tool IS NOT DISTINCT FROM 'esp-idf')
+    """)
+  end
+
+  def down() do
+    execute("ALTER TABLE firmwares DROP CONSTRAINT firmwares_signed_unless_esp_idf")
+    execute("ALTER TABLE firmwares ALTER COLUMN org_key_id SET NOT NULL")
+
+    alter table(:products) do
+      remove(:allow_unsigned_esp_idf_firmware)
+      remove(:allowed_update_tools)
+    end
+  end
+end

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -18,7 +18,7 @@ else
   IP="${PRIVATE_IP:-${POD_IP}}"
 
   export RELEASE_DISTRIBUTION=name
-  export RELEASE_NODE=$APP_NAME@$IP
+  export RELEASE_NODE=$APP_NAME-${NERVES_HUB_APP:-all}@$IP
 
   echo " Node name: $RELEASE_NODE"
 fi

--- a/test/nerves_hub/firmwares/device_metadata_test.exs
+++ b/test/nerves_hub/firmwares/device_metadata_test.exs
@@ -124,7 +124,7 @@ defmodule NervesHub.Firmwares.DeviceMetadataTest do
     test "derives the same uuid the uploaded image was given" do
       user = Fixtures.user_fixture()
       org = Fixtures.org_fixture(user)
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
       _esp_key = Fixtures.esp_idf_key_fixture(org, user)
 
       raw = :crypto.strong_rand_bytes(32)

--- a/test/nerves_hub/firmwares/firmware_test.exs
+++ b/test/nerves_hub/firmwares/firmware_test.exs
@@ -29,10 +29,11 @@ defmodule NervesHub.Firmwares.FirmwareTest do
     end
   end
 
-  # `org_key_id` has been NOT NULL since 2018 (`firmware_must_be_signed`). It
-  # was briefly nullable while ESP-IDF images could not be signature-verified;
-  # now that they can, every format is signed and the column is NOT NULL again.
-  describe "signing is enforced by the database" do
+  # `org_key_id` was NOT NULL from 2018 (`firmware_must_be_signed`). A product
+  # may now allow unsigned ESP-IDF images, and that rule lives in `products` —
+  # it cannot be expressed as a constraint on this table. So the database holds
+  # the guarantee for fwup and defers to the application for ESP-IDF.
+  describe "signing is enforced by the database for fwup" do
     @describetag :tmp_dir
 
     setup %{tmp_dir: tmp_dir} do
@@ -45,21 +46,30 @@ defmodule NervesHub.Firmwares.FirmwareTest do
       {:ok, %{firmware: firmware}}
     end
 
-    test "no firmware may be left unsigned", %{firmware: firmware} do
-      assert_raise Postgrex.Error, ~r/org_key_id/, fn ->
+    test "an fwup firmware cannot be left unsigned", %{firmware: firmware} do
+      assert firmware.tool == "fwup"
+
+      assert_raise Postgrex.Error, ~r/firmwares_signed_unless_esp_idf/, fn ->
         Firmware
         |> where(id: ^firmware.id)
         |> Repo.update_all(set: [org_key_id: nil])
       end
     end
 
-    # Including ESP-IDF, which was the one exception while verification was
-    # unimplemented.
-    test "not even an esp-idf firmware", %{firmware: firmware} do
-      assert_raise Postgrex.Error, ~r/org_key_id/, fn ->
+    test "an esp-idf firmware may be unsigned", %{firmware: firmware} do
+      assert {1, _} =
+               Firmware
+               |> where(id: ^firmware.id)
+               |> Repo.update_all(set: [tool: "esp-idf", org_key_id: nil])
+    end
+
+    # `tool` is nullable, so `= 'esp-idf'` would evaluate to NULL here and a
+    # CHECK passes on NULL. `IS NOT DISTINCT FROM` is what closes that.
+    test "a firmware with no tool cannot be left unsigned either", %{firmware: firmware} do
+      assert_raise Postgrex.Error, ~r/firmwares_signed_unless_esp_idf/, fn ->
         Firmware
         |> where(id: ^firmware.id)
-        |> Repo.update_all(set: [tool: "esp-idf", org_key_id: nil])
+        |> Repo.update_all(set: [tool: nil, org_key_id: nil])
       end
     end
   end

--- a/test/nerves_hub/firmwares/product_update_tool_settings_test.exs
+++ b/test/nerves_hub/firmwares/product_update_tool_settings_test.exs
@@ -1,0 +1,117 @@
+defmodule NervesHub.Firmwares.ProductUpdateToolSettingsTest do
+  @moduledoc """
+  Per-product control over which firmware formats are accepted, and whether an
+  unsigned ESP-IDF image is allowed.
+  """
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Firmwares
+  alias NervesHub.Fixtures
+  alias NervesHub.Products
+  alias NervesHub.Products.Product
+  alias NervesHub.Support.EspIdf
+  alias NervesHub.Support.Fwup
+
+  @moduletag :tmp_dir
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+
+    {:ok, %{user: user, org: org}}
+  end
+
+  defp upload(org, product, opts \\ []) do
+    {:ok, path} = EspIdf.create_firmware(product.name, opts)
+    Firmwares.create_firmware(org, path, product: product)
+  end
+
+  describe "allowed_update_tools" do
+    test "defaults to fwup only", %{user: user, org: org} do
+      product = Fixtures.product_fixture(user, org)
+
+      assert product.allowed_update_tools == ["fwup"]
+      assert Product.accepts_update_tool?(product, "fwup")
+      refute Product.accepts_update_tool?(product, "esp-idf")
+    end
+
+    # The whole point: a product does not start accepting a new format because
+    # the platform gained support for one.
+    test "an esp-idf upload is refused by a default product", %{user: user, org: org} do
+      product = Fixtures.product_fixture(user, org)
+      _key = Fixtures.esp_idf_key_fixture(org, user)
+
+      assert {:error, {:update_tool_not_allowed, "esp-idf", name}} = upload(org, product)
+      assert name == product.name
+    end
+
+    test "an esp-idf upload succeeds once the product opts in", %{user: user, org: org} do
+      product = Fixtures.esp_idf_product_fixture(user, org)
+      key = Fixtures.esp_idf_key_fixture(org, user)
+
+      assert {:ok, firmware} = upload(org, product)
+      assert firmware.tool == "esp-idf"
+      assert firmware.org_key_id == key.id
+    end
+
+    test "fwup keeps working on an esp-idf product", %{user: user, org: org, tmp_dir: tmp_dir} do
+      product = Fixtures.esp_idf_product_fixture(user, org)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      assert %{tool: "fwup"} = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    end
+
+    test "an unknown tool is rejected at the changeset", %{user: user, org: org} do
+      product = Fixtures.product_fixture(user, org)
+
+      assert {:error, changeset} =
+               Products.update_product(product, %{allowed_update_tools: ["fwup", "wat"]})
+
+      assert "unknown update tool(s): wat" in errors_on(changeset).allowed_update_tools
+    end
+  end
+
+  describe "allow_unsigned_esp_idf_firmware" do
+    test "defaults to false, so an unsigned image is refused", %{user: user, org: org} do
+      product = Fixtures.esp_idf_product_fixture(user, org)
+
+      refute product.allow_unsigned_esp_idf_firmware
+      assert {:error, :firmware_not_signed} = upload(org, product, signed: false)
+    end
+
+    test "allows an unsigned image when set", %{user: user, org: org} do
+      product =
+        Fixtures.esp_idf_product_fixture(user, org, %{allow_unsigned_esp_idf_firmware: true})
+
+      assert {:ok, firmware} = upload(org, product, signed: false)
+      assert firmware.tool == "esp-idf"
+      assert is_nil(firmware.org_key_id)
+    end
+
+    # The setting excuses a *missing* signature, never a bad one — otherwise it
+    # would quietly accept an image signed by a key nobody registered.
+    test "still refuses an image signed by an unregistered key", %{user: user, org: org} do
+      product =
+        Fixtures.esp_idf_product_fixture(user, org, %{allow_unsigned_esp_idf_firmware: true})
+
+      # Signed, but the org registered no matching key.
+      assert {:error, :invalid_signature} = upload(org, product)
+    end
+
+    # fwup is verified by fwup itself; no product setting reaches that path.
+    test "does not weaken fwup", %{user: user, org: org, tmp_dir: tmp_dir} do
+      product =
+        Fixtures.esp_idf_product_fixture(user, org, %{allow_unsigned_esp_idf_firmware: true})
+
+      :ok = Fwup.gen_key_pair("unregistered", tmp_dir)
+
+      {:ok, path} =
+        Fwup.create_signed_firmware("unregistered", "unsigned", "signed", %{
+          product: product.name,
+          dir: tmp_dir
+        })
+
+      assert {:error, :no_public_keys} = Firmwares.create_firmware(org, path, product: product)
+    end
+  end
+end

--- a/test/nerves_hub_web/channels/websocket_esp_idf_test.exs
+++ b/test/nerves_hub_web/channels/websocket_esp_idf_test.exs
@@ -64,7 +64,7 @@ defmodule NervesHubWeb.WebsocketEspIdfTest do
 
     user = Fixtures.user_fixture()
     org = Fixtures.org_fixture(user)
-    product = Fixtures.product_fixture(user, org, %{name: "my_app"})
+    product = Fixtures.esp_idf_product_fixture(user, org, %{name: "my_app"})
     _esp_key = Fixtures.esp_idf_key_fixture(org, user)
 
     # A real ESP-IDF image, uploaded the same way a user would.

--- a/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/firmware_controller_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.API.FirmwareControllerTest do
   alias NervesHub.Firmwares
   alias NervesHub.Firmwares.Upload
   alias NervesHub.Fixtures
+  alias NervesHub.Products
   alias NervesHub.Support.EspIdf
   alias NervesHub.Support.Fwup
 
@@ -125,10 +126,12 @@ defmodule NervesHubWeb.API.FirmwareControllerTest do
   end
 
   describe "create ESP-IDF firmware" do
-    setup %{org: org, user: user} do
-      # ESP-IDF images must be signed, so the org needs the matching public key
-      # exactly as it needs an fwup key for a `.fw`.
-      {:ok, %{esp_key: Fixtures.esp_idf_key_fixture(org, user)}}
+    setup %{org: org, user: user, product: product} do
+      # Products take only fwup until opted in, and ESP-IDF images must be
+      # signed — so this needs both the setting and the matching public key.
+      {:ok, product} = Products.update_product(product, %{allowed_update_tools: ["fwup", "esp-idf"]})
+
+      {:ok, %{product: product, esp_key: Fixtures.esp_idf_key_fixture(org, user)}}
     end
 
     test "uploads an ESP-IDF application image", %{conn: conn, org: org, product: product} do

--- a/test/nerves_hub_web/controllers/api/product_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/product_controller_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.API.ProductControllerTest do
 
   alias NervesHub.Accounts
   alias NervesHub.Fixtures
+  alias NervesHub.Repo
 
   setup context do
     org = Fixtures.org_fixture(context.user, %{name: "api_test"})
@@ -69,6 +70,111 @@ defmodule NervesHubWeb.API.ProductControllerTest do
     end
   end
 
+  describe "show" do
+    setup [:create_product]
+
+    test "includes the product's settings", %{conn: conn, org: org, product: product} do
+      conn = get(conn, Routes.api_product_path(conn, :show, org.name, product.name))
+
+      assert json_response(conn, 200)["data"] == %{
+               "name" => product.name,
+               "require_unique_firmware_version" => true,
+               "allowed_update_tools" => ["fwup"],
+               "allow_unsigned_esp_idf_firmware" => false
+             }
+    end
+  end
+
+  describe "update product" do
+    setup [:create_product]
+
+    test "updates the settings that were sent, and only those", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      conn =
+        put(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+          allowed_update_tools: ["fwup", "esp-idf"]
+        })
+
+      assert json_response(conn, 200)["data"]["allowed_update_tools"] == ["fwup", "esp-idf"]
+
+      product = Repo.reload(product)
+      assert product.allowed_update_tools == ["fwup", "esp-idf"]
+      # Untouched by a request that did not mention it.
+      assert product.require_unique_firmware_version
+      refute product.allow_unsigned_esp_idf_firmware
+    end
+
+    test "accepts a patch as well as a put", %{conn: conn, org: org, product: product} do
+      conn =
+        patch(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+          require_unique_firmware_version: false
+        })
+
+      assert json_response(conn, 200)["data"]["require_unique_firmware_version"] == false
+      refute Repo.reload(product).require_unique_firmware_version
+    end
+
+    test "rejects an unknown update tool", %{conn: conn, org: org, product: product} do
+      conn =
+        put(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+          allowed_update_tools: ["fwup", "wat"]
+        })
+
+      assert json_response(conn, 422)["errors"]["allowed_update_tools"] == [
+               "unknown update tool(s): wat"
+             ]
+    end
+
+    # Silently ignoring these would report success for a request that changed
+    # nothing — a rename in particular looks like it worked.
+    test "refuses fields it cannot set rather than dropping them", %{
+      conn: conn,
+      org: org,
+      product: product
+    } do
+      conn =
+        put(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+          name: "renamed",
+          org_id: 1
+        })
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ ~s("name")
+      assert json_response(conn, 422)["errors"]["detail"] =~ ~s("org_id")
+      assert Repo.reload(product).name == product.name
+    end
+  end
+
+  describe "update product roles" do
+    setup [:create_product]
+
+    test "ok: org manage", %{user2: user, conn2: conn, org: org, product: product} do
+      Accounts.add_org_user(org, user, %{role: :manage})
+
+      conn =
+        put(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+          allow_unsigned_esp_idf_firmware: true
+        })
+
+      assert json_response(conn, 200)["data"]["allow_unsigned_esp_idf_firmware"] == true
+    end
+
+    test "error: org view", %{user2: user, conn2: conn, org: org, product: product} do
+      Accounts.add_org_user(org, user, %{role: :view})
+
+      assert_error_sent(401, fn ->
+        put(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+          allow_unsigned_esp_idf_firmware: true
+        })
+      end)
+      |> assert_authorization_error()
+
+      refute Repo.reload(product).allow_unsigned_esp_idf_firmware
+    end
+  end
+
   describe "delete product" do
     setup [:create_product]
 
@@ -109,7 +215,37 @@ defmodule NervesHubWeb.API.ProductControllerTest do
   end
 
   defp create_product(%{user: user, org: org}) do
-    product = Fixtures.product_fixture(user, org, %{name: "api"})
+    product =
+      Fixtures.product_fixture(user, org, %{name: "api", require_unique_firmware_version: true})
+
     {:ok, %{product: product}}
+  end
+end
+
+defmodule NervesHubWeb.API.ProductControllerPlatformGateTest do
+  # Not async: the platform gate is global application state, and flipping it
+  # while another suite is uploading firmware would change that suite's answer.
+  use NervesHubWeb.APIConnCase, async: false
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Repo
+
+  test "a product cannot list a tool the instance has not enabled", %{conn: conn, user: user} do
+    Application.put_env(:nerves_hub, :esp_idf_firmware_enabled, false)
+    on_exit(fn -> Application.put_env(:nerves_hub, :esp_idf_firmware_enabled, true) end)
+
+    org = Fixtures.org_fixture(user, %{name: "api_gate_test"})
+    product = Fixtures.product_fixture(user, org, %{name: "api"})
+
+    conn =
+      put(conn, Routes.api_product_path(conn, :update, org.name, product.name), %{
+        allowed_update_tools: ["fwup", "esp-idf"]
+      })
+
+    assert json_response(conn, 422)["errors"]["allowed_update_tools"] == [
+             "not enabled on this NervesHub instance: esp-idf"
+           ]
+
+    assert Repo.reload(product).allowed_update_tools == ["fwup"]
   end
 end

--- a/test/nerves_hub_web/live/firmware_esp_idf_test.exs
+++ b/test/nerves_hub_web/live/firmware_esp_idf_test.exs
@@ -16,7 +16,7 @@ defmodule NervesHubWeb.Live.FirmwareEspIdfTest do
 
   describe "index" do
     test "lists an ESP-IDF firmware alongside its tool", %{conn: conn, user: user, org: org} do
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
       _key = Fixtures.esp_idf_key_fixture(org, user)
       firmware = upload_esp_idf!(org, product, version: "1.4.0", chip_id: 0x0009)
 
@@ -29,7 +29,7 @@ defmodule NervesHubWeb.Live.FirmwareEspIdfTest do
     end
 
     test "shows the key that signed it", %{conn: conn, user: user, org: org} do
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
       key = Fixtures.esp_idf_key_fixture(org, user)
       firmware = upload_esp_idf!(org, product)
 
@@ -41,7 +41,7 @@ defmodule NervesHubWeb.Live.FirmwareEspIdfTest do
     end
 
     test "shows fwup and ESP-IDF firmware side by side", %{conn: conn, user: user, org: org, tmp_dir: tmp_dir} do
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
       org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
       _esp_key = Fixtures.esp_idf_key_fixture(org, user)
       fwup_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
@@ -58,7 +58,7 @@ defmodule NervesHubWeb.Live.FirmwareEspIdfTest do
 
   describe "show" do
     test "renders the ESP-IDF metadata", %{conn: conn, user: user, org: org} do
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
       _key = Fixtures.esp_idf_key_fixture(org, user)
       firmware = upload_esp_idf!(org, product, version: "2.1.0", chip_id: 0x000D)
 
@@ -73,7 +73,7 @@ defmodule NervesHubWeb.Live.FirmwareEspIdfTest do
     end
 
     test "renders the signing key on the show page", %{conn: conn, user: user, org: org} do
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
       key = Fixtures.esp_idf_key_fixture(org, user)
       firmware = upload_esp_idf!(org, product)
 
@@ -85,7 +85,7 @@ defmodule NervesHubWeb.Live.FirmwareEspIdfTest do
 
   describe "upload" do
     test "the file picker accepts ESP-IDF images", %{conn: conn, user: user, org: org} do
-      product = Fixtures.product_fixture(user, org)
+      product = Fixtures.esp_idf_product_fixture(user, org)
 
       # `accept` reaches the browser as the input's accept attribute, so this is
       # the only place a client-side rejection of .bin would show up.

--- a/test/nerves_hub_web/live/product/settings_test.exs
+++ b/test/nerves_hub_web/live/product/settings_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
 
   alias NervesHub.Fixtures
   alias NervesHub.Products
+  alias NervesHub.Repo
 
   describe "delete product" do
     test "soft deletes the product", %{conn: conn, org: org, user: user} do
@@ -27,6 +28,48 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
       conn
       |> visit("/org/#{org.name}/#{product.name}/settings")
       |> assert_has("div", text: "Require unique firmware versions")
+    end
+  end
+
+  describe "esp-idf settings" do
+    test "toggling acceptance also reveals the unsigned setting", %{
+      conn: conn,
+      org: org,
+      user: user
+    } do
+      product = Fixtures.product_fixture(user, org)
+      {:ok, view, html} = live(conn, "/org/#{org.name}/#{product.name}/settings")
+
+      assert html =~ "Accept ESP-IDF application images"
+      # Only meaningful once the format is accepted at all.
+      refute html =~ "Allow unsigned ESP-IDF images"
+
+      html =
+        view
+        |> element("#allow-esp-idf-firmware")
+        |> render_click(%{"value" => "on"})
+
+      assert html =~ "Allow unsigned ESP-IDF images"
+      assert Repo.reload(product).allowed_update_tools == ["fwup", "esp-idf"]
+
+      html =
+        view
+        |> element("#allow-unsigned-esp-idf-firmware")
+        |> render_click(%{"value" => "on"})
+
+      assert html =~ "Unsigned ESP-IDF images are now allowed"
+      assert Repo.reload(product).allow_unsigned_esp_idf_firmware
+    end
+
+    test "turning acceptance back off keeps fwup", %{conn: conn, org: org, user: user} do
+      product = Fixtures.esp_idf_product_fixture(user, org)
+      {:ok, view, _html} = live(conn, "/org/#{org.name}/#{product.name}/settings")
+
+      view
+      |> element("#allow-esp-idf-firmware")
+      |> render_click(%{})
+
+      assert Repo.reload(product).allowed_update_tools == ["fwup"]
     end
   end
 
@@ -82,5 +125,27 @@ defmodule NervesHubWeb.Live.Product.SettingsTest do
         end
       end)
     end
+  end
+end
+
+defmodule NervesHubWeb.Live.Product.SettingsPlatformGateTest do
+  # Not async: the platform gate is global application state, and flipping it
+  # while another suite is uploading firmware would change that suite's answer.
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  alias NervesHub.Fixtures
+
+  test "the esp-idf settings are hidden when the platform has not enabled esp-idf", %{
+    conn: conn,
+    org: org,
+    user: user
+  } do
+    Application.put_env(:nerves_hub, :esp_idf_firmware_enabled, false)
+    on_exit(fn -> Application.put_env(:nerves_hub, :esp_idf_firmware_enabled, true) end)
+
+    product = Fixtures.product_fixture(user, org)
+    {:ok, _view, html} = live(conn, "/org/#{org.name}/#{product.name}/settings")
+
+    refute html =~ "Accept ESP-IDF application images"
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -178,6 +178,18 @@ defmodule NervesHub.Fixtures do
     user
   end
 
+  @doc """
+  A product that accepts ESP-IDF images as well as fwup archives.
+
+  Products only take fwup by default, so anything uploading a `.bin` needs this
+  rather than `product_fixture/3`.
+  """
+  def esp_idf_product_fixture(user, org, params \\ %{}) do
+    params
+    |> Enum.into(%{allowed_update_tools: ["fwup", "esp-idf"]})
+    |> then(&product_fixture(user, org, &1))
+  end
+
   def product_fixture(_user, _org, params \\ %{})
 
   def product_fixture(%Accounts.User{}, %Accounts.Org{} = org, params) do


### PR DESCRIPTION
Sixth and last of the ESP-IDF stack. Builds on #2909.

ESP-IDF support was gated only by `ESP_IDF_FIRMWARE_ENABLED`, which is instance-wide: turning it on opted in every product on the instance, including ones that only ever ship fwup and for which a `.bin` upload can only be a mistake.

Two settings on the product, under **Product → Settings → Firmware**:

| Setting | Column | Default |
| --- | --- | --- |
| Accept ESP-IDF application images | `products.allowed_update_tools` | `["fwup"]` |
| Allow unsigned ESP-IDF images | `products.allow_unsigned_esp_idf_firmware` | `false` |

An existing product keeps refusing anything but fwup until someone opts it in, and the platform flag still bounds the whole thing — a product cannot enable a format the instance has not. The settings are hidden entirely when the flag is off.

### On the unsigned setting

It excuses a *missing* Secure Boot v2 signature block and nothing more. An image that carries a signature is still verified against the org's registered keys, so the setting cannot be used to accept an image signed by a key nobody registered. It is there for board bring-up, before Secure Boot has been provisioned.

### On the database constraint

The rule is now "signed unless the product says otherwise, and only ESP-IDF may say otherwise", which cannot be expressed as a constraint on `firmwares`. So the CHECK covers what it can — `org_key_id IS NOT NULL OR tool IS NOT DISTINCT FROM 'esp-idf'` — and the application covers the rest. fwup still cannot be left unsigned at the database level, and there is a test for each half of that.

(`IS NOT DISTINCT FROM` rather than `=` because `tool` is nullable, and a CHECK passes on NULL.)

### Tested

`test/nerves_hub/firmwares/product_update_tool_settings_test.exs` covers the default, the rejection, the opt-in, the unknown-tool changeset error, the unsigned allowance, and that the allowance extends neither to a bad signature nor to fwup. `settings_test.exs` covers the toggles, including that the second only appears once the first is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
