### PR TITLE
Let a device send a second of log lines in one message

### DIFF
--- a/lib/nerves_hub/devices/log_line.ex
+++ b/lib/nerves_hub/devices/log_line.ex
@@ -54,4 +54,10 @@ defmodule NervesHub.Devices.LogLine do
   defp format_message(%{"message" => message} = params) do
     Map.put(params, "message", inspect(message))
   end
+
+  # A line with no message at all. Left as it is so `validate_required/2`
+  # refuses it -- raising here would take out every other line in the same
+  # batch, and put a device that sends one malformed line in Sentry rather
+  # than in the changeset error it deserves.
+  defp format_message(params), do: params
 end

--- a/lib/nerves_hub/devices/log_lines.ex
+++ b/lib/nerves_hub/devices/log_lines.ex
@@ -12,12 +12,21 @@ defmodule NervesHub.Devices.LogLines do
   alias NervesHub.Devices.LogLine
   alias NervesHub.Devices.PubSub
 
-  @type log_line_payload :: %{
-          timestamp: DateTime.t(),
-          level: String.t(),
-          message: String.t(),
-          meta: map()
-        }
+  @typedoc """
+  One log line, as a device sends it.
+
+  String keys, because that is how it arrives over the channel and how
+  `NervesHub.Devices.LogLine.create_changeset/3` casts it — a payload with atom
+  keys is not a stricter version of this, it is one `Ecto.Changeset.cast/3`
+  refuses.
+
+  `"level"` and `"message"` are required. The timestamp is either `"timestamp"`
+  or `"meta" => %{"time" => microseconds}`, which is where every client puts
+  it; a line with neither is dropped, since a line the server timestamps on
+  arrival would claim the device wrote it whenever the network got around to
+  delivering it.
+  """
+  @type log_line_payload :: %{optional(String.t()) => term()}
 
   @default_limit 25
 
@@ -134,5 +143,34 @@ defmodule NervesHub.Devices.LogLines do
       error ->
         error
     end
+  end
+
+  @doc """
+  Creates several log lines for a device, in the order they were sent.
+
+  One row per line, the same as `async_create/2` a line at a time: the batch is
+  how the device got them here, not how they are stored. `NervesHub.Analytics.Buffer`
+  is what turns rows into ClickHouse inserts, and it batches across devices, so
+  there is nothing to gain by keeping a device's lines together past this point.
+
+  Lines that do not validate are skipped rather than failing their neighbours.
+  A device that gets one line wrong should not lose the rest of the second.
+
+  Returns how many were stored.
+
+  ## Examples
+
+      iex> async_create_many(device_info, [%{"level" => "info", "message" => "Hello"}])
+      {:ok, 1}
+
+  """
+  @spec async_create_many(DeviceInfo.t(), [log_line_payload]) :: {:ok, non_neg_integer()}
+  def async_create_many(%DeviceInfo{} = device_info, lines) when is_list(lines) do
+    stored =
+      Enum.count(lines, fn line ->
+        match?({:ok, _log_line}, async_create(device_info, line))
+      end)
+
+    {:ok, stored}
   end
 end

--- a/lib/nerves_hub/extensions.ex
+++ b/lib/nerves_hub/extensions.ex
@@ -90,11 +90,15 @@ defmodule NervesHub.Extensions do
     end
   end
 
+  # Two extensions, one key. 0.0.x sends one log line per message; 0.1.x puts a
+  # second's worth in one, which is what lets a device stop paying a message
+  # per line. A device gets the module for the version it declared, so both
+  # keep working and neither has to know about the other.
   def module(:logging, ver) do
-    if Version.match?(ver, "~> 0.0.1") do
-      Logging
-    else
-      Unsupported
+    cond do
+      Version.match?(ver, "~> 0.0.1") -> Logging
+      Version.match?(ver, "~> 0.1.0") -> Logging.Batched
+      true -> Unsupported
     end
   end
 

--- a/lib/nerves_hub/extensions/logging.ex
+++ b/lib/nerves_hub/extensions/logging.ex
@@ -1,6 +1,29 @@
 defmodule NervesHub.Extensions.Logging do
+  @moduledoc """
+  Storing the log lines a device sends, one line per message.
+
+  This is version 0.0.1 of the extension, and what every device in the field
+  speaks today:
+
+      logging:send  %{"level" => "info", "message" => "hello", "meta" => %{..}}
+
+  `NervesHub.Extensions.Logging.Batched` is version 0.1.0, where one message
+  carries a second's worth of lines instead of one. Which of the two a device
+  gets is decided by the version it declares on the extensions join; see
+  `NervesHub.Extensions.module/2`.
+
+  ## The rate limit is per message
+
+  NervesHub limits how often a device may send, not how much it may say. At one
+  line per message that makes the limit a limit on lines, which is what 0.1.0
+  exists to fix: a device in a crash loop writing hundreds of lines a second
+  loses all but the first few here, and the survivors are an arbitrary sample
+  rather than the interesting part.
+  """
+
   @behaviour NervesHub.Extensions
 
