### PR TITLE
Fix several paths where memory grows and is never released

### DIFF
--- a/lib/nerves_hub/fwup.ex
+++ b/lib/nerves_hub/fwup.ex
@@ -28,17 +28,20 @@ defmodule NervesHub.Fwup do
     end
   end
 
+  # Every `meta-*` key in the file used to be atomised here, and only then did
+  # `transform_to_struct/1` throw the unrecognised ones away. Atoms are never
+  # reclaimed, so a firmware carrying arbitrary metadata keys left the node
+  # permanently heavier -- and enough of them would exhaust the atom table.
+  # Match against the names we actually keep instead, and mint nothing.
   defp parse_metadata(metadata) do
+    known = Map.new(Metadata.keys(), &{Atom.to_string(&1), &1})
+
     Regex.scan(~r/meta-(?<key>[^\n]+)=\"?(?<value>[^\"\n]+)/, metadata)
-    |> Enum.reduce(%{}, fn line, acc ->
-      [_, key, value] = line
-
-      key =
-        key
-        |> String.replace("-", "_")
-        |> String.to_atom()
-
-      Map.put(acc, key, value)
+    |> Enum.reduce(%{}, fn [_, key, value], acc ->
+      case Map.fetch(known, String.replace(key, "-", "_")) do
+        {:ok, key} -> Map.put(acc, key, value)
+        :error -> acc
+      end
     end)
   end
 

--- a/lib/nerves_hub/metrics_poller.ex
+++ b/lib/nerves_hub/metrics_poller.ex
@@ -11,9 +11,22 @@ defmodule NervesHub.MetricsPoller do
   def report_device_count() do
     # an ugly way to get the connected device count for a node
     # (we can't use the device registry because it's been removed)
+    #
+    # Ask for the dictionary alone. `Process.info/1` returns sixteen items --
+    # including `links` and the `garbage_collection` keyword list -- and copies
+    # all of them into this process. On a node holding a device channel per
+    # device that ran to millions of terms allocated here every minute, and a
+    # process heap that stays inflated until it happens to full-sweep.
     device_count =
-      Enum.count(Process.list(), fn p ->
-        Process.info(p)[:dictionary][:"$initial_call"] == {NervesHubWeb.DeviceChannel, :join, 3}
+      Enum.count(Process.list(), fn pid ->
+        case Process.info(pid, :dictionary) do
+          {:dictionary, dictionary} ->
+            dictionary[:"$initial_call"] == {NervesHubWeb.DeviceChannel, :join, 3}
+
+          # the process exited while we were walking the list
+          nil ->
+            false
+        end
       end)
 
     :telemetry.execute([:nerves_hub, :devices, :online], %{count: device_count}, %{node: node()})

--- a/lib/nerves_hub/scripts/runner.ex
+++ b/lib/nerves_hub/scripts/runner.ex
@@ -17,25 +17,33 @@ defmodule NervesHub.Scripts.Runner do
   alias NervesHubWeb.Endpoint
   alias Phoenix.Socket.Broadcast
 
+  @default_timeout to_timeout(second: 30)
+
+  # The runner outlives the caller's deadline by this much, so a caller that is
+  # still waiting always ends the call on its own `GenServer.call` timeout. The
+  # deadline below is a backstop for the runner itself, not the usual path.
+  @deadline_grace to_timeout(second: 1)
+
   defmodule State do
-    defstruct [:buffer, :device_channel, :from, :receive_channel, :send_channel, :text]
+    defstruct [:buffer, :device_channel, :from, :receive_channel, :send_channel, :text, :timeout]
   end
 
-  def send(device, command, timeout \\ to_timeout(second: 30)) do
-    {:ok, pid} = start_link(device)
+  def send(device, command, timeout \\ @default_timeout) do
+    {:ok, pid} = start_link(device, timeout)
     {:ok, GenServer.call(pid, {:send, command.text}, timeout)}
   catch
     :exit, _ -> {:error, "device did not respond in #{timeout} milliseconds"}
   end
 
-  def start_link(device) do
-    GenServer.start_link(__MODULE__, device.id)
+  def start_link(device, timeout \\ @default_timeout) do
+    GenServer.start_link(__MODULE__, {device.id, timeout})
   end
 
-  def init(device_id) do
+  def init({device_id, timeout}) do
     state = %State{
       buffer: <<>>,
       from: nil,
+      timeout: timeout,
       device_channel: "device:#{device_id}",
       receive_channel: "user:console:#{device_id}",
       send_channel: "device:console:#{device_id}"
@@ -51,6 +59,14 @@ defmodule NervesHub.Scripts.Runner do
       state.device_channel,
       {:run_script, self(), text}
     )
+
+    # Nothing is guaranteed to answer: the device may be offline, so the
+    # broadcast reaches nobody, or it may be too old to run scripts, in which
+    # case we fall back to scraping the console for output that never arrives.
+    # `send/3` catches its own call timeout, so without this the runner was left
+    # running for the life of the node -- holding a console subscription and
+    # appending every line the device printed to `buffer`.
+    _ = Process.send_after(self(), :deadline, state.timeout + @deadline_grace)
 
     {:noreply, %{state | from: from, text: text}}
   end
@@ -89,6 +105,10 @@ defmodule NervesHub.Scripts.Runner do
       {:noreply, state}
     end
   end
+
+  # The caller has already given up by now (see `@deadline_grace`), so there is
+  # nobody left to reply to.
+  def handle_info(:deadline, state), do: {:stop, :normal, state}
 
   def handle_info(_, state), do: {:noreply, state}
 end

--- a/lib/nerves_hub/uploads.ex
+++ b/lib/nerves_hub/uploads.ex
@@ -77,6 +77,8 @@ defmodule NervesHub.Uploads.S3 do
 
   alias ExAws.S3
 
+  @upload_timeout to_timeout(minute: 1)
+
   def bucket() do
     Application.get_env(:nerves_hub, __MODULE__)[:bucket]
   end
@@ -93,8 +95,14 @@ defmodule NervesHub.Uploads.S3 do
 
   @impl NervesHub.Uploads
   def upload(file_path, key, opts) do
-    bucket()
-    |> S3.put_object(key, File.read!(file_path), Keyword.get(opts, :meta, []))
+    # Stream the file up in parts rather than reading it whole. Archives and
+    # firmware images run to tens of megabytes, and `File.read!/1` put the
+    # entire thing in the calling process as one binary -- a spike the size of
+    # the file per upload, several times that when a few land together.
+    # `NervesHub.Firmwares.Upload.S3` already uploads this way.
+    file_path
+    |> S3.Upload.stream_file()
+    |> S3.upload(bucket(), key, [timeout: @upload_timeout] ++ Keyword.take(opts, [:meta]))
     |> ExAws.request!()
 
     :ok

--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -2,12 +2,13 @@
 defmodule NervesHubWeb.ConsoleChannel do
   use Phoenix.Channel
 
+  alias NervesHubWeb.Channels.Scrollback
   alias Phoenix.Socket.Broadcast
 
   def join("console", payload, socket) do
     send(self(), {:after_join, payload})
 
-    {:ok, assign(socket, %{current_line: "", buffer: CircularBuffer.new(1024)})}
+    {:ok, assign(socket, :scrollback, Scrollback.new())}
   end
 
   def terminate(_, _socket) do
@@ -15,18 +16,8 @@ defmodule NervesHubWeb.ConsoleChannel do
   end
 
   def handle_in("up", payload, socket) do
-    current_line = socket.assigns.current_line <> payload["data"]
-    [current_line | lines] = Enum.reverse(String.split(current_line, "\n"))
-
-    buffer =
-      Enum.reduce(Enum.reverse(lines), socket.assigns.buffer, fn line, buffer ->
-        CircularBuffer.insert(buffer, line <> "\n")
-      end)
-
-    socket =
-      socket
-      |> assign(:current_line, current_line)
-      |> assign(:buffer, buffer)
+    scrollback = Scrollback.append(socket.assigns.scrollback, payload["data"])
+    socket = assign(socket, :scrollback, scrollback)
 
     user_topic(socket)
     |> socket.endpoint.broadcast!("up", payload)
@@ -78,8 +69,7 @@ defmodule NervesHubWeb.ConsoleChannel do
     metadata = %{version: socket.assigns.version}
     send(pid, {:metadata, metadata})
 
-    lines = Enum.join(socket.assigns.buffer) <> socket.assigns.current_line
-    send(pid, {:cache, lines})
+    send(pid, {:cache, Scrollback.text(socket.assigns.scrollback)})
 
     {:noreply, socket}
   end

--- a/lib/nerves_hub_web/channels/scrollback.ex
+++ b/lib/nerves_hub_web/channels/scrollback.ex
@@ -15,6 +15,12 @@ defmodule NervesHubWeb.Channels.Scrollback do
 
   @default_lines 1024
 
+  # Only a newline moves output into the bounded buffer, so a device that never
+  # sends one -- a `\r` progress bar, a loop of `IO.write/1`, raw bytes -- grew
+  # `current_line` without limit inside a process that lives as long as the
+  # connection. Past this many bytes we bank what we have and carry on.
+  @max_line_bytes 1024
+
   @spec new(pos_integer()) :: t()
   def new(lines \\ @default_lines), do: %__MODULE__{buffer: CircularBuffer.new(lines)}
 
@@ -34,8 +40,24 @@ defmodule NervesHubWeb.Channels.Scrollback do
       |> Enum.reverse()
       |> Enum.reduce(scrollback.buffer, &CircularBuffer.insert(&2, &1 <> "\n"))
 
-    %{scrollback | current_line: current_line, buffer: buffer}
+    bank_overlong_line(%{scrollback | current_line: current_line, buffer: buffer})
   end
+
+  # Banked pieces carry no newline of their own, so `text/1` still stitches the
+  # original stream back together. Splitting on graphemes rather than bytes
+  # keeps the pieces from cutting a codepoint in half; the guard stays on
+  # `byte_size/1` because it runs on every line of output.
+  defp bank_overlong_line(%__MODULE__{current_line: line} = scrollback) when byte_size(line) >= @max_line_bytes do
+    {banked, rest} = String.split_at(line, @max_line_bytes)
+
+    bank_overlong_line(%{
+      scrollback
+      | current_line: rest,
+        buffer: CircularBuffer.insert(scrollback.buffer, banked)
+    })
+  end
+
+  defp bank_overlong_line(scrollback), do: scrollback
 
   @doc "Everything recorded, including the line still being written."
   @spec text(t()) :: String.t()

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -3,6 +3,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
 
   alias NervesHub.Devices.Metrics
   alias NervesHub.Products
+  alias Phoenix.LiveView.AsyncResult
 
   @time_frame_opts [
     {"hour", 3},
@@ -45,27 +46,54 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   @tick_interval 55_000
 
   def tab_params(_params, _uri, socket) do
-    _ = if connected?(socket), do: Process.send_after(self(), :tick, @tick_interval)
-
     socket
+    |> schedule_tick()
     |> update_from_and_until_timestamps()
     |> assign(:time_frame_opts, @time_frame_opts)
     |> assign(:latest_metrics, Metrics.get_latest_metric_set(socket.assigns.device.id))
     |> assign(:custom_health_labels, Products.custom_health_metrics_labels(socket.assigns.product))
     |> assign(:editing_label_key, nil)
+    |> assign(:chart_data, %{})
+    |> assign(:has_chart_data, %{})
     |> async_assign_charts()
     |> cont()
   end
 
   def cleanup() do
-    [:time_frame, :time_frame_opts, :charts, :custom_health_labels, :editing_label_key]
+    [
+      :time_frame,
+      :time_frame_opts,
+      :charts,
+      :chart_data,
+      :has_chart_data,
+      :custom_health_labels,
+      :editing_label_key
+    ]
+  end
+
+  def hooked_async("load_chart:" <> key, {:ok, results}, socket) do
+    socket
+    |> put_chart_data(key, AsyncResult.ok(chart_data(socket, key), results))
+    |> halt()
+  end
+
+  def hooked_async("load_chart:" <> key, {:exit, reason}, socket) do
+    _ =
+      Sentry.capture_message("Unexpected error when loading device health charts",
+        extra: %{key: key, reason: reason},
+        result: :none
+      )
+
+    socket
+    |> put_chart_data(key, AsyncResult.failed(chart_data(socket, key), {:exit, reason}))
+    |> halt()
   end
 
   def hooked_async("update_chart:" <> key, {:ok, results}, socket) do
     {from, until} = fetch_from_and_until(socket)
 
     socket
-    |> assign(has_chart_data_key(key), Enum.any?(results))
+    |> put_has_chart_data(key, Enum.any?(results))
     |> push_event("update-charts", %{
       key: key,
       data: results,
@@ -158,16 +186,15 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
 
         socket
         |> push_event("add-data-point", %{key: key, data: data, from: from, until: until})
-        |> assign(has_chart_data_key(key), true)
+        |> put_has_chart_data(key, true)
       end)
     end
     |> halt()
   end
 
   def hooked_info(:tick, socket) do
-    Process.send_after(self(), :tick, @tick_interval)
-
     socket
+    |> schedule_tick()
     |> update_from_and_until_timestamps()
     |> then(fn socket ->
       {from, until} = fetch_from_and_until(socket)
@@ -307,7 +334,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
               </div>
             </div>
             <div class="relative flex h-[200px] w-full">
-              <.async_result :let={chart_data} assign={assigns[chart_data_key(key)]}>
+              <.async_result :let={chart_data} assign={@chart_data[key]}>
                 <:loading>
                   <div class="bg-base-900/70 absolute inset-0 flex items-center justify-center">
                     <span class="text-base-500 font-extralight">Loading history for {key}...</span>
@@ -330,7 +357,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
                   data-maxtime={Jason.encode!(@charts_until_timestamp)}
                   data-unit="minute"
                 ></canvas>
-                <div :if={not assigns[has_chart_data_key(key)] && Enum.empty?(chart_data)} class="bg-base-900/70 absolute inset-0 flex items-center justify-center">
+                <div :if={!@has_chart_data[key] && Enum.empty?(chart_data)} class="bg-base-900/70 absolute inset-0 flex items-center justify-center">
                   <span class="text-base-500 font-extralight">No metrics for {key} found for the selected period.</span>
                 </div>
               </.async_result>
@@ -409,10 +436,9 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     |> metrics_to_chart()
     |> Enum.reduce(socket, fn key, socket ->
       socket
-      |> assign_async(chart_data_key(key), fn ->
-        {:ok, %{chart_data_key(key) => formatted_metrics(device_id, key, time_frame)}}
-      end)
-      |> assign(has_chart_data_key(key), false)
+      |> put_chart_data(key, AsyncResult.loading())
+      |> put_has_chart_data(key, false)
+      |> start_async("load_chart:#{key}", fn -> formatted_metrics(device_id, key, time_frame) end)
     end)
   end
 
@@ -492,6 +518,22 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     |> chart_title()
   end
 
+  # `tab_params/3` runs from a `:handle_params` hook, so it fires again every
+  # time the user navigates back onto this tab. A tick left over from an earlier
+  # visit that lands while the tab is open re-arms itself alongside the new one,
+  # and from then on both chains run for the life of the LiveView. Hold the ref
+  # so a stale tick can be cancelled -- which is also why `:tick_timer` is not
+  # in `cleanup/0`; dropping it would lose the only handle we have on it.
+  defp schedule_tick(socket) do
+    _ = if ref = socket.assigns[:tick_timer], do: Process.cancel_timer(ref)
+
+    if connected?(socket) do
+      assign(socket, :tick_timer, Process.send_after(self(), :tick, @tick_interval))
+    else
+      assign(socket, :tick_timer, nil)
+    end
+  end
+
   defp get_time_unit({"hour", _}), do: "minute"
   defp get_time_unit({"day", 1}), do: "hour"
   defp get_time_unit({"day", _}), do: "day"
@@ -509,8 +551,21 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     |> String.capitalize()
   end
 
-  defp chart_data_key(key), do: String.to_atom("#{key}_chart_data")
-  defp has_chart_data_key(key), do: String.to_atom("#{key}_has_chart_data")
+  # Charts are keyed by metric name, and metric names come from the device --
+  # `Extensions.Health` stores whatever keys a report carries. Deriving an
+  # assign key per metric meant `String.to_atom/1` on device-controlled input,
+  # and atoms are never reclaimed, so a fleet reporting novel keys made every
+  # node that rendered this tab permanently heavier. A map keyed by the string
+  # mints nothing.
+  defp chart_data(socket, key), do: Map.get(socket.assigns.chart_data, key, AsyncResult.loading())
+
+  defp put_chart_data(socket, key, result) do
+    assign(socket, :chart_data, Map.put(socket.assigns.chart_data, key, result))
+  end
+
+  defp put_has_chart_data(socket, key, has_data?) do
+    assign(socket, :has_chart_data, Map.put(socket.assigns.has_chart_data, key, has_data?))
+  end
 
   defp validate_time_unit(unit) when unit in ~w(hour day minute second), do: unit
   defp validate_time_unit(_unit), do: elem(@default_time_frame, 0)

--- a/lib/nerves_hub_web/controllers/api/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/api/device_controller.ex
@@ -45,8 +45,7 @@ defmodule NervesHubWeb.API.DeviceController do
 
     opts =
       if sort_field = Map.get(params, "sort") do
-        sort_direction = Map.get(params, "sort_direction", "asc")
-        Map.put(opts, :sort, {String.to_atom(sort_direction), String.to_existing_atom(sort_field)})
+        Map.put(opts, :sort, {sort_direction(params), String.to_existing_atom(sort_field)})
       else
         opts
       end
@@ -216,6 +215,19 @@ defmodule NervesHubWeb.API.DeviceController do
           # fallback controller will render this
           {:error, changeset}
       end
+    end
+  end
+
+  # `sort_direction` arrives as a raw query param — the OpenAPI spec types it as
+  # a free-form string and nothing casts it before we get here. Running it
+  # through `String.to_atom/1` minted a permanent atom per distinct value, so
+  # anyone with `org: :view` could grow the atom table until the node hit the
+  # limit and aborted. Only two directions mean anything; everything else is
+  # the default.
+  defp sort_direction(params) do
+    case Map.get(params, "sort_direction") do
+      "desc" -> :desc
+      _ -> :asc
     end
   end
 end

--- a/test/nerves_hub/scripts/runner_test.exs
+++ b/test/nerves_hub/scripts/runner_test.exs
@@ -1,0 +1,45 @@
+defmodule NervesHub.Scripts.RunnerTest do
+  use ExUnit.Case, async: true
+
+  alias NervesHub.Scripts.Runner
+
+  # `Runner.send/3` only reads `device.id` and `command.text`, so there is no
+  # need to put either in the database to exercise the runner itself.
+  defp device(), do: %{id: System.unique_integer([:positive])}
+
+  defp start_runner(device, timeout) do
+    :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, "device:#{device.id}")
+
+    # `Task.async` stands in for the callers that leaked runners: it exits
+    # `:normal` once the call returns, which a linked runner ignores.
+    task = Task.async(fn -> Runner.send(device, %{text: "IO.puts(:hi)"}, timeout) end)
+
+    assert_receive {:run_script, runner, "IO.puts(:hi)"}, 1_000
+
+    {task, runner}
+  end
+
+  test "stops itself when nothing answers the script" do
+    device = device()
+    {task, runner} = start_runner(device, 50)
+    ref = Process.monitor(runner)
+
+    assert {:error, message} = Task.await(task, 5_000)
+    assert message =~ "did not respond"
+
+    # Before the deadline was added the runner outlived its caller for the life
+    # of the node, holding a console subscription and buffering device output.
+    assert_receive {:DOWN, ^ref, :process, ^runner, :normal}, 5_000
+  end
+
+  test "returns the device's output and stops" do
+    device = device()
+    {task, runner} = start_runner(device, to_timeout(second: 5))
+    ref = Process.monitor(runner)
+
+    send(runner, {:output, "hello from the device"})
+
+    assert {:ok, "hello from the device"} = Task.await(task, 5_000)
+    assert_receive {:DOWN, ^ref, :process, ^runner, :normal}, 1_000
+  end
+end

--- a/test/nerves_hub_web/channels/scrollback_test.exs
+++ b/test/nerves_hub_web/channels/scrollback_test.exs
@@ -1,0 +1,46 @@
+defmodule NervesHubWeb.Channels.ScrollbackTest do
+  use ExUnit.Case, async: true
+
+  alias NervesHubWeb.Channels.Scrollback
+
+  defp append_all(scrollback, chunks), do: Enum.reduce(chunks, scrollback, &Scrollback.append(&2, &1))
+
+  describe "append/2" do
+    test "holds the line still being written and replays it with the rest" do
+      scrollback = append_all(Scrollback.new(), ["one\ntw", "o\nthree"])
+
+      assert Scrollback.text(scrollback) == "one\ntwo\nthree"
+    end
+
+    test "drops the oldest lines once the buffer is full" do
+      scrollback = append_all(Scrollback.new(2), ["a\n", "b\n", "c\n"])
+
+      assert Scrollback.text(scrollback) == "b\nc\n"
+    end
+
+    test "bounds output that never sends a newline" do
+      # A `\r` progress bar or a loop of `IO.write/1` used to grow the held line
+      # without limit, in a process that lives as long as the connection.
+      scrollback = append_all(Scrollback.new(4), List.duplicate(String.duplicate("x", 500), 40))
+
+      assert byte_size(Scrollback.text(scrollback)) < 20_000
+    end
+
+    test "banked pieces still reconstruct the original stream" do
+      data = String.duplicate("y", 2_500)
+      scrollback = append_all(Scrollback.new(), [data])
+
+      assert Scrollback.text(scrollback) == data
+    end
+
+    test "does not split a multibyte codepoint across pieces" do
+      data = String.duplicate("é", 2_000)
+      scrollback = append_all(Scrollback.new(), [data])
+
+      text = Scrollback.text(scrollback)
+
+      assert String.valid?(text)
+      assert text == data
+    end
+  end
+end

--- a/test/nerves_hub_web/live/devices/show/health_tab_test.exs
+++ b/test/nerves_hub_web/live/devices/show/health_tab_test.exs
@@ -328,6 +328,36 @@ defmodule NervesHubWeb.Live.Devices.Show.HealthTabTest do
     end
   end
 
+  test "rendering a device-reported metric key mints no atoms", %{
+    conn: conn,
+    org: org,
+    product: product,
+    device: device
+  } do
+    # Metric keys are whatever the device put in its health report, and atoms
+    # are never reclaimed -- so deriving assign keys from them used to make the
+    # node permanently heavier for every novel key a fleet reported.
+    key = "totally_novel_metric_#{System.unique_integer([:positive])}"
+
+    {1, _} =
+      Repo.insert_all(DeviceMetric, [
+        DeviceMetric.save_with_timestamp(%{
+          device_id: device.id,
+          key: key,
+          value: 12.5,
+          inserted_at: DateTime.now!("Etc/UTC")
+        }).changes
+      ])
+
+    before_count = :erlang.system_info(:atom_count)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}/health")
+    |> assert_has("##{key}-chart", timeout: 100)
+
+    assert :erlang.system_info(:atom_count) == before_count
+  end
+
   defp save_metrics_with_timestamp(device_id, timestamp) do
     entries =
       Enum.map(@metrics, fn {key, val} ->


### PR DESCRIPTION
Fixes for memory that grows and never comes back, found by reading the device link, the channels, the LiveViews, and the long-lived OTP processes. Each commit stands alone.

## Atoms

Atoms are never garbage collected, and the table has a hard limit. Past it the VM aborts. Three paths derived atoms from strings someone else controls.

The one that matters most is the devices API: `sort_direction` went through `String.to_atom/1`, it is a raw query param, the OpenAPI spec types it as a free-form string, and no cast plug runs. Anyone with `org: :view` could mint an atom per request in a loop.

The other two are slower. `Fwup.parse_metadata/1` atomised every `meta-*` key in an uploaded firmware file and only then discarded the unrecognised ones. And the device health tab built two assign keys per metric out of the metric name. Those names come from the device, and `Extensions.Health` stores whatever a report carries.

The health tab needed the most work: `assign_async` requires an atom, so the initial chart load moved to `start_async` with a string name and manages its own `AsyncResult`. The file already named an async that way for `update_chart:`, so the pattern was there.

## A leaked process per unanswered script

`Scripts.Runner.send/3` catches its own `GenServer.call` timeout. The caller therefore never dies, no exit signal reaches the linked runner, and the runner has no deadline of its own, so it ran until the node restarted.

This is the ordinary path, not an edge case. Running a script against an offline device means the broadcast reaches nobody; the API endpoint renders "device not available or responding" and leaves a process behind. The LiveView caller is worse, since `start_async` tasks exit `:normal` and linked processes ignore that. On the console-fallback path the orphan also held a PubSub subscription and appended every line the device printed to its buffer.

## Console output with no newline in it

Only a newline moved output into the bounded `CircularBuffer`, so the line still being written grew without limit inside a process that lives as long as the connection. A `\r` progress bar or a loop of `IO.write/1` is enough. The scrollback moduledoc budgets around 89KB for a full buffer, which that assumption breaks.

`ConsoleChannel` had its own copy of this logic, predating `Scrollback` and identical to it down to the buffer size, so it now uses `Scrollback` rather than carrying the same bug separately.

## Allocation churn

`MetricsPoller` walks every process once a minute asking for `Process.info/1`, which returns sixteen items, `links` and the `garbage_collection` keyword list among them, and copies all of them into the poller. On a device node that is millions of terms a minute, in one long-lived process whose heap stays inflated. It only reads `:dictionary`.

`Uploads.S3.upload/3` read whole firmware and archive images into memory before uploading. It now streams, the way `Firmwares.Upload.S3` already did.

## Also fixed

The health tab's 55s tick is armed from a `:handle_params` hook, so it fired again every time you navigated back onto the tab. A leftover tick landing while the tab was open re-armed itself alongside the new one and both chains ran for the life of the LiveView. It now holds the ref and cancels a stale one first.

