### PR TITLE
Make connection history versions strictly increasing

### DIFF
--- a/lib/nerves_hub/devices/device_connection_history.ex
+++ b/lib/nerves_hub/devices/device_connection_history.ex
@@ -7,6 +7,12 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
 
   @type t :: %__MODULE__{}
 
+  @version_counter {__MODULE__, :version}
+
+  # Creating the counter as the module loads means it exists before any process
+  # can call the module, so no two writers can race to create one each.
+  @on_load :init_version_counter
+
   @primary_key false
   schema "device_connection_history" do
     field(:ref, Ch, type: "UUID")
@@ -52,9 +58,28 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
   # connected, heartbeats, disconnected) are usually written within the same
   # second, so a second-resolution version leaves them tied and ClickHouse picks
   # between them arbitrarily - the merged view could report an already
-  # disconnected connection as still open. Microseconds keep the writes strictly
-  # ordered, so the most recent one always wins.
-  defp current_version(), do: DateTime.to_unix(DateTime.utc_now(), :microsecond)
+  # disconnected connection as still open.
+  #
+  # Microsecond resolution narrows that window but doesn't close it: two rows
+  # can still land in the same microsecond, and a wall clock read can step
+  # backwards when the host's clock is adjusted, which would put a disconnect
+  # *behind* the heartbeat it follows. `System.system_time/1` reads the BEAM's
+  # corrected clock, which never steps backwards, and the high water mark below
+  # turns it into a strictly increasing sequence, so each row a node writes for
+  # a connection beats the one before it.
+  defp current_version() do
+    next_version(:persistent_term.get(@version_counter), System.system_time(:microsecond))
+  end
+
+  defp next_version(counter, now) do
+    previous = :atomics.get(counter, 1)
+    version = max(now, previous + 1)
+
+    case :atomics.compare_exchange(counter, 1, previous, version) do
+      :ok -> version
+      _bumped_concurrently -> next_version(counter, now)
+    end
+  end
 
   @doc """
   Builds a new history row from an existing one.
@@ -65,12 +90,19 @@ defmodule NervesHub.Devices.DeviceConnectionHistory do
   collapses to this disconnected state.
   """
   def mark_as_stale_and_disconnected_changeset(%__MODULE__{} = connection) do
-    now = DateTime.utc_now()
-
     connection
     |> change()
-    |> put_change(:disconnected_at, now)
+    |> put_change(:disconnected_at, DateTime.utc_now())
     |> put_change(:disconnected_reason, "Stale connection")
-    |> put_change(:version, DateTime.to_unix(now, :microsecond))
+    |> put_change(:version, current_version())
+  end
+
+  # Keeps the counter across a code reload so the high water mark isn't reset
+  # back behind the versions already handed out.
+  defp init_version_counter() do
+    case :persistent_term.get(@version_counter, nil) do
+      nil -> :persistent_term.put(@version_counter, :atomics.new(1, signed: false))
+      _counter -> :ok
+    end
   end
 end

--- a/test/nerves_hub/devices/device_connection_history_test.exs
+++ b/test/nerves_hub/devices/device_connection_history_test.exs
@@ -71,13 +71,15 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
         last_seen_at: ~U[2020-01-01 00:05:00.000000Z]
       }
 
-      before = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+      one_second = 1_000_000
+      before = System.system_time(:microsecond)
       changes = DeviceConnectionHistory.from_device_connection_changeset(connection).changes
-      later = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
 
-      # version tracks the current time at insert, independent of last_seen_at
+      # version tracks the current time at insert, independent of last_seen_at -
+      # it can sit a hair past the clock when a tie has to be broken, so the
+      # upper bound is loose
       assert changes.version >= before
-      assert changes.version <= later
+      assert changes.version <= before + one_second
     end
 
     test "successive rows for the same connection get strictly increasing versions" do
@@ -126,14 +128,31 @@ defmodule NervesHub.Devices.DeviceConnectionHistoryTest do
     end
 
     test "mark_as_stale_and_disconnected_changeset bumps the version past the row it carries forward" do
+      ref = UUIDv7.generate()
+
+      # version the carried forward row the way the writer would have, so the
+      # bump has to beat it even when both land in the same microsecond
+      carried_forward_version =
+        %DeviceConnection{
+          id: ref,
+          org_id: 1,
+          product_id: 2,
+          device_id: 3,
+          established_at: ~U[2026-06-20 10:00:00.000000Z],
+          last_seen_at: ~U[2026-06-20 10:05:00.000000Z]
+        }
+        |> DeviceConnectionHistory.from_device_connection_changeset()
+        |> Map.fetch!(:changes)
+        |> Map.fetch!(:version)
+
       history = %DeviceConnectionHistory{
         org_id: 1,
         product_id: 2,
         device_id: 3,
-        ref: UUIDv7.generate(),
+        ref: ref,
         established_at: ~U[2026-06-20 10:00:00.000000Z],
         last_seen_at: ~U[2026-06-20 10:05:00.000000Z],
-        version: DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+        version: carried_forward_version
       }
 
       changes = DeviceConnectionHistory.mark_as_stale_and_disconnected_changeset(history).changes


### PR DESCRIPTION
`device_connection_history` is a ReplacingMergeTree that dedupes on
`(org_id, product_id, device_id, established_at)` - a key every row for a single
connection shares - and keeps the row with the highest `version`. So the
connecting, connected, heartbeat and disconnected rows for one connection are
competing on `version` alone, and if the wrong one wins the merged view reports
a connection that closed as still open.

`version` was a wall clock read, `DateTime.to_unix(DateTime.utc_now(), :microsecond)`,
which leaves two gaps:

- two rows can land in the same microsecond, and ClickHouse then picks between
  them arbitrarily. In a tight loop the old generator returned 24,436 unique
  values out of 80,000 reads, so the clock ties far more often than microsecond
  resolution suggests. Real writes for one connection are much further apart
  than that, but the margin is thinner than the comment claimed.
- `DateTime.utc_now/0` reads raw OS time, which steps backwards when the host's
  clock is adjusted. A backwards step between a heartbeat and the disconnect
  that follows it puts the disconnect behind, which is exactly the case
  `version` exists to prevent. No amount of resolution fixes that one.

`current_version/0` now reads `System.system_time/1`, which comes off the BEAM's
corrected clock and doesn't step backwards, and passes it through a node wide
atomic high water mark, so each value is `max(now, previous + 1)`.
`mark_as_stale_and_disconnected_changeset/1` uses the same generator instead of
deriving a version from its own `DateTime.utc_now/0` call.

The counter is created in `@on_load` rather than on first use. That isn't
stylistic: lazy creation is broken under concurrency, because `:persistent_term.put/2`
is slow enough that racing first callers each create and store their own counter.
Measured: 50,456 unique values out of 80,000. Creating it as the module
loads means it exists before any process can call the module.