### PR TITLE
Send the firmware size and checksums when pushing an update to a device

### DIFF
--- a/lib/nerves_hub/events/device_events.ex
+++ b/lib/nerves_hub/events/device_events.ex
@@ -101,14 +101,12 @@ defmodule NervesHub.DeviceEvents do
 
   def manual_update(device, firmware, user, opts \\ []) do
     Repo.transact(fn ->
-      url =
-        if opts[:delta] do
-          {:ok, url} = Firmwares.get_delta_url(device, firmware)
-          url
-        else
-          {:ok, url} = Firmwares.get_firmware_url(firmware)
-          url
-        end
+      # When a delta is being sent it is the delta that the device downloads, so
+      # it is the delta that describes the download.
+      {:ok, firmware_or_delta} =
+        if opts[:delta], do: Firmwares.get_delta(device, firmware), else: {:ok, firmware}
+
+      {:ok, url} = Firmwares.get_firmware_url(firmware_or_delta)
 
       firmware_url =
         if opts[:firmware_proxy_url] do
@@ -129,7 +127,10 @@ defmodule NervesHub.DeviceEvents do
       payload = %UpdatePayload{
         update_available: true,
         firmware_url: firmware_url,
-        firmware_meta: meta
+        firmware_meta: meta,
+        size: firmware_or_delta.size,
+        checksum: firmware_or_delta.checksum,
+        partials_checksums: firmware_or_delta.partials_checksums
       }
 
       :telemetry.execute([:nerves_hub, :devices, :update, :manual], %{count: 1})

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -593,14 +593,20 @@ defmodule NervesHub.Firmwares do
 
   def get_delta_or_firmware(%Device{}, %DeploymentGroup{current_release: %{firmware: target}}), do: {:ok, target}
 
-  @spec get_delta_url(Device.t(), Firmware.t()) ::
-          {:ok, String.t()}
-          | {:error, :failure}
-  def get_delta_url(%Device{firmware_metadata: %{uuid: source_uuid}}, %Firmware{id: target_id, product_id: product_id}) do
+  @doc """
+  The delta that takes the device from the firmware it is running to `firmware`.
+
+  Returns the delta itself rather than a URL for it, because the delta is what
+  the device downloads, and so it is the delta's size and checksums that
+  describe that download.
+  """
+  @spec get_delta(Device.t(), Firmware.t()) ::
+          {:ok, FirmwareDelta.t()}
+          | {:error, :not_found}
+  def get_delta(%Device{firmware_metadata: %{uuid: source_uuid}}, %Firmware{id: target_id, product_id: product_id}) do
     source_uuid
     |> firmware_delta_query(product_id, target_id)
-    |> Repo.one()
-    |> get_firmware_url()
+    |> Repo.fetch()
   end
 
   @spec get_delta_if_ready(Device.t(), Firmware.t(), Firmware.t()) ::
@@ -622,7 +628,7 @@ defmodule NervesHub.Firmwares do
   end
 
   # Builds the FirmwareDelta query from the device's current (source) firmware
-  # UUID to the target firmware id. Shared by delta_ready?/2 and get_delta_url/2.
+  # UUID to the target firmware id. Shared by delta_ready?/2 and get_delta/2.
   defp firmware_delta_query(source_uuid, product_id, target_id) do
     source_firmware_id_query =
       Firmware

--- a/test/nerves_hub/events/device_events_test.exs
+++ b/test/nerves_hub/events/device_events_test.exs
@@ -1,0 +1,94 @@
+defmodule NervesHub.DeviceEventsTest do
+  @moduledoc """
+  Tests for the update messages sent to a single device.
+
+  Deployments and manual pushes build the update payload separately, and it is
+  easy for the two to drift. What the device needs to verify and resume a
+  download - the size and checksums of the file it is about to fetch - has to be
+  in both.
+  """
+
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.DeviceEvents
+  alias NervesHub.Fixtures
+  alias Phoenix.Socket.Broadcast
+
+  setup %{tmp_dir: tmp_dir} do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, DeviceEvents.topic(device))
+
+    {:ok,
+     %{
+       device: device,
+       firmware: firmware,
+       org: org,
+       org_key: org_key,
+       product: product,
+       tmp_dir: tmp_dir,
+       user: user
+     }}
+  end
+
+  describe "manual_update/4" do
+    test "describes the firmware being sent", context do
+      %{device: device, org_key: org_key, product: product, tmp_dir: tmp_dir, user: user} = context
+
+      new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      {:ok, _device} = DeviceEvents.manual_update(device, new_firmware, user)
+
+      assert_receive %Broadcast{event: "update", payload: payload}
+
+      assert payload.update_available
+      assert payload.firmware_meta.uuid == new_firmware.uuid
+
+      # without these the device can't check what it downloaded, or pick up
+      # where it left off after a restart
+      assert payload.size == new_firmware.size
+      assert payload.checksum == new_firmware.checksum
+      assert payload.partials_checksums == new_firmware.partials_checksums
+
+      refute is_nil(payload.checksum)
+      refute payload.partials_checksums == []
+    end
+
+    test "describes the delta being sent rather than the firmware it produces", context do
+      %{device: device, firmware: firmware, org_key: org_key} = context
+      %{product: product, tmp_dir: tmp_dir, user: user} = context
+
+      new_firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      # a delta has its own size and checksums, because the delta is the file
+      # the device downloads
+      delta =
+        firmware
+        |> Fixtures.firmware_delta_fixture(new_firmware)
+        |> Ecto.Changeset.change(%{
+          checksum: String.duplicate("A", 64),
+          partials_checksums: [String.duplicate("B", 64), String.duplicate("C", 64)]
+        })
+        |> Repo.update!()
+
+      {:ok, _device} = DeviceEvents.manual_update(device, new_firmware, user, delta: true)
+
+      assert_receive %Broadcast{event: "update", payload: payload}
+
+      # the metadata still describes the firmware the device ends up running
+      assert payload.firmware_meta.uuid == new_firmware.uuid
+
+      assert payload.size == delta.size
+      assert payload.checksum == delta.checksum
+      assert payload.partials_checksums == delta.partials_checksums
+
+      refute payload.size == new_firmware.size
+      refute payload.checksum == new_firmware.checksum
+    end
+  end
+end


