### PR TITLE
Record device messages where the platform produces them

### DIFF
--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -498,9 +498,16 @@ defmodule NervesHub.DeviceLink do
           {:ok, ExtensionDispatch.extensions(), [extension_effect()]} | :unknown
   def extension_message(extensions, scoped_event, payload) do
     device_info = ExtensionDispatch.device_info(extensions)
-    :ok = record_extension_received(device_info, scoped_event, payload)
+    :ok = record(device_info, :received, :extensions, scoped_event, payload)
 
-    record_extension_pushes(ExtensionDispatch.message(extensions, scoped_event, payload), device_info)
+    case ExtensionDispatch.message(extensions, scoped_event, payload) do
+      {:ok, extensions, effects} ->
+        :ok = record_pushes(device_info, :extensions, effects)
+        {:ok, extensions, effects}
+
+      :unknown ->
+        :unknown
+    end
   end
 
   @doc """
@@ -512,10 +519,11 @@ defmodule NervesHub.DeviceLink do
   @spec extension_info(ExtensionDispatch.extensions(), module(), msg :: term()) ::
           {:ok, ExtensionDispatch.extensions(), [extension_effect()]}
   def extension_info(extensions, module, msg) do
-    record_extension_pushes(
-      ExtensionDispatch.info(extensions, module, msg),
-      ExtensionDispatch.device_info(extensions)
-    )
+    device_info = ExtensionDispatch.device_info(extensions)
+    {:ok, extensions, effects} = ExtensionDispatch.info(extensions, module, msg)
+    :ok = record_pushes(device_info, :extensions, effects)
+
+    {:ok, extensions, effects}
   end
 
   @doc """
@@ -772,36 +780,24 @@ defmodule NervesHub.DeviceLink do
   # it was put on its way.
   defp record_pushes(device_info, topic, effects) do
     Enum.each(effects, fn
-      {:push, event, payload} -> DeviceMessages.record(device_info, :sent, topic, event, payload)
+      {:push, event, payload} -> record(device_info, :sent, topic, event, payload)
       _effect -> :ok
     end)
+  end
+
+  # A device whose declared extensions are all unknown to this deployment has no
+  # `DeviceInfo` to attribute traffic to. Nothing is dispatched for it either, so
+  # there is nothing the record would be missing.
+  defp record(nil, _direction, _topic, _event, _payload), do: :ok
+
+  defp record(device_info, direction, topic, event, payload) do
+    DeviceMessages.record(device_info, direction, topic, event, payload)
   end
 
   defp record_effect_pushes({session, effects}, topic) do
     :ok = record_pushes(session.device_info, topic, effects)
     {session, effects}
   end
-
-  # A device whose declared extensions are all unknown to this deployment has no
-  # `DeviceInfo` to attribute traffic to. Nothing is dispatched for it either, so
-  # there is nothing the record would be missing.
-  defp record_extension_received(nil, _event, _payload), do: :ok
-
-  defp record_extension_received(device_info, event, payload) do
-    DeviceMessages.record(device_info, :received, :extensions, event, payload)
-  end
-
-  # Nothing to attribute the pushes to, so nothing is recorded — but the result
-  # still has to travel: the caller is waiting on `{:ok, extensions, effects}`
-  # or `:unknown`, not on whether recording happened.
-  defp record_extension_pushes(result, nil), do: result
-
-  defp record_extension_pushes({:ok, extensions, effects}, device_info) do
-    :ok = record_pushes(device_info, :extensions, effects)
-    {:ok, extensions, effects}
-  end
-
-  defp record_extension_pushes(other, _device_info), do: other
 
   # Everything broadcast on a device's own topic from here — the archive and the
   # public key messages — is fastlaned by Phoenix straight to the device's

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -44,6 +44,19 @@ defmodule NervesHub.DeviceLink do
   @spec device_join(DeviceInfo.t(), params :: map()) ::
           {:ok, Session.t(), [Effect.t()]} | {:error, any()}
   def device_join(device_info, params) do
+    :ok = DeviceMessages.record(device_info, :received, :device, "join", params)
+
+    case do_device_join(device_info, params) do
+      {:ok, session, effects} ->
+        :ok = record_pushes(device_info, :device, effects)
+        {:ok, session, effects}
+
+      other ->
+        other
+    end
+  end
+
+  defp do_device_join(device_info, params) do
     params = sanitize_device_api_version(params)
 
     case join(device_info, params) do
