### PR TITLE
Stop the device list loading health payloads it never renders

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -15,6 +15,7 @@ defmodule NervesHub.Devices do
   alias NervesHub.Devices.DeviceCertificate
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.DeviceFirmwares
+  alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Devices.NetworkIdentity
   alias NervesHub.Devices.PinnedDevice
   alias NervesHub.Devices.SharedSecretAuth
@@ -133,10 +134,19 @@ defmodule NervesHub.Devices do
   def filter(product, user, opts) do
     common_filter_query(user)
     |> preload([latest_connection: lc], latest_connection: lc)
-    |> preload([latest_health: lh], latest_health: lh)
+    |> preload(latest_health: ^health_status_query())
     |> preload([deployment_group: dg], deployment_group: dg)
     |> preload([inflight_update: ifu], inflight_update: ifu)
     |> CommonFiltering.filter(product, opts)
+  end
+
+  # The device list renders the health icon and its tooltip, and nothing else
+  # off `latest_health` - but the row carries every metric the device last
+  # reported in `data`. Preloading from a narrowed query rather than the joined
+  # binding leaves that payload in the database. The join itself stays: the
+  # alarm and health status filters read `data` from it in SQL.
+  defp health_status_query() do
+    from(dh in DeviceHealth, select: [:id, :status, :status_reasons])
   end
 
   @spec filter_query(Product.t(), User.t(), map()) :: Ecto.Query.t()

--- a/test/nerves_hub/devices/advanced_query_test.exs
+++ b/test/nerves_hub/devices/advanced_query_test.exs
@@ -133,6 +133,20 @@ defmodule NervesHub.Devices.AdvancedQueryTest do
       assert via_filter(product, user, ~s|health_status = "healthy"|) == ["tagged"]
     end
 
