### PR TITLE
Cut device node memory: zlib contexts and allocator retention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,18 @@ ENV LC_ALL=en_US.UTF-8
 COPY --from=jemalloc /usr/local/lib/libjemalloc.so.2 /usr/local/lib/libjemalloc.so.2
 ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
 
+# jemalloc was preloaded but never configured, so it ran on defaults: one arena
+# per CPU times four, each holding onto its own freed pages, and purging only
+# when allocation traffic happens to drive the decay. On a device node that
+# left ~395MB of a 1.2GB RSS as memory the BEAM had already freed.
+#
+# Fewer arenas concentrates that retention, and the shorter decay returns pages
+# sooner. `background_thread` would purge on a timer instead of on allocation
+# traffic and would help more, but this image shells out to fwup and detools,
+# and jemalloc background threads across fork have a bad history -- so it stays
+# off.
+ENV MALLOC_CONF=narenas:4,dirty_decay_ms:5000,muzzy_decay_ms:5000
+
 # Copy over the statically built fwup
 COPY --from=fwup /usr/local/bin/fwup /usr/local/bin/fwup
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -225,6 +225,22 @@ if config_env() == :prod do
         http_options: [
           log_protocol_errors: false
         ],
+        # The sockets set `compress: true`, so Bandit builds a zlib deflate and
+        # inflate context per connection and holds both for as long as the
+        # device stays connected. At the default mem_level of 8 the deflate
+        # hash table alone is 128KB, and measured end to end that is 271KB per
+        # device -- around 375MB of `:erlang.memory(:system)` on a node holding
+        # 1400 devices.
+        #
+        # Device frames are small and repetitive, so the hash table buys
+        # nothing here: over a representative mix of heartbeats, progress and
+        # health reports, mem_level 4 emits byte-identical output to mem_level
+        # 8. It costs 121KB less per connection.
+        #
+        # This has to live in Bandit's server-wide `websocket_options`. Bandit
+        # reads `deflate_options` from there, not from the per-socket
+        # `websocket:` list in the endpoint.
+        websocket_options: [deflate_options: [mem_level: 4]],
         thousand_island_options: [
           transport_module: NervesHub.DeviceSSLTransport,
           transport_options: transport_options

--- a/lib/nerves_hub_web/channels/effects.ex
+++ b/lib/nerves_hub_web/channels/effects.ex
@@ -27,6 +27,32 @@ defmodule NervesHubWeb.Channels.Effects do
   @spec apply_all(Socket.t(), [Effect.t()]) :: Socket.t()
   def apply_all(socket, effects), do: Enum.reduce(effects, socket, &apply_one(&2, &1))
 
+  @doc """
+  Re-arm a repeating timer whose message has just arrived.
+
+  `:start_timer` promises delivery every `interval_ms`, and the VM's timer
+  wheel only does one-shots, so the repeat has to be re-armed somewhere. It
+  happens here, before the message is dispatched, rather than by asking the
+  extension to re-arm itself: `NervesHub.Extensions.Dispatch` swallows an
+  extension that raises, and a re-arm missed that way would stop the timer for
+  the life of the connection with nothing to show for it.
+
+  Messages that are not a live interval's are returned untouched.
+  """
+  @spec reschedule(Socket.t(), message :: term()) :: Socket.t()
+  def reschedule(socket, message) do
+    socket.assigns[@timers]
+    |> Kernel.||(%{})
+    |> Enum.find(fn {_key, timer} -> match?({:interval, _ref, ^message, _ms}, timer) end)
+    |> case do
+      nil ->
+        socket
+
+      {key, {:interval, _ref, _message, interval_ms}} ->
+        put_timer(socket, key, {:interval, Process.send_after(self(), message, interval_ms), message, interval_ms})
+    end
+  end
+
   defp apply_one(socket, {:push, event, payload}) do
     :ok = Channel.push(socket, event, payload)
     socket
@@ -54,11 +80,16 @@ defmodule NervesHubWeb.Channels.Effects do
     put_timer(socket, key, {:send_after, ref})
   end
 
+  # `:timer.send_interval/2` spawns a process per interval, and that process
+  # lives as long as the connection does. One per device for the health check
+  # alone came to 1425 processes and about 40MB on a production device node.
+  # `Process.send_after/3` uses the VM's timer wheel and costs no process at
+  # all, so the repeat is re-armed in `reschedule/2` instead.
   defp apply_one(socket, {:start_timer, key, message, interval_ms}) do
     socket = cancel(socket, key)
-    {:ok, ref} = :timer.send_interval(interval_ms, message)
+    ref = Process.send_after(self(), message, interval_ms)
 
-    put_timer(socket, key, {:interval, ref})
+    put_timer(socket, key, {:interval, ref, message, interval_ms})
   end
 
   defp apply_one(socket, {:cancel_timer, key}), do: cancel(socket, key)
@@ -94,5 +125,5 @@ defmodule NervesHubWeb.Channels.Effects do
   end
 
   defp cancel_ref({:send_after, ref}), do: Process.cancel_timer(ref)
-  defp cancel_ref({:interval, ref}), do: :timer.cancel(ref)
+  defp cancel_ref({:interval, ref, _message, _interval_ms}), do: Process.cancel_timer(ref)
 end

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -72,7 +72,12 @@ defmodule NervesHubWeb.ExtensionsChannel do
   end
 
   @decorate with_span("Channels.ExtensionsChannel.handle_info[Broadcast]")
-  def handle_info({mod, msg}, socket) do
+  def handle_info({mod, msg} = message, socket) do
+    # Before dispatching, not after: an extension that raises is swallowed by
+    # `NervesHub.Extensions.Dispatch`, and re-arming afterwards would let that
+    # silently end a repeating timer for the rest of the connection.
+    socket = Effects.reschedule(socket, message)
+
     {:ok, extensions, effects} = DeviceLink.extension_info(socket.assigns.extensions, mod, msg)
 
     socket

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,11 +1,14 @@
-## Allocator strategy: address-order best-fit, helps fragmentation
-+MBas aoffcbf
-+MHas aoffcbf
-+MBacul 0
-+MHacul 0
-
-## Reduce sys_alloc calls by sizing carriers appropriately
+## Cap the largest multiblock carrier for the binary and heap allocators at
+## 512KB, down from the 5MB default. Smaller carriers mean the allocator hands
+## memory back to the OS in smaller pieces, which matters on a device node
+## where RSS is dominated by connection churn rather than steady-state size.
+##
+## The `as`, `acul` and `smbcs` settings that used to sit here were removed:
+## every one of them restated the OTP default (aoffcbf, 0, and 256KB
+## respectively, for both binary_alloc and eheap_alloc), so they only made it
+## look like more tuning had happened than actually had. Check before adding
+## more:
+##
+##   erlang:system_info({allocator, binary_alloc}) -> options -> lmbcs/smbcs/as/acul
 +MBlmbcs 512
 +MHlmbcs 512
-+MBsmbcs 256
-+MHsmbcs 256

--- a/test/nerves_hub_web/channels/effects_test.exs
+++ b/test/nerves_hub_web/channels/effects_test.exs
@@ -1,0 +1,67 @@
+defmodule NervesHubWeb.Channels.EffectsTest do
+  use ExUnit.Case, async: true
+
+  alias NervesHubWeb.Channels.Effects
+  alias Phoenix.Socket
+
+  defp socket(), do: Effects.init(%Socket{})
+
+  describe "repeating timers" do
+    test "delivers the message and keeps delivering it once re-armed" do
+      socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 20}])
+
+      assert_receive {Health, :check}, 500
+
+      # The channel re-arms on delivery; that is what makes it repeat.
+      socket = Effects.reschedule(socket, {Health, :check})
+      assert_receive {Health, :check}, 500
+
+      _ = Effects.reschedule(socket, {Health, :check})
+      assert_receive {Health, :check}, 500
+    end
+
+    test "costs no process, unlike :timer.send_interval/2" do
+      before = :erlang.system_info(:process_count)
+
+      socket =
+        Enum.reduce(1..50, socket(), fn i, socket ->
+          Effects.apply_all(socket, [{:start_timer, {"health", i}, {Health, i}, 60_000}])
+        end)
+
+      assert :erlang.system_info(:process_count) - before == 0
+
+      # and they are all still cancellable
+      Enum.reduce(1..50, socket, fn i, socket ->
+        Effects.apply_all(socket, [{:cancel_timer, {"health", i}}])
+      end)
+    end
+
+    test "cancelling stops the repeat" do
+      socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 20}])
+
+      assert_receive {Health, :check}, 500
+
+      socket = Effects.reschedule(socket, {Health, :check})
+      _socket = Effects.apply_all(socket, [{:cancel_timer, {"health", :check}}])
+
+      refute_receive {Health, :check}, 200
+    end
+
+    test "re-arming a message that is not a live timer changes nothing" do
+      socket = socket()
+
+      assert Effects.reschedule(socket, {Health, :check}) == socket
+      refute_receive {Health, :check}, 100
+    end
+
+    test "starting the same key twice does not leave the first timer running" do
+      socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :first}, 50}])
+      socket = Effects.apply_all(socket, [{:start_timer, {"health", :check}, {Health, :second}, 50}])
+
+      assert_receive {Health, :second}, 500
+      refute_received {Health, :first}
+
+      _ = socket
+    end
+  end
+end


