### PR TITLE
Use deployment group IDs in URL slug instead of encoded names

### DIFF
--- a/lib/nerves_hub/command_palette.ex
+++ b/lib/nerves_hub/command_palette.ex
@@ -99,6 +99,7 @@ defmodule NervesHub.CommandPalette do
     |> order_by([dg], asc: dg.name)
     |> limit(^limit)
     |> select([dg, product: p, org: o], %{
+      id: dg.id,
       name: dg.name,
       org_name: o.name,
       product_name: p.name

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -108,21 +108,53 @@ defmodule NervesHub.ManagedDeployments do
   def get_by_product_and_name!(product, name, with_device_count \\ false)
 
   def get_by_product_and_name!(product, name, true) do
-    subquery =
-      Device
-      |> select([d], %{device_count: count()})
-      |> Repo.exclude_deleted()
-      |> where([d], d.deployment_id == parent_as(:deployment_group).id)
-
     get_by_product_and_name_query(product, name)
-    |> join(:left_lateral, [d], dev in subquery(subquery), on: true, as: :devices)
-    |> select_merge([_f, devices: devices], %{device_count: devices.device_count})
+    |> with_device_count_lateral()
     |> Repo.one!()
   end
 
   def get_by_product_and_name!(product, name, false) do
     get_by_product_and_name_query(product, name)
     |> Repo.one!()
+  end
+
+  @spec get_by_product_and_id!(Product.t(), integer(), boolean()) :: DeploymentGroup.t()
+  def get_by_product_and_id!(product, id, with_device_count \\ false)
+
+  def get_by_product_and_id!(product, id, true) do
+    get_by_product_and_id_query(product, id)
+    |> with_device_count_lateral()
+    |> Repo.one!()
+  end
+
+  def get_by_product_and_id!(product, id, false) do
+    get_by_product_and_id_query(product, id)
+    |> Repo.one!()
+  end
+
+  @doc """
+  Looks up a Deployment Group by ID, falling back to its name.
+
+  Supports old bookmarked/shared links that reference the name instead of the ID.
+  """
+  @spec get_by_product_and_id_or_name!(Product.t(), String.t(), boolean()) :: DeploymentGroup.t()
+  def get_by_product_and_id_or_name!(product, id_or_name, with_device_count \\ false) do
+    case Integer.parse(id_or_name) do
+      {id, ""} -> get_by_product_and_id!(product, id, with_device_count)
+      _ -> get_by_product_and_name!(product, id_or_name, with_device_count)
+    end
+  end
+
+  defp with_device_count_lateral(query) do
+    subquery =
+      Device
+      |> select([d], %{device_count: count()})
+      |> Repo.exclude_deleted()
+      |> where([d], d.deployment_id == parent_as(:deployment_group).id)
+
+    query
+    |> join(:left_lateral, [d], dev in subquery(subquery), on: true, as: :devices)
+    |> select_merge([_f, devices: devices], %{device_count: devices.device_count})
   end
 
   @spec get_by_product_and_platforms(Product.t(), [binary()]) :: [DeploymentGroup.t()]
@@ -156,10 +188,35 @@ defmodule NervesHub.ManagedDeployments do
     |> Repo.fetch()
   end
 
+  @doc """
+  Looks up a Deployment Group by ID, falling back to its name.
+
+  Supports old bookmarked/shared links that reference the name instead of the ID.
+  """
+  @spec get_deployment_group_by_id_or_name(Product.t(), String.t()) ::
+          {:ok, DeploymentGroup.t()} | {:error, :not_found}
+  def get_deployment_group_by_id_or_name(product, id_or_name) do
+    case Integer.parse(id_or_name) do
+      {id, ""} -> get_by_product_and_id_query(product, id) |> Repo.fetch()
+      _ -> get_deployment_group_by_name(product, id_or_name)
+    end
+  end
+
   defp get_by_product_and_name_query(%Product{id: product_id}, name) do
     DeploymentGroup
     |> from(as: :deployment_group)
     |> where(name: ^name)
+    |> where(product_id: ^product_id)
+    |> join(:left, [deployment_group: d], p in assoc(d, :product), as: :product)
+    |> join_current_release(true)
+    |> join_counts()
+    |> preload([product: p], product: p)
+  end
+
+  defp get_by_product_and_id_query(%Product{id: product_id}, id) do
+    DeploymentGroup
+    |> from(as: :deployment_group)
+    |> where([deployment_group: d], d.id == ^id)
     |> where(product_id: ^product_id)
     |> join(:left, [deployment_group: d], p in assoc(d, :product), as: :product)
     |> join_current_release(true)

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -133,15 +133,23 @@ defmodule NervesHub.ManagedDeployments do
   end
 
   @doc """
-  Looks up a Deployment Group by ID, falling back to its name.
+  Looks up a Deployment Group by name, falling back to its ID.
 
-  Supports old bookmarked/shared links that reference the name instead of the ID.
+  Supports old bookmarked/shared links that reference the ID instead of the name.
+  A deployment group's name can itself be numeric, so the name is tried first
+  to avoid misinterpreting it as an ID.
   """
-  @spec get_by_product_and_id_or_name!(Product.t(), String.t(), boolean()) :: DeploymentGroup.t()
-  def get_by_product_and_id_or_name!(product, id_or_name, with_device_count \\ false) do
-    case Integer.parse(id_or_name) do
-      {id, ""} -> get_by_product_and_id!(product, id, with_device_count)
-      _ -> get_by_product_and_name!(product, id_or_name, with_device_count)
+  @spec get_by_product_and_name_or_id!(Product.t(), String.t(), boolean()) :: DeploymentGroup.t()
+  def get_by_product_and_name_or_id!(product, name_or_id, with_device_count \\ false) do
+    case get_deployment_group_by_name(product, name_or_id) do
+      {:ok, _deployment_group} ->
+        get_by_product_and_name!(product, name_or_id, with_device_count)
+
+      {:error, :not_found} ->
+        case Integer.parse(name_or_id) do
+          {id, ""} -> get_by_product_and_id!(product, id, with_device_count)
+          _ -> get_by_product_and_name!(product, name_or_id, with_device_count)
+        end
     end
   end
 
@@ -189,16 +197,24 @@ defmodule NervesHub.ManagedDeployments do
   end
 
   @doc """
-  Looks up a Deployment Group by ID, falling back to its name.
+  Looks up a Deployment Group by name, falling back to its ID.
 
-  Supports old bookmarked/shared links that reference the name instead of the ID.
+  Supports old bookmarked/shared links that reference the ID instead of the name.
+  A deployment group's name can itself be numeric, so the name is tried first
+  to avoid misinterpreting it as an ID.
   """
-  @spec get_deployment_group_by_id_or_name(Product.t(), String.t()) ::
+  @spec get_deployment_group_by_name_or_id(Product.t(), String.t()) ::
           {:ok, DeploymentGroup.t()} | {:error, :not_found}
-  def get_deployment_group_by_id_or_name(product, id_or_name) do
-    case Integer.parse(id_or_name) do
-      {id, ""} -> get_by_product_and_id_query(product, id) |> Repo.fetch()
-      _ -> get_deployment_group_by_name(product, id_or_name)
+  def get_deployment_group_by_name_or_id(product, name_or_id) do
+    case get_deployment_group_by_name(product, name_or_id) do
+      {:ok, deployment_group} ->
+        {:ok, deployment_group}
+
+      {:error, :not_found} ->
+        case Integer.parse(name_or_id) do
+          {id, ""} -> get_by_product_and_id_query(product, id) |> Repo.fetch()
+          _ -> {:error, :not_found}
+        end
     end
   end
 

--- a/lib/nerves_hub/managed_deployments/deployment_group.ex
+++ b/lib/nerves_hub/managed_deployments/deployment_group.ex
@@ -28,7 +28,7 @@ defmodule NervesHub.ManagedDeployments.DeploymentGroup do
     :penalty_timeout_minutes
   ]
 
-  @derive {Phoenix.Param, key: :name}
+  @derive {Phoenix.Param, key: :id}
   schema "deployments" do
     belongs_to(:product, Product, where: [deleted_at: nil])
     belongs_to(:org, Org, where: [deleted_at: nil])

--- a/lib/nerves_hub_web/components/command_palette.ex
+++ b/lib/nerves_hub_web/components/command_palette.ex
@@ -107,7 +107,7 @@ defmodule NervesHubWeb.Components.CommandPalette do
                 <.result_group :if={results.deployment_groups != []} title="Deployment Groups">
                   <.result_item
                     :for={group <- results.deployment_groups}
-                    navigate={~p"/org/#{group.org_name}/#{group.product_name}/deployment_groups/#{group.name}"}
+                    navigate={~p"/org/#{group.org_name}/#{group.product_name}/deployment_groups/#{group.id}"}
                     icon="lucide-rocket--light"
                     label={group.name}
                     hint={"#{group.org_name} / #{group.product_name}"}

--- a/lib/nerves_hub_web/controllers/deployment_group_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_group_controller.ex
@@ -6,9 +6,9 @@ defmodule NervesHubWeb.DeploymentGroupController do
 
   plug(:validate_role, org: :view)
 
-  def export_audit_logs(%{assigns: %{org: org, product: product}} = conn, %{"name" => deployment_name}) do
+  def export_audit_logs(%{assigns: %{org: org, product: product}} = conn, %{"id" => id}) do
     {:ok, deployment_group} =
-      ManagedDeployments.get_deployment_group_by_name(product, deployment_name)
+      ManagedDeployments.get_deployment_group_by_id_or_name(product, id)
 
     case AuditLogs.logs_for(deployment_group) do
       [] ->

--- a/lib/nerves_hub_web/controllers/deployment_group_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_group_controller.ex
@@ -8,7 +8,7 @@ defmodule NervesHubWeb.DeploymentGroupController do
 
   def export_audit_logs(%{assigns: %{org: org, product: product}} = conn, %{"id" => id}) do
     {:ok, deployment_group} =
-      ManagedDeployments.get_deployment_group_by_id_or_name(product, id)
+      ManagedDeployments.get_deployment_group_by_name_or_id(product, id)
 
     case AuditLogs.logs_for(deployment_group) do
       [] ->

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -18,7 +18,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
     %{"id" => id} = params
     %{current_scope: %{org: org, product: product, user: user}} = socket.assigns
 
-    deployment_group = ManagedDeployments.get_by_product_and_id_or_name!(product, id, true)
+    deployment_group = ManagedDeployments.get_by_product_and_name_or_id!(product, id, true)
 
     Logger.metadata(user_id: user.id, product_id: product.id, deployment_group_id: deployment_group.id)
 

--- a/lib/nerves_hub_web/live/deployment_groups/show.ex
+++ b/lib/nerves_hub_web/live/deployment_groups/show.ex
@@ -15,10 +15,10 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show do
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do
-    %{"name" => name} = params
+    %{"id" => id} = params
     %{current_scope: %{org: org, product: product, user: user}} = socket.assigns
 
-    deployment_group = ManagedDeployments.get_by_product_and_name!(product, name, true)
+    deployment_group = ManagedDeployments.get_by_product_and_id_or_name!(product, id, true)
 
     Logger.metadata(user_id: user.id, product_id: product.id, deployment_group_id: deployment_group.id)
 

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -280,7 +280,7 @@ defmodule NervesHubWeb.Router do
     get("/firmware/:uuid/download", DownloadController, :firmware)
 
     get(
-      "/deployment_groups/:name/audit_logs/download",
+      "/deployment_groups/:id/audit_logs/download",
       DeploymentGroupController,
       :export_audit_logs
     )
@@ -386,25 +386,25 @@ defmodule NervesHubWeb.Router do
       live("/org/:org_name/:product_name/deployment_groups/new", Live.DeploymentGroups.New)
 
       live(
-        "/org/:org_name/:product_name/deployment_groups/:name",
+        "/org/:org_name/:product_name/deployment_groups/:id",
         Live.DeploymentGroups.Show,
         :summary
       )
 
       live(
-        "/org/:org_name/:product_name/deployment_groups/:name/releases",
+        "/org/:org_name/:product_name/deployment_groups/:id/releases",
         Live.DeploymentGroups.Show,
         :releases
       )
 
       live(
-        "/org/:org_name/:product_name/deployment_groups/:name/activity",
+        "/org/:org_name/:product_name/deployment_groups/:id/activity",
         Live.DeploymentGroups.Show,
         :activity
       )
 
       live(
-        "/org/:org_name/:product_name/deployment_groups/:name/settings",
+        "/org/:org_name/:product_name/deployment_groups/:id/settings",
         Live.DeploymentGroups.Show,
         :settings
       )

--- a/test/nerves_hub/managed_deployments_test.exs
+++ b/test/nerves_hub/managed_deployments_test.exs
@@ -1611,4 +1611,34 @@ defmodule NervesHub.ManagedDeploymentsTest do
       assert other_dg.id in ids
     end
   end
+
+  describe "get_by_product_and_name_or_id!/3" do
+    test "finds a deployment group by name", %{product: product, deployment_group: deployment_group} do
+      result = ManagedDeployments.get_by_product_and_name_or_id!(product, deployment_group.name)
+
+      assert result.id == deployment_group.id
+    end
+
+    test "falls back to id when no name matches", %{product: product, deployment_group: deployment_group} do
+      result = ManagedDeployments.get_by_product_and_name_or_id!(product, to_string(deployment_group.id))
+
+      assert result.id == deployment_group.id
+    end
+
+    test "prefers a numeric name over an id, even when a deployment group with that id exists", %{
+      product: product,
+      deployment_group: other_deployment_group,
+      firmware: firmware,
+      user: user
+    } do
+      numeric_name = to_string(other_deployment_group.id)
+
+      numerically_named_group =
+        Fixtures.deployment_group_fixture(firmware, %{name: numeric_name, user: user})
+
+      result = ManagedDeployments.get_by_product_and_name_or_id!(product, numeric_name)
+
+      assert result.id == numerically_named_group.id
+    end
+  end
 end

--- a/test/nerves_hub_web/live/command_palette_test.exs
+++ b/test/nerves_hub_web/live/command_palette_test.exs
@@ -47,8 +47,7 @@ defmodule NervesHubWeb.Live.CommandPaletteTest do
     product: product,
     deployment_group: deployment_group
   } do
