### PR TITLE
Add a copy button to the device identifier in the header

### DIFF
--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -433,7 +433,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
                     data-copy-value={value}
                     aria-label={"Copy #{key} value"}
                     title="Copy value"
-                    class="hover:text-base-200 text-base-500 shrink-0 cursor-pointer opacity-0 transition-opacity group-hover/meta:opacity-100 focus:opacity-100"
+                    class="hover:text-base-200 text-base-500 shrink-0 cursor-pointer opacity-0 transition-opacity group-hover/meta:opacity-100 focus-visible:opacity-100"
                   >
                     <span data-icon="copy" class="lucide-copy--light size-4"></span>
                     <span data-icon="check" class="lucide-check--light text-success hidden size-4"></span>

--- a/lib/nerves_hub_web/live/devices/show.html.heex
+++ b/lib/nerves_hub_web/live/devices/show.html.heex
@@ -44,7 +44,7 @@
   <:big_header>
     <FwupProgress.render :if={@firmware_update_stage} stage={@firmware_update_stage} progress={@firmware_update_progress} />
 
-    <div class="flex shrink-0 items-center gap-3">
+    <div class="group/identifier flex shrink-0 items-center gap-3">
       <svg
         data-connection-status={Map.get(@device_connection || %{}, :status) || "unknown"}
         class="data-[connection-status=connected]:fill-success data-[connection-status=connecting]:fill-primary-500 data-[connection-status=disconnected]:fill-base-500 data-[connection-status=unknown]:fill-base-500 size-3 shrink-0 data-[connection-status=connecting]:animate-pulse"
@@ -57,6 +57,18 @@
       <h1 class="text-base-50 shrink-0 font-mono text-xl leading-[30px] font-semibold">
         {@device.identifier}
       </h1>
+      <button
+        id="copy-device-identifier"
+        type="button"
+        phx-hook="CopyToClipboard"
+        data-copy-value={@device.identifier}
+        aria-label="Copy device identifier"
+        title="Copy device identifier"
+        class="hover:text-base-200 text-base-500 shrink-0 cursor-pointer opacity-0 transition-opacity group-hover/identifier:opacity-100 focus-visible:opacity-100"
+      >
+        <span data-icon="copy" class="lucide-copy--light size-4"></span>
+        <span data-icon="check" class="lucide-check--light text-success hidden size-4"></span>
+      </button>
     </div>
 
     <div class="flex items-center gap-2">

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -56,6 +56,66 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
       |> assert_has("h1", text: "no-firmware-device")
     end
+
+    test "with a button for copying the identifier", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has(
+        ~s(button#copy-device-identifier[phx-hook="CopyToClipboard"][data-copy-value="#{device.identifier}"])
+      )
+    end
+
+    test "with a button for copying each metadata value", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      {:ok, _} =
+        Health.save_device_health(%{
+          "device_id" => device.id,
+          "data" => %{"metadata" => %{"serial_number" => "SN-1234"}},
+          "status" => :healthy,
+          "status_reasons" => %{}
+        })
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has(~s(button#copy-metadata-serial_number[phx-hook="CopyToClipboard"][data-copy-value="SN-1234"]))
+    end
+  end
+
+  describe "the copy buttons" do
+    test "reveal on keyboard focus, but not after a mouse click", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      {:ok, _} =
+        Health.save_device_health(%{
+          "device_id" => device.id,
+          "data" => %{"metadata" => %{"serial_number" => "SN-1234"}},
+          "status" => :healthy,
+          "status_reasons" => %{}
+        })
+
+      session = visit(conn, "/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+
+      # A click leaves the button focused, so `focus:` would keep it visible
+      # after the pointer moves away. `focus-visible:` only matches keyboard
+      # focus, which is what we want here.
+      for id <- ["copy-device-identifier", "copy-metadata-serial_number"] do
+        session
+        |> assert_has(~s(button##{id}[class*="focus-visible:opacity-100"]))
+        |> refute_has(~s(button##{id}[class*="focus:opacity-100"]))
+      end
+    end
   end
 
   describe "who is currently viewing the device page" do


### PR DESCRIPTION
## What

The device identifier is often needed elsewhere — support scripts, the CLI, a bug report — and selecting it by hand out of the header is fiddly. This adds a copy button beside it on the device show page.

It reuses the existing `CopyToClipboard` hook and the same hover-reveal pattern as the metadata copy buttons in the details tab: hidden at rest, fades in on hover of the identifier, and briefly swaps the copy icon for a check to confirm.

## Drive-by fix

The metadata copy buttons used `focus:opacity-100`. A click leaves a button focused, so after copying, the button stayed visible even once the pointer moved away. Both those buttons and the new one now use `focus-visible:`, which only matches keyboard focus — so the button still appears when you Tab to it, but no longer sticks around after a mouse click.