### PR TITLE
Pick CLI session cache warm-up nodes from platform membership

### DIFF
--- a/lib/nerves_hub/cli_session_cache.ex
+++ b/lib/nerves_hub/cli_session_cache.ex
@@ -1,6 +1,8 @@
 defmodule NervesHub.CLISessionCache do
   use GenServer
 
+  alias NervesHub.DeviceLink.Handlers
+
   @table :cli_session_cache
 
   def start_link(_) do
@@ -128,20 +130,35 @@ defmodule NervesHub.CLISessionCache do
   end
 
   defp fetch_data_from_cluster() do
-    # Gets all connected nodes excluding the current node
-    nodes = Node.list()
+    fetch_from(candidates())
+  end
 
-    if Enum.empty?(nodes) do
-      :no_nodes_available
-    else
-      # Query the first available node to dump its table via RPC
-      [target_node | _] = nodes
+  # Prefer nodes known to carry the platform stack. `Node.list/0` is every node
+  # that joined the topology, which is not the same thing: `device` nodes do not
+  # run this cache, and neither does anything else that joins without carrying
+  # the platform stack. Asking one of those for the table is a wasted round trip
+  # at best.
+  #
+  # At boot the `:pg` group may not have synced yet, and a cold cache is worse
+  # than an imperfect guess, so fall back to any connected node — `fetch_from/1`
+  # skips whatever cannot answer.
+  defp candidates() do
+    case Handlers.nodes() -- [node()] do
+      [] -> Node.list()
+      platform -> platform
+    end
+  end
 
-      # :ets.tab2list/1 converts the entire ETS table into a list of tuples
-      case :rpc.call(target_node, :ets, :tab2list, [@table]) do
-        {:badrpc, _reason} -> :no_nodes_available
-        data when is_list(data) -> {:ok, data}
-      end
+  defp fetch_from([]), do: :no_nodes_available
+
+  # Walks the candidates rather than taking the head and giving up: a single
+  # node that cannot answer used to leave this node with an empty cache for the
+  # life of the process.
+  defp fetch_from([node | rest]) do
+    # :ets.tab2list/1 converts the entire ETS table into a list of tuples
+    case :rpc.call(node, :ets, :tab2list, [@table]) do
+      {:badrpc, _reason} -> fetch_from(rest)
+      data when is_list(data) -> {:ok, data}
     end
   end
 end

--- a/lib/nerves_hub/device_link/handlers.ex
+++ b/lib/nerves_hub/device_link/handlers.ex
@@ -1,11 +1,12 @@
 defmodule NervesHub.DeviceLink.Handlers do
   @moduledoc """
-  Which nodes can service `NervesHub.DeviceLink` calls.
+  Which nodes carry the platform stack — the database, the contexts, the
+  extensions — and can therefore service a call that needs it.
 
-  A node joins by starting this process, which it does when it carries the
-  platform stack — the database, the contexts, the extensions. Membership is
-  tracked by `:pg`, so it follows nodes joining and leaving the cluster without
-  anything polling or asking each node what it is.
+  A node joins by starting this process, which it does when it carries that
+  stack: `web` and `all` nodes join, `device` nodes start the scope without
+  joining. Membership is tracked by `:pg`, so it follows nodes joining and
+  leaving the cluster without anything polling or asking each node what it is.
 
   Ordering is deterministic on a routing key, which matters more than it looks.
   Some per-device state is node-local and not shared — the log line rate limiter
@@ -15,6 +16,26 @@ defmodule NervesHub.DeviceLink.Handlers do
 
   Rehashing when membership changes costs nothing here, because no state lives
   on a handler between calls.
+
+  ## Reading this group
+
+  `NervesHub.DeviceLink.Dispatcher.Remote` is one reader and the one this module
+  is named after, but it is not the only one — `NervesHub.CLISessionCache` uses
+  it to find a node that actually holds the table it wants. Anything that needs
+  somewhere to send a call should ask here rather than filter `Node.list/0`: a
+  node can join the topology without carrying the platform stack, and a call
+  sent to one of those fails in a way that reads as an outage.
+
+  That makes `@scope` and `@group` closer to a published contract than a private
+  detail, including for anything outside this application that joins the same
+  topology. They are derived from the module name, so renaming this module
+  silently renames the scope, splitting membership between old and new nodes for
+  the length of a rolling deploy. Pin the atoms first if it is ever moved.
+
+  A node connected as *hidden* cannot read the group locally at all: `:pg`
+  discovers its peers through `net_kernel:monitor_nodes/1` and `nodes/0`, both of
+  which are visible-only. Such a node has to read membership over `:erpc` from a
+  node that is in the scope.
   """
 
   use GenServer
@@ -22,7 +43,11 @@ defmodule NervesHub.DeviceLink.Handlers do
   @scope __MODULE__.PG
   @group :handlers
 
-  @doc "The :pg scope, started on every node so membership can be read."
+  @doc """
+  The `:pg` scope, started on every node so membership can be read.
+
+  Part of the contract described above — see the moduledoc before changing it.
+  """
   @spec scope() :: __MODULE__.PG
   def scope(), do: @scope
 
@@ -32,7 +57,11 @@ defmodule NervesHub.DeviceLink.Handlers do
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
-  @doc "Handler nodes, sorted so every node orders them the same way."
+  @doc """
+  Platform nodes, sorted so every node orders them the same way.
+
+  Includes the local node when it is one.
+  """
   @spec nodes() :: [node()]
   def nodes() do
     @scope


### PR DESCRIPTION
## The bug

`CLISessionCache.fetch_data_from_cluster/0` warms a booting node's cache from a peer:

```elixir
nodes = Node.list()
...
[target_node | _] = nodes

case :rpc.call(target_node, :ets, :tab2list, [@table]) do
  {:badrpc, _reason} -> :no_nodes_available
  data when is_list(data) -> {:ok, data}
end
```

Two problems:

1. **`Node.list/0` is not the set of nodes that run this cache.** `device` nodes don't — `cli_session_cache/0` in `application.ex` excludes them — and neither does anything else that joins the same topology without carrying the platform stack. On those, `:ets.tab2list(:cli_session_cache)` raises and `:rpc.call` comes back `{:badrpc, _}`.
2. **It takes the head and gives up.** One unlucky pick and the node runs with a permanently cold cache for the life of the process. `Node.list/0` ordering is arbitrary, so it is intermittent.

## The fix

Ask `DeviceLink.Handlers` — which already tracks exactly "nodes carrying the platform stack" — and walk the candidates instead of taking the head.

At boot the `:pg` group may not have synced yet, so an empty group falls back to `Node.list/0`. With the walk in place that fallback is safe: a wrong guess now costs a round trip instead of the cache.

## Also: `Handlers` docs

`DeviceLink.Dispatcher.Remote` is no longer the only reader of this group, and anything that needs somewhere to send a call should be asking it rather than filtering `Node.list/0`. That makes `@scope` and `@group` closer to a published contract than a private detail — including for anything outside this application that joins the same topology.

They are derived from `__MODULE__`, so renaming the module silently renames the scope and splits membership between old and new nodes for the length of a rolling deploy. I did **not** rename it for that reason, and instead wrote the constraint down where someone attempting the rename would look. If you do want the name generalized, the safe path is pinning the atoms as literals and shipping that a release ahead of the move.

The docs also note why a node connected as hidden cannot read the group locally: `:pg` discovers peers through `net_kernel:monitor_nodes/1` and `nodes/0`, both of which are visible-only, so such a node has to read membership over `:erpc` from a node that is in the scope.