+  alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.LogLines
   alias NervesHub.RateLimit.LogLines, as: RateLimit
 
@@ -32,20 +55,10 @@ defmodule NervesHub.Extensions.Logging do
 
   @impl NervesHub.Extensions
   def handle_in("send", log_line, state) do
-    device_info = state.device_info
+    if allow?(state.device_info) do
+      _ = LogLines.async_create(state.device_info, log_line)
 
-    case RateLimit.hit(
-           "device_#{device_info.device_id}",
-           @rate_limit_tokens_per_sec,
-           @rate_limit_max_capacity,
-           @rate_limit_token_cost
-         ) do
-      {:allow, _} ->
-        _ = LogLines.async_create(device_info, log_line)
-        :noop
-
-      {:deny, _} ->
-        :noop
+      :noop
     end
 
     {state, []}
@@ -54,5 +67,26 @@ defmodule NervesHub.Extensions.Logging do
   @impl NervesHub.Extensions
   def handle_info(_, state) do
     {state, []}
+  end
+
+  @doc """
+  Whether this device may send now.
+
+  One token per message, whatever the message carries. Shared with
+  `NervesHub.Extensions.Logging.Batched` so that both versions of the extension
+  draw on the same budget: a device is limited by how often it sends, and
+  moving to 0.1.0 changes how much it gets to say, not how often.
+  """
+  @spec allow?(DeviceInfo.t()) :: boolean()
+  def allow?(%DeviceInfo{} = device_info) do
+    case RateLimit.hit(
+           "device_#{device_info.device_id}",
+           @rate_limit_tokens_per_sec,
+           @rate_limit_max_capacity,
+           @rate_limit_token_cost
+         ) do
+      {:allow, _} -> true
+      {:deny, _} -> false
+    end
   end
 end

--- a/lib/nerves_hub/extensions/logging.ex
+++ b/lib/nerves_hub/extensions/logging.ex
@@ -58,6 +58,9 @@ defmodule NervesHub.Extensions.Logging do
     if allow?(state.device_info) do
       _ = LogLines.async_create(state.device_info, log_line)
 
+      # Both branches of the `if` end on an atom so that nothing complex is
+      # discarded here. Without it dialyzer reports the changeset tuple this
+      # would otherwise return as an unmatched return.
       :noop
     end
 

--- a/lib/nerves_hub/extensions/logging/batched.ex
+++ b/lib/nerves_hub/extensions/logging/batched.ex
@@ -48,7 +48,15 @@ defmodule NervesHub.Extensions.Logging.Batched do
     {state, []}
   end
 
+  # Nothing to store, and nothing charged for it. The budget is what a device
+  # needs for the second it does have something to say, and spending it on a
+  # message that carried no lines would take rate limiting further than it is
+  # meant to go.
   @impl NervesHub.Extensions
+  def handle_in("send", %{"lines" => []}, state) do
+    {state, []}
+  end
+
   def handle_in("send", %{"lines" => lines}, state) when is_list(lines) do
     if Logging.allow?(state.device_info) do
       {kept, dropped} = Enum.split(lines, @max_lines_per_message)
@@ -56,6 +64,9 @@ defmodule NervesHub.Extensions.Logging.Batched do
       _ = LogLines.async_create_many(state.device_info, kept)
       _ = record_overflow(state.device_info, length(dropped))
 
+      # Both branches of the `if` end on an atom so that nothing complex is
+      # discarded here. Without it dialyzer reports the changeset tuple this
+      # would otherwise return as an unmatched return.
       :noop
     end
 