### PR DESCRIPTION
Deployments and manual pushes build the update payload separately, and the two have drifted. [`Updates.resolve_update/3`](https://github.com/nerves-hub/nerves_hub_web/blob/main/lib/nerves_hub/devices/updates.ex#L238) sends `size`, `checksum` and `partials_checksums`, but `manual_update/4` only ever sent the URL and the firmware metadata:

```elixir
payload = %UpdatePayload{
  update_available: true,
  firmware_url: firmware_url,
  firmware_meta: meta
}
```

They default to `nil` on the struct, so they went out as nil even when the firmware record had them stored. A device given firmware from the device page, the devices list, or the API `upgrade` endpoint therefore had no way to verify what it downloaded, and no way to tell a complete download from a partial one when resuming after a restart.

`NervesHubLink`'s parts based updater logs a warning when the checksums are missing, which is how this surfaced.

## Deltas

A delta has its own `size`, `checksum` and `partials_checksums`, because the delta is the file the device downloads. Sending the target firmware's numbers for a delta would be worse than sending none at all — every part would fail verification.

`get_delta_url/2` threw the delta record away to return a URL, so there was nothing to read those from. It becomes `get_delta/2` and returns the record, with the caller composing it with `get_firmware_url/1` — the same shape `resolve_update/3` already uses with `get_delta_or_firmware/2`. It had a single caller. It now uses `Repo.fetch/1` too, so a missing delta is `{:error, :not_found}` rather than `nil` flowing into `download_file/1`.