### PR DESCRIPTION
Memory work on the device nodes, driven by measurements from a production machine holding 1420 devices at 1219MB RSS.

Where that 1219MB actually goes:

| | | |
|---|---|---|
| zlib permessage-deflate contexts | 376MB | 31% |
| freed but not returned to the OS | 395MB | 32% |
| process heaps | 239MB | 20% |
| loaded code | 79MB | 6% |
| ETS | 32MB | 3% |
| binaries | 19MB | 2% |

The first two are two thirds of the machine and neither is doing any work. This branch goes after both.

## zlib per connection

Both device sockets set `compress: true`, so Bandit builds a deflate and an inflate context per connection and holds them for the life of the device's connection. I measured it through `PerMessageDeflate.negotiate/2` rather than estimating: 270.6KB per device, 376MB across the fleet. A sample of 25 live connections came back compressed 25, plain 0, so every device is paying it.

Most of that is the deflate hash table, `1 <<< (mem_level + 9)` bytes, which is 128KB at the default mem_level of 8. Device frames do not need it. Over a representative mix of heartbeats, update progress and health reports, mem_level 8, 6, 4 and 2 all emit **byte-identical output**; only mem_level 1 gets worse, by 2.3%. At mem_level 4 a connection holds 150.5KB instead of 270.6KB, which is about 167MB back for no change in what goes over the wire.

