### PR TITLE
Do not generate deltas for formats that cannot be patched

### DIFF
--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -747,16 +747,44 @@ defmodule NervesHub.Firmwares do
     |> preload([d, p], product: p)
   end
 
+  @doc """
+  Whether this firmware's format can be delta updated at all.
+
+  Distinct from the `delta_updatable` flag on the firmware, which answers for
+  one archive. This answers for the format, and a format that cannot be patched
+  answers no however anything is configured.
+  """
+  @spec delta_capable_format?(Firmware.t()) :: boolean()
+  def delta_capable_format?(firmware) do
+    case UpdateTool.for_firmware(firmware) do
+      {:ok, tool} -> tool.supports_deltas?()
+      {:error, _} -> false
+    end
+  end
+
   @spec attempt_firmware_delta(
           source_id :: non_neg_integer(),
           target_id :: non_neg_integer(),
           recalculate_deployment_statuses :: boolean()
         ) ::
           {:ok, :started}
+          | {:ok, :no_delta_support}
           | {:error, :delta_already_exists}
           | {:error, :failed_to_insert_delta}
           | {:error, :failed_to_insert_job}
   def attempt_firmware_delta(source_id, target_id, recalculate_deployment_statuses \\ true) do
+    # Nothing is recorded for a format that cannot be patched, because nothing
+    # was attempted. Starting one and failing it reads in the UI as "Deltas
+    # failed to generate", which describes a broken build rather than a
+    # deployment group doing exactly what it should.
+    if delta_capable_format?(get_firmware!(target_id)) do
+      do_attempt_firmware_delta(source_id, target_id, recalculate_deployment_statuses)
+    else
+      {:ok, :no_delta_support}
+    end
+  end
+
+  defp do_attempt_firmware_delta(source_id, target_id, recalculate_deployment_statuses) do
     Repo.transact(fn ->
       with {:error, :not_found} <-
              get_firmware_delta_by_source_and_target(source_id, target_id, [:processing, :completed]),

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -638,6 +638,27 @@ defmodule NervesHub.Firmwares do
           :ok
           | {:error, Ecto.Changeset.t() | :no_delta_support_in_firmware}
   def generate_firmware_delta(firmware_delta, source_firmware, target_firmware) do
+    # Whether deltas are *wanted* is a deployment group setting, and whether a
+    # particular archive can be patched is `delta_updatable` on the firmware,
+    # checked when an update is sent. Neither answers whether the format can be
+    # patched at all.
+    #
+    # Without that question, a group with deltas enabled generates patches for
+    # an ESP-IDF image — which no device can apply, so `device_update_type/2`
+    # always sends the full image — and the patch is built, stored, and never
+    # used. It also shows in the UI as though deltas were working.
+    with {:ok, tool} <- UpdateTool.for_firmware(target_firmware) do
+      if tool.supports_deltas?() do
+        do_generate_firmware_delta(firmware_delta, source_firmware, target_firmware)
+      else
+        Logger.info("Skipping delta for #{target_firmware.uuid}: #{target_firmware.tool} images cannot be patched.")
+
+        {:error, :no_delta_support_in_firmware}
+      end
+    end
+  end
+
+  defp do_generate_firmware_delta(firmware_delta, source_firmware, target_firmware) do
     {:ok, work_dir} = Briefly.create(type: :directory)
 
     Logger.info("Creating firmware delta between #{source_firmware.uuid} and #{target_firmware.uuid}.")

--- a/lib/nerves_hub/firmwares/update_tool.ex
+++ b/lib/nerves_hub/firmwares/update_tool.ex
@@ -169,6 +169,16 @@ defmodule NervesHub.Firmwares.UpdateTool do
   @callback cleanup_firmware_delta_files(String.t()) :: :ok
 
   @doc """
+  Whether this format can be delta updated at all.
+
+  Distinct from `c:delta_updatable?/1`, which answers for one archive: this
+  answers for the format. A tool returning false never has deltas generated for
+  it, however a deployment group is configured — generating a patch nothing can
+  apply costs worker time and object storage and reports success in the UI.
+  """
+  @callback supports_deltas?() :: boolean()
+
+  @doc """
   Checks whether delta updating is enabled for the firmware the metadata describes.
 
   Takes the map returned by `c:get_firmware_metadata_from_file/1` so that a tool

--- a/lib/nerves_hub/firmwares/update_tool/esp_idf.ex
+++ b/lib/nerves_hub/firmwares/update_tool/esp_idf.ex
@@ -390,6 +390,12 @@ defmodule NervesHub.Firmwares.UpdateTool.EspIdf do
     ]
   end
 
+  # Nothing on the device applies a patch to an OTA slot, so no ESP-IDF image can
+  # be delta updated regardless of how it was built or which deployment group it
+  # belongs to.
+  @impl UpdateTool
+  def supports_deltas?(), do: false
+
   @impl UpdateTool
   def delta_updatable?(_metadata) do
     # False until a device agent can apply a patch. Reporting `true` would have
@@ -407,6 +413,10 @@ defmodule NervesHub.Firmwares.UpdateTool.EspIdf do
     :full
   end
 
+  # Kept working, but not reached: `delta_updatable?/1` reports false, so
+  # `Firmwares.generate_firmware_delta/3` refuses before getting here. The
+  # implementation stays because the missing piece is on the device — nothing
+  # applies an xdelta3 patch to an OTA slot yet — and not in the generation.
   @impl UpdateTool
   def create_firmware_delta_file({_source_uuid, source_url}, {target_uuid, target_url}, work_dir) do
     source_path = Path.join(work_dir, "source.bin") |> Path.expand()

--- a/lib/nerves_hub/firmwares/update_tool/fwup.ex
+++ b/lib/nerves_hub/firmwares/update_tool/fwup.ex
@@ -166,6 +166,9 @@ defmodule NervesHub.Firmwares.UpdateTool.Fwup do
   end
 
   @impl UpdateTool
+  def supports_deltas?(), do: true
+
+  @impl UpdateTool
   def delta_updatable?(%{path: meta_conf_path}) do
     {:ok, feature_usage} = Confuse.Fwup.get_feature_usage(meta_conf_path)
 

--- a/lib/nerves_hub/managed_deployments.ex
+++ b/lib/nerves_hub/managed_deployments.ex
@@ -446,7 +446,7 @@ defmodule NervesHub.ManagedDeployments do
   defp maybe_trigger_delta_generation(_deployment_group, _changeset), do: {:ok, :no_deltas_started}
 
   @spec trigger_delta_generation_for_deployment_group(DeploymentGroup.t()) ::
-          {:ok, :deltas_started | :deltas_already_generated | :some_deltas_started}
+          {:ok, :deltas_started | :deltas_already_generated | :some_deltas_started | :no_delta_support}
           | {:error, :deltas_not_enabled | :delta_generation_failed}
   def trigger_delta_generation_for_deployment_group(%{delta_updatable: false}) do
     {:error, :deltas_not_enabled}
@@ -460,6 +460,7 @@ defmodule NervesHub.ManagedDeployments do
     |> then(fn results ->
       cond do
         Enum.any?(results, &match?({:error, _}, &1)) -> {:error, :delta_generation_failed}
+        Enum.all?(results, &match?({:ok, :no_delta_support}, &1)) -> {:ok, :no_delta_support}
         Enum.all?(results, &match?({:ok, :delta_already_exists}, &1)) -> {:ok, :deltas_already_generated}
         not Enum.any?(results, &match?({:ok, :delta_already_exists}, &1)) -> {:ok, :deltas_started}
         true -> {:ok, :some_deltas_started}

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -430,6 +430,35 @@ defmodule NervesHub.FirmwaresTest do
     end
   end
 
+  describe "generate_firmware_delta/3 for a format that cannot be patched" do
+    @tag :tmp_dir
+    test "refuses, without downloading either image", %{
+      firmware: source,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      # An ESP-IDF image can never be patched — nothing on the device applies
+      # one — so a deployment group with deltas enabled must not have patches
+      # built for it. Downloading is what makes that expensive: two full images
+      # fetched to produce a file that is never sent.
+      {:ok, target} =
+        target
+        |> Ecto.Changeset.change(%{tool: "esp-idf"})
+        |> Repo.update()
+
+      reject(&UploadFile.download_file/1)
+      reject(&UpdateToolDefault.create_firmware_delta_file/3)
+
+      assert {:ok, firmware_delta} = Firmwares.start_firmware_delta(source.id, target.id)
+
+      assert {:error, :no_delta_support_in_firmware} =
+               Firmwares.generate_firmware_delta(firmware_delta, source, target)
+    end
+  end
+
   describe "create_firmware_delta/2" do
     @tag :tmp_dir
     test "creates a new firmware delta when one doesn't exist, and saves the checksum and partials checksums", %{

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -705,6 +705,32 @@ defmodule NervesHub.FirmwaresTest do
 
       {:ok, :delta_already_exists} = Firmwares.attempt_firmware_delta(source.id, target.id)
     end
+
+    # An ESP-IDF image can never be patched, so there is nothing to record. A
+    # started-then-failed delta reads in the UI as "Deltas failed to generate",
+    # and -- worse -- leaves the deployment group in `:deltas_failed`, where the
+    # orchestrator refuses to send anything at all. A group of ESP32s would
+    # silently stop receiving updates because of a patch that was never possible.
+    test "it records nothing for a format that cannot be patched", %{
+      firmware: source,
+      org_key: org_key,
+      product: product,
+      tmp_dir: tmp_dir
+    } do
+      target = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      {:ok, target} =
+        target
+        |> Ecto.Changeset.change(%{tool: "esp-idf"})
+        |> Repo.update()
+
+      assert {:ok, :no_delta_support} = Firmwares.attempt_firmware_delta(source.id, target.id)
+
+      assert {:error, :not_found} =
+               Firmwares.get_firmware_delta_by_source_and_target(source.id, target.id)
+
+      assert [] = all_enqueued(worker: FirmwareDeltaBuilder)
+    end
   end
 
   describe "get_firmwares_by_product_and_platform/2" do


### PR DESCRIPTION
A deployment group with delta updates enabled generated xdelta3 patches for ESP-IDF firmware. Nothing on the device can apply one — `device_update_type/2` always returns `:full` — so each patch was built, uploaded, and never sent. It also showed in the UI as though deltas were working.

Found by watching it happen: creating a release on a deployment group with `delta_updatable: true` queued a `FirmwareDeltaBuilder` job for two ESP-IDF images.

## Three questions, one of which nobody was asking

| Question | Where it lives | Consulted |
| --- | --- | --- |
| Are deltas wanted? | `deployment_groups.delta_updatable` | yes, before generating |
| Can *this archive* be patched? | `firmwares.delta_updatable` | yes, when an update is sent |
| Can this **format** be patched at all? | nowhere | — |

The third is the one that rules out ESP-IDF no matter how a group is configured, so the update tool now answers it: `supports_deltas?/0`, true for fwup and false for ESP-IDF. Generation refuses before either image is downloaded, returning the same `:no_delta_support_in_firmware` the fwup path already returns and the delta builder already discards on.

## Why not gate on `firmwares.delta_updatable`

That was my first attempt, and the existing tests rejected it: fwup archives built without delta support have patches generated for them today, and several tests depend on that. Narrowing it would be a change to fwup's behaviour rather than a fix for this bug — worth discussing separately, since those patches presumably cannot be sent either.