-    href =
-      "/org/#{org.name}/#{product.name}/deployment_groups/#{URI.encode(deployment_group.name)}"
+    href = "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.id}"
 
     conn
     |> visit(deployment_groups_path(org, product))

--- a/test/nerves_hub_web/live/deployment_groups/new_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/new_test.exs
@@ -32,19 +32,22 @@ defmodule NervesHubWeb.Live.DelploymentGroups.NewTest do
       firmware =
         Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir, platform: "taramasalata"})
 
-      conn
-      |> visit("/org/#{org.name}/#{product.name}/deployment_groups/new")
-      |> assert_has("h1", text: "Add Deployment Group")
-      |> assert_has("option", text: "Choose a platform")
-      |> select("Platform", option: firmware.platform)
-      |> select("Architecture", option: firmware.architecture)
-      |> fill_in("Name", with: "Moussaka")
-      |> fill_in("Tag(s) distributed to", with: "josh, lars")
-      |> select("Firmware", option: firmware.uuid, exact_option: false)
-      |> click_button("Save changes")
-      |> assert_path(URI.encode("/org/#{org.name}/#{product.name}/deployment_groups/Moussaka"))
-      |> assert_has("div", text: "Deployment Group created")
-      |> assert_has("h1", text: "Moussaka")
+      conn =
+        conn
+        |> visit("/org/#{org.name}/#{product.name}/deployment_groups/new")
+        |> assert_has("h1", text: "Add Deployment Group")
+        |> assert_has("option", text: "Choose a platform")
+        |> select("Platform", option: firmware.platform)
+        |> select("Architecture", option: firmware.architecture)
+        |> fill_in("Name", with: "Moussaka")
+        |> fill_in("Tag(s) distributed to", with: "josh, lars")
+        |> select("Firmware", option: firmware.uuid, exact_option: false)
+        |> click_button("Save changes")
+        |> assert_has("div", text: "Deployment Group created")
+        |> assert_has("h1", text: "Moussaka")
+
+      deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Moussaka"))
+      assert_path(conn, "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.id}")
 
       [%{resource_type: DeploymentGroup}, %{resource_type: DeploymentGroup}] = AuditLogs.logs_by(user)
     end
