### PR TITLE
Verify a bundle's signer the way the device will

### DIFF
--- a/lib/nerves_hub/firmwares/update_tool/rauc.ex
+++ b/lib/nerves_hub/firmwares/update_tool/rauc.ex
@@ -295,17 +295,36 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
 
   defp find_signing_key(filepath, keys) do
     with {:ok, signature} <- read_signature(filepath) do
-      signed_key =
-        Enum.find(keys, fn %OrgKey{key: certificate} ->
-          match?({:ok, _manifest}, verify_cms(signature, certificate))
+      attempts =
+        Enum.map(keys, fn %OrgKey{key: certificate} = key ->
+          {key, verify_cms(signature, certificate)}
         end)
 
-      case signed_key do
-        %OrgKey{} = key -> {:ok, key}
-        nil -> {:error, :invalid_signature}
+      case Enum.find(attempts, fn {_key, result} -> match?({:ok, _manifest}, result) end) do
+        {%OrgKey{} = key, _result} ->
+          {:ok, key}
+
+        nil ->
+          # "This certificate cannot sign anything" and "this certificate did
+          # not sign this bundle" are different problems, and only one of them
+          # is fixed by uploading a different file. Reported separately so the
+          # message points at the key rather than at the bundle.
+          if Enum.any?(attempts, fn {_key, result} -> unsuitable_purpose?(result) end) do
+            {:error, :unsuitable_certificate_purpose}
+          else
+            {:error, :invalid_signature}
+          end
       end
     end
   end
+
+  # openssl's own wording. It comes from its error table rather than a locale,
+  # which is what makes matching on it reasonable.
+  defp unsuitable_purpose?({:error, {:openssl_failed, _status, output}}) do
+    String.contains?(output, "unsuitable certificate purpose")
+  end
+
+  defp unsuitable_purpose?(_result), do: false
 
   @doc """
   The manifest, as text.
@@ -421,13 +440,20 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
          #
          # So these, not `-CAfile`, are what scope trust to the org's keyring.
          "-no-CApath",
-         "-no-CAstore",
-         # RAUC's signing certificates are not issued for any particular
-         # purpose, and openssl's default expects an S/MIME signer. Without
-         # this a perfectly good bundle fails as "unsupported certificate
-         # purpose", which reads like a bad signature.
-         "-purpose",
-         "any"
+         "-no-CAstore"
+         # No `-purpose any` here, deliberately.
+         #
+         # RAUC verifies a bundle with CMS_verify, which applies openssl's
+         # default S/MIME signing purpose. Relaxing it here made NervesHub
+         # accept bundles no device could install: a certificate carrying
+         # `extendedKeyUsage=codeSigning` -- the obvious choice for firmware --
+         # passes `-purpose any` and is then refused on every device with
+         # "unsuitable certificate purpose", mid-install.
+         #
+         # A certificate with no EKU is valid for every purpose and passes the
+         # default check, which is the ordinary case and needs no help. So the
+         # flag only ever admitted certificates that were going to fail later,
+         # somewhere far more expensive than an upload.
        ]}
     end
   end

--- a/lib/nerves_hub/firmwares/update_tool/rauc.ex
+++ b/lib/nerves_hub/firmwares/update_tool/rauc.ex
@@ -305,16 +305,20 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
           {:ok, key}
 
         nil ->
-          # "This certificate cannot sign anything" and "this certificate did
-          # not sign this bundle" are different problems, and only one of them
-          # is fixed by uploading a different file. Reported separately so the
-          # message points at the key rather than at the bundle.
-          if Enum.any?(attempts, fn {_key, result} -> unsuitable_purpose?(result) end) do
-            {:error, :unsuitable_certificate_purpose}
-          else
-            {:error, :invalid_signature}
-          end
+          no_key_matched(attempts)
       end
+    end
+  end
+
+  # "This certificate cannot sign anything" and "this certificate did not sign
+  # this bundle" are different problems, and only one of them is fixed by
+  # uploading a different file. Reported separately so the message points at
+  # the key rather than at the bundle.
+  defp no_key_matched(attempts) do
+    if Enum.any?(attempts, fn {_key, result} -> unsuitable_purpose?(result) end) do
+      {:error, :unsuitable_certificate_purpose}
+    else
+      {:error, :invalid_signature}
     end
   end
 

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -300,6 +300,15 @@ defmodule NervesHubWeb.Live.Firmware do
       "the bundle to a deployment."
   end
 
+  defp upload_error(:unsuitable_certificate_purpose) do
+    "This bundle's signing certificate is not valid for signing. RAUC verifies " <>
+      "with openssl's CMS, which expects a certificate usable for S/MIME " <>
+      "signing — an `extendedKeyUsage` of `codeSigning` alone excludes that, " <>
+      "and a device would refuse the bundle mid-install. Reissue the signing " <>
+      "certificate without a restrictive extendedKeyUsage; `openssl x509 " <>
+      "-purpose` should report \"S/MIME signing: Yes\"."
+  end
+
   defp upload_error({:invalid_manifest_field, field}) do
     "This RAUC bundle's manifest has a #{field} that is not a UUID. NervesHub " <>
       "stores firmware identifiers in a UUID column, so a declared uuid has to " <>

--- a/test/nerves_hub/firmwares/update_tool/rauc_test.exs
+++ b/test/nerves_hub/firmwares/update_tool/rauc_test.exs
@@ -164,6 +164,32 @@ defmodule NervesHub.Firmwares.UpdateTool.RaucTest do
       assert {:error, :invalid_signature} = Rauc.verify_signature(path, [key])
     end
 
+    test "refuses a signer that is not valid for signing", %{path: path} do
+      # A certificate carrying extendedKeyUsage=codeSigning is the obvious
+      # choice for firmware and the wrong one here: openssl's CMS verification
+      # applies the S/MIME signing purpose, which codeSigning alone excludes.
+      #
+      # NervesHub used to pass `-purpose any` and accept this. The bundle then
+      # failed on every device it reached, mid-install, with the device
+      # reporting "unsuitable certificate purpose" -- a long way from the
+      # upload that could have caught it.
+      code_signing = RaucBundle.keypair("code-signer", extended_key_usage: "codeSigning")
+      RaucBundle.write(path, code_signing)
+
+      key = %OrgKey{name: "code", key: code_signing.certificate, scheme: :x509_certificate}
+
+      assert {:error, :unsuitable_certificate_purpose} = Rauc.verify_signature(path, [key])
+    end
+
+    test "a signer with no extended key usage is fine", %{signer: signer, key: key, path: path} do
+      # The ordinary case, and the reason `-purpose any` looked unnecessary
+      # rather than harmful: a certificate with no EKU is valid for every
+      # purpose, so the default check passes it without help.
+      RaucBundle.write(path, signer)
+
+      assert {:ok, %OrgKey{}} = Rauc.verify_signature(path, [key])
+    end
+
     test "ignores keys belonging to other tools", %{signer: signer, path: path} do
       RaucBundle.write(path, signer)
 

--- a/test/support/rauc_bundle.ex
+++ b/test/support/rauc_bundle.ex
@@ -22,7 +22,7 @@ defmodule NervesHub.Support.RaucBundle do
   Self-signed: the certificate is both the signer and the trust anchor, which is
   what an organization registering a single key in NervesHub has.
   """
-  def keypair(common_name \\ "test-signer") do
+  def keypair(common_name \\ "test-signer", opts \\ []) do
     dir = tmp_dir()
     key_path = Path.join(dir, "key.pem")
     cert_path = Path.join(dir, "cert.pem")
@@ -44,7 +44,7 @@ defmodule NervesHub.Support.RaucBundle do
           "-nodes",
           "-subj",
           "/CN=#{common_name}"
-        ],
+        ] ++ extra_extensions(opts),
         stderr_to_stdout: true,
         # Nothing here needs the caller's environment, and inheriting it means
         # openssl reads whatever OPENSSL_* the shell happened to carry.
