### PR TITLE
Let a RAUC bundle declare its own UUID

### DIFF
--- a/lib/nerves_hub/firmwares/update_tool/rauc.ex
+++ b/lib/nerves_hub/firmwares/update_tool/rauc.ex
@@ -53,7 +53,18 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
 
   ## The UUID
 
-  RAUC has no notion of one, so it is derived from the SHA-256 over the manifest
+  Declared if the manifest declares one, derived otherwise.
+
+  A build that sets `uuid` in `[meta.nerveshub]` is naming the firmware itself,
+  and that is preferred. The reason is that a *derived* uuid cannot be embedded
+  in the firmware it identifies — it hashes the manifest, which records the
+  rootfs's own sha256, so writing it into the image changes it. A device
+  flashed by anything other than `rauc install` was therefore unable to say
+  what it was running until its first update. Declaring the uuid breaks that
+  circularity: the same value goes into the manifest and into the image. A
+  declared value must be a UUID, because `firmware.uuid` is a UUID column.
+
+  Without one it is derived from the SHA-256 over the manifest
   as embedded in the signature — the digest RAUC itself computes and reports as
   `hash` in `rauc info --output-format=json`. Verified against a bundle built by
   RAUC 1.13: the digest matches byte for byte.
@@ -431,14 +442,15 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
 
     with {:ok, compatible} <- required(compatible, "[update] compatible"),
          {:ok, version} <- required(Map.get(update, "version"), "[update] version"),
