### PR TITLE
Fix the Sentry source code path config key

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -149,7 +149,7 @@ config :phoenix,
 
 config :sentry,
   enable_source_code_context: true,
-  root_source_code_path: [File.cwd!()]
+  root_source_code_paths: [File.cwd!()]
 
 config :swoosh, :api_client, Finch
 


### PR DESCRIPTION
#2922 moved the Sentry source context config into `config/config.exs` and spelled the path option `root_source_code_path`. It's `root_source_code_paths`, plural.

Sentry filters its config with `Keyword.take(@valid_keys)`, so an unknown key is dropped rather than rejected. Nothing warns; `root_source_code_paths` just falls back to its `[]` default and `mix sentry.package_source_code` packages nothing, so Sentry issues arrive without source context.

Verified locally:

```
$ mix sentry.package_source_code --debug
Loaded source code map with 357 files in 325 ms
Encoded source code map in 170 ms
Wrote 357 files in 503.88 kb to: _build/dev/lib/sentry/priv/sentry.map
```

Before the change the same task reports 0 files.