@@ -73,7 +86,15 @@ defmodule NervesHub.DeviceLink do
   The device sent us something.
   """
   @spec device_message(Session.t(), event :: String.t(), payload :: map()) :: {Session.t(), [Effect.t()]}
-  def device_message(session, "firmware_validated", _payload) do
+  def device_message(session, event, payload) do
+    :ok = DeviceMessages.record(session.device_info, :received, :device, event, payload)
+
+    session
+    |> do_device_message(event, payload)
+    |> record_effect_pushes(:device)
+  end
+
+  defp do_device_message(session, "firmware_validated", _payload) do
     :ok = firmware_validated(session.device_info)
     {session, []}
   end
@@ -83,8 +104,8 @@ defmodule NervesHub.DeviceLink do
   # `update_progress` is the same message under a name that does not presume
   # fwup, and is what a non-Nerves agent should send. Both carry the same
   # payload: a `value` percentage and an optional `stage`.
-  def device_message(session, event, %{"value" => percent} = params)
-      when event in ["fwup_progress", "update_progress"] do
+  defp do_device_message(session, event, %{"value" => percent} = params)
+       when event in ["fwup_progress", "update_progress"] do
     {stage, percent} =
       case {params["stage"], percent} do
         {nil, 100} -> {"completed", nil}
@@ -97,26 +118,26 @@ defmodule NervesHub.DeviceLink do
     {session, []}
   end
 
-  def device_message(session, "connection_types", %{"values" => types}) do
+  defp do_device_message(session, "connection_types", %{"values" => types}) do
     :ok = update_connection_metadata(session.device_info.connection_ref, %{"connection_types" => types})
 
     {session, []}
   end
 
-  def device_message(session, "status_update", params) do
+  defp do_device_message(session, "status_update", params) do
     :ok = status_update(session.device_info, params)
     {session, []}
   end
 
-  def device_message(session, "rebooting", _payload), do: {session, []}
+  defp do_device_message(session, "rebooting", _payload), do: {session, []}
 
-  def device_message(session, "scripts/run", %{
-        "ref" => "connecting_code",
-        "result" => result,
-        "return" => return,
-        "output" => output
-      })
-      when result == "error" or return == "nil" do
+  defp do_device_message(session, "scripts/run", %{
+         "ref" => "connecting_code",
+         "result" => result,
+         "return" => return,
+         "output" => output
+       })
+       when result == "error" or return == "nil" do
     :telemetry.execute([:nerves_hub, :devices, :connecting_code_failure], %{
       output: output,
       identifier: session.device_info.device_identifier
@@ -125,12 +146,12 @@ defmodule NervesHub.DeviceLink do
     {session, []}
   end
 
-  def device_message(session, "scripts/run", %{"ref" => "connecting_code"}) do
+  defp do_device_message(session, "scripts/run", %{"ref" => "connecting_code"}) do
     :telemetry.execute([:nerves_hub, :devices, :connecting_code_success], %{count: 1})
     {session, []}
   end
 
-  def device_message(session, "scripts/run", params) do
+  defp do_device_message(session, "scripts/run", params) do
     ref = params["ref"]
 
     case session.script_refs[ref] do
@@ -152,7 +173,7 @@ defmodule NervesHub.DeviceLink do
     end
   end
 
-  def device_message(session, "report_network_interface", %{"interface" => interface}) do
+  defp do_device_message(session, "report_network_interface", %{"interface" => interface}) do
     case report_network_interface(session.device_info, interface) do
       {:ok, device_info} ->
         {%{session | device_info: device_info}, []}
@@ -166,7 +187,7 @@ defmodule NervesHub.DeviceLink do
     end
   end
 
-  def device_message(session, event, params) do
+  defp do_device_message(session, event, params) do
     # Ignore unhandled messages so that it doesn't crash the link process
     # preventing cascading problems.
     :telemetry.execute([:nerves_hub, :devices, :unhandled_in], %{count: 1}, %{
@@ -182,7 +203,13 @@ defmodule NervesHub.DeviceLink do
   Something in the platform addressed this device's link directly.
   """
   @spec device_notify(Session.t(), message :: term()) :: {Session.t(), [Effect.t()]}
-  def device_notify(session, {:after_join, params}) do
+  def device_notify(session, message) do
+    session
+    |> do_device_notify(message)
+    |> record_effect_pushes(:device)
+  end
+
+  defp do_device_notify(session, {:after_join, params}) do
     :ok = after_join(session.device_info, params)
 
     effects =
