### PR TITLE
Offer the RAUC signing key scheme in the UI

### DIFF
--- a/lib/nerves_hub/accounts/org_key.ex
+++ b/lib/nerves_hub/accounts/org_key.ex
@@ -162,6 +162,33 @@ defmodule NervesHub.Accounts.OrgKey do
 
   def decode_certificate(_), do: :error
 
+  @doc """
+  A certificate's SHA-256 fingerprint, formatted as `openssl x509
+  -fingerprint -sha256` prints it.
+
+  A PEM is 600+ bytes of base64 that reads the same for every certificate, so
+  it is useless for recognising one. The fingerprint is what an operator can
+  compare against the keyring built into an image.
+  """
+  @spec certificate_fingerprint(binary()) :: {:ok, String.t()} | :error
+  def certificate_fingerprint(pem) when is_binary(pem) do
+    case :public_key.pem_decode(pem) do
+      [{:Certificate, der, _cipher} | _] ->
+        {:ok,
+         :sha256
+         |> :crypto.hash(der)
+         |> Base.encode16()
+         |> String.replace(~r/(..)(?=.)/, "\\1:")}
+
+      _ ->
+        :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  def certificate_fingerprint(_), do: :error
+
   defp bit_size_of(modulus) when is_integer(modulus) do
     modulus |> :binary.encode_unsigned() |> byte_size() |> Kernel.*(8)
   end

--- a/lib/nerves_hub_web/live/org/signing_keys.ex
+++ b/lib/nerves_hub_web/live/org/signing_keys.ex
@@ -76,20 +76,34 @@ defmodule NervesHubWeb.Live.Org.SigningKeys do
   defp scheme_options() do
     [
       {"fwup (Ed25519)", :ed25519},
-      {"ESP-IDF Secure Boot v2 (RSA-3072)", :secure_boot_v2_rsa}
+      {"ESP-IDF Secure Boot v2 (RSA-3072)", :secure_boot_v2_rsa},
+      {"RAUC (X.509 certificate)", :x509_certificate}
     ]
   end
 
   defp scheme_label(:ed25519), do: "ed25519"
   defp scheme_label(:secure_boot_v2_rsa), do: "secure-boot-v2-rsa"
+  defp scheme_label(:x509_certificate), do: "x509-certificate"
   defp scheme_label(other), do: to_string(other)
 
   defp key_label(%{scheme: :secure_boot_v2_rsa}), do: "eFuse digest"
+  defp key_label(%{scheme: :x509_certificate}), do: "SHA-256 fingerprint"
   defp key_label(_), do: nil
 
   # An Ed25519 key is one short line and is worth showing whole — it is how
   # operators recognise it.
   defp key_preview(%{scheme: :ed25519, key: key}), do: key
+
+  # RAUC verifies a bundle's CMS signature against a certificate chain, so the
+  # organization key is a certificate rather than a bare public key. The
+  # fingerprint is what identifies it, and what can be checked against the
+  # keyring an image was built with.
+  defp key_preview(%{scheme: :x509_certificate, key: key}) do
+    case OrgKey.certificate_fingerprint(key) do
+      {:ok, fingerprint} -> fingerprint
+      _ -> boundary_lines(key)
+    end
+  end
 
   # A PEM is 600+ bytes of base64 that reads the same for every key. The Secure
   # Boot v2 key digest is what `espsecure.py digest-sbv2-public-key` produces

--- a/test/nerves_hub_web/live/org/signing_keys_test.exs
+++ b/test/nerves_hub_web/live/org/signing_keys_test.exs
@@ -5,6 +5,7 @@ defmodule NervesHubWeb.Live.Org.SigningKeysTest do
   alias NervesHub.Firmwares.UpdateTool
   alias NervesHub.Fixtures
   alias NervesHub.Support.EspIdf
+  alias NervesHub.Support.RaucBundle
 
   describe "list" do
     test "no signing keys", %{conn: conn, user: user} do
@@ -50,6 +51,37 @@ defmodule NervesHubWeb.Live.Org.SigningKeysTest do
       |> assert_has("div", text: "Signing Key created successfully.")
       |> assert_has("h3", text: "my amazing key")
       |> assert_has("div", text: "FMBdNKrU3qlyErQtpqxsq50nGAXz03DCeEXPt2iKBe0=")
+    end
+  end
+
+  describe "create a RAUC signing key" do
+    test "accepts a PEM X.509 certificate", %{conn: conn, org: org} do
+      # RAUC signs bundles with CMS against a certificate chain, so the
+      # organization key is a certificate rather than a bare public key. Without
+      # the scheme in this dropdown there was no way to add one at all, and
+      # therefore no way to upload a bundle.
+      signer = RaucBundle.keypair()
+
+      conn
+      |> visit("/org/#{org.name}/settings/keys/new")
+      |> select("Scheme", option: "RAUC (X.509 certificate)")
+      |> fill_in("Name", with: "rauc release key")
+      |> fill_in("Key", with: signer.certificate)
+      |> click_button("Create Key")
+      |> assert_path("/org/#{org.name}/settings/keys")
+      |> assert_has("div", text: "Signing Key created successfully.")
+      |> assert_has("h3", text: "rauc release key")
+      |> assert_has("code", text: "x509-certificate")
+    end
+
+    test "rejects something that is not a certificate", %{conn: conn, org: org} do
+      conn
+      |> visit("/org/#{org.name}/settings/keys/new")
+      |> select("Scheme", option: "RAUC (X.509 certificate)")
+      |> fill_in("Name", with: "wrong scheme")
+      |> fill_in("Key", with: "FMBdNKrU3qlyErQtpqxsq50nGAXz03DCeEXPt2iKBe0=")
+      |> click_button("Create Key")
+      |> assert_has("div", text: "expected a PEM-encoded X.509 certificate")
     end
   end
 


### PR DESCRIPTION
RAUC signing keys could not be added through the UI.

The backend has supported them since #2946: `x509_certificate` is in
`OrgKey`'s `@schemes`, and `key_format_check/2` validates a PEM certificate.
The scheme dropdown just never listed it:

```elixir
defp scheme_options() do
  [
    {"fwup (Ed25519)", :ed25519},
    {"ESP-IDF Secure Boot v2 (RSA-3072)", :secure_boot_v2_rsa}
  ]
end
```

Which blocks the whole RAUC path rather than a corner of it: the organization
key has to exist before an upload can verify a bundle's signature, so with no
way to add one there is no way to upload a bundle.

Found while adding a key for a real device.

## Fingerprints

A certificate preview is its SHA-256 fingerprint, formatted as `openssl x509
-fingerprint -sha256` prints it. The other schemes show something identifying —
an Ed25519 key whole, an eFuse digest for Secure Boot v2 — and a PEM is 600+
bytes of base64 that reads the same for every certificate.

The fingerprint is also checkable: it is what an operator compares against the
keyring built into an image. Verified against `openssl` for the certificate a
real device is running.
