### PR TITLE
Load the device list filter data once instead of on every navigation

### DIFF
--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -750,6 +750,12 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> noreply()
   end
 
+  # Every one of these depends only on the product, so sorting, paging and
+  # filtering the list cannot change them - and `handle_params/3` runs on all
+  # three. Load them once and leave them; a failed load clears `filters_ready?`
+  # and gets retried on the next navigation.
+  defp assign_filter_data(%{assigns: %{filters_ready?: true}} = socket), do: socket
+
   defp assign_filter_data(%{assigns: %{current_scope: %{product: product}}} = socket) do
     socket
     |> start_async(:update_filter_data, fn ->

--- a/test/nerves_hub_web/live/devices/index_filter_data_test.exs
+++ b/test/nerves_hub_web/live/devices/index_filter_data_test.exs
@@ -1,0 +1,73 @@
+defmodule NervesHubWeb.Live.Devices.IndexFilterDataTest do
+  # Not async: counts repo queries via telemetry, which is process-global.
+  use NervesHubWeb.ConnCase.Browser, async: false
+  use AssertEventually, timeout: 2000, interval: 50
+
+  import Phoenix.LiveViewTest
+
+  alias NervesHub.Fixtures
+
+  setup %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+    product = Fixtures.product_fixture(user, org, %{name: "Filter Data"})
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    _device = Fixtures.device_fixture(org, product, firmware, %{tags: ["prod"]})
+
+    %{product: product}
+  end
+
+  # Sorting and paging re-run `handle_params/3`, which used to re-run all of the
+  # filter dropdown queries even though they only depend on the product.
+  test "filter data is loaded once, not on every navigation", %{conn: conn, org: org, product: product} do
+    counter = start_counter()
+    path = "/org/#{org.name}/#{product.name}/devices"
+
+    {:ok, view, _html} = live(conn, path)
+
+    # Both the device list and the filter data are requested from mount.
+    assert_eventually(count(counter, :device_list) == 1)
+    assert_eventually(count(counter, :filter_data) == 1)
+
+    _ = render_patch(view, path <> "?sort=identifier&sort_direction=desc")
+    assert_eventually(count(counter, :device_list) == 2)
+
+    _ = render_patch(view, path <> "?page_number=1&page_size=50")
+    assert_eventually(count(counter, :device_list) == 3)
+
+    # The device list was re-queried twice more, so anything `handle_params/3`
+    # dispatched alongside it has had its chance to run.
+    assert count(counter, :filter_data) == 1
+  end
+
+  defp start_counter() do
+    counter = :counters.new(2, [])
+    handler_id = "filter-data-counter-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:nerves_hub, :repo, :query],
+      fn _event, _measurements, %{query: query}, _config ->
+        cond do
+          # `Devices.distinct_tags/1`, one of the eight filter dropdown queries
+          String.contains?(query, "DISTINCT unnest") ->
+            :counters.add(counter, 2, 1)
+
+          # the paginated device list itself
+          String.contains?(query, ~s|FROM "devices" AS d0 LEFT OUTER JOIN|) and
+              String.contains?(query, "LIMIT") ->
+            :counters.add(counter, 1, 1)
+
+          true ->
+            :ok
+        end
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    counter
+  end
+
+  defp count(counter, :device_list), do: :counters.get(counter, 1)
+  defp count(counter, :filter_data), do: :counters.get(counter, 2)
+end


### PR DESCRIPTION
The data behind the device list's filter dropdowns was loaded from `handle_params/3`, which fires on every sort click, page click, page size change and filter change. Eight lookups, seven of which hit the database, and all of them depend only on the product. Clicking through five pages ran thirty five queries for five identical answers.

```elixir
defp assign_filter_data(%{assigns: %{filters_ready?: true}} = socket), do: socket
```

## What it was costing

Two of the seven are the expensive kind:

- `Metrics.distinct_keys/1` is a `DISTINCT` on `key` over `device_metrics` joined to `devices`. That is the highest volume table in the system, and it has no `product_id` column, so the product filter can only apply after the join. Its indexes are `[device_id, inserted_at]`, `[key, inserted_at]` and `[inserted_at]`, none of which serve this shape.
- `Devices.distinct_tags/1` is a `DISTINCT unnest(tags) ORDER BY unnest(tags)`, which the GIN index on `tags` cannot answer.

`platforms` and `architectures` have expression indexes (`devices_firmware_plat_path_index` and `devices_firmware_arch_path_index`), but Postgres has no loose index scan, so a `DISTINCT` still walks the whole index for the product.

Counting repo telemetry on one navigation with a three term advanced query active, twelve queries went to the database:

| Source | Queries |
|---|---|
| `assign_filter_data/1` | 7 |
| `advanced_query_error/2` in `handle_params/3` | 1 |
| `filter/3`, parse via `references_column?/3` | 1 |
| `filter/3`, parse via `apply_to_query/3` | 1 |
| `filter/3`, the device list and its count | 2 |

Two of the twelve are the device list.

## Staleness

The filter values are now fixed for the life of the mount, so a platform, tag, alarm type or deployment group that appears after the page loads will not show up in the dropdowns until the next full load.

That is already how the sidebar behaves. `available_tags` and `soft_deleted_devices_exist` are loaded once in `mount/3` and never refreshed, and `available_tags` is what fills the filter sidebar's tag list. This makes the rest consistent with it rather than introducing a second model.

Refreshing on the existing sixty second list timer would undo the saving in the other direction: an idle page currently runs these queries zero times after mount, and a timer would make it seven per minute for every open tab. If the dropdowns need to stay fresh, a longer dedicated timer or reloading them when the filter sidebar opens are both better trades than that, and either is a separate change.

## `filters_ready?`

It was assigned in three places and read in none. It already tracked exactly the thing the guard needs, so it now has a reader. The failure path already clears it, so a failed load is retried on the next navigation.