### PR TITLE
Tell a device which extension versions it can have

### DIFF
--- a/docs/extensions_protocol.md
+++ b/docs/extensions_protocol.md
@@ -1,0 +1,116 @@
+# The Extensions Protocol
+
+An extension is something NervesHub can ask a device for that is not firmware:
+health metrics, a location, logs, a shell. Extensions are negotiated rather
+than assumed, and this document is what that negotiation is. Until now the
+only statement of it was `nerves_hub_link`'s implementation, which is why two
+of the other clients diverged from it.
+
+Two rules shape everything below. Extension traffic must never get in the way
+of an update, so extensions are negotiated after the device topic is joined and
+never before. And both sides have to agree, so an extension nobody asked for is
+never sent: a device that starts reporting something an operator did not turn
+on is worse than one that reports nothing.
+
+## The handshake
+
+Four frames, in this order.
+
+```text
+1.  server -> device   extensions:get        {"extensions": {"logging": ["0.1.0", "0.0.1"], ..}}
+2.  device -> server   phx_join "extensions" {"logging": "0.1.0", "health": "0.0.1"}
+3.  server -> device   phx_reply             ["logging", "health"]
+4.  device -> server   logging:attached      {}
+```
+
+**1. The platform asks, and says what it has.** Sent once the device has joined
+the `device` topic, and only to devices declaring `device_api_version >=
+2.2.0`. The payload is every version of every extension this deployment
+implements and has switched on, newest first per key. An extension turned off
+for the deployment is absent entirely.
+
+**2. The device answers by joining.** One version per extension, and only
+extensions it wants to serve. This frame is the device's commitment: there is
+no second choice in it, which is why frame 1 exists.
+
+A client must not join the `extensions` topic before frame 1 arrives. Joining
+early is accepted by the platform, but it means declaring versions without
+knowing what the platform has, which is the thing the advertisement is for.
+
+**3. The platform replies with the attach list.** The subset of what the device
+offered that this *particular* device may use, which is narrower than what the
+platform implements: an extension can be turned off per product or per device.
+Keys only, no versions — the device already knows what it declared.
+
+An extension left out here is not attached. A device should treat that as a
+fact worth reporting locally, since from the outside it is indistinguishable
+from a feature quietly not working.
+
+**4. The device confirms each one.** Only after `<key>:attached` does the
+platform start asking that extension for anything.
+
+Everything after the handshake is scoped `<key>:<event>` in both directions.
+
+## Choosing a version
+
+For each extension it implements, a client walks **its own** versions, most
+preferred first, and takes the first that also appears in the platform's list
+for that key. Match by string equality; there is no version arithmetic to do
+here, and requiring it would mean a version parser in Erlang on AtomVM and
+another in Rust to answer a question the platform has already answered by
+listing what it has.
+
+- **No overlap for a key**, or **the key is absent** from the advertisement:
+  omit it from the join. The platform cannot serve anything the device speaks.
+- **No advertisement at all**: declare the **lowest** version of each extension
+  the client implements. That is the version most likely to be understood by a
+  platform old enough not to advertise.
+
+A client must not wait indefinitely for frame 1. A platform that predates the
+advertisement never sends it, and a client that waits forever loses every
+extension against those platforms. **Join anyway five seconds after the device
+topic's join reply**, using the fallback versions above.
+
+## Adding a version of an extension
+
+Platform side, in `NervesHub.Extensions`:
+
+```elixir
+@implementations [
+  logging: [
+    {"0.1.0", "~> 0.1.0", Logging.Batched},
+    {"0.0.1", "~> 0.0.1", Logging}
+  ],
+  ...
+]
+```
+
+One row per version, newest first, and the only place a version is written
+down. `module/2` reads it to serve a device, `versions/1` and `advertisement/0`
+read it to tell devices what is on offer.
+
+The row is `{advertised, requirement, module}`. `advertised` is the exact
+version a device may declare and what goes out in frame 1. `requirement` is
+what a declared version is matched against, and is deliberately looser: a
+device declaring `0.0.5` predates the advertisement and still has to be served.
+`module` implements that version and nothing else — a module per version is
+what keeps each one readable, rather than one module branching on payload
+shape.
+
+Old and new versions run side by side indefinitely. Devices in the field do not
+upgrade in step with the platform, and some never upgrade at all.
+
+## Failure modes worth knowing
+
+**A device declares a version the platform does not implement.** It resolves to
+`Unsupported`, the key is left out of the attach list, and nothing is attached.
+This is the correct answer and not a fallback: attaching the device to whichever
+module was closest would have it sending messages nothing can read.
+
+**A device sends a list of versions instead of a string.** `Version.parse/1`
+raises on a non-binary and the extensions join fails entirely, taking every
+other extension with it. The advertisement exists so no client needs to try.
+
+**An extension raises while handling a message.** It is logged, reported to
+Sentry and swallowed, so one misbehaving extension cannot take a device's
+connection with it. Attach and detach are deliberately not rescued.

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -18,6 +18,7 @@ defmodule NervesHub.DeviceLink do
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceMessages
   alias NervesHub.Devices.Updates
