### PR TITLE
Stop long audit log descriptions from crashing their callers

### DIFF
--- a/lib/nerves_hub/audit_logs/audit_log.ex
+++ b/lib/nerves_hub/audit_logs/audit_log.ex
@@ -19,6 +19,8 @@ defmodule NervesHub.AuditLogs.AuditLog do
   ]
   @optional_params [:reference_id]
 
+  @description_max_length 500
+
   schema "audit_logs" do
     belongs_to(:org, Org, where: [deleted_at: nil])
 
@@ -71,6 +73,22 @@ defmodule NervesHub.AuditLogs.AuditLog do
   def changeset(%__MODULE__{} = audit_log, params) do
     audit_log
     |> cast(params, @required_params ++ @optional_params)
+    |> update_change(:description, &truncate_description/1)
     |> validate_required(@required_params)
   end
+
+  # Descriptions are built by interpolating values which are either unbounded
+  # (a device supplied failure reason) or columns which are themselves 255
+  # characters wide, so cap what gets stored. Truncating rather than validating
+  # is deliberate: most callers use `audit!/3`, where a validation error would
+  # raise and take down the caller, which is the failure this guards against.
+  defp truncate_description(description) when is_binary(description) do
+    if String.length(description) > @description_max_length do
+      String.slice(description, 0, @description_max_length - 1) <> "…"
+    else
+      description
+    end
+  end
+
+  defp truncate_description(description), do: description
 end

--- a/lib/nerves_hub/audit_logs/templates/device_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/device_templates.ex
@@ -12,6 +12,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
   alias NervesHub.Firmwares.Firmware
   alias NervesHub.ManagedDeployments.DeploymentGroup
 
+  @reason_max_length 200
+
   ## General
 
   @spec audit_reboot(User.t(), Device.t()) :: :ok
@@ -79,6 +81,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
 
   @spec audit_firmware_upgrade_ignored(Device.t(), DeploymentGroup.t() | nil, String.t() | nil) :: :ok
   def audit_firmware_upgrade_ignored(device, nil, reason) do
+    reason = truncate_reason(reason)
+
     description = """
     Device #{device.identifier} ignored the manual firmware upgrade request#{reason && " because of \"#{reason}\""}.
     """
@@ -87,6 +91,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
   end
 
   def audit_firmware_upgrade_ignored(device, deployment_group, reason) do
+    reason = truncate_reason(reason)
+
     description = """
     Device #{device.identifier} ignored the scheduled firmware upgrade request#{reason && " because of \"#{reason}\""}.
     Firmware upgrades are blocked for #{deployment_group.penalty_timeout_minutes} minutes.
@@ -112,6 +118,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
         reason
       )
       when is_nil(deployment_group) do
+    reason = truncate_reason(reason)
+
     description = """
     During a manual firmware update request, device #{device.identifier} requested firmware upgrades be rescheduled #{Timex.from_now(blocked_until)} time #{reason && "because \"#{reason}\""}.
     The update will not be automatically retried.
@@ -125,6 +133,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
         blocked_until,
         reason
       ) do
+    reason = truncate_reason(reason)
+
     description = """
     During an update request from \"#{deployment_group.name}\", device #{device.identifier} requested firmware upgrades be rescheduled #{Timex.from_now(blocked_until)} time #{reason && "because \"#{reason}\""}.
     """
@@ -137,6 +147,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
 
   def audit_firmware_upgrade_failed(%{inflight_update: %{deployment_group: deployment_group}} = device, reason, _)
       when is_nil(deployment_group) do
+    reason = truncate_reason(reason)
+
     description = """
     Device #{device.identifier} reported an error #{reason && "(\"#{reason}\") "}while trying to update its firmware.
     """
@@ -145,6 +157,8 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
   end
 
   def audit_firmware_upgrade_failed(%{inflight_update: %{deployment_group: deployment_group}} = device, reason, opts) do
+    reason = truncate_reason(reason)
+
     description = """
     Device #{device.identifier} reported an error #{reason && "(\"#{reason}\") "}while trying to update its firmware during a deployment release. Updates will be blocked for #{opts[:penalty_timeout_minutes]} minutes.
     """
@@ -207,5 +221,18 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     AuditLogs.audit_with_ref!(device, device, description, reference_id)
 
     :ok
