### PR TITLE
Let the connection join the local shell group, not the extension

### DIFF
--- a/lib/nerves_hub/consoles/pub_sub.ex
+++ b/lib/nerves_hub/consoles/pub_sub.ex
@@ -145,21 +145,42 @@ defmodule NervesHub.Consoles.PubSub do
 
   # -- Local shell ------------------------------------------------------------
 
-  @doc "Join the device-side extensions channel to the local-shell registry (on attach)."
+  @doc """
+  The group key the device-side extensions channel joins while the shell is
+  attached.
+
+  Public because the join cannot always happen here. `Group.join/4` joins the
+  calling process, and the process that has to be joined is the one holding the
+  device's connection — which is only this one when `NervesHub.DeviceLink` runs
+  in the connection's own process. `LocalShell` therefore returns
+  `{:group_join, key}` / `{:group_leave, key}` effects and lets the connection
+  carry them out; see `NervesHub.DeviceLink.Effect`.
+  """
+  @spec local_shell_key(integer()) :: String.t()
+  def local_shell_key(device_id), do: "local_shell/#{device_id}"
+
+  @doc """
+  Join the local-shell registry from the calling process.
+
+  For a caller that is itself the device's connection. `LocalShell` does not use
+  this — it returns a `{:group_join, key}` effect, because the extension does not
+  run in the connection's process on every deployment.
+  """
   @spec join_local_shell(integer()) :: :ok
   def join_local_shell(device_id) do
     :ok = Group.join(@group, local_shell_key(device_id), %{})
   end
 
   @doc """
-  Leave the local-shell registry (on detach).
+  Leave the local-shell registry from the calling process.
 
   Leaving when never attached is not an error. `detach/1` is driven by a
   device-sent `local_shell:detached`, which `Extensions.Dispatch` delivers
   without checking that an `attached` came first -- and it does not rescue the
   call, so returning `Group.leave/2`'s `{:error, :not_in_group}` raw would let a
   device take down its own extensions channel by sending `detached` twice, or
-  without ever attaching.
+  without ever attaching. The `{:group_leave, key}` effect tolerates it the same
+  way.
   """
   @spec leave_local_shell(integer()) :: :ok
   def leave_local_shell(device_id) do
@@ -236,7 +257,6 @@ defmodule NervesHub.Consoles.PubSub do
   defp device_console_key(device_id), do: "device:console/#{device_id}"
   defp internal_console_key(device_id), do: "device:console:internal/#{device_id}"
   defp user_console_key(device_id), do: "user:console/#{device_id}"
-  defp local_shell_key(device_id), do: "local_shell/#{device_id}"
   defp user_local_shell_key(device_id), do: "user:local_shell/#{device_id}"
 
   # -- Topic strings (preserved as the previous `Phoenix.PubSub` topics) ------

--- a/lib/nerves_hub/device_link/effect.ex
+++ b/lib/nerves_hub/device_link/effect.ex
@@ -10,6 +10,10 @@ defmodule NervesHub.DeviceLink.Effect do
     * `{:push, event, payload}` — send a message to the device
     * `{:subscribe, topic}` / `{:unsubscribe, topic}` — follow or stop following
       a PubSub topic on the connection's behalf
+    * `{:group_join, key}` / `{:group_leave, key}` — join or leave a `:group`
+      key on the connection's behalf. `Group.dispatch/3` delivers to the
+      processes that joined a key, so a group whose point is to reach the
+      device has to be joined by the connection and by nothing else.
     * `{:send_self, message}` — deliver `message` back to the connection now
     * `{:send_after, key, message, delay_ms}` — deliver it once, later
     * `{:start_timer, key, message, interval_ms}` — deliver it repeatedly
@@ -18,9 +22,11 @@ defmodule NervesHub.DeviceLink.Effect do
     * `{:scrollback_replay, pid}` — send everything recorded to `pid` as `{:cache, text}`
     * `{:scrollback_clear}` — forget it
 