@@ -93,35 +96,39 @@ defmodule NervesHubWeb.Live.DelploymentGroups.NewTest do
   end
 
   test "delta updates are enabled by default", %{conn: conn, org: org, product: product} do
-    conn
-    |> assert_has("input[name='deployment_group[delta_updatable]']", value: "true")
-    |> fill_in("Name", with: "Canaries")
-    |> select("Platform", option: "platform")
-    |> select("Architecture", option: "x86_64")
-    |> select("Firmware", option: "1.0.0", exact_option: false)
-    |> submit()
-    |> assert_path(~p"/org/#{org}/#{product}/deployment_groups/Canaries")
+    conn =
+      conn
+      |> assert_has("input[name='deployment_group[delta_updatable]']", value: "true")
+      |> fill_in("Name", with: "Canaries")
+      |> select("Platform", option: "platform")
+      |> select("Architecture", option: "x86_64")
+      |> select("Firmware", option: "1.0.0", exact_option: false)
+      |> submit()
 
     deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert_path(conn, ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group.id}")
+
     assert deployment_group.delta_updatable
   end
 
   test "disable delta updates when creating a deployment group", %{conn: conn, org: org, product: product} do
-    conn
-    |> assert_has("input[name='deployment_group[delta_updatable]']", checked: true)
-    |> fill_in("Name", with: "Canaries")
-    |> uncheck("Delta updates")
-    |> select("Platform", option: "platform")
-    |> select("Architecture", option: "x86_64")
-    |> select("Firmware", option: "1.0.0", exact_option: false)
-    |> submit()
-    |> assert_path("/org/#{org.name}/#{product.name}/deployment_groups/Canaries")
+    conn =
+      conn
+      |> assert_has("input[name='deployment_group[delta_updatable]']", checked: true)
+      |> fill_in("Name", with: "Canaries")
+      |> uncheck("Delta updates")
+      |> select("Platform", option: "platform")
+      |> select("Architecture", option: "x86_64")
+      |> select("Firmware", option: "1.0.0", exact_option: false)
+      |> submit()
 
     deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert_path(conn, "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.id}")