+  end
+
+  # Failure reasons come straight off the device socket payload, so they are
+  # unbounded. Cap them before they reach a description, and keep `nil` as
+  # `nil` so the templates can omit the reason clause entirely.
+  defp truncate_reason(nil), do: nil
+
+  defp truncate_reason(reason) when is_binary(reason) do
+    if String.length(reason) > @reason_max_length do
+      String.slice(reason, 0, @reason_max_length - 1) <> "…"
+    else
+      reason
+    end
   end
 end

--- a/priv/repo/migrations/20260820011628_change_audit_logs_description_to_text.exs
+++ b/priv/repo/migrations/20260820011628_change_audit_logs_description_to_text.exs
@@ -1,0 +1,20 @@
+defmodule NervesHub.Repo.Migrations.ChangeAuditLogsDescriptionToText do
+  use Ecto.Migration
+
+  # varchar(255) -> text is binary coercible, so this is a catalog only change:
+  # no table rewrite, and nothing indexes `description`. It still needs a brief
+  # ACCESS EXCLUSIVE lock, so fail fast rather than queueing behind long reads.
+  def up() do
+    execute("SET lock_timeout = '5s'")
+    execute("ALTER TABLE audit_logs ALTER COLUMN description TYPE text")
+  end
+
+  def down() do
+    execute("SET lock_timeout = '5s'")
+
+    execute("""
+    ALTER TABLE audit_logs
+    ALTER COLUMN description TYPE varchar(255) USING left(description, 255)
+    """)
+  end
+end

--- a/test/nerves_hub/audit_logs/audit_log_test.exs
+++ b/test/nerves_hub/audit_logs/audit_log_test.exs
@@ -1,6 +1,8 @@
 defmodule NervesHub.AuditLogs.AuditLogTest do
   use NervesHub.DataCase, async: true
 
+  import Ecto.Changeset, only: [get_change: 2]
+
   alias NervesHub.AuditLogs.AuditLog
   alias NervesHub.Fixtures
 
@@ -13,6 +15,40 @@ defmodule NervesHub.AuditLogs.AuditLogTest do
       description = "what just happened?!"
       al = AuditLog.build(user, device, description)
       assert al.description == description
+    end
+  end
+
+  describe "changeset" do
+    test "leaves a description at the limit alone", %{device: device, user: user} do
+      description = String.duplicate("a", 500)
+
+      changeset =
+        AuditLog.build(user, device, description)
+        |> AuditLog.changeset()
+
+      assert get_change(changeset, :description) == description
+    end
+
+    test "truncates a description over the limit", %{device: device, user: user} do
+      changeset =
+        AuditLog.build(user, device, String.duplicate("a", 501))
+        |> AuditLog.changeset()
+
+      truncated = get_change(changeset, :description)
+
+      assert String.length(truncated) == 500
+      assert String.ends_with?(truncated, "…")
+    end
+
+    test "truncation counts graphemes, not bytes", %{device: device, user: user} do
+      changeset =
+        AuditLog.build(user, device, String.duplicate("日", 600))
+        |> AuditLog.changeset()
+
+      truncated = get_change(changeset, :description)
+
+      assert String.length(truncated) == 500
+      assert String.valid?(truncated)
     end
   end
 end

