### PR TITLE
Stagger the health and geo timers across the fleet

### DIFF
--- a/lib/nerves_hub/device_link/effect.ex
+++ b/lib/nerves_hub/device_link/effect.ex
@@ -43,6 +43,7 @@ defmodule NervesHub.DeviceLink.Effect do
           | {:send_self, message :: term()}
           | {:send_after, key :: term(), message :: term(), delay_ms :: non_neg_integer()}
           | {:start_timer, key :: term(), message :: term(), interval_ms :: pos_integer()}
+          | {:start_timer, key :: term(), message :: term(), first_ms :: pos_integer(), interval_ms :: pos_integer()}
           | {:cancel_timer, key :: term()}
           | {:scrollback_append, data :: binary()}
           | {:scrollback_replay, pid()}

--- a/lib/nerves_hub/extensions/dispatch.ex
+++ b/lib/nerves_hub/extensions/dispatch.ex
@@ -166,6 +166,8 @@ defmodule NervesHub.Extensions.Dispatch do
   # something they can key a timer by, without knowing which module is involved.
   defp translate({:tick, tag}, _key, mod), do: {:send_self, {mod, tag}}
   defp translate({:start_timer, tag, ms}, key, mod), do: {:start_timer, {key, tag}, {mod, tag}, ms}
+
+  defp translate({:start_timer, tag, first_ms, ms}, key, mod), do: {:start_timer, {key, tag}, {mod, tag}, first_ms, ms}
   defp translate({:cancel_timer, tag}, key, _mod), do: {:cancel_timer, {key, tag}}
 
   # Effects that name no extension-specific thing pass straight through.

--- a/lib/nerves_hub/extensions/geo.ex
+++ b/lib/nerves_hub/extensions/geo.ex
@@ -3,6 +3,7 @@ defmodule NervesHub.Extensions.Geo do
 
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.PubSub
+  alias NervesHub.Extensions.Jitter
 
   @impl NervesHub.Extensions
   def description() do
@@ -23,7 +24,8 @@ defmodule NervesHub.Extensions.Geo do
     effects =
       case geo_interval_minutes() do
         interval when interval > 0 ->
-          [{:tick, :location_request}, {:start_timer, :location_request, to_timeout(minute: interval)}]
+          ms = to_timeout(minute: interval)
+          [{:tick, :location_request}, {:start_timer, :location_request, Jitter.start_delay(ms), ms}]
 
         _ ->
           [{:tick, :location_request}]

--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -4,6 +4,7 @@ defmodule NervesHub.Extensions.Health do
   alias NervesHub.Devices.Health
   alias NervesHub.Devices.HealthStatus
   alias NervesHub.Devices.Metrics
+  alias NervesHub.Extensions.Jitter
   alias NervesHub.Extensions.PubSub
   alias NervesHub.Helpers.Logging
 
@@ -25,11 +26,11 @@ defmodule NervesHub.Extensions.Health do
 
   @impl NervesHub.Extensions
   def attach(state) do
-    interval = to_timeout(minute: health_interval_minutes())
-
     # Ask for a report immediately, then on an interval. The tick is delivered
     # before the first timer fires, which preserves the previous ordering.
-    {state, [{:tick, :check}, {:start_timer, :check, interval}]}
+    interval = to_timeout(minute: health_interval_minutes())
+
+    {state, [{:tick, :check}, {:start_timer, :check, Jitter.start_delay(interval), interval}]}
   end
 
   @impl NervesHub.Extensions

