### PR TITLE
Deliver Effects timers in a ref-carrying envelope

### DIFF
--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -68,7 +68,12 @@ defmodule NervesHubWeb.DeviceChannel do
   @impl Phoenix.Channel
   @decorate with_span("Channels.DeviceChannel.handle_info")
   def handle_info(message, socket) do
-    advance(socket, &DeviceLink.device_notify(&1, message))
+    # Timers armed through `Effects` deliver in an envelope; the rest passes through.
+    case Effects.timer_fired(socket, message) do
+      {:deliver, message, socket} -> advance(socket, &DeviceLink.device_notify(&1, message))
+      {:drop, socket} -> {:noreply, socket}
+      :not_timer -> advance(socket, &DeviceLink.device_notify(&1, message))
+    end
   end
 
   @impl Phoenix.Channel

--- a/lib/nerves_hub_web/channels/effects.ex
+++ b/lib/nerves_hub_web/channels/effects.ex
@@ -9,6 +9,15 @@ defmodule NervesHubWeb.Channels.Effects do
 
   Timers are tracked per channel process under the `:link_timers` assign, so
   `:cancel_timer` needs only the key that started it.
+
+  ## Timer deliveries
+
+  A timer armed here delivers `{:timeout, ref, {key, message}}` — the envelope
+  `:erlang.start_timer/3` produces — rather than the bare message. Channels
+  hand these to `timer_fired/2`, which re-arms intervals, retires one-shots,
+  unwraps the message, and drops deliveries from timers that no longer exist.
+  Matching on the ref keeps a timer firing distinct from any other way the
+  same message term might arrive.
   """
 
   alias NervesHub.DeviceLink.Effect
@@ -28,30 +37,33 @@ defmodule NervesHubWeb.Channels.Effects do
   def apply_all(socket, effects), do: Enum.reduce(effects, socket, &apply_one(&2, &1))
 
   @doc """
-  Re-arm a repeating timer whose message has just arrived.
+  Recognize a timer delivery, keep the timer's promise, and unwrap its message.
 
-  `:start_timer` promises delivery every `interval_ms`, and the VM's timer
-  wheel only does one-shots, so the repeat has to be re-armed somewhere. It
-  happens here, before the message is dispatched, rather than by asking the
-  extension to re-arm itself: `NervesHub.Extensions.Dispatch` swallows an
-  extension that raises, and a re-arm missed that way would stop the timer for
-  the life of the connection with nothing to show for it.
+  Channels offer this every info message before handling it themselves:
 