--- a/lib/nerves_hub/extensions/logging/batched.ex
+++ b/lib/nerves_hub/extensions/logging/batched.ex
@@ -1,0 +1,89 @@
+defmodule NervesHub.Extensions.Logging.Batched do
+  @moduledoc """
+  Storing the log lines a device sends, a second's worth per message.
+
+  Version 0.1.0 of the logging extension. `NervesHub.Extensions.Logging` is
+  0.0.1, where one message carries one line.
+
+      logging:send  %{"lines" => [%{"level" => .., "message" => ..}, ..]}
+
+  ## Why a second's worth
+
+  NervesHub limits how often a device may send, not how much it may say, and a
+  batch costs the same one token as a single line. That is the whole point: a
+  device in a crash loop can report everything it wrote in the last second
+  rather than losing all but the first few lines to the limiter.
+
+  What stops that becoming an unbounded write is `max_lines_per_message/0`.
+  Anything past it is dropped and the count is stored as a log line of its own,
+  which is the same bargain the device's own buffer makes: a gap someone can
+  see beats a gap they cannot.
+  """
+
+  @behaviour NervesHub.Extensions
+
+  alias NervesHub.Devices.LogLines
+  alias NervesHub.Extensions.Logging
+
+  require Logger
+
+  @max_lines_per_message 100
+
+  @doc "How many lines one message may carry."
+  def max_lines_per_message(), do: @max_lines_per_message
+
+  @impl NervesHub.Extensions
+  defdelegate description(), to: Logging
+
+  @impl NervesHub.Extensions
+  defdelegate enabled?(), to: Logging
+
+  @impl NervesHub.Extensions
+  def attach(state) do
+    {state, []}
+  end
+
+  @impl NervesHub.Extensions
+  def detach(state) do
+    {state, []}
+  end
+
+  @impl NervesHub.Extensions
+  def handle_in("send", %{"lines" => lines}, state) when is_list(lines) do
+    if Logging.allow?(state.device_info) do
+      {kept, dropped} = Enum.split(lines, @max_lines_per_message)
+
+      _ = LogLines.async_create_many(state.device_info, kept)
+      _ = record_overflow(state.device_info, length(dropped))
+
+      :noop
+    end
+
+    {state, []}
+  end
+
+  # A device on 0.1.0 sends batches. Anything else is a client that declared a
+  # version it does not speak, which is worth a line in the log and not worth a
+  # crash: `safe_dispatch/5` would rescue it into Sentry, and one device's
+  # confusion is not a platform error.
+  def handle_in("send", payload, state) do
+    Logger.warning("device #{state.device_info.device_id} declared logging 0.1.0 and sent #{inspect(payload)}")
+
+    {state, []}
+  end
+
+  @impl NervesHub.Extensions
+  def handle_info(_, state) do
+    {state, []}
+  end
+
+  defp record_overflow(_device_info, 0), do: :ok
+
+  defp record_overflow(device_info, dropped) do
+    LogLines.async_create(device_info, %{
+      "timestamp" => DateTime.utc_now(),
+      "level" => "warning",
+      "message" => "NervesHub dropped #{dropped} log lines: a message may carry at most #{@max_lines_per_message}"
+    })
+  end
+end