--- a/lib/nerves_hub/extensions/jitter.ex
+++ b/lib/nerves_hub/extensions/jitter.ex
@@ -1,0 +1,39 @@
+defmodule NervesHub.Extensions.Jitter do
+  @moduledoc """
+  Picks a random start offset so a fleet does not ask in unison.
+
+  An extension that starts a repeating timer on attach gives every device the
+  same phase, because they attach together: a deploy reconnects the whole fleet
+  inside a few seconds, and that alignment lasts as long as the connections do.
+  Measured on a production device node, 74% of 1519 devices had their health
+  check due inside the same 30 second window, against the 5% an even spread
+  would put there. An hour later it had barely moved, because device
+  connections are long-lived -- only the handful that had reconnected since
+  were spread out.
+
+  What that costs is one burst per interval instead of a steady trickle: every
+  device pushed a request at once, every device answering at once, and two
+  database writes per answer. It shows up as a spike in CPU, in egress and in
+  database traffic, at exactly the interval length.
+
+  Only the first delay is offset. The period after that is exact, so a device
+  asked to report every ten minutes still reports every ten minutes -- it just
+  starts somewhere random inside the first one. That also decouples the phase
+  from the connect time, so devices reconnecting together stops mattering
+  rather than having to even out on its own.
+
+  `NervesHubWeb.DeviceSocket` staggers last-seen updates for the same reason,
+  which is why those never showed up as a spike.
+  """
+
+  @doc """
+  A random delay in `1..interval_ms`, for the first fire of a repeating timer.
+
+  Uniform across the whole interval, so a fleet attaching at the same instant
+  ends up evenly spread rather than merely smeared.
+  """
+  @spec start_delay(pos_integer()) :: pos_integer()
+  def start_delay(interval_ms) when is_integer(interval_ms) and interval_ms > 0 do
+    Enum.random(1..interval_ms)
+  end
+end

--- a/lib/nerves_hub/extensions/state.ex
+++ b/lib/nerves_hub/extensions/state.ex
@@ -48,6 +48,7 @@ defmodule NervesHub.Extensions.State do
           {:push, event :: String.t(), payload :: map()}
           | {:tick, tag :: term()}
           | {:start_timer, tag :: term(), interval_ms :: pos_integer()}
+          | {:start_timer, tag :: term(), first_ms :: pos_integer(), interval_ms :: pos_integer()}
           | {:cancel_timer, tag :: term()}
           | {:scrollback_append, data :: binary()}
           | {:scrollback_replay, pid()}

--- a/lib/nerves_hub_web/channels/effects.ex
+++ b/lib/nerves_hub_web/channels/effects.ex
@@ -117,6 +117,16 @@ defmodule NervesHubWeb.Channels.Effects do
     put_timer(socket, key, {:interval, arm(key, message, interval_ms), interval_ms})
   end
 
+  # As above, but the first delivery is offset. `timer_fired/2` re-arms from the
+  # stored interval rather than from what was armed, so the period is exact from
+  # the first fire onward -- which is what lets a fleet be spread out without
+  # changing how often any one device reports. See `NervesHub.Extensions.Jitter`.
+  defp apply_one(socket, {:start_timer, key, message, first_ms, interval_ms}) do
+    socket = cancel(socket, key)
+
+    put_timer(socket, key, {:interval, arm(key, message, first_ms), interval_ms})
+  end
+
   defp apply_one(socket, {:cancel_timer, key}), do: cancel(socket, key)
 
   defp apply_one(socket, {:scrollback_append, data}) do

--- a/test/nerves_hub/extensions/jitter_test.exs
+++ b/test/nerves_hub/extensions/jitter_test.exs
@@ -1,0 +1,36 @@
+defmodule NervesHub.Extensions.JitterTest do
+  use ExUnit.Case, async: true
+
+  alias NervesHub.Extensions.Jitter
+
+  @interval to_timeout(minute: 10)
+
+  describe "start_delay/1" do
+    test "never exceeds the interval, so the first report is not delayed past one period" do
+      for _ <- 1..2_000 do
+        delay = Jitter.start_delay(@interval)
+        assert delay >= 1
+        assert delay <= @interval
+      end
+    end
+
+    test "spreads a fleet that attaches together across the whole interval" do
+      # What a deploy produces: every device attaching inside the same second.
+      # Unjittered, all 1500 land on the identical millisecond and stay there,
+      # because device connections are long-lived.
+      delays = for _ <- 1..1_500, do: Jitter.start_delay(@interval)
+
+      # Concentration, not range: a few outliers can widen the range while the
+      # bulk still fires together. Production measured 74% in one 30s bucket.
+      bucket = to_timeout(second: 30)
+      peak = delays |> Enum.frequencies_by(&div(&1, bucket)) |> Map.values() |> Enum.max()
+
+      assert peak / 1_500 < 0.10, "#{round(peak / 15)}% of devices landed in one 30s bucket"
+    end
+
+    test "rejects a non-positive interval rather than arming a nonsense timer" do
+      assert_raise FunctionClauseError, fn -> Jitter.start_delay(0) end
+      assert_raise FunctionClauseError, fn -> Jitter.start_delay(-5) end
+    end
+  end
+end