-  Messages that are not a live interval's are returned untouched.
+    * `{:deliver, message, socket}` — a live timer fired. An interval has been
+      re-armed, a one-shot's bookkeeping retired; dispatch `message`.
+    * `{:drop, socket}` — the timer this came from was cancelled or replaced
+      between firing and delivery. There is nothing to act on.
+    * `:not_timer` — not a timer delivery; handle the message as usual.
   """
-  @spec reschedule(Socket.t(), message :: term()) :: Socket.t()
-  def reschedule(socket, message) do
-    socket.assigns[@timers]
-    |> Kernel.||(%{})
-    |> Enum.find(fn {_key, timer} -> match?({:interval, _ref, ^message, _ms}, timer) end)
-    |> case do
-      nil ->
-        socket
+  @spec timer_fired(Socket.t(), message :: term()) ::
+          {:deliver, term(), Socket.t()} | {:drop, Socket.t()} | :not_timer
+  def timer_fired(socket, {:timeout, ref, {key, message}}) when is_reference(ref) do
+    case timers(socket)[key] do
+      {:interval, ^ref, interval_ms} ->
+        {:deliver, message, put_timer(socket, key, {:interval, arm(key, message, interval_ms), interval_ms})}
 
-      {key, {:interval, _ref, _message, interval_ms}} ->
-        put_timer(socket, key, {:interval, Process.send_after(self(), message, interval_ms), message, interval_ms})
+      {:send_after, ^ref} ->
+        # Fired and delivered — the entry is done.
+        {:deliver, message, Socket.assign(socket, @timers, Map.delete(timers(socket), key))}
+
+      _ ->
+        {:drop, socket}
     end
   end
+
+  def timer_fired(_socket, _message), do: :not_timer
 
   defp apply_one(socket, {:push, event, payload}) do
     :ok = Channel.push(socket, event, payload)
@@ -75,21 +87,18 @@ defmodule NervesHubWeb.Channels.Effects do
 
   defp apply_one(socket, {:send_after, key, message, delay_ms}) do
     socket = cancel(socket, key)
-    ref = Process.send_after(self(), message, delay_ms)
 
-    put_timer(socket, key, {:send_after, ref})
+    put_timer(socket, key, {:send_after, arm(key, message, delay_ms)})
   end
 
-  # `:timer.send_interval/2` spawns a process per interval, and that process
-  # lives as long as the connection does. One per device for the health check
-  # alone came to 1425 processes and about 40MB on a production device node.
-  # `Process.send_after/3` uses the VM's timer wheel and costs no process at
-  # all, so the repeat is re-armed in `reschedule/2` instead.
+  # `:timer.send_interval/2` spawns a process per interval that lives as long
+  # as the connection (about 40MB across a production device node). The VM's
+  # timer wheel costs no process but only does one-shots, so `timer_fired/2`
+  # re-arms on each delivery.
   defp apply_one(socket, {:start_timer, key, message, interval_ms}) do
     socket = cancel(socket, key)
-    ref = Process.send_after(self(), message, interval_ms)
 
-    put_timer(socket, key, {:interval, ref, message, interval_ms})
+    put_timer(socket, key, {:interval, arm(key, message, interval_ms), interval_ms})
   end
 
   defp apply_one(socket, {:cancel_timer, key}), do: cancel(socket, key)
@@ -107,23 +116,29 @@ defmodule NervesHubWeb.Channels.Effects do
     Socket.assign(socket, @scrollback, Scrollback.new())
   end
 
+  # `:erlang.start_timer/3` stamps the timer's ref into what it delivers,
+  # letting `timer_fired/2` recognize a firing by ref rather than by message.
+  defp arm(key, message, ms), do: :erlang.start_timer(ms, self(), {key, message})
+
   defp scrollback(socket), do: socket.assigns[@scrollback] || Scrollback.new()
 
-  defp put_timer(socket, key, ref) do
-    Socket.assign(socket, @timers, Map.put(socket.assigns[@timers] || %{}, key, ref))
+  defp timers(socket), do: socket.assigns[@timers] || %{}
+
+  defp put_timer(socket, key, timer) do
+    Socket.assign(socket, @timers, Map.put(timers(socket), key, timer))
   end
 
   defp cancel(socket, key) do
-    case Map.pop(socket.assigns[@timers] || %{}, key) do
+    case Map.pop(timers(socket), key) do
       {nil, _timers} ->
         socket
 
-      {ref, timers} ->
-        _ = cancel_ref(ref)
+      {timer, timers} ->
+        _ = cancel_ref(timer)
         Socket.assign(socket, @timers, timers)
     end
   end
 
   defp cancel_ref({:send_after, ref}), do: Process.cancel_timer(ref)
-  defp cancel_ref({:interval, ref, _message, _interval_ms}), do: Process.cancel_timer(ref)
+  defp cancel_ref({:interval, ref, _interval_ms}), do: Process.cancel_timer(ref)
 end

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -76,21 +76,30 @@ defmodule NervesHubWeb.ExtensionsChannel do
     {:noreply, socket}
   end
 
-  @decorate with_span("Channels.ExtensionsChannel.handle_info[Broadcast]")
-  def handle_info({mod, msg} = message, socket) do
-    # Before dispatching, not after: an extension that raises is swallowed by
-    # `NervesHub.Extensions.Dispatch`, and re-arming afterwards would let that
-    # silently end a repeating timer for the rest of the connection.
-    socket = Effects.reschedule(socket, message)
+  # A timer armed through `Effects` delivering; `timer_fired/2` re-arms it.
+  @decorate with_span("Channels.ExtensionsChannel.handle_info[timer]")
+  def handle_info({:timeout, _ref, _payload} = timer, socket) do
+    case Effects.timer_fired(socket, timer) do
+      {:deliver, {mod, msg}, socket} -> extension_info(socket, mod, msg)
+      {:drop, socket} -> {:noreply, socket}
+      :not_timer -> {:noreply, socket}
+    end
+  end
 
+  @decorate with_span("Channels.ExtensionsChannel.handle_info[extension]")
+  def handle_info({mod, msg}, socket) do
+    extension_info(socket, mod, msg)
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp extension_info(socket, mod, msg) do
     {:ok, extensions, effects} = DeviceLink.extension_info(socket.assigns.extensions, mod, msg)
 
     socket
     |> assign(:extensions, extensions)
     |> apply_effects(effects)
   end
-
-  def handle_info(_msg, socket), do: {:noreply, socket}
 
   defp apply_effects(socket, effects) do
     device_info = device_info(socket)

--- a/test/nerves_hub_web/channels/effects_test.exs
+++ b/test/nerves_hub_web/channels/effects_test.exs
@@ -13,17 +13,18 @@ defmodule NervesHubWeb.Channels.EffectsTest do
   end
 
   describe "repeating timers" do
-    test "delivers the message and keeps delivering it once re-armed" do
+    test "delivers in an envelope and keeps delivering once each firing is handed back" do
       socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 20}])
 
-      assert_receive {Health, :check}, 500
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      assert {:deliver, {Health, :check}, socket} = Effects.timer_fired(socket, timer)
 
-      # The channel re-arms on delivery; that is what makes it repeat.
-      socket = Effects.reschedule(socket, {Health, :check})
-      assert_receive {Health, :check}, 500
+      # The hand-back is what re-arms it; that is what makes it repeat.
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      assert {:deliver, {Health, :check}, socket} = Effects.timer_fired(socket, timer)
 
-      _ = Effects.reschedule(socket, {Health, :check})
-      assert_receive {Health, :check}, 500
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      assert {:deliver, {Health, :check}, _socket} = Effects.timer_fired(socket, timer)
     end
 
     test "costs no process, unlike :timer.send_interval/2" do
@@ -38,11 +39,11 @@ defmodule NervesHubWeb.Channels.EffectsTest do
       # the node: the suite runs async, so a total is other tests' noise.
       assert timer_processes() == before
 
-      # `Process.send_after/3` hands back a bare reference. `:timer` hands back
-      # `{:interval, ref}`, so this tells the two apart without counting
+      # `:erlang.start_timer/3` hands back a bare reference. `:timer` hands
+      # back `{:interval, ref}`, so this tells the two apart without counting
       # anything.
       for {_key, timer} <- socket.assigns.link_timers do
-        assert {:interval, ref, {Health, _}, 60_000} = timer
+        assert {:interval, ref, 60_000} = timer
         assert is_reference(ref)
       end
 
@@ -55,29 +56,82 @@ defmodule NervesHubWeb.Channels.EffectsTest do
     test "cancelling stops the repeat" do
       socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 20}])
 
-      assert_receive {Health, :check}, 500
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      assert {:deliver, {Health, :check}, socket} = Effects.timer_fired(socket, timer)
 
-      socket = Effects.reschedule(socket, {Health, :check})
       _socket = Effects.apply_all(socket, [{:cancel_timer, {"health", :check}}])
 
-      refute_receive {Health, :check}, 200
+      refute_receive {:timeout, _ref, _payload}, 200
     end
 
-    test "re-arming a message that is not a live timer changes nothing" do
-      socket = socket()
+    test "a tick carrying the same message as the interval cannot pass for it firing" do
+      # `Extensions.Health.attach/1` asks for a report now and then every
+      # interval, both as the same term. Only the envelope counts as a firing.
+      message = {Health, :check}
 
-      assert Effects.reschedule(socket, {Health, :check}) == socket
-      refute_receive {Health, :check}, 100
+      socket =
+        Effects.apply_all(socket(), [
+          {:send_self, message},
+          {:start_timer, {"health", :check}, message, 100}
+        ])
+
+      # The tick arrives bare and must not be claimed as a timer delivery.
+      assert_receive ^message, 50
+      assert Effects.timer_fired(socket, message) == :not_timer
+
+      # One delivery per interval, nothing in between.
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      refute_receive _anything, 50
+      assert {:deliver, ^message, socket} = Effects.timer_fired(socket, timer)
+
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      refute_receive _anything, 50
+      assert {:deliver, ^message, _socket} = Effects.timer_fired(socket, timer)
     end
 
-    test "starting the same key twice does not leave the first timer running" do
-      socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :first}, 50}])
-      socket = Effects.apply_all(socket, [{:start_timer, {"health", :check}, {Health, :second}, 50}])
+    test "a delivery from a timer cancelled after firing is dropped" do
+      socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 10}])
 
-      assert_receive {Health, :second}, 500
-      refute_received {Health, :first}
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      socket = Effects.apply_all(socket, [{:cancel_timer, {"health", :check}}])
 
-      _ = socket
+      assert {:drop, _socket} = Effects.timer_fired(socket, timer)
+    end
+
+    test "a delivery from a timer replaced after firing is dropped" do
+      socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 10}])
+
+      assert_receive {:timeout, _ref, _payload} = stale, 500
+      socket = Effects.apply_all(socket, [{:start_timer, {"health", :check}, {Health, :check}, 60_000}])
+
+      # Same key, same message — only the ref tells the stale firing apart.
+      assert {:drop, _socket} = Effects.timer_fired(socket, stale)
+    end
+
+    test "a message that is not a timer delivery is not claimed" do
+      assert Effects.timer_fired(socket(), {Health, :check}) == :not_timer
+      refute_receive _anything, 50
+    end
+  end
+
+  describe "one-shot timers" do
+    test "delivers once and retires its bookkeeping" do
+      socket = Effects.apply_all(socket(), [{:send_after, {:script_ref, "abc"}, {:clear_script_ref, "abc"}, 10}])
+
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      assert {:deliver, {:clear_script_ref, "abc"}, socket} = Effects.timer_fired(socket, timer)
+
+      # Fired means done — nothing left to cancel.
+      assert socket.assigns.link_timers == %{}
+      refute_receive {:timeout, _ref, _payload}, 100
+    end
+
+    test "cancelling before it fires stops the delivery" do
+      socket = Effects.apply_all(socket(), [{:send_after, {:script_ref, "abc"}, {:clear_script_ref, "abc"}, 50}])
+      socket = Effects.apply_all(socket, [{:cancel_timer, {:script_ref, "abc"}}])
+
+      assert socket.assigns.link_timers == %{}
+      refute_receive {:timeout, _ref, _payload}, 200
     end
   end
 end


### PR DESCRIPTION
Extensions.Health.attach/1 asks for a report immediately (a tick) and then on an interval, and both arrive as the same message term. Effects.reschedule/2 decided "the interval fired" by matching on that term, so the tick re-armed the interval while the original stayed armed and unfired. From then on the device was asked for a health report twice per interval, moments apart — with the second request sampling CPU while the device was still busy producing the first report, reading busy on an idle device. Extensions.Geo has the same attach shape and was double-firing too. Introduced in #2943.

The underlying problem is inferring "my timer fired" from the content of a message that other senders legitimately deliver. So stop inferring: arm timers with :erlang.start_timer/3, which stamps the timer's own ref into what it delivers ({:timeout, ref, {key, message}}), and have the channels hand any such envelope to Effects.timer_fired/2. It re-arms intervals, retires one-shots, unwraps the message, and drops deliveries whose ref no longer matches a live timer.

Matching on the ref makes the call exact, and closes two smaller races the old shape allowed: a timer cancelled or replaced after firing but before delivery is now dropped rather than dispatched, and a fired one-shot no longer leaves its bookkeeping entry behind (DeviceLink's compensating cancel for the script timeout becomes a no-op).