+
     refute deployment_group.delta_updatable
   end
 
-  test "can update only version", %{conn: conn, org: org, product: product, fixture: fixture} do
+  test "can update only version", %{conn: conn, product: product, fixture: fixture} do
     conn
     |> fill_in("Name", with: "Canaries")
     |> select("Platform", option: "platform")
@@ -130,7 +137,6 @@ defmodule NervesHubWeb.Live.DelploymentGroups.NewTest do
     |> fill_in("Tag(s) distributed to", with: "a, b")
     |> fill_in("Version requirement", with: "1.2.3")
     |> submit()
-    |> assert_path("/org/#{org.name}/#{product.name}/deployment_groups/Canaries")
 
     deployment_group = ManagedDeployments.get_by_product_and_name!(product, "Canaries")
 
@@ -152,27 +158,32 @@ defmodule NervesHubWeb.Live.DelploymentGroups.NewTest do
   end
 
   test "can set notes when creating a deployment group", %{conn: conn, org: org, product: product} do
-    conn
-    |> fill_in("Name", with: "Canaries")
-    |> fill_in("Notes", with: "Created for the summer campaign hardware batch")
-    |> select("Platform", option: "platform")
-    |> select("Architecture", option: "x86_64")
-    |> select("Firmware", option: "1.0.0", exact_option: false)
-    |> submit()
-    |> assert_path(~p"/org/#{org}/#{product}/deployment_groups/Canaries")
+    conn =
+      conn
+      |> fill_in("Name", with: "Canaries")
+      |> fill_in("Notes", with: "Created for the summer campaign hardware batch")
+      |> select("Platform", option: "platform")
+      |> select("Architecture", option: "x86_64")
+      |> select("Firmware", option: "1.0.0", exact_option: false)
+      |> submit()
 
     deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert_path(conn, ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group.id}")