+  alias NervesHub.Extensions
   alias NervesHub.Extensions.Dispatch, as: ExtensionDispatch
   alias NervesHub.Firmwares
   alias NervesHub.FirmwareUpdates
@@ -680,9 +681,13 @@ defmodule NervesHub.DeviceLink do
     :ok
   end
 
+  # The device answers by joining the `extensions` topic, declaring one version
+  # per extension it wants. It picks those versions out of what this says the
+  # platform has, so a device implementing two versions of an extension does not
+  # have to guess which one it is talking to.
   defp maybe_request_extensions(device_info, device_api_version) do
     if Version.match?(device_api_version, ">= 2.2.0"),
-      do: broadcast(device_info, "extensions:get", %{})
+      do: broadcast(device_info, "extensions:get", %{"extensions" => Extensions.advertisement()})
 
     :ok
   end

--- a/lib/nerves_hub/extensions.ex
+++ b/lib/nerves_hub/extensions.ex
@@ -44,7 +44,37 @@ defmodule NervesHub.Extensions do
   @callback description() :: String.t()
   @callback enabled?() :: boolean()
 
-  @supported_extensions [:health, :geo, :local_shell, :logging, :network_identity]
+  @typedoc """
+  Every version of every extension this platform implements.
+
+  Ordered newest first per key, and the single place a version is written down:
+  `module/2` reads it to serve a device, `versions/1` and `advertisement/0` read
+  it to tell devices what is on offer. Adding a version means adding a row here
+  and nothing else.
+
+  Each row is `{advertised, requirement, module}`:
+
+  - `advertised` is the exact version a device may declare, and what goes out
+    in `extensions:get`.
+  - `requirement` is what a device's declared version is matched against, which
+    is looser than the advertised version on purpose: a device declaring
+    `0.0.5` predates the advertisement and still has to be served.
+  - `module` implements that version of the extension.
+  """
+  @type implementation() :: {String.t(), String.t(), module()}
+
+  @implementations [
+    health: [{"0.0.1", "~> 0.0.1", Health}],
+    geo: [{"0.0.1", "~> 0.0.1", Geo}],
+    local_shell: [{"0.0.1", "~> 0.0.1", LocalShell}],
+    logging: [
+      {"0.1.0", "~> 0.1.0", Logging.Batched},
+      {"0.0.1", "~> 0.0.1", Logging}
+    ],
+    network_identity: [{"0.0.1", "~> 0.0.1", NetworkIdentity}]
+  ]
+
+  @supported_extensions Keyword.keys(@implementations)
   @type extension() :: :health | :geo | :local_shell | :logging | :network_identity
 
   @doc """
@@ -52,6 +82,40 @@ defmodule NervesHub.Extensions do
   """
   @spec list() :: [:network_identity | :geo | :health | :local_shell | :logging, ...]
   def list(), do: @supported_extensions
+
+  @doc """
+  Every version of `key` this platform implements, newest first.
+  """
+  @spec versions(extension()) :: [String.t()]
+  def versions(key) do
+    for {version, _requirement, _module} <- implementations(key), do: version
+  end
+
+  @doc """
+  What to tell a device it can have, as `%{key => versions}`.
+
+  Sent in `extensions:get` so that a device implementing more than one version
+  of an extension can declare the best one both sides have, rather than naming
+  a version before it knows anything about the platform and finding out from
+  the attach list whether it guessed right.
+
+  Extensions that are switched off for this deployment are left out entirely: a
+  device that is not told about logging does not buffer log lines for a
+  platform that would throw them away.
+
+  Not narrowed to one device. Whether a *particular* device may use an
+  extension is a product and device setting, and it stays where it already is,
+  in the attach list — one authority for that, and nothing for a device to act
+  on that a later setting change would contradict.
+  """
+  @spec advertisement() :: %{String.t() => [String.t()]}
+  def advertisement() do
+    for {key, implementations} <- @implementations,
+        versions = enabled_versions(implementations),
+        versions != [],
+        into: %{},
+        do: {to_string(key), versions}
+  end
 
   @spec module(extension()) ::
           NetworkIdentity
@@ -65,53 +129,28 @@ defmodule NervesHub.Extensions do
   def module(:logging), do: Logging
   def module(:network_identity), do: NetworkIdentity
 