-  `message` and `key` are opaque to whoever carries the effect out: it sends the
-  one and files timers under the other, and inspects neither. That is what lets
-  a connection be held somewhere that has none of the platform's code.
+  `message`, `key` and a group key are opaque to whoever carries the effect out:
+  it sends the one, files timers under the next, and joins the last without
+  inspecting any of them. That is what lets a connection be held somewhere that
+  has none of the platform's code — including somewhere that cannot compute the
+  group key itself.
 
   Scrollback is here for the same reason timers are. The platform has no use for
   a device's terminal output beyond passing it on, and the record is large and
@@ -32,6 +38,8 @@ defmodule NervesHub.DeviceLink.Effect do
           {:push, event :: String.t(), payload :: map()}
           | {:subscribe, topic :: String.t()}
           | {:unsubscribe, topic :: String.t()}
+          | {:group_join, key :: String.t()}
+          | {:group_leave, key :: String.t()}
           | {:send_self, message :: term()}
           | {:send_after, key :: term(), message :: term(), delay_ms :: non_neg_integer()}
           | {:start_timer, key :: term(), message :: term(), interval_ms :: pos_integer()}

--- a/lib/nerves_hub/extensions/dispatch.ex
+++ b/lib/nerves_hub/extensions/dispatch.ex
@@ -173,6 +173,8 @@ defmodule NervesHub.Extensions.Dispatch do
   defp translate({:scrollback_append, _data} = effect, _key, _mod), do: effect
   defp translate({:scrollback_replay, _pid} = effect, _key, _mod), do: effect
   defp translate({:scrollback_clear} = effect, _key, _mod), do: effect
+  defp translate({:group_join, _group_key} = effect, _key, _mod), do: effect
+  defp translate({:group_leave, _group_key} = effect, _key, _mod), do: effect
 
   defp put_state(extensions, key, state) do
     update_in(extensions[key], &%{&1 | state: state})

--- a/lib/nerves_hub/extensions/local_shell.ex
+++ b/lib/nerves_hub/extensions/local_shell.ex
@@ -32,16 +32,16 @@ defmodule NervesHub.Extensions.LocalShell do
 
   @impl NervesHub.Extensions
   def attach(state) do
-    :ok = Consoles.PubSub.join_local_shell(state.device_info.device_id)
+    key = Consoles.PubSub.local_shell_key(state.device_info.device_id)
 
-    {state, [{:push, "local_shell:request_shell", %{}}, {:scrollback_clear}]}
+    {state, [{:group_join, key}, {:push, "local_shell:request_shell", %{}}, {:scrollback_clear}]}
   end
 
   @impl NervesHub.Extensions
   def detach(state) do
-    :ok = Consoles.PubSub.leave_local_shell(state.device_info.device_id)
+    key = Consoles.PubSub.local_shell_key(state.device_info.device_id)
 
-    {state, [{:scrollback_clear}]}
+    {state, [{:group_leave, key}, {:scrollback_clear}]}
   end
 
   @impl NervesHub.Extensions

--- a/lib/nerves_hub/extensions/state.ex
+++ b/lib/nerves_hub/extensions/state.ex
@@ -36,6 +36,13 @@ defmodule NervesHub.Extensions.State do
   The scrollback effects are for output an extension wants remembered but has no
   use for itself; see `NervesHub.DeviceLink.Effect`. They pass through to the
   caller unchanged, since they name nothing extension-specific.
