### PR TITLE
Only re-subscribe the devices that joined or left the page

### DIFF
--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -131,6 +131,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:live_refresh_timer, nil)
     |> assign(:live_refresh_pending?, false)
     |> assign(:received_connection_change_identifiers, %{})
+    |> assign(:subscribed_device_ids, MapSet.new())
     |> assign(:current_alarms, [])
     |> assign(:metrics_keys, [])
     |> assign(:deployment_groups, [])
@@ -841,21 +842,15 @@ defmodule NervesHubWeb.Live.Devices.Index do
     %{devices: old_devices, device_statuses: old_device_statuses, paginate_opts: paginate_opts} =
       socket.assigns
 
-    Enum.each(
-      old_devices.result || [],
-      fn device -> socket.endpoint.unsubscribe("internal:device:#{device.id}") end
-    )
-
     updated_device_statuses =
       Map.new(updated_devices, fn device ->
-        socket.endpoint.subscribe("internal:device:#{device.id}")
-
         status = socket.assigns.received_connection_change_identifiers[device.id]
 
         {device.id, status || Tracker.connection_status(device)}
       end)
 
     socket
+    |> sync_device_subscriptions(updated_devices)
     |> assign(:devices, AsyncResult.ok(old_devices, updated_devices))
     |> assign(:device_statuses, AsyncResult.ok(old_device_statuses, updated_device_statuses))
     |> assign(:received_connection_change_identifiers, %{})
@@ -1268,6 +1263,27 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:selected_have_deployment_groups, has_deployment_groups)
     |> assign(:valid_deployment_groups_for_selected, valid_dgs)
     |> assign(:target_deployment_group, nil)
+  end
+
+  # A refresh usually returns the page it already had, so only the devices that
+  # came or went change hands. Re-subscribing to the whole page each time cost
+  # two registry writes per device for a set that had not moved.
+  #
+  # The subscribed ids are tracked here rather than read back off `:devices`,
+  # which is an `AsyncResult` the display code resets on its own schedule.
+  defp sync_device_subscriptions(socket, devices) do
+    subscribed = socket.assigns.subscribed_device_ids
+    wanted = MapSet.new(devices, & &1.id)
+
+    Enum.each(MapSet.difference(subscribed, wanted), fn device_id ->
+      socket.endpoint.unsubscribe("internal:device:#{device_id}")
+    end)
+
+    Enum.each(MapSet.difference(wanted, subscribed), fn device_id ->
+      socket.endpoint.subscribe("internal:device:#{device_id}")
+    end)
+
+    assign(socket, :subscribed_device_ids, wanted)
   end
 
   defp safe_refresh(socket) do

--- a/test/nerves_hub_web/live/devices/index_subscriptions_test.exs
+++ b/test/nerves_hub_web/live/devices/index_subscriptions_test.exs
@@ -1,0 +1,79 @@
+defmodule NervesHubWeb.Live.Devices.IndexSubscriptionsTest do
+  use NervesHubWeb.ConnCase.Browser, async: true
+  use AssertEventually, timeout: 2000, interval: 50
+
+  import Phoenix.LiveViewTest
+
+  alias NervesHub.Fixtures
+
+  setup %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+    product = Fixtures.product_fixture(user, org, %{name: "Subscriptions"})
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+    devices =
+      for n <- 1..3 do
+        Fixtures.device_fixture(org, product, firmware, %{identifier: "sub-device-#{n}"})
+      end
+
+    %{product: product, devices: devices}
+  end
+
+  test "subscribes once per device on the page", %{conn: conn, org: org, product: product, devices: devices} do
+    {:ok, view, _html} = live(conn, devices_path(org, product))
+
+    for device <- devices do
+      assert_eventually(subscriptions(view.pid, device) == 1)
+    end
+  end
+
+  # A duplicate subscription would have the LiveView handle every event for that
+  # device twice, and each one can trigger a refresh.
+  test "a refresh does not accumulate duplicate subscriptions", %{
+    conn: conn,
+    org: org,
+    product: product,
+    devices: devices
+  } do
+    {:ok, view, _html} = live(conn, devices_path(org, product))
+    [device | _] = devices
+
+    assert_eventually(subscriptions(view.pid, device) == 1)
+
+    send(view.pid, :refresh_device_list)
+    _ = render(view)
+
+    for device <- devices do
+      assert_eventually(subscriptions(view.pid, device) == 1)
+    end
+  end
+
+  test "devices that leave the page are unsubscribed", %{
+    conn: conn,
+    org: org,
+    product: product,
+    devices: devices
+  } do
+    {:ok, view, _html} = live(conn, devices_path(org, product))
+    [kept, dropped, also_dropped] = devices
+
+    for device <- devices do
+      assert_eventually(subscriptions(view.pid, device) == 1)
+    end
+
+    # Patch rather than re-mount, so the filter narrows the page on the same
+    # process that holds the subscriptions.
+    _ = render_patch(view, devices_path(org, product) <> "?identifier=#{kept.identifier}")
+
+    assert_eventually(subscriptions(view.pid, dropped) == 0)
+    assert_eventually(subscriptions(view.pid, also_dropped) == 0)
+    assert subscriptions(view.pid, kept) == 1
+  end
+
+  defp devices_path(org, product), do: "/org/#{org.name}/#{product.name}/devices"
+
+  defp subscriptions(view_pid, device) do
+    NervesHub.PubSub
+    |> Registry.lookup("internal:device:#{device.id}")
+    |> Enum.count(fn {subscriber, _} -> subscriber == view_pid end)
+  end
+end


### PR DESCRIPTION
Every completed device list refresh unsubscribed from all the page's `internal:device:` topics and then subscribed to them again:

```elixir
Enum.each(old_devices.result || [], fn device ->
  socket.endpoint.unsubscribe("internal:device:#{device.id}")
end)

updated_device_statuses =
  Map.new(updated_devices, fn device ->
    socket.endpoint.subscribe("internal:device:#{device.id}")
    ...
  end)
```

A refresh usually returns the page it already had, so at 100 devices that was 200 writes to the partitioned registry to end up exactly where it started. The list refreshes on a one second debounce whenever anything on the product topic fires, so on a busy product that repeats about once a second per viewer.

The refresh now diffs the ids and only touches the devices that came or went.

## Where the subscribed ids live

`sync_device_subscriptions/2` reads what the process holds from its own assign rather than from `:devices`.

`:devices` is an `AsyncResult` the display code resets on its own schedule, and pointing subscription bookkeeping at it would couple the two invisibly. Today the two happen to agree, since `AsyncResult.failed/2` keeps both `result` and `ok?`, so `assign_display_devices/1` does not reset a list that had already loaded. That is a property of a library struct nothing in this file asserts, and it is the kind of thing that changes quietly. A wrong reset would either leak subscriptions or duplicate them, and a duplicate has the LiveView handle every event for that device twice, each of which can trigger its own refresh.

Subscribing is also no longer a side effect tucked inside the `Map.new/2` that builds the status map.