--- a/test/nerves_hub_web/channels/effects_test.exs
+++ b/test/nerves_hub_web/channels/effects_test.exs
@@ -12,6 +12,35 @@ defmodule NervesHubWeb.Channels.EffectsTest do
     end)
   end
 
+  describe "repeating timers with an offset start" do
+    test "offsets only the first delivery; the period after it is exact" do
+      # What `Extensions.Jitter` relies on: a fleet can be spread out without
+      # any one device's reporting cadence changing.
+      key = {"health", :check}
+      socket = Effects.apply_all(socket(), [{:start_timer, key, {Health, :check}, 20, 60_000}])
+
+      # Armed with the offset, but the stored period is the nominal one.
+      assert %{^key => {:interval, ref, 60_000}} = socket.assigns.link_timers
+      assert Process.read_timer(ref) <= 20
+
+      assert_receive {:timeout, _ref, _payload} = timer, 500
+      assert {:deliver, {Health, :check}, socket} = Effects.timer_fired(socket, timer)
+
+      # Re-armed from the stored period, not from the offset.
+      assert %{^key => {:interval, next, 60_000}} = socket.assigns.link_timers
+      assert Process.read_timer(next) > 50_000
+    end
+
+    test "cancelling an offset timer works the same as any other" do
+      key = {"health", :check}
+      socket = Effects.apply_all(socket(), [{:start_timer, key, {Health, :check}, 50, 60_000}])
+      socket = Effects.apply_all(socket, [{:cancel_timer, key}])
+
+      assert socket.assigns.link_timers == %{}
+      refute_receive {:timeout, _ref, _payload}, 200
+    end
+  end
+
   describe "repeating timers" do
     test "delivers in an envelope and keeps delivering once each firing is handed back" do
       socket = Effects.apply_all(socket(), [{:start_timer, {"health", :check}, {Health, :check}, 20}])


### PR DESCRIPTION
A device node showed a CPU and network egress spike every ten minutes, matching the configured health check interval. It is the whole fleet asking at the same instant.

## What is happening

`DeviceSocket` staggers its last-seen updates:

```elixir
interval + Enum.random(-jitter..jitter)
```

`Extensions.Health` and `Extensions.Geo` do not. They start a repeating timer on attach with a fixed interval, so every device gets the same phase, because they attach together: a deploy reconnects the whole fleet inside a few seconds.

Measured on a production device node running a ten minute interval, sampling every extension channel's pending timer:

```
== {"health", :check} -- 1519 devices, interval 10.0m ==
       0ms                                                    10
     ...
      6.0m ################################################## 1133
      6.5m #########                                          214
     ...
```

74% of the fleet due inside one 30 second window, 89% inside one minute, against the 5% an even spread would put there. That is a 15x spike. An hour after the deploy it had barely moved, because device connections are long-lived, so only the ~170 that had reconnected since were spread out.

Each tick pushes a request to every device at once. At 1500 devices that is 1500 serialisations, 1500 permessage-deflate compressions and 1500 socket writes in one burst, then 1500 replies, each producing a `save_device_health` and a `save_metrics` write. CPU, egress and database traffic all spike together, once per interval.

## The fix

Offset the first delay, keep the period exact.

A device asked to report every ten minutes still reports every ten minutes. It starts somewhere random inside the first one, and the immediate tick on attach is unchanged, so the first report still lands at connect.

Varying the interval instead would have been a smaller change, but it makes the reporting cadence per device fuzzy, and the point of a ten minute setting is ten minutes. Offsetting the phase also decouples it from the connect time, so devices reconnecting together stops mattering rather than needing to even out on its own.

`Effects` already re-arms an interval from the stored period rather than from whatever was armed, thanks to the envelope work in #2945, so carrying a distinct first delay is one additive clause:

```elixir
defp apply_one(socket, {:start_timer, key, message, first_ms, interval_ms}) do
  socket = cancel(socket, key)
  put_timer(socket, key, {:interval, arm(key, message, first_ms), interval_ms})
end
```

`timer_fired/2` is untouched, and the existing four-tuple behaves exactly as before.