+
+  - `{:group_join, key}` / `{:group_leave, key}` — join or leave a `:group` key
+
+  These pass through unchanged for the same reason. An extension cannot join a
+  group itself: `Group.join/4` joins the calling process, and the process that
+  needs to be a member is the one holding the connection, which the extension
+  does not own — the same reason `:tick` and `:start_timer` exist.
   """
   @type effect ::
           {:push, event :: String.t(), payload :: map()}
@@ -45,6 +52,8 @@ defmodule NervesHub.Extensions.State do
           | {:scrollback_append, data :: binary()}
           | {:scrollback_replay, pid()}
           | {:scrollback_clear}
+          | {:group_join, key :: String.t()}
+          | {:group_leave, key :: String.t()}
 
   @type t :: %__MODULE__{
           device_info: DeviceInfo.t(),

--- a/lib/nerves_hub_web/channels/effects.ex
+++ b/lib/nerves_hub_web/channels/effects.ex
@@ -80,6 +80,22 @@ defmodule NervesHubWeb.Channels.Effects do
     socket
   end
 
+  defp apply_one(socket, {:group_join, key}) do
+    :ok = Group.join(NervesHub.Group, key, %{})
+    socket
+  end
+
+  # Leaving a group never joined is not an error here. A leave is driven by
+  # something the device said -- `local_shell:detached` is delivered without
+  # checking that an attach came first -- so surfacing `{:error, :not_in_group}`
+  # would let a device take down its own channel by detaching twice.
+  defp apply_one(socket, {:group_leave, key}) do
+    case Group.leave(NervesHub.Group, key) do
+      :ok -> socket
+      {:error, :not_in_group} -> socket
+    end
+  end
+
   defp apply_one(socket, {:send_self, message}) do
     send(self(), message)
     socket

--- a/test/nerves_hub/extensions/local_shell_test.exs
+++ b/test/nerves_hub/extensions/local_shell_test.exs
@@ -1,0 +1,49 @@
+defmodule NervesHub.Extensions.LocalShellTest do
+  use ExUnit.Case, async: true
+
+  alias NervesHub.Consoles
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Extensions.LocalShell
+  alias NervesHub.Extensions.State
+
+  defp state(device_id) do
+    State.new(%DeviceInfo{device_id: device_id, org_id: 1, product_id: 1})
+  end
+
+  defp device_id(), do: System.unique_integer([:positive])
+
+  describe "attach/1" do
+    # `Group.join/4` joins the calling process, and the process that has to be a
+    # member is the one holding the device's connection. Those are the same
+    # process only when `NervesHub.DeviceLink` runs in the connection's own
+    # process; where it is reached over `:erpc` they are on different nodes, and
+    # joining here would bind the membership to a transient RPC handler that
+    # exits as soon as the call returns.
+    test "asks the connection to join rather than joining itself" do
+      id = device_id()
+
+      {_state, effects} = LocalShell.attach(state(id))
+
+      assert {:group_join, Consoles.PubSub.local_shell_key(id)} in effects
+      refute Consoles.PubSub.local_shell_active?(id)
+    end
+
+    test "still asks the device for a shell and clears the scrollback" do
+      {_state, effects} = LocalShell.attach(state(device_id()))
+
+      assert {:push, "local_shell:request_shell", %{}} in effects
+      assert {:scrollback_clear} in effects
+    end
+  end
+
+  describe "detach/1" do
+    test "asks the connection to leave" do
+      id = device_id()
+
+      {_state, effects} = LocalShell.detach(state(id))
+
+      assert {:group_leave, Consoles.PubSub.local_shell_key(id)} in effects
+      assert {:scrollback_clear} in effects
+    end
+  end
+end

--- a/test/nerves_hub_web/channels/effects_test.exs
+++ b/test/nerves_hub_web/channels/effects_test.exs
@@ -134,4 +134,36 @@ defmodule NervesHubWeb.Channels.EffectsTest do
       refute_receive {:timeout, _ref, _payload}, 200
     end
   end
+
+  describe "group membership" do
+    test "joins the process carrying the effect out" do
+      key = "effects-test/#{System.unique_integer([:positive])}"
+
+      _socket = Effects.apply_all(socket(), [{:group_join, key}])
+
+      assert [{pid, _meta}] = Group.members(NervesHub.Group, key)
+      assert pid == self()
+    end
+
+    test "leaving gives up the membership" do
+      key = "effects-test/#{System.unique_integer([:positive])}"
+
+      socket = Effects.apply_all(socket(), [{:group_join, key}])
+      _socket = Effects.apply_all(socket, [{:group_leave, key}])
+
+      assert Group.members(NervesHub.Group, key) == []
+    end
+
+    # A leave is driven by something the device said, and nothing checks that a
+    # join came first, so a device must not be able to raise here by detaching
+    # twice or without attaching.
+    test "leaving a group never joined is not an error" do
+      key = "effects-test/#{System.unique_integer([:positive])}"
+
+      assert %Socket{} = Effects.apply_all(socket(), [{:group_leave, key}])
+
+      socket = Effects.apply_all(socket(), [{:group_join, key}, {:group_leave, key}])
+      assert %Socket{} = Effects.apply_all(socket, [{:group_leave, key}])
+    end
+  end
 end


### PR DESCRIPTION
## The bug

`LocalShell.attach/1` joins the local-shell group inline:

```elixir
def attach(state) do
  :ok = Consoles.PubSub.join_local_shell(state.device_info.device_id)
  {state, [{:push, "local_shell:request_shell", %{}}, {:scrollback_clear}]}
end
```

`Group.join/4` joins **the calling process**. The process that has to be a member is the one holding the device's connection. Those are the same process only when `NervesHub.DeviceLink` runs in the connection's own process — which is the case for a device node using `Dispatcher.Local`, and is why this works today.

It is not the case for a connection held somewhere that reaches DeviceLink over `:erpc` via `Dispatcher.Remote`. There the join lands on a transient RPC handler on a platform node, which exits as soon as the call returns and takes the membership with it. `local_shell_active?/1` reads false, `broadcast_to_local_shell/3` and `connect_to_local_shell/2` reach nobody, and the local shell is simply dead — with the UI reporting no shell rather than a broken one.

This is a regression against the contract #2893 set up. Before #2851 the user→device stream was a `Phoenix.PubSub` subscription, and that already travelled as a `{:subscribe, topic}` effect for exactly this reason.

## The fix

`NervesHub.DeviceLink.Effect` is described as "the vocabulary `NervesHub.DeviceLink` uses to ask for something that only the process holding a device's connection can do", and it already carries `{:subscribe, topic}` / `{:unsubscribe, topic}`. This adds `{:group_join, key}` / `{:group_leave, key}` beside them, and `attach/1` / `detach/1` return them instead of joining.

The key travels as an opaque string, exactly like a topic does. That is what lets a connection carry the effect out without being able to compute the key — or without having the platform's code at all.

Two details worth a look:

- **`Extensions.Dispatch.translate/3` has no catch-all clause**, so an extension emitting an untranslated effect raises `FunctionClauseError` at runtime rather than failing to compile. The new effects get pass-through clauses there; they name nothing extension-specific, same as the scrollback effects.
- **`join_local_shell/1` and `leave_local_shell/1` stay.** They are correct for a caller that *is* the connection, and the existing tests use them to stand one up. `local_shell_key/1` becomes public because the join now happens elsewhere. The tolerance for leaving a group never joined — a device can send `local_shell:detached` twice, or without ever attaching, and `Dispatch` neither checks nor rescues — is repeated in the effect applier, with the reasoning carried over.

## Tests

`test/nerves_hub/extensions/local_shell_test.exs` is new and is the regression test: `attach/1` returns the `{:group_join, key}` effect **and leaves the calling process a non-member**. That is the property that was broken; asserting it at the effect level catches it without needing a remote dispatcher to reproduce with.

`effects_test.exs` gains coverage for the applier: joining makes the carrying process a member, leaving gives it up, and leaving a group never joined does not raise.

## Verification

`mix compile --warnings-as-errors` and `mix format --check-formatted` clean.

`mix test test/nerves_hub_web/channels/ test/nerves_hub/consoles/ test/nerves_hub/extensions/ test/nerves_hub_web/live/devices/show/local_shell_tab_test.exs` → **176/177**. The one failure is a `users_email_index` collision in `Fixtures.user_fixture/1`; that file scores 5/6 identically on an unmodified tree, so it is a dirty local test database rather than this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)