+
     assert deployment_group.notes == "Created for the summer campaign hardware batch"
   end
 
   test "notes is optional when creating a deployment group", %{conn: conn, org: org, product: product} do
-    conn
-    |> fill_in("Name", with: "Canaries")
-    |> select("Platform", option: "platform")
-    |> select("Architecture", option: "x86_64")
-    |> select("Firmware", option: "1.0.0", exact_option: false)
-    |> submit()
-    |> assert_path(~p"/org/#{org}/#{product}/deployment_groups/Canaries")
+    conn =
+      conn
+      |> fill_in("Name", with: "Canaries")
+      |> select("Platform", option: "platform")
+      |> select("Architecture", option: "x86_64")
+      |> select("Firmware", option: "1.0.0", exact_option: false)
+      |> submit()
+
+    deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
+    assert_path(conn, ~p"/org/#{org}/#{product}/deployment_groups/#{deployment_group.id}")
 
     deployment_group = Repo.one!(from(d in DeploymentGroup, where: d.name == "Canaries"))
     assert deployment_group.notes == nil

--- a/test/nerves_hub_web/live/deployment_groups/show/activity_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/activity_tab_test.exs
@@ -45,14 +45,12 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.ActivityTabTest do
         NervesHub.AuditLogs.audit!(user, deployment_group, "Pagination test entry #{i}")
       end)
 