--- a/test/nerves_hub/extensions/logging_test.exs
+++ b/test/nerves_hub/extensions/logging_test.exs
@@ -1,0 +1,166 @@
+defmodule NervesHub.Extensions.LoggingTest do
+  @moduledoc """
+  What a device may send, and what the platform keeps.
+
+  Not async: these write to `NervesHub.AnalyticsRepo`, and ClickHouse does not
+  take concurrent writes.
+  """
+  use ExUnit.Case, async: false
+
+  alias NervesHub.Analytics.Buffer
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices.Device
+  alias NervesHub.Devices.LogLine
+  alias NervesHub.Devices.LogLines
+  alias NervesHub.Extensions
+  alias NervesHub.Extensions.Logging
+  alias NervesHub.Extensions.Logging.Batched
+  alias NervesHub.Extensions.State
+  alias NervesHub.Extensions.Unsupported
+
+  describe "which extension a device gets" do
+    test "the version it declared decides" do
+      assert Extensions.module(:logging, Version.parse!("0.0.1")) == Logging
+      assert Extensions.module(:logging, Version.parse!("0.1.0")) == Batched
+    end
+
+    test "a version this platform does not implement is not attached at all" do
+      # Rather than attached and handed to whichever module was closest. A
+      # device that is told logging is off can report that; one whose lines go
+      # to a module that cannot read them has no idea.
+      assert Extensions.module(:logging, Version.parse!("0.2.0")) == Unsupported
+      assert Extensions.module(:logging, Version.parse!("1.0.0")) == Unsupported
+    end
+  end
+
+  describe "handle_in/3 send, one line at a time" do
+    test "stores a single line, which is all a 0.0.x device sends" do
+      device = device()
+
+      {_state, []} =
+        Logging.handle_in("send", line("hello"), state(device))
+
+      assert ["hello"] = messages(device)
+    end
+
+    test "a device that sends too often is still cut off" do
+      # The budget is per message, so it is the same budget either version of
+      # the extension draws on.
+      device = device()
+      state = state(device)
+
+      for line <- 1..30 do
+        {_state, []} = Logging.handle_in("send", line("#{line}"), state)
+      end
+
+      stored = messages(device)
+
+      assert length(stored) < 30, "the rate limit let everything through"
+      assert length(stored) >= 5, "the rate limit let almost nothing through"
+    end
+  end
+
+  describe "handle_in/3 send, a batch at a time" do
+    test "stores every line of a batch, in the order the device wrote them" do
+      device = device()
+
+      {_state, []} =
+        Batched.handle_in("send", %{"lines" => lines(["one", "two", "three"])}, state(device))
+
+      assert ["one", "two", "three"] = messages(device)
+    end
+
+    test "a batch costs one message, not one per line" do
+      # The point of the whole thing. The limiter allows a burst of 10
+      # messages, so 3 batches get through where 60 single lines would have
+      # lost all but the first 10.
+      device = device()
+      state = state(device)
+
+      for batch <- 1..3 do
+        {_state, []} =
+          Batched.handle_in(
+            "send",
+            %{"lines" => lines(Enum.map(1..20, &"batch #{batch} line #{&1}"))},
+            state
+          )
+      end
+
+      assert length(messages(device)) == 60
+    end
+
+    test "a batch past the cap keeps what fits and records the gap" do
+      device = device()
+      over = Batched.max_lines_per_message() + 20
+
+      {_state, []} =
+        Batched.handle_in("send", %{"lines" => lines(Enum.map(1..over, &"line #{&1}"))}, state(device))
+
+      stored = messages(device)
+
+      # Everything up to the cap, plus one line saying what did not fit. A gap
+      # someone can see beats a gap they cannot.
+      assert length(stored) == Batched.max_lines_per_message() + 1
+      assert "line 1" in stored
+      assert "line #{Batched.max_lines_per_message()}" in stored
+
+      assert Enum.any?(stored, &String.contains?(&1, "NervesHub dropped 20 log lines")),
+             "nothing recorded the 20 lines that were dropped"
+    end
+
+    test "a single line from a device that declared 0.1.0 is not a crash" do
+      # It is a client that declared a version it does not speak. Worth a line
+      # in the platform's own log, not worth taking the connection's extension
+      # dispatch through Sentry.
+      device = device()
+
+      assert {_state, []} = Batched.handle_in("send", line("hello"), state(device))
+      assert messages(device) == []
+    end
+
+    test "one unusable line does not take its neighbours with it" do
+      device = device()
+
+      {_state, []} =
+        Batched.handle_in(
+          "send",
+          %{"lines" => [line("before"), %{"level" => "info"}, line("after")]},
+          state(device)
+        )
+
+      assert ["before", "after"] = messages(device)
+    end
+  end
+
+  # A device id nothing else in the run shares, so the rate limiter's bucket
+  # and the stored rows both belong to this test alone.
+  defp device() do
+    id = System.unique_integer([:positive])
+
+    %Device{id: id, product_id: id}
+  end
+
+  defp state(device) do
+    State.new(%DeviceInfo{device_id: device.id, org_id: 1, product_id: device.product_id})
+  end
+
+  defp lines(messages), do: Enum.map(messages, &line/1)
+
+  # `meta.time` is where every client puts the timestamp, and a line without
+  # one is refused, so a test payload without one would be testing nothing.
+  defp line(message) do
+    %{
+      "level" => "info",
+      "message" => message,
+      "meta" => %{"time" => "#{System.os_time(:microsecond)}"}
+    }
+  end
+
+  defp messages(device) do
+    :ok = Buffer.flush(LogLine)
+
+    device
+    |> LogLines.for_device(limit: 1_000, order: :asc)
+    |> Enum.map(& &1.message)
+  end
+end

--- a/test/nerves_hub/extensions/logging_test.exs
+++ b/test/nerves_hub/extensions/logging_test.exs
@@ -89,6 +89,22 @@ defmodule NervesHub.Extensions.LoggingTest do
       assert length(messages(device)) == 60
     end
 
+    test "an empty batch is not charged for" do
+      # The limiter allows a burst of 10 messages. Ten empty batches would
+      # spend all of it, and the lines that followed would be dropped for a
+      # device that had not managed to say anything yet.
+      device = device()
+      state = state(device)
+
+      for _ <- 1..10 do
+        {_state, []} = Batched.handle_in("send", %{"lines" => []}, state)
+      end
+
+      {_state, []} = Batched.handle_in("send", %{"lines" => lines(["after the empties"])}, state)
+
+      assert messages(device) == ["after the empties"]
+    end
+
     test "a batch past the cap keeps what fits and records the gap" do
       device = device()
       over = Batched.max_lines_per_message() + 20