@@ -194,15 +221,15 @@ defmodule NervesHub.DeviceLink do
   end
 
   # we can ignore this message
-  def device_notify(session, %Broadcast{event: "deployments/update"}), do: {session, []}
+  defp do_device_notify(session, %Broadcast{event: "deployments/update"}), do: {session, []}
 
   # listen for notifications about archive updates for deployment groups
-  def device_notify(session, %Broadcast{event: "archives/updated"}) do
+  defp do_device_notify(session, %Broadcast{event: "archives/updated"}) do
     :ok = maybe_send_archive(session.device_info, session.device_api_version, audit_log: true)
     {session, []}
   end
 
-  def device_notify(session, {:run_script, pid, text}) do
+  defp do_device_notify(session, {:run_script, pid, text}) do
     if safe_to_run_scripts?(session) do
       ref = Base.encode64(:crypto.strong_rand_bytes(4), padding: false)
       session = %{session | script_refs: Map.put(session.script_refs, ref, pid)}
@@ -221,11 +248,11 @@ defmodule NervesHub.DeviceLink do
   # The script never answered. Drop the reference, and the timeout's own
   # bookkeeping with it -- a one-shot timer that has fired leaves an entry
   # behind otherwise, and on a connection held for weeks those accumulate.
-  def device_notify(session, {:clear_script_ref, ref}) do
+  defp do_device_notify(session, {:clear_script_ref, ref}) do
     {release_script_ref(session, ref), [cancel_script_timeout(ref)]}
   end
 