-  @spec module(extension(), Version.t()) :: module() | Unsupported
-  def module(:health, ver) do
-    if Version.match?(ver, "~> 0.0.1") do
-      Health
-    else
-      Unsupported
-    end
+  @doc """
+  The module that serves `key` for a device that declared `ver`.
+
+  `Unsupported` when this platform has no version matching what the device
+  asked for, which leaves the extension out of the attach list. That is the
+  answer a device can see and report; attaching it to whichever module was
+  closest would have the device sending messages nothing can read.
+  """
+  @spec module(extension(), Version.t()) :: module()
+  def module(key, ver) do
+    Enum.find_value(implementations(key), Unsupported, fn {_advertised, requirement, module} ->
+      Version.match?(ver, requirement) && module
+    end)
   end
 
-  def module(:geo, ver) do
-    if Version.match?(ver, "~> 0.0.1") do
-      Geo
-    else
-      Unsupported
-    end
-  end
+  defp implementations(key) when is_atom(key), do: Keyword.get(@implementations, key, [])
+  defp implementations(_key), do: []
 
-  def module(:local_shell, ver) do
-    if Version.match?(ver, "~> 0.0.1") do
-      LocalShell
-    else
-      Unsupported
-    end
-  end
-
-  # Two extensions, one key. 0.0.x sends one log line per message; 0.1.x puts a
-  # second's worth in one, which is what lets a device stop paying a message
-  # per line. A device gets the module for the version it declared, so both
-  # keep working and neither has to know about the other.
-  def module(:logging, ver) do
-    cond do
-      Version.match?(ver, "~> 0.0.1") -> Logging
-      Version.match?(ver, "~> 0.1.0") -> Logging.Batched
-      true -> Unsupported
-    end
-  end
-
-  def module(:network_identity, ver) do
-    if Version.match?(ver, "~> 0.0.1") do
-      NetworkIdentity
-    else
-      Unsupported
-    end
-  end
-
-  def module(_key, _ver) do
-    Unsupported
+  defp enabled_versions(implementations) do
+    for {version, _requirement, module} <- implementations,
+        Code.ensure_loaded?(module) && module.enabled?(),
+        do: version
   end
 
   def broadcast_extension_event(%Device{} = device, event, extension) do

--- a/test/nerves_hub/extensions_test.exs
+++ b/test/nerves_hub/extensions_test.exs
@@ -1,0 +1,82 @@
+defmodule NervesHub.ExtensionsTest do
+  @moduledoc """
+  What the platform tells devices it implements, and what it does with what
+  they declare back.
+  """
+  use ExUnit.Case, async: false
+
+  alias NervesHub.Extensions
+  alias NervesHub.Extensions.Health
+  alias NervesHub.Extensions.Logging
+  alias NervesHub.Extensions.Unsupported
+
+  setup do
+    enabled = Application.get_env(:nerves_hub, :analytics_enabled)
+    on_exit(fn -> Application.put_env(:nerves_hub, :analytics_enabled, enabled) end)
+
+    Application.put_env(:nerves_hub, :analytics_enabled, true)
+
+    :ok
+  end
+
+  describe "advertisement/0" do
+    test "offers every version of every extension, newest first" do
+      advertisement = Extensions.advertisement()
+
+      assert advertisement["logging"] == ["0.1.0", "0.0.1"]
+      assert advertisement["health"] == ["0.0.1"]
+    end
+
+    test "leaves out an extension this deployment has switched off" do
+      # A device that is not told about logging does not buffer log lines for a
+      # platform that would only throw them away.
+      Application.put_env(:nerves_hub, :analytics_enabled, false)
+
+      advertisement = Extensions.advertisement()
+
+      refute Map.has_key?(advertisement, "logging")
+      assert advertisement["health"] == ["0.0.1"]
+    end
+
+    test "every version offered is one a device can actually be served" do
+      # The advertisement and the dispatch read the same table, and this is what
+      # says so. An advertised version that resolved to `Unsupported` would have
+      # the platform inviting devices to declare something it then refuses.
+      for {key, versions} <- Extensions.advertisement(), version <- versions do
+        module = Extensions.module(String.to_existing_atom(key), Version.parse!(version))
+
+        refute module == Unsupported, "#{key} #{version} is advertised but not implemented"
+      end
+    end
+
+    test "says the same thing as versions/1" do
+      for {key, versions} <- Extensions.advertisement() do
+        assert versions == Extensions.versions(String.to_existing_atom(key))
+      end
+    end
+  end
+
+  describe "module/2" do
+    test "serves the version the device declared" do
+      assert Extensions.module(:logging, Version.parse!("0.0.1")) == Logging
+      assert Extensions.module(:logging, Version.parse!("0.1.0")) == Logging.Batched
+      assert Extensions.module(:health, Version.parse!("0.0.1")) == Health
+    end
+
+    test "serves a device that predates the advertisement" do
+      # It declared a patch version of its own rather than one this platform
+      # names, which is why the table matches on a requirement and not on the
+      # advertised string.
+      assert Extensions.module(:logging, Version.parse!("0.0.5")) == Logging
+    end
+
+    test "refuses a version this platform does not implement" do
+      assert Extensions.module(:logging, Version.parse!("0.2.0")) == Unsupported
+      assert Extensions.module(:health, Version.parse!("1.0.0")) == Unsupported
+    end
+
+    test "refuses an extension it has never heard of" do
+      assert Extensions.module(:telepathy, Version.parse!("0.0.1")) == Unsupported
+    end
+  end
+end

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -256,6 +256,28 @@ defmodule NervesHubWeb.DeviceChannelTest do
     end
   end
 