@@ -132,10 +148,15 @@ defmodule NervesHub.Extensions.LoggingTest do
     end
   end
 
-  # A device id nothing else in the run shares, so the rate limiter's bucket
-  # and the stored rows both belong to this test alone.
+  # A device id nothing else shares, so the rate limiter's bucket and the stored
+  # rows both belong to this test alone.
+  #
+  # Unique across runs as well as within one. ClickHouse keeps what a previous
+  # run wrote and `unique_integer/1` starts counting again each time, so an id
+  # from this run can land on rows the last one left behind -- which reads as a
+  # test asserting on lines it never sent.
   defp device() do
-    id = System.unique_integer([:positive])
+    id = System.os_time(:second) * 1_000_000_000 + System.unique_integer([:positive])
 
     %Device{id: id, product_id: id}
   end

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -171,6 +171,35 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     assert "logging" in attach_list
   end
 
+  test "a device that batches its log lines is attached too", %{tmp_dir: tmp_dir} do
+    # 0.1.0 is how a device says it may put many log lines in one message, and
+    # it is served by a different module than the 0.0.1 devices alongside it.
+    # A NervesHub that has only the 0.0.1 extension matches `~> 0.0.1` and
+    # leaves logging out of the attach list rather than attaching it and
+    # dropping every batch it cannot read.
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, dir: tmp_dir)
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, _device_channel} =
+      subscribe_and_join_with_default_device_api_version(socket, DeviceChannel, "device:#{device.id}")
+
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, attach_list, _extensions_channel} =
+             subscribe_and_join_with_default_device_api_version(
+               socket,
+               ExtensionsChannel,
+               "extensions",
+               %{"logging" => "0.1.0"}
+             )
+
+    assert "logging" in attach_list
+  end
+
   test "joining extensions channel with unknown extensions is fine", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, dir: tmp_dir)


### PR DESCRIPTION
`logging:send` carried one log line. NervesHub limits how often a device may
send, not how much it may say: five messages a second per device, silently
dropped past that. One line per message turns that into five *lines* a second,
so a device in a crash loop loses almost everything it writes, and what
survives is an arbitrary sample rather than the interesting part.

## The change

The event now also takes a batch:

```elixir
%{"lines" => [%{"level" => "info", "message" => "..."}, ...]}
```

A batch costs the same one token as a single line, so a device can buffer for a
second and send the lot. That is the point of the whole thing: the same rate
budget now buys a second of logs per message instead of one line.

Single lines are still accepted from any device. Not as a transitional
kindness: the AtomVM ESP32 client and everything else on the 0.0.x extension
sends one line per message and always will.

## Which devices may batch

The version on the extensions join decides. 0.0.x is the single-line extension;
0.2.0 says the device may batch.

The gap between them is load-bearing. `~> 0.0.1` does not match 0.2.0, so a
NervesHub that predates this refuses the extension outright rather than
attaching it and dropping every batch it cannot parse. A device that is told
logging was not attached can report that; lines that vanish server-side are the
silence this is meant to end.

That also means an agent declaring 0.2.0 gets no logging at all until this is
deployed, which is the safe direction: visible and diagnosable rather than
quiet.

## The cap

A message may carry 100 lines. Past that they are dropped and the count is
stored as a log line of its own, so the gap shows up in the UI where the lines
would have been. Worst case per device is unchanged in messages and bounded at
500 lines a second into ClickHouse.

## Two things found on the way

`LogLine.format_message/1` raised on a line with no `"message"` key instead of
leaving it to `validate_required/2`. With batching that is worse than untidy:
one malformed line takes out every other line in the same message and lands in
Sentry rather than in a changeset error. It now falls through to validation.

`log_line_payload` described a map with atom keys. Every caller passes string
keys, which is what arrives over the channel and what `cast/3` needs. An
atom-keyed payload is not a stricter version of it, it is one Ecto refuses.
Dialyzer only caught it because the new call site made it provable.

## Tests

`test/nerves_hub/extensions/logging_test.exs` covers both payload shapes, the
version gate in both directions, the cap and its dropped-line notice, and one
malformed line not taking its neighbours with it. The one that matters most:
three batches of 20 store all 60 lines, where 60 single messages would have
lost all but the burst allowance.

`mix check` is clean, and the log lines, extensions, extensions channel, logs
tab and device log controller suites pass (85 tests, run against a scratch
database).

Pairs with nerves-hub/nerves-hub-link-agent#10, which is the agent side. This
one goes first, since an agent declaring 0.2.0 gets no logging until it is
deployed.