@@ -57,6 +57,20 @@ defmodule NervesHub.Support.RaucBundle do
       key_path: key_path,
       dir: dir
     }
+  end
+
+  # `extended_key_usage: "codeSigning"` produces the certificate that started
+  # this: valid for code signing, and therefore *not* valid for the S/MIME
+  # signing purpose openssl's CMS verification applies. RAUC refuses it on the
+  # device with "unsuitable certificate purpose".
+  #
+  # A certificate with no EKU is valid for every purpose, which is what the
+  # default fixture makes and what a working signer looks like.
+  defp extra_extensions(opts) do
+    case Keyword.get(opts, :extended_key_usage) do
+      nil -> []
+      usage -> ["-addext", "extendedKeyUsage=#{usage}"]
+    end
   end
 
   @doc """


### PR DESCRIPTION
NervesHub accepted a RAUC bundle that no device could install.

## What happened

A bundle uploaded and deployed cleanly, then failed on the device mid-install:

```
install failed: rauc: exited with exit status: 1
LastError: signature verification failed: Verify error: unsuitable certificate purpose
```

The signing certificate carried `extendedKeyUsage=codeSigning`. That is the
obvious choice for firmware and the wrong one here: RAUC verifies with
`CMS_verify`, which applies openssl's default **S/MIME signing** purpose, and
`codeSigning` alone excludes it.

```
$ openssl x509 -in signer.pem -noout -purpose
S/MIME signing : No
Code signing   : Yes
```

NervesHub did not catch it because it verified with `-purpose any`.

## Why the flag was there

```elixir
# RAUC's signing certificates are not issued for any particular
# purpose, and openssl's default expects an S/MIME signer. Without
# this a perfectly good bundle fails as "unsupported certificate
# purpose", which reads like a bad signature.
"-purpose",
"any"
```

The premise is right for a certificate with *no* EKU — that is valid for every
purpose and passes the default check unaided. It does not hold for one with a
restrictive EKU, and those are exactly the certificates the flag admitted. So
it never rescued a working signer; it only deferred a failure from one upload
to every device in a fleet.

## The change

`-purpose any` is gone, so an upload applies the same check the device will.

A purpose failure is also reported separately from a signature that does not
match. "This certificate cannot sign anything" and "this certificate did not
sign this bundle" want different fixes, and only one of them is fixed by
uploading a different file — previously both surfaced as `:invalid_signature`,
which points at the bundle rather than the key.

The upload error says what to do:

> This bundle's signing certificate is not valid for signing. RAUC verifies
> with openssl's CMS, which expects a certificate usable for S/MIME signing —
> an `extendedKeyUsage` of `codeSigning` alone excludes that, and a device
> would refuse the bundle mid-install. Reissue the signing certificate without
> a restrictive extendedKeyUsage; `openssl x509 -purpose` should report
> "S/MIME signing: Yes".

## Behaviour change

An organization whose signing certificate carries a restrictive
`extendedKeyUsage` will start failing at upload where it previously succeeded.
That looks like a regression and is not: those bundles could never be installed
by a device. The failure moves from a fleet mid-install to one upload with a
message naming the cause.

## Testing

Two tests: a `codeSigning` signer is refused with `:unsuitable_certificate_purpose`,
and a signer with no EKU still verifies — the ordinary case, and the one that
made the flag look unnecessary rather than harmful. The bundle fixture takes an
`extended_key_usage` option to build the bad certificate.

61 tests pass across the RAUC suites; `mix check` is clean.

Found on a CompuLab IOT-GATE-iMX8PLUS running the RAUC agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