+  test "the extensions request tells the device which versions it can have", %{tmp_dir: tmp_dir} do
+    # This is the only point in the handshake where the platform speaks before
+    # the device commits to a version, so what it carries is what lets a device
+    # implementing two versions of an extension pick the one both sides have.
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, device_channel} =
+      subscribe_and_join(socket, DeviceChannel, "device:#{device.id}", %{"device_api_version" => "2.2.0"})
+
+    assert_push("extensions:get", %{"extensions" => advertised})
+
+    assert advertised == NervesHub.Extensions.advertisement()
+    assert advertised["health"] == ["0.0.1"]
+
+    close_cleanly(device_channel)
+  end
+
   test "extensions are requested from device if version is above 2.2.0", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)


### PR DESCRIPTION
Stacked on #2962, and targets its branch, so the diff here is the second commit
only.

Implements the platform half of the [version negotiation spec](https://claude.ai/code/artifact/daef7b3a-2f8b-408f-a700-d7c7b7118f1d).

## The problem

`extensions:get` carried `%{}`. It is the only frame in the handshake where the
platform speaks before the device commits to a version, and it said nothing, so
a device implementing two versions of an extension had to pick one before
learning anything about what it was talking to. Pick the newer one and an older
NervesHub leaves it unattached; pick the older one and it never gets the newer,
however new the platform is.

That was fine while every extension had exactly one version. Logging now has
two.

## The change

The payload now carries what this deployment implements:

```json
{"extensions": {"logging": ["0.1.0", "0.0.1"], "health": ["0.0.1"], ...}}
```

The device picks, per extension, the best version both sides have and declares
that one in the join. Frames 2, 3 and 4 keep their exact shapes.

That is what makes this deployable on its own: every client today ignores this
payload, so nothing changes for anything in the field until a client is taught
to read it. No client has to change first, or at all.

## One table

`@implementations` is now the only place a version is written down.
`module/2`, `versions/1` and `advertisement/0` all read it, so the
advertisement cannot drift from what the dispatch will actually serve. There is
a test that asserts exactly that: every advertised version must resolve to
something other than `Unsupported`.

Each row is `{advertised, requirement, module}`. The requirement stays looser
than the advertised version deliberately — a device declaring `0.0.5` predates
all of this and still has to be served, so `~> 0.0.1` keeps matching it.

## Decisions from the spec, as agreed

- **Not narrowed per device.** Whether a particular device may use an extension
  is a product and device setting, and it stays in the attach list. One
  authority for it, and nothing for a device to act on that a later settings
  change would contradict.
- **Extensions switched off for the deployment are omitted entirely.** A device
  that is not told about logging does not buffer log lines for a platform that
  would throw them away.
- **The attach reply still carries keys only.** Changing its shape is the one
  move that breaks every deployed client.

## Documentation

`docs/extensions_protocol.md` writes the handshake down: the four frames, how a
client chooses a version, what to do when the platform never advertises (join
anyway after five seconds, using the lowest supported versions), and what
adding a version of an extension takes on the platform side.

The protocol was only ever stated by `nerves_hub_link`'s implementation. Both
clients written since diverged from it and join the extensions topic without
waiting for `extensions:get`, which is why neither can be handed an
advertisement today. Bringing them back in line is client work, tracked
separately.

## Tests

`mix check` is clean. 193 tests pass across the extensions, extensions channel,
device channel and device link suites, run against a scratch database.

New coverage: the advertisement lists every implemented version and omits
disabled extensions; it stays in step with `module/2` and `versions/1`; a
device that predates the advertisement is still served; and the device channel
test asserts the advertisement actually reaches the device rather than just
that some push happened.