The setting has to live in Bandit's server-wide `websocket_options`. Phoenix accepts `:deflate_options` in the per-socket `websocket:` list, but Bandit reads it from the server config, so putting it there would have silently done nothing.

If you would rather have the whole 376MB than keep compression, `compress: false` on both sockets does that. I did not take that route because devices on metered cellular are the ones paying for it, and that is a product call rather than a memory one.

## jemalloc

jemalloc has been LD_PRELOADed since it was added but never given a `MALLOC_CONF`, so it ran on defaults: four arenas per CPU, each holding its own freed pages, purging only when allocation traffic drives the decay. That is the 395MB gap between RSS and `:erlang.memory(:total)`.

**This commit is the one to be careful with.** The 395MB is measured; how much of it comes back is not. Roll it out to a single device machine and compare RSS before merging, and drop the commit if it does not move. `background_thread:true` would purge on a timer instead of on allocation traffic and would probably help more, but this image shells out to fwup and detools and jemalloc background threads across fork have a history of deadlocking, so it stays off.

## vm.args

Six of the eight allocator flags set values OTP already uses. Against the running VM:

```
erlang:system_info({allocator, binary_alloc}) -> options
lmbcs=5242880  smbcs=262144  as=aoffcbf  acul=0
```

eheap_alloc reports the same. So `+MBas`/`+MHas aoffcbf`, `+MBacul`/`+MHacul 0` and `+MBsmbcs`/`+MHsmbcs 256` did nothing except make the file look like more tuning had happened than had. The two `lmbcs` flags do change something and stay, but their comment claimed the reverse of their effect, so it is reworded.

## A process per device, to send one message an hour

1425 processes on the node were sitting in `:timer.interval_loop/5`, one per device, holding about 40MB between them. Since OTP 25 `:timer.send_interval/2` spawns a process per interval that lives as long as whoever asked for it, and `Extensions.Health` asks for one on attach so it can poll the device hourly. `Extensions.Geo` does the same.

`Process.send_after/3` uses the VM's timer wheel and spawns nothing: 364 bytes against 3.9KB for a freshly started interval, and the gap widens once an interval process has been running long enough to grow its heap, which is where the 28.4KB p50 on that node came from.

The wheel only does one-shots, so the repeat is re-armed in `Effects` when the message comes back. That happens in the channel before the message is dispatched, rather than by asking the extension to re-arm itself, because `Extensions.Dispatch` swallows an extension that raises and a re-arm missed that way would quietly end the timer for the rest of the connection.

## What I looked at and left alone

Channel processes are not a problem. DeviceChannel sits at a 3.7KB p50, ExtensionsChannel 3.8KB, ConsoleChannel 2.6KB, about 15MB for all 4265 of them. Phoenix's default `hibernate_after` is doing its job.

Console scrollback is not a problem either. Every device joins the console channel, and I expected those 1024-line buffers to be full; they total 3.6MB with a 2.7KB max, because devices join but never print.

`Sentry.Sources` holds 7.6MB on every node for stack-trace context. `enable_source_code_context` is compile-time and the same image runs web and device nodes, so switching it off for devices means a second build. Not worth it for 0.6%.

TLS is the largest slice of process memory at 62.8MB, but its p50 is 9.1KB against a 1089KB max, so it is a small tail of busy connections rather than a per-connection cost. Left alone.


## Testing

`mix check` is clean, and the full suite passes apart from two `UpdateToolTest` FAT/delta tests that fail the same way on an untouched `main` on my machine. `effects_test.exs` covers the repeat, cancellation, replacement and the process count; reverting to `:timer.send_interval/2` fails three of its five tests.

Every number above was measured on Elixir 1.20.3 / OTP 29, which matches `.tool-versions`, but the zlib figures come from a local VM rather than the production release.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