--- a/test/nerves_hub/audit_logs/device_templates_test.exs
+++ b/test/nerves_hub/audit_logs/device_templates_test.exs
@@ -1,0 +1,91 @@
+defmodule NervesHub.AuditLogs.DeviceTemplatesTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.AuditLogs
+  alias NervesHub.AuditLogs.DeviceTemplates
+  alias NervesHub.Fixtures
+
+  setup %{tmp_dir: tmp_dir} do
+    Fixtures.standard_fixture(tmp_dir)
+  end
+
+  describe "device supplied failure reasons" do
+    test "a long reason is truncated instead of overflowing the description", %{device: device} do
+      # Devices report fwup stderr verbatim, which can run to any length.
+      reason = String.duplicate("fwup: error writing to /dev/mmcblk0 at offset 12345678; ", 20)
+
+      device = %{device | inflight_update: %{deployment_group: nil}}
+
+      :ok = DeviceTemplates.audit_firmware_upgrade_failed(device, reason)
+
+      [log] = AuditLogs.logs_for(device)
+
+      assert log.description =~ "reported an error"
+      assert log.description =~ "fwup: error writing"
+      assert String.length(log.description) <= 500
+      refute log.description =~ String.duplicate("fwup", 3)
+    end
+
+    test "a reason under the limit is kept whole", %{device: device} do
+      reason = "fwup: partition table mismatch"
+
+      device = %{device | inflight_update: %{deployment_group: nil}}
+
+      :ok = DeviceTemplates.audit_firmware_upgrade_failed(device, reason)
+
+      [log] = AuditLogs.logs_for(device)
+
+      assert log.description =~ "(\"#{reason}\")"
+    end
+
+    test "a nil reason omits the reason clause entirely", %{device: device} do
+      device = %{device | inflight_update: %{deployment_group: nil}}
+
+      :ok = DeviceTemplates.audit_firmware_upgrade_failed(device, nil)
+
+      [log] = AuditLogs.logs_for(device)
+
+      assert log.description =~ "reported an error while trying to update its firmware"
+      refute log.description =~ "("
+    end
+
+    test "long reasons are truncated for ignored upgrades too", %{device: device} do
+      :ok = DeviceTemplates.audit_firmware_upgrade_ignored(device, nil, String.duplicate("b", 600))
+
+      [log] = AuditLogs.logs_for(device)
+
+      assert String.length(log.description) <= 500
+    end
+
+    test "long reasons are truncated for rescheduled upgrades too", %{device: device} do
+      device = %{device | inflight_update: %{deployment_group: nil}}
+      blocked_until = NaiveDateTime.utc_now() |> NaiveDateTime.add(60, :second)
+
+      :ok =
+        DeviceTemplates.audit_firmware_upgrade_rescheduled(
+          device,
+          blocked_until,
+          String.duplicate("c", 600)
+        )
+
+      [log] = AuditLogs.logs_for(device)
+
+      assert String.length(log.description) <= 500
+    end
+  end
+
+  describe "long but legal column values" do
+    test "a 255 character device identifier no longer overflows the description", %{
+      device: device,
+      user: user
+    } do
+      device = %{device | identifier: String.duplicate("d", 255)}
+
+      :ok = DeviceTemplates.audit_reboot(user, device)
+
+      [log] = AuditLogs.logs_for(device)
+
+      assert log.description =~ "rebooted device"
+    end
+  end
+end


### PR DESCRIPTION
## The error

Sentry has been reporting `(string_data_right_truncation) value too long for type character varying(255)` from the `FirmwareUpdates` context.

`audit_logs.description` is `varchar(255)`, and nothing in the app layer bounds what goes into it — the changeset casts and requires the description but never checks its length. Every description is built by interpolating values which are either **unbounded** or columns which are themselves 255 characters wide.

The unbounded one is the device's own failure reason: `info["reason"]` arrives verbatim from the device socket payload and is interpolated straight into the description. Device-authored fwup error text routinely exceeds the budget left over — for `audit_firmware_upgrade_rescheduled/3` the template's fixed text alone is 156 characters, leaving 99 for the identifier, the timestamp and the reason combined.

## Why it's worse than a lost audit row

All the affected sites use `audit!`, so the `Postgrex.Error` propagates rather than returning an error tuple:

- The reason templates run inside the transaction in `do_status_update/5`, and `DeviceChannel.advance/2` has no rescue. The channel process dies, the inflight update is never cleared and the penalty box block is rolled back, so the device can re-enter the same failing update.
- `audit_firmware_updated/1` runs inside the transaction in `firmware_update_successful/2`. An overflow there rolls back the entire success path: inflight update not deleted, `UpdateStats.log_update` undone, `clear_updates_information_changeset` undone.

## Changes

1. **Column widened to `text`.** `varchar(255) → text` is binary coercible, so this is a catalog-only change — no table rewrite, and nothing indexes `description`. Verified locally that `relfilenode` is unchanged across the `ALTER`. It sets a `lock_timeout` so it fails fast rather than queueing behind long reads on `audit_logs`.
2. **Descriptions truncated to 500 characters** in `AuditLog.changeset/2`, with an ellipsis so a truncated entry reads as truncated. Truncating rather than `validate_length` is deliberate: 41 call sites go through `audit!`/`audit_with_ref!`, where a validation error would raise `Ecto.InvalidChangesetError` and crash the same callers a `Postgrex.Error` does today.
3. **Device-supplied reasons truncated to 200 characters**, applied in `DeviceTemplates` rather than in `FirmwareUpdates` so every caller of the six affected templates is covered. `nil` stays `nil`, since the templates rely on `reason && "…"` to omit the clause when there is no reason.

Truncation is grapheme-based, so it can't sever a multi-byte character.