### PR TITLE
Install npm packages during mix assets.setup

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -184,7 +184,11 @@ defmodule NervesHub.MixProject do
   defp aliases() do
     [
       setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
-      "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
+      "assets.setup": [
+        "tailwind.install --if-missing",
+        "esbuild.install --if-missing",
+        "cmd --cd assets npm install"
+      ],
       "assets.build": ["compile", "tailwind default", "esbuild default", "esbuild stoplight"],
       "assets.deploy": [
         "tailwind default --minify",


### PR DESCRIPTION
## Problem

`mix setup` on a fresh clone fails:

```
≈ tailwindcss v4.2.2

Error: Can't resolve 'highlight.js/styles/stackoverflow-light.css' in '/…/assets/css'
** (Mix) `mix tailwind default` exited with 1
```

## Cause

`assets/css/app.css:3` imports `highlight.js/styles/stackoverflow-light.css`, and `assets/js/hooks/highlightCode.js` imports from `highlight.js/lib/*`. `highlight.js` is declared in `assets/package.json`, but no Mix alias ever populates `assets/node_modules`, so both Tailwind and esbuild fail to resolve it.

`Dockerfile` runs `npm ci` before the asset build, so release images and CI were unaffected — this only breaks local development following the README's `mix setup` instruction.

## Fix

Add `cmd --cd assets npm install` to the `assets.setup` alias, so `mix setup` (and `mix assets.setup` on its own) produces a working asset build.

`npm install` is used rather than `npm ci` because `assets/package-lock.json` pins the `file:../deps/phoenix` and `file:../deps/phoenix_live_view` entries at specific versions; those drift as Hex deps are updated, and `npm ci` would hard-fail on the mismatch.

## Verification

```
$ mix format --check-formatted mix.exs   # ok
$ mix assets.setup
added 683 packages, and audited 687 packages in 14s
$ mix assets.build
≈ tailwindcss v4.2.2
Done in 141ms
  ../priv/static/assets/js/app.js  4.9mb
  ../priv/static/assets/js/stoplight.js     3.0mb
  ../priv/static/assets/js/stoplight.css  377.5kb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)