### PR TITLE
Exclude soft deleted devices from product and org device counts

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -409,6 +409,7 @@ defmodule NervesHub.Accounts do
       |> join(:inner, [d], p in assoc(d, :product))
       |> where([_d, _dc, p], p.org_id == parent_as(:org).id)
       |> where([_d, dc], dc.status == :connected)
+      |> Repo.exclude_deleted()
       |> select([d], %{count: count()})
 
     disconnected_org_devices_count =
@@ -417,6 +418,7 @@ defmodule NervesHub.Accounts do
       |> join(:inner, [d], p in assoc(d, :product))
       |> where([_d, _dc, p], p.org_id == parent_as(:org).id)
       |> where([_d, dc], is_nil(dc) or dc.status != :connected)
+      |> Repo.exclude_deleted()
       |> select([d], %{count: count()})
 
     Org
@@ -438,6 +440,7 @@ defmodule NervesHub.Accounts do
       |> join(:inner, [d], lc in assoc(d, :latest_connection))
       |> where([d], d.product_id == parent_as(:product).id)
       |> where([_d, dc], dc.status == :connected)
+      |> Repo.exclude_deleted()
       |> select([d], %{count: count()})
 
     disconnected_devices_count =
@@ -445,6 +448,7 @@ defmodule NervesHub.Accounts do
       |> join(:left, [d], lc in assoc(d, :latest_connection))
       |> where([d], d.product_id == parent_as(:product).id)
       |> where([_d, dc], is_nil(dc) or dc.status != :connected)
+      |> Repo.exclude_deleted()
       |> select([d], %{count: count()})
 
     Product

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -55,6 +55,7 @@ defmodule NervesHub.Products do
       |> join(:inner, [d], lc in assoc(d, :latest_connection))
       |> where([d], d.product_id == parent_as(:product).id)
       |> where([_d, dc], dc.status == :connected)
+      |> Repo.exclude_deleted()
       |> select([d], count())
 
     select_merge(query, %{connected_devices_count: subquery(connected_devices_count)})
@@ -70,6 +71,7 @@ defmodule NervesHub.Products do
       |> join(:left, [d], lc in assoc(d, :latest_connection))
       |> where([d], d.product_id == parent_as(:product).id)
       |> where([_d, dc], is_nil(dc) or dc.status != :connected)
+      |> Repo.exclude_deleted()
       |> select([d], count())
 
     select_merge(query, %{disconnected_devices_count: subquery(disconnected_devices_count)})

--- a/test/nerves_hub/products/products_test.exs
+++ b/test/nerves_hub/products/products_test.exs
@@ -2,6 +2,8 @@ defmodule NervesHub.ProductsTest do
   use NervesHub.DataCase, async: true
 
   alias NervesHub.Accounts
+  alias NervesHub.Accounts.Scope
+  alias NervesHub.Devices
   alias NervesHub.Fixtures
   alias NervesHub.Products
   alias NervesHub.Products.Product
@@ -201,6 +203,61 @@ defmodule NervesHub.ProductsTest do
 
       assert Products.custom_health_metrics_labels(product) == %{"cpu_temp" => "CPU Heat"}
       assert Products.custom_health_metrics_labels(other_product) == %{}
+    end
+  end
+
+  describe "get_products/2 with counts" do
+    @describetag :tmp_dir
+
+    setup %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      product = Fixtures.product_fixture(user, org)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+      scope =
+        user
+        |> Scope.for_user()
+        |> Scope.put_org(org)
+
+      %{scope: scope, org: org, product: product, firmware: firmware}
+    end
+
+    test "counts connected and disconnected devices", context do
+      connect(context, :connected)
+      connect(context, :disconnected)
+      connect(context, :disconnected)
+
+      assert [product] = Products.get_products(context.scope, with_counts: true)
+      assert product.connected_devices_count == 1
+      assert product.disconnected_devices_count == 2
+    end
+
+    test "counts a device that has never connected as disconnected", context do
+      Fixtures.device_fixture(context.org, context.product, context.firmware)
+
+      assert [product] = Products.get_products(context.scope, with_counts: true)
+      assert product.connected_devices_count == 0
+      assert product.disconnected_devices_count == 1
+    end
+
+    test "does not count soft deleted devices", context do
+      connect(context, :connected)
+      connect(context, :disconnected)
+
+      {:ok, _} = Devices.delete_device(connect(context, :connected))
+      {:ok, _} = Devices.delete_device(connect(context, :disconnected))
+
+      assert [product] = Products.get_products(context.scope, with_counts: true)
+      assert product.connected_devices_count == 1
+      assert product.disconnected_devices_count == 1
+    end
+
+    defp connect(context, status) do
+      device = Fixtures.device_fixture(context.org, context.product, context.firmware)
+      Fixtures.device_connection_fixture(device, %{status: status})
+      device
     end
   end
 end


### PR DESCRIPTION
## The bug

`Products.get_products/2` and `Accounts.get_orgs/1` build their connected/disconnected counts from correlated subqueries over `Device`. None of the six applied `Repo.exclude_deleted()`:

```elixir
defp add_disconnected_devices_count(query, true) do
  disconnected_devices_count =
    Device
    |> join(:left, [d], lc in assoc(d, :latest_connection))
    |> where([d], d.product_id == parent_as(:product).id)
    |> where([_d, dc], is_nil(dc) or dc.status != :connected)
    |> select([d], count())
```

So deleting a device never decreased the count beside its product or org. The totals only grew, drifting further from the real fleet the longer a product had been in use.

They also disagree with every other count in the codebase. `Devices.total_count/1`, `online_count/1` and `offline_count/1` all exclude deleted devices, and so do the deployment group counts in `ManagedDeployments` — which is what makes these six look like oversights rather than intent.

Seen in production: a product holding **four** devices and four deleted ones reports **eight** disconnected, while its own insights page and its device list both report four.

## The fix

`|> Repo.exclude_deleted()` on all six subqueries — two in `Products.get_products/2`, four in `Accounts.get_orgs/1` (two org-level, two in its `products_subquery/0`). `exclude_deleted/1` binds to the first binding, which is `Device` in every one of them.

## Tests

`get_products/2` had no coverage of the counts at all, so this adds three: connected vs disconnected, a device that has never connected (counts as disconnected), and the soft deleted case that was wrong.

They do catch it — reverting just the `products.ex` change fails the last one:

```
     Assertion with == failed
     code:  assert product.connected_devices_count == 1
     left:  2
     right: 1
```