### PR TITLE
Fix doubled health sampling from the tick re-arming the interval

### DIFF
--- a/lib/nerves_hub_web/channels/effects.ex
+++ b/lib/nerves_hub_web/channels/effects.ex
@@ -48,8 +48,19 @@ defmodule NervesHubWeb.Channels.Effects do
       nil ->
         socket
 
-      {key, {:interval, _ref, _message, interval_ms}} ->
-        put_timer(socket, key, {:interval, Process.send_after(self(), message, interval_ms), message, interval_ms})
+      {key, {:interval, ref, _message, interval_ms}} ->
+        # Only re-arm when this message came from the timer. The same term can
+        # also arrive through `:send_self` — an extension's `:tick` on attach
+        # uses the very message its interval does — and re-arming on that
+        # would leave the original timer running alongside the new one, so the
+        # extension would hear from two timers every interval from then on.
+        # `read_timer/1` is `false` once the timer has fired; a cancelled ref
+        # never stays in the map, so that is the only way to get `false` here.
+        if Process.read_timer(ref) == false do
+          put_timer(socket, key, {:interval, Process.send_after(self(), message, interval_ms), message, interval_ms})
+        else
+          socket
+        end
     end
   end
 

--- a/test/nerves_hub_web/channels/effects_test.exs
+++ b/test/nerves_hub_web/channels/effects_test.exs
@@ -63,6 +63,32 @@ defmodule NervesHubWeb.Channels.EffectsTest do
       refute_receive {Health, :check}, 200
     end
 
+    test "a tick carrying the same message does not start a second timer" do
+      # This is the shape `Extensions.Health.attach/1` produces: ask for a
+      # report now, then every interval. Both arrive as the same term.
+      message = {Health, :check}
+
+      socket =
+        Effects.apply_all(socket(), [
+          {:send_self, message},
+          {:start_timer, {"health", :check}, message, 100}
+        ])
+
+      # The tick. The channel reschedules on every delivery, without knowing
+      # whether it came from the timer or not.
+      assert_receive ^message, 50
+      socket = Effects.reschedule(socket, message)
+
+      # Only the one timer from attach should fire, once per interval.
+      assert_receive ^message, 500
+      refute_receive ^message, 50
+      socket = Effects.reschedule(socket, message)
+
+      assert_receive ^message, 500
+      refute_receive ^message, 50
+      _ = Effects.reschedule(socket, message)
+    end
+
     test "re-arming a message that is not a live timer changes nothing" do
       socket = socket()
 


### PR DESCRIPTION
Extensions.Health.attach/1 asks for a report immediately (a tick) and then on an interval, and both arrive as the same message term. Effects.reschedule/2 decided "the interval fired" by matching on that term, so the tick re-armed the interval while the original stayed armed and unfired. From then on the device was asked for a health report twice per interval, moments apart — with the second request sampling CPU while the device was still busy producing the first report, reading busy on an idle device.

Only re-arm when the tracked timer has actually fired: Process.read_timer/1 returns false for a fired ref, and a cancelled ref never stays in the timers map, so a still-pending ref means the message came from somewhere else.

Extensions.Geo has the same attach shape and was double-firing too. Introduced in #2943.