-  def device_notify(session, message) do
+  defp do_device_notify(session, message) do
     :telemetry.execute([:nerves_hub, :devices, :unhandled_info], %{count: 1}, %{
       identifier: session.device_info.device_identifier,
       msg: message
@@ -238,14 +265,20 @@ defmodule NervesHub.DeviceLink do
   An intercepted broadcast, handled before the device sees anything.
   """
   @spec device_broadcast(Session.t(), event :: String.t(), payload :: map()) :: {Session.t(), [Effect.t()]}
-  def device_broadcast(session, "updated", _payload) do
+  def device_broadcast(session, event, payload) do
+    session
+    |> do_device_broadcast(event, payload)
+    |> record_effect_pushes(:device)
+  end
+
+  defp do_device_broadcast(session, "updated", _payload) do
     device_info = refresh_device_info(session.device_info)
     :ok = maybe_send_archive(device_info, session.device_api_version, audit_log: true)
 
     follow_deployment_group(%{session | device_info: device_info})
   end
 
-  def device_broadcast(session, "deployment_updated", payload) do
+  defp do_device_broadcast(session, "deployment_updated", payload) do
     device_info = %{session.device_info | deployment_id: payload.deployment_id}
     :ok = maybe_send_archive(device_info, session.device_api_version, audit_log: true)
 
@@ -463,7 +496,12 @@ defmodule NervesHub.DeviceLink do
   """
   @spec extension_message(ExtensionDispatch.extensions(), scoped_event :: String.t(), payload :: term()) ::
           {:ok, ExtensionDispatch.extensions(), [extension_effect()]} | :unknown
-  defdelegate extension_message(extensions, scoped_event, payload), to: ExtensionDispatch, as: :message
+  def extension_message(extensions, scoped_event, payload) do
+    device_info = ExtensionDispatch.device_info(extensions)
+    :ok = record_extension_received(device_info, scoped_event, payload)
+
+    record_extension_pushes(ExtensionDispatch.message(extensions, scoped_event, payload), device_info)
+  end
 
   @doc """
   Deliver a message addressed to an extension module.
@@ -473,7 +511,12 @@ defmodule NervesHub.DeviceLink do
   """
   @spec extension_info(ExtensionDispatch.extensions(), module(), msg :: term()) ::
           {:ok, ExtensionDispatch.extensions(), [extension_effect()]}
-  defdelegate extension_info(extensions, module, msg), to: ExtensionDispatch, as: :info
+  def extension_info(extensions, module, msg) do
+    record_extension_pushes(
+      ExtensionDispatch.info(extensions, module, msg),
+      ExtensionDispatch.device_info(extensions)
+    )
+  end
 
   @doc """
   The device has confirmed the firmware it is running is good.
@@ -716,6 +759,46 @@ defmodule NervesHub.DeviceLink do
   defp topic(%DeviceInfo{device_id: id}) do
     "device:#{id}"
   end
+
+  # A push is the only effect that reaches the device; subscribing, timers and
+  # scrollback stay on the connection and have nothing to record.
+  #
+  # Recorded here, where the effect is produced, rather than where it is carried
+  # out. The connection holding the device is not always this node — it may be
+  # reached over `:erpc`, with no database of its own to write to — so the point
+  # of production is the last place every deployment has in common. That makes
+  # this a record of what the platform sent, in the same sense as the fastlaned
+  # sends below: `record_pushes/3` cannot know the device received it, only that
+  # it was put on its way.
+  defp record_pushes(device_info, topic, effects) do
+    Enum.each(effects, fn
+      {:push, event, payload} -> DeviceMessages.record(device_info, :sent, topic, event, payload)
+      _effect -> :ok
+    end)
+  end
+
+  defp record_effect_pushes({session, effects}, topic) do
+    :ok = record_pushes(session.device_info, topic, effects)
+    {session, effects}
+  end
+
+  # A device whose declared extensions are all unknown to this deployment has no
+  # `DeviceInfo` to attribute traffic to. Nothing is dispatched for it either, so
+  # there is nothing the record would be missing.
+  defp record_extension_received(nil, _event, _payload), do: :ok
+
+  defp record_extension_received(device_info, event, payload) do
+    DeviceMessages.record(device_info, :received, :extensions, event, payload)
+  end
+
+  defp record_extension_pushes(_result, nil), do: :ok
+
+  defp record_extension_pushes({:ok, extensions, effects}, device_info) do
+    :ok = record_pushes(device_info, :extensions, effects)
+    {:ok, extensions, effects}
+  end
+
+  defp record_extension_pushes(other, _device_info), do: other
 
   # Everything broadcast on a device's own topic from here — the archive and the
   # public key messages — is fastlaned by Phoenix straight to the device's

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -791,7 +791,10 @@ defmodule NervesHub.DeviceLink do
     DeviceMessages.record(device_info, :received, :extensions, event, payload)
   end
 
-  defp record_extension_pushes(_result, nil), do: :ok
+  # Nothing to attribute the pushes to, so nothing is recorded — but the result
+  # still has to travel: the caller is waiting on `{:ok, extensions, effects}`
+  # or `:unknown`, not on whether recording happened.
+  defp record_extension_pushes(result, nil), do: result
 
   defp record_extension_pushes({:ok, extensions, effects}, device_info) do
     :ok = record_pushes(device_info, :extensions, effects)

--- a/lib/nerves_hub/extensions.ex
+++ b/lib/nerves_hub/extensions.ex
@@ -112,7 +112,7 @@ defmodule NervesHub.Extensions do
 
   def broadcast_extension_event(%Device{} = device, event, extension) do
     # web -> device: only the device's extensions channel consumes this.
-    PubSub.broadcast_to_device(device.id, event, %{"extensions" => [extension]})
+    PubSub.broadcast_to_device(device, event, %{"extensions" => [extension]})
   end
 
   def broadcast_extension_event(%Product{} = product, event, extension) do

--- a/lib/nerves_hub/extensions/dispatch.ex
+++ b/lib/nerves_hub/extensions/dispatch.ex
@@ -182,5 +182,22 @@ defmodule NervesHub.Extensions.Dispatch do
     update_in(extensions[key], &%{&1 | status: status})
   end
 
+  @doc """
+  The device these extensions belong to.
+
+  Every extension in the set carries the same `DeviceInfo`, so any of them
+  answers. Public so `NervesHub.DeviceLink` can record a device's extension
+  traffic without the caller having to pass the device separately.
+  """
+  @spec device_info(extensions()) :: DeviceInfo.t() | nil
+  def device_info(extensions) do
+    # An extension the device declared but this deployment does not know carries
+    # no state at all, so the answer comes from whichever entry has one.
+    Enum.find_value(extensions, fn
+      {_key, %{state: %State{device_info: device_info}}} -> device_info
+      {_key, _entry} -> nil
+    end)
+  end
+
   defp device_info(extensions, key), do: extensions[key].state.device_info
 end

--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -90,7 +90,7 @@ defmodule NervesHub.Extensions.Health do
   end
 
   def request_health_check(device) do
-    :ok = PubSub.broadcast_to_device(device.id, "health:check", %{})
+    :ok = PubSub.broadcast_to_device(device, "health:check", %{})
   end
 
   defp health_interval_minutes() do

--- a/lib/nerves_hub/extensions/pub_sub.ex
+++ b/lib/nerves_hub/extensions/pub_sub.ex
@@ -50,6 +50,8 @@ defmodule NervesHub.Extensions.PubSub do
   pub/sub goes through one module.
   """
 
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.DeviceMessages
   alias Phoenix.Channel.Server, as: ChannelServer
   alias Phoenix.Socket.Broadcast
 
@@ -68,9 +70,14 @@ defmodule NervesHub.Extensions.PubSub do
   end
 
   @doc "Send a web -> device extensions event (`health:check`, `attach`, `detach`)."
-  @spec broadcast_to_device(integer(), String.t(), map()) :: :ok
-  def broadcast_to_device(device_id, event, payload) do
-    ChannelServer.broadcast!(NervesHub.PubSub, topic(device_id), event, payload)
+  @spec broadcast_to_device(Device.t(), String.t(), map()) :: :ok
+  def broadcast_to_device(%Device{} = device, event, payload) do
+    # Recorded here rather than in the channel that pushes it. The connection
+    # holding the device is not always this node, and a connection reached over
+    # `:erpc` has no database to write to, so this is the last point every
+    # deployment has in common. See `NervesHub.Devices.DeviceMessages`.
+    :ok = DeviceMessages.record(device, :sent, :extensions, event, payload)
+    ChannelServer.broadcast!(NervesHub.PubSub, topic(device.id), event, payload)
   end
 
   @doc "Join the calling process (a device Show LiveView) to receive device -> web reports."

--- a/lib/nerves_hub_web/channels/console_channel.ex
+++ b/lib/nerves_hub_web/channels/console_channel.ex
@@ -3,7 +3,6 @@ defmodule NervesHubWeb.ConsoleChannel do
   use Phoenix.Channel
 
   alias NervesHub.Consoles.PubSub
-  alias NervesHub.Devices.DeviceMessages
   alias NervesHubWeb.Channels.Scrollback
   alias Phoenix.Socket.Broadcast
 
@@ -18,8 +17,6 @@ defmodule NervesHubWeb.ConsoleChannel do
   end
 
   def handle_in("up", payload, socket) do
-    :ok = record(socket, :received, "up", payload)
-
     scrollback = Scrollback.append(socket.assigns.scrollback, payload["data"])
     socket = assign(socket, :scrollback, scrollback)
 
@@ -29,24 +26,18 @@ defmodule NervesHubWeb.ConsoleChannel do
   end
 
   def handle_in("file-data/start", payload, socket) do
-    :ok = record(socket, :received, "file-data/start", payload)
-
     PubSub.broadcast_to_user_console(device_id(socket), "file-data/start", payload)
 
     {:noreply, socket}
   end
 
   def handle_in("file-data", payload, socket) do
-    :ok = record(socket, :received, "file-data", payload)
-
     PubSub.broadcast_to_user_console(device_id(socket), "file-data", payload)
 
     {:noreply, socket}
   end
 
   def handle_in("file-data/stop", payload, socket) do
-    :ok = record(socket, :received, "file-data/stop", payload)
-
     PubSub.broadcast_to_user_console(device_id(socket), "file-data/stop", payload)
 
     {:noreply, socket}
@@ -77,17 +68,8 @@ defmodule NervesHubWeb.ConsoleChannel do
   end
 
   def handle_info(%Broadcast{payload: payload, event: event}, socket) do
-    :ok = record(socket, :sent, event, payload)
-
     push(socket, event, payload)
     {:noreply, socket}
-  end
-
-  # Console traffic is recorded by size only, never by content — it is raw
-  # terminal I/O, so its contents are whatever was typed at a prompt.
-  # See `NervesHub.Devices.DeviceMessages`.
-  defp record(socket, direction, event, payload) do
-    DeviceMessages.record_size_only(socket.assigns.device_info, direction, :console, event, payload)
   end
 
   defp device_id(socket), do: socket.assigns.device_info.device_id

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -30,7 +30,6 @@ defmodule NervesHubWeb.DeviceChannel do
   use OpenTelemetryDecorator
 
   alias NervesHub.DeviceLink.Client, as: DeviceLink
-  alias NervesHub.Devices.DeviceMessages
   alias NervesHubWeb.Channels.Effects
 
   intercept(["updated", "deployment_updated"])
@@ -41,9 +40,6 @@ defmodule NervesHubWeb.DeviceChannel do
 
     case DeviceLink.device_join(device_info, params) do
       {:ok, session, effects} ->
-        :ok = DeviceMessages.record(device_info, :received, :device, "join", params)
-        :ok = record_pushes(device_info, effects)
-
         socket =
           socket
           |> assign(:session, session)
@@ -60,8 +56,6 @@ defmodule NervesHubWeb.DeviceChannel do
   @impl Phoenix.Channel
   @decorate with_span("Channels.DeviceChannel.handle_in")
   def handle_in(event, payload, socket) do
-    :ok = DeviceMessages.record(device_info(socket), :received, :device, event, payload)
-
     advance(socket, &DeviceLink.device_message(&1, event, payload))
   end
 
@@ -85,8 +79,6 @@ defmodule NervesHubWeb.DeviceChannel do
   defp advance(socket, fun) do
     {session, effects} = fun.(socket.assigns.session)
 
-    :ok = record_pushes(session.device_info, effects)
-
     socket =
       socket
       |> assign(:session, session)
@@ -94,20 +86,4 @@ defmodule NervesHubWeb.DeviceChannel do
 
     {:noreply, socket}
   end
-
-  # Only pushes cross the wire. The rest of the effect vocabulary — subscribing,
-  # timers, scrollback — never reaches the device and has nothing to record.
-  #
-  # This does not see the platform's fastlaned sends (identify, reboot, update,
-  # archive, the public keys): Phoenix delivers those from the broadcast to the
-  # transport without this process running. They are recorded where they are
-  # broadcast instead. See `NervesHub.Devices.DeviceMessages`.
-  defp record_pushes(device_info, effects) do
-    Enum.each(effects, fn
-      {:push, event, payload} -> DeviceMessages.record(device_info, :sent, :device, event, payload)
-      _effect -> :ok
-    end)
-  end
-
-  defp device_info(socket), do: socket.assigns.session.device_info
 end

--- a/lib/nerves_hub_web/channels/extensions_channel.ex
+++ b/lib/nerves_hub_web/channels/extensions_channel.ex
@@ -13,7 +13,6 @@ defmodule NervesHubWeb.ExtensionsChannel do
   use OpenTelemetryDecorator
 
   alias NervesHub.DeviceLink.Client, as: DeviceLink
-  alias NervesHub.Devices.DeviceMessages
   alias NervesHub.Extensions
   alias NervesHubWeb.Channels.Effects
   alias Phoenix.Socket.Broadcast
@@ -45,8 +44,6 @@ defmodule NervesHubWeb.ExtensionsChannel do
   @impl Phoenix.Channel
   @decorate with_span("Channels.ExtensionsChannel.handle_in")
   def handle_in(scoped_event, payload, socket) do
-    :ok = DeviceMessages.record(device_info(socket), :received, :extensions, scoped_event, payload)
-
     case DeviceLink.extension_message(socket.assigns.extensions, scoped_event, payload) do
       {:ok, extensions, effects} ->
         socket
@@ -68,8 +65,6 @@ defmodule NervesHubWeb.ExtensionsChannel do
 
   @decorate with_span("Channels.ExtensionsChannel.handle_info[Broadcast]")
   def handle_info(%Broadcast{event: event, payload: payload}, socket) do
-    :ok = DeviceMessages.record(device_info(socket), :sent, :extensions, event, payload)
-
     push(socket, event, payload)
     {:noreply, socket}
   end
@@ -99,16 +94,5 @@ defmodule NervesHubWeb.ExtensionsChannel do
     |> apply_effects(effects)
   end
 
-  defp apply_effects(socket, effects) do
-    device_info = device_info(socket)
-
-    Enum.each(effects, fn
-      {:push, event, payload} -> DeviceMessages.record(device_info, :sent, :extensions, event, payload)
-      _effect -> :ok
-    end)
-
-    {:noreply, Effects.apply_all(socket, effects)}
-  end
-
-  defp device_info(socket), do: socket.assigns.device_info
+  defp apply_effects(socket, effects), do: {:noreply, Effects.apply_all(socket, effects)}
 end

--- a/lib/nerves_hub_web/channels/user_console_channel.ex
+++ b/lib/nerves_hub_web/channels/user_console_channel.ex
@@ -6,6 +6,7 @@ defmodule NervesHubWeb.UserConsoleChannel do
   alias NervesHub.Accounts.Scope
   alias NervesHub.Consoles.PubSub
   alias NervesHub.Devices
+  alias NervesHub.Devices.DeviceMessages
   alias NervesHubWeb.Helpers.Authorization
   alias Phoenix.Socket.Broadcast
 
@@ -15,7 +16,7 @@ defmodule NervesHubWeb.UserConsoleChannel do
 
       _ = PubSub.connect_to_console(device.id, self())
 
-      {:ok, assign(socket, :device_id, device.id)}
+      {:ok, socket |> assign(:device_id, device.id) |> assign(:device, device)}
     else
       {:error, %{reason: "unauthorized"}}
     end
@@ -29,17 +30,20 @@ defmodule NervesHubWeb.UserConsoleChannel do
 
   def handle_in("file-data/start", payload, socket) do
     payload = Map.put(payload, :uploaded_by, socket.assigns.user.id)
+    :ok = record(socket, :sent, "file-data/start", payload)
     PubSub.broadcast_to_console(socket.assigns.device_id, "file-data/start", payload)
     {:noreply, socket}
   end
 
   def handle_in("file-data", payload, socket) do
+    :ok = record(socket, :sent, "file-data", payload)
     PubSub.broadcast_to_console(socket.assigns.device_id, "file-data", payload)
     {:noreply, socket}
   end
 
   def handle_in("file-data/stop", payload, socket) do
     payload = Map.put(payload, :uploaded_by, socket.assigns.user.id)
+    :ok = record(socket, :sent, "file-data/stop", payload)
     PubSub.broadcast_to_console(socket.assigns.device_id, "file-data/stop", payload)
     {:noreply, socket}
   end
@@ -47,6 +51,7 @@ defmodule NervesHubWeb.UserConsoleChannel do
   def handle_in(event, payload, socket) do
     # Key presses are coming in here raw
     # Send them to the device
+    :ok = record(socket, :sent, event, payload)
     PubSub.broadcast_to_console(socket.assigns.device_id, event, payload)
     {:noreply, socket}
   end
@@ -63,6 +68,8 @@ defmodule NervesHubWeb.UserConsoleChannel do
 
   # This ties in the messages from Device that need to be handled in the console
   def handle_info(%Broadcast{payload: payload, event: event}, socket) do
+    :ok = record(socket, :received, event, payload)
+
     push(socket, event, payload)
     {:noreply, socket}
   end
@@ -77,6 +84,19 @@ defmodule NervesHubWeb.UserConsoleChannel do
       end
 
     socket
+  end
+
+  # Console traffic is recorded here rather than on the device-side channel.
+  # Both directions pass through this process, and this process always runs
+  # where the platform does — the device-side channel may be held on a
+  # connection reached over `:erpc`, with no database of its own to write to.
+  # Console traffic only exists while a user is attached, so nothing is missed
+  # by recording at the user's end.
+  #
+  # By size only, never by content: it is raw terminal I/O, so its contents are
+  # whatever was typed at a prompt. See `NervesHub.Devices.DeviceMessages`.
+  defp record(socket, direction, event, payload) do
+    DeviceMessages.record_size_only(socket.assigns.device, direction, :console, event, payload)
   end
 
   defp authorized?(user, identifier) do

--- a/test/nerves_hub/extensions/pub_sub_test.exs
+++ b/test/nerves_hub/extensions/pub_sub_test.exs
@@ -1,18 +1,26 @@
 defmodule NervesHub.Extensions.PubSubTest do
   use ExUnit.Case, async: true
 
+  alias NervesHub.Devices.Device
   alias NervesHub.Extensions.PubSub
   alias Phoenix.Socket.Broadcast
 
-  # Unique per test so concurrent tests don't share a group key or topic.
+  # Unique per test so concurrent tests don't share a group key or topic. The
+  # struct is built rather than inserted: nothing here reads it back, and
+  # `broadcast_to_device/3` only needs the ids to attribute what it records.
   setup do
-    %{device_id: System.unique_integer([:positive])}
+    device_id = System.unique_integer([:positive])
+
+    %{device_id: device_id, device: %Device{id: device_id, org_id: 1, product_id: 1}}
   end
 
-  test "broadcast_to_device reaches the device-side extensions channel", %{device_id: device_id} do
+  test "broadcast_to_device reaches the device-side extensions channel", %{
+    device_id: device_id,
+    device: device
+  } do
     :ok = PubSub.subscribe_device(device_id)
 
-    :ok = PubSub.broadcast_to_device(device_id, "health:check", %{})
+    :ok = PubSub.broadcast_to_device(device, "health:check", %{})
 
     topic = "device:#{device_id}:extensions"
     assert_receive %Broadcast{topic: ^topic, event: "health:check", payload: %{}}, 500
@@ -39,10 +47,13 @@ defmodule NervesHub.Extensions.PubSubTest do
     refute_receive %Broadcast{event: "health_check_report"}, 200
   end
 
-  test "a report subscriber does NOT receive web->device commands", %{device_id: device_id} do
+  test "a report subscriber does NOT receive web->device commands", %{
+    device_id: device_id,
+    device: device
+  } do
     :ok = PubSub.subscribe_reports(device_id)
 
-    :ok = PubSub.broadcast_to_device(device_id, "health:check", %{})
+    :ok = PubSub.broadcast_to_device(device, "health:check", %{})
 
     refute_receive %Broadcast{event: "health:check"}, 200
   end


### PR DESCRIPTION
## Why

Recording lives in the channels — `device_channel.ex`, `extensions_channel.ex`, `console_channel.ex`. That works while the channel and the platform are the same process, which is the case for a device node using `Dispatcher.Local`.

It is not the case for a connection reached over `:erpc` through `Dispatcher.Remote`. Those channels run somewhere with no database to write to, so every message the device sent and every push it was sent in reply goes unrecorded — while the platform's own fastlaned sends (`device_link.ex`, `device_events.ex`) keep being recorded.

That leaves a Data History showing one side of a conversation, which is worse than showing neither. The question the tab exists to answer is *was the device ever told*, and half an answer looks like a whole one.

## What moves where

`NervesHub.DeviceLink` is the one point every deployment has in common — `Dispatcher.Local` applies it in the connection's process, `Dispatcher.Remote` reaches it over `:erpc` — so recording moves there.

**`:received` is exactly as truthful as before.** DeviceLink is *called because* a message crossed the wire; there is no path that reaches it otherwise. The moduledoc's "recorded because it actually crossed the wire rather than because something intended it to" still holds.

**`:sent` is weaker, deliberately.** A push is recorded when the effect carrying it is produced, not when the connection carries it out — so it records what the platform sent in the sense of putting it on its way. This is the same trade already made for the fastlaned sends, which are recorded at the broadcast because the channel process never sees them.

**Console moves the other way — to the user-side channel.** The device-side channel is the half that may be held remotely; the user's half always runs where the platform does, and both directions pass through it. Console traffic only exists while a user is attached, so nothing is missed by recording at that end, and it goes on being recorded by size only, never by content.

## Details worth a look

- The multi-clause `device_join/2`, `device_message/3`, `device_notify/2` and `device_broadcast/3` are renamed to `do_*` so a single recording head wraps each. No behaviour change; there were no recursive self-calls.
- `extension_message/3` and `extension_info/3` stop being `defdelegate`s and become wrappers.
- `Extensions.Dispatch.device_info/1` is new and public, so DeviceLink can attribute extension traffic without the caller passing the device separately. It skips entries with no state — an extension the device declared but this deployment does not know carries none — and returns `nil` when no entry has one. Recording is a no-op in that case, which is correct: nothing is dispatched for such a device either.
- `Extensions.PubSub.broadcast_to_device/3` now takes the device rather than its id, for the same reason `device_link.ex` records at its own `broadcast/3` — it is the last point that sees the message with something to attribute it to. Both callers already had the struct.

## Verification

`mix compile --warnings-as-errors` and `mix format --check-formatted` clean.

`mix test test/nerves_hub_web/channels/ test/nerves_hub/extensions/ test/nerves_hub/device_link_test.exs test/nerves_hub/devices/` → **416/417**.

The one failure is a `users_email_index` collision in `Fixtures.user_fixture/1`, and it lands on a different test on every run (`clean_stale_connections/0`, `total_stats_by_product/1`, `join/3 unauthorized user…`). The cause is a single stale fixture user left in the local `nerves_hub_test` database from a crashed run on 2026-08-22 — it is the only row in `users`, and whichever test draws counter 1 collides with it. Unrelated to this change, but worth clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)