+    # `latest_health` is preloaded from a narrowed query, so the join is the only
+    # thing left serving filters that read `data` in SQL. The compiler tests
+    # supply their own bindings and would not catch the join going away.
+    test "alarm_status reads data off the latest_health join", %{product: product, user: user} do
+      assert via_filter(product, user, ~s|alarm_status = "with"|) == ["tagged"]
+
+      assert via_filter(product, user, ~s|alarm_status = "without"|) ==
+               ["connected", "never_connected", "untagged"]
+    end
+
+    test "alarm reads the alarm name off the latest_health join", %{product: product, user: user} do
+      assert via_filter(product, user, ~s|alarm contains "SomeAlarm"|) == ["tagged"]
+    end
+
     test "connection uses the latest_connection binding", %{product: product, user: user} do
       assert via_filter(product, user, ~s|connection = "connected"|) == ["connected"]
     end

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -2753,6 +2753,45 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
+  describe "filter/3 health preload" do
+    setup %{device: device} do
+      {:ok, _} =
+        Health.save_device_health(%{
+          "device_id" => device.id,
+          "data" => %{"metrics" => %{"cpu_temp" => 41.2}, "alarms" => %{"SomeAlarm" => "boom"}},
+          "status" => "warning",
+          "status_reasons" => %{"warning" => %{"cpu_temp" => %{"value" => 41.2, "threshold" => 40}}}
+        })
+
+      :ok
+    end
+
+    test "loads what the device list renders", %{product: product, user: user, device: device} do
+      health = filtered_health(product, user, device)
+
+      assert health.status == :warning
+      assert health.status_reasons == %{"warning" => %{"cpu_temp" => %{"value" => 41.2, "threshold" => 40}}}
+    end
+
+    # The list only renders the health icon and its tooltip. `data` holds every
+    # metric the device last reported, so it stays in the database - anything
+    # needing it should load the device through `get_by_identifier!/3` instead.
+    test "leaves the metrics payload behind", %{product: product, user: user, device: device} do
+      assert filtered_health(product, user, device).data == nil
+    end
+
+    defp filtered_health(product, user, device) do
+      opts = %{
+        sort: {:asc, :identifier},
+        filters: %{display_deleted: "exclude", identifier: device.identifier}
+      }
+
+      {[%Device{} = filtered], _meta} = Devices.filter(product, user, opts)
+
+      filtered.latest_health
+    end
+  end
+
   def to_device_info(device) do
     %DeviceInfo{
       device_id: device.id,

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -388,6 +388,37 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> refute_has("a", text: device2.identifier)
     end
 
+    # `Devices.filter/3` preloads only the columns behind the health icon and its
+    # tooltip, so this asserts the tooltip still has what it renders from.
+    test "renders the health tooltip from the trimmed preload", %{conn: conn, fixture: fixture} do
+      %{device: device, org: org, product: product, firmware: firmware} = fixture
+
+      healthy = Fixtures.device_fixture(org, product, firmware)
+
+      {:ok, _} =
+        Health.save_device_health(%{
+          "device_id" => healthy.id,
+          "data" => %{"metrics" => %{"cpu_temp" => 41.2}},
+          "status" => :healthy
+        })
+
+      {:ok, _} =
+        Health.save_device_health(%{
+          "device_id" => device.id,
+          "data" => %{"metrics" => %{"cpu_temp" => 41.2}},
+          "status" => :warning,
+          "status_reasons" => %{"warning" => %{"cpu_temp" => %{"value" => 41.2, "threshold" => 40}}}
+        })
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices")
+      |> assert_has("a", text: device.identifier, timeout: 1000)
+      # from `status_reasons`
+      |> assert_has("div", text: "Warning: Cpu Temp: 41.2 (threshold is 40)")
+      # from `status`, when there are no reasons to show
+      |> assert_has("div", text: "Device is healthy.")
+    end
+
     test "by health status", %{conn: conn, fixture: fixture} do
       %{
         device: device,


### PR DESCRIPTION
`Devices.filter/3` preloaded the entire `DeviceHealth` row for every device on the page.

The health extension stores the device's whole report verbatim in `data` (`"data" => device_report` in `NervesHub.Extensions.Health`), so a page of 100 devices pulled 100 complete health reports out of Postgres, kept them in the LiveView's assigns for diff tracking, and re-fetched them on every list refresh. The device list reads two fields off that row, `status` and `status_reasons`, to draw the health icon and its tooltip.

The preload now comes from a narrowed query instead of the joined binding:

```elixir
|> preload(latest_health: ^health_status_query())
```

## What the SQL looks like now

The main select no longer names a single `device_health` column. Before, it carried all six including the `data` JSONB; the join alias now appears only in the `JOIN` and `WHERE`:

```sql
... FROM "devices" AS d0
LEFT OUTER JOIN "device_health" AS d2 ON d2."id" = d0."latest_health_id"
WHERE ... AND (d2."data"->'alarms' != '{}')
```

Health arrives in a second query keyed by the page's ids, which is one round trip regardless of page size rather than one per device:

```sql
SELECT d0."id", d0."status", d0."status_reasons" FROM "device_health" AS d0 WHERE (d0."id" = $1)
```

The trade is one round trip against the JSONB detoast and transfer for up to 100 rows, so the win scales with how much each device reports.

## Why the join stays

`latest_health` serves double duty. The preload wanted two columns, but the alarm and health status filters read `data` off the same binding in SQL, in `DeviceFiltering` and in `AdvancedQuery.Compiler`:

```elixir
where(query, [latest_health: lh], fragment("?->'alarms' != '{}'", lh.data))
```

Narrowing the join would have broken those, so only the preload source changed.

## What still loads the full row

`get_by_identifier!/3` still preloads the full row. The device show page, its health tab, and `Alarms.current_alarms_for_device/1` all read `data`, and they load devices through that path rather than through `filter/3`. `Devices.filter/3` has one caller, the device index LiveView.

`Pinning.get_pinned_devices/1` has the same over-fetch feeding the same component, but it returns a handful of rows, so an extra round trip there is a wash. Left alone.