-      encoded_name = URI.encode(deployment_group.name)
-
       conn
       |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/activity")
       |> assert_has("button[phx-value-page=\"2\"]")
       |> click_button(~s(button[phx-click="paginate"][phx-value-page="2"]), "2")
       |> assert_path(
-        "/org/#{org.name}/#{product.name}/deployment_groups/#{encoded_name}/activity",
+        "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.id}/activity",
         query_params: %{"page_number" => "2", "page_size" => "25"}
       )
       |> assert_has("div.flex.items-center.gap-6", count: 6)
@@ -69,13 +67,11 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.ActivityTabTest do
         NervesHub.AuditLogs.audit!(user, deployment_group, "Page size test entry #{i}")
       end)
 
-      encoded_name = URI.encode(deployment_group.name)
-
       conn
       |> visit("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/activity")
       |> click_button("50")
       |> assert_path(
-        "/org/#{org.name}/#{product.name}/deployment_groups/#{encoded_name}/activity",
+        "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.id}/activity",
         query_params: %{"page_number" => "1", "page_size" => "50"}
       )
       |> assert_has("div.flex.items-center.gap-6", count: 50)

--- a/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/settings_tab_test.exs
@@ -79,7 +79,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
       ManagedDeployments.get_deployment_group(deployment_group.id)
 
     conn
-    |> assert_path(URI.encode("/org/#{org.name}/#{product.name}/deployment_groups/#{reloaded_deployment_group.name}"))
+    |> assert_path(URI.encode("/org/#{org.name}/#{product.name}/deployment_groups/#{reloaded_deployment_group.id}"))
     |> assert_has("div", text: "Deployment Group updated")
 
     assert reloaded_deployment_group.name == "Moussaka"
@@ -117,7 +117,7 @@ defmodule NervesHubWeb.Live.DeploymentGroups.Show.SettingsTabTest do
     |> fill_in("Tag(s) distributed to", with: "")
     |> fill_in("Version requirement", with: "")
     |> click_button("Save changes")
-    |> assert_path(URI.encode("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}"))
+    |> assert_path(URI.encode("/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.id}"))
 
     deployment_group = Repo.reload(deployment_group)
 


### PR DESCRIPTION
For a variety of support reasons, it's nice to be able to get the numeric IDs of deployment groups.

Example:
<img width="2690" height="1894" alt="CleanShot 2026-08-20 at 15 20 42@2x" src="https://github.com/user-attachments/assets/e493a3da-db2f-4bde-ac60-f9426f4ebfa1" />

This isn't a hard requirement neccesarily, but it'd be a lovely short-term value add for us. 🙏 

I also added a fallback so that existing URLs that use the encoded name should still resolve correctly.