-         {:ok, architecture} <- required_meta(ours, "architecture") do
+         {:ok, architecture} <- required_meta(ours, "architecture"),
+         {:ok, uuid} <- uuid(ours, manifest) do
       {:ok,
        %{
          firmware_metadata: %UpdateTool.Metadata{
            architecture: architecture,
            platform: Map.get(ours, "platform", compatible),
            product: Map.get(ours, "product", compatible),
-           uuid: uuid_from_manifest(manifest),
+           uuid: uuid,
            version: version,
            author: Map.get(ours, "author"),
            description: Map.get(update, "description"),
@@ -456,6 +468,34 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
          tool_delta_required_version: @minimum_device_version,
          tool_full_required_version: @minimum_device_version
        }}
+    end
+  end
+
+  # Declared if the manifest declares one, derived otherwise.
+  #
+  # A derived uuid cannot be embedded in the firmware it identifies: it hashes
+  # the manifest, which records the rootfs's own sha256, so writing it into the
+  # image would change it. That left a device flashed by anything other than
+  # `rauc install` — UUU or dd at a factory — unable to say what it was running
+  # until its first update, which is a poor default for a fleet.
+  #
+  # A build that sets `uuid` in `[meta.nerveshub]` writes the same value into
+  # the manifest and into the image, so the device knows its identity from its
+  # first boot however it was flashed. Both sides then name the same firmware,
+  # which is what `firmware.uuid` has to match for a device to be recognised.
+  defp uuid(ours, manifest) do
+    case Map.get(ours, "uuid") do
+      nil ->
+        {:ok, uuid_from_manifest(manifest)}
+
+      declared ->
+        # `firmware.uuid` is a UUID column, so a declared value that is not one
+        # would fail later as a cast error against a changeset, well away from
+        # the manifest that caused it.
+        case Ecto.UUID.cast(declared) do
+          {:ok, uuid} -> {:ok, uuid}
+          :error -> {:error, {:invalid_manifest_field, "[meta.nerveshub] uuid"}}
+        end
     end
   end
 

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -300,6 +300,12 @@ defmodule NervesHubWeb.Live.Firmware do
       "the bundle to a deployment."
   end
 
+  defp upload_error({:invalid_manifest_field, field}) do
+    "This RAUC bundle's manifest has a #{field} that is not a UUID. NervesHub " <>
+      "stores firmware identifiers in a UUID column, so a declared uuid has to " <>
+      "be one — a UUIDv4 generated once per build is the usual answer."
+  end
+
   defp upload_error({:missing_manifest_section, key}) do
     "This RAUC bundle's manifest has no [meta.nerveshub] section, so NervesHub " <>
       "cannot read #{key}. Meta sections require RAUC 1.9 or newer — older " <>

--- a/test/nerves_hub/firmwares/update_tool/rauc_test.exs
+++ b/test/nerves_hub/firmwares/update_tool/rauc_test.exs
@@ -218,6 +218,42 @@ defmodule NervesHub.Firmwares.UpdateTool.RaucTest do
                Rauc.get_firmware_metadata_from_file(path)
     end
 
+    test "a declared uuid is preferred over the derived one", %{signer: signer, path: path} do
+      declared = "9f3a1c22-6f1b-4d0e-9b3a-0d2f7c5e8a41"
+      manifest = RaucBundle.manifest(meta: [uuid: declared])
+      RaucBundle.write(path, signer, manifest: manifest)
+
+      # The point of declaring it: a uuid derived by hashing the manifest cannot
+      # be written into the image the manifest describes, so a device flashed by
+      # anything other than `rauc install` could not know what it was running.
+      # Declaring it lets the build put the same value in both places.
+      assert {:ok, %{firmware_metadata: %{uuid: ^declared}}} =
+               Rauc.get_firmware_metadata_from_file(path)
+    end
+
+    test "without a declared uuid it is still derived from the manifest",
+         %{signer: signer, path: path} do
+      RaucBundle.write(path, signer)
+
+      {:ok, %{firmware_metadata: %{uuid: uuid}}} =
+        Rauc.get_firmware_metadata_from_file(path)
+
+      # Every bundle built before uuid could be declared keeps the identity it
+      # already had.
+      assert {:ok, _} = Ecto.UUID.cast(uuid)
+      refute uuid == "9f3a1c22-6f1b-4d0e-9b3a-0d2f7c5e8a41"
+    end
+
+    test "a declared uuid that is not a uuid is refused", %{signer: signer, path: path} do
+      manifest = RaucBundle.manifest(meta: [uuid: "release-1"])
+      RaucBundle.write(path, signer, manifest: manifest)
+
+      # firmware.uuid is a UUID column. Caught here, against the manifest that
+      # caused it, rather than later as a changeset cast error.
+      assert {:error, {:invalid_manifest_field, "[meta.nerveshub] uuid"}} =
+               Rauc.get_firmware_metadata_from_file(path)
+    end
+
     test "a missing version is refused", %{signer: signer, path: path} do
       manifest = RaucBundle.manifest(update: [version: nil])
       RaucBundle.write(path, signer, manifest: manifest)


### PR DESCRIPTION
A RAUC bundle can now name itself. If its manifest sets `uuid` in
`[meta.nerveshub]`, NervesHub records that; otherwise it derives one from the
manifest as before.

## Why

The derived UUID is a SHA-256 over the manifest, and the manifest records the
rootfs's own sha256. So it cannot be written into the image it identifies:
doing that changes the image, which changes the manifest, which changes the
UUID.

RAUC only records a bundle hash against a slot it installed itself. A device
flashed at the factory with `uuu`, `dd`, or a card image therefore has no
identity at all, and no way to acquire one except by taking an update. But
NervesHub matches deployments through firmware metadata, so a device that
cannot report has nothing to match on. Enrolment deadlocks on the thing
enrolment was supposed to fix.

Declaring the UUID breaks the circularity, because a declared value is an input
rather than a function of the content. The build writes the same UUID into the
manifest and into the image, and the device reads it from its own rootfs, from
first boot, however it was flashed.

This is roughly what fwup devices already get. fwup writes `nerves_fw_uuid`
into the U-Boot environment as part of flashing, because it is both the flasher
and the updater. RAUC is only the updater, so nothing fills that role unless
the image carries it.

## What changed

`metadata/1` prefers `[meta.nerveshub] uuid` and falls back to
`uuid_from_manifest/1`. Bundles built before this keep the identity they
already had, so nothing needs rebuilding.

A declared value is validated with `Ecto.UUID.cast/1`. `firmware.uuid` is a
UUID column, so a manifest carrying something like `release-1` would otherwise
fail much later as a changeset cast error, well away from the manifest that
caused it. It is refused at upload instead, with a message that says what the
field has to be.

## The device side

The agent reads `/etc/nerves-hub/firmware`, a file the image build writes:

```
uuid=31e6b4a8-2ddb-4c70-a1a4-fe26284cdb87
version=1.0.0
product=my-product
platform=my-board
architecture=aarch64
```

It falls back to RAUC's recorded bundle hash when the file is absent, so images
built before this keep working. Those changes are in nerves-hub-link-agent and
are not part of this PR.

Identity in the rootfs also cannot drift: it is replaced atomically with the
slot it describes, unlike RAUC's slot status, which lives on a data partition
and can outlive a rollback.

## Testing

Three tests in `rauc_test.exs`: a declared UUID is preferred, a bundle without
one still derives, and a declared value that is not a UUID is refused. Verified
end to end against a CompuLab IOT-GATE-iMX8PLUS: the rootfs file and the
bundle manifest carry the same UUID, which is the thing that has to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
