### PR TITLE
Let the device channel own the health check pace

### DIFF
--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -1,17 +1,43 @@
 defmodule NervesHub.Extensions.Health do
+  @moduledoc """
+  Device metrics, metadata and alarms, reported on a pace this module sets.
+
+  The platform decides when a device reports, and nothing else asks: a `check`
+  goes out on one timer per connection, so however many people have the device's
+  page open, the device is asked once. It used to be the other way around -- the
+  Show LiveView ran its own timer and requested a check directly, on top of this
+  one, once per open page -- which meant two people looking at a device asked it
+  for three reports a minute between them, none of them aligned.
+
+  The pace has two settings, and which one is in force is the `:mode` assign:
+
+    * `:idle` -- nobody is looking. Report every `interval_minutes` (an hour by
+      default), the first one offset so a fleet does not answer in unison; see
+      `NervesHub.Extensions.Jitter`.
+    * `:watched` -- at least one device Show LiveView is open. Report every
+      `ui_polling_seconds` (a minute by default), because somebody is reading
+      the numbers and a stale reading is the thing they would notice.
+
+  Both transitions come from `NervesHub.Extensions.PubSub`, and they are not
+  symmetric: opening a page announces itself, closing one cannot. See
+  `NervesHub.Extensions.PubSub.watch_health/1` for why each direction works the
+  way it does.
+  """
+
   @behaviour NervesHub.Extensions
 
-  alias NervesHub.Devices.DeviceMessages
   alias NervesHub.Devices.Health
   alias NervesHub.Devices.HealthStatus
   alias NervesHub.Devices.Metrics
   alias NervesHub.Extensions.Jitter
   alias NervesHub.Extensions.PubSub
+  alias NervesHub.Extensions.State
   alias NervesHub.Helpers.Logging
 
   require Logger
 
   @default_interval_minutes 60
+  @default_ui_polling_seconds 60
 
   @impl NervesHub.Extensions
   def description() do
@@ -29,14 +55,20 @@ defmodule NervesHub.Extensions.Health do
   def attach(state) do
     # Ask for a report immediately, then on an interval. The tick is delivered
     # before the first timer fires, which preserves the previous ordering.
-    interval = to_timeout(minute: health_interval_minutes())
+    #
+    # The pace is settled here rather than starting slow and being told,
+    # because a page that was already open when the device connected has
+    # nothing left to announce -- its join happened before there was anything
+    # to announce it to.
+    mode = current_mode(state)
 
-    {state, [{:tick, :check}, {:start_timer, :check, Jitter.start_delay(interval), interval}]}
+    {State.assign(state, :mode, mode),
+     [{:group_join, PubSub.health_key(device_id(state))}, {:tick, :check}, timer(mode)]}
   end
 
   @impl NervesHub.Extensions
   def detach(state) do
-    {state, [{:cancel_timer, :check}]}
+    {State.assign(state, :mode, nil), [{:cancel_timer, :check}, {:group_leave, PubSub.health_key(device_id(state))}]}
   end
 
   @impl NervesHub.Extensions
@@ -88,21 +120,75 @@ defmodule NervesHub.Extensions.Health do
 
   @impl NervesHub.Extensions
   def handle_info(:check, state) do
-    {state, [{:push, "health:check", %{}}]}
+    # A check is also when the pace is reconsidered, which is what makes the
+    # slowdown work without anything having to announce a page closing: while
+    # watched, this runs every minute, so the last person leaving costs the
+    # device one extra report. Doing it here rather than on a monitor of the
+    # watchers group also means the read is never racing the join it is reading
+    # -- by now it has long since replicated.
+    {state, effects} = reconsider(state)
+
+    {state, [{:push, "health:check", %{}} | effects]}
   end
 
-  def request_health_check(device) do
-    # Recorded here rather than in the wrapper; see `NervesHub.Extensions.PubSub`.
-    :ok = DeviceMessages.record(device, :sent, :extensions, "health:check", %{})
-    :ok = PubSub.broadcast_to_device(device.id, "health:check", %{})
+  # A device Show LiveView has opened on this device. Announced rather than
+  # discovered so that speeding up does not wait on the join replicating to
+  # whichever node this is running on; see
+  # `NervesHub.Extensions.PubSub.watch_health/1`.
+  def handle_info(:watching, state) do
+    if State.get(state, :mode) == :watched do
+      {state, []}
+    else
+      # Somebody has just opened the page and is looking at numbers taken up to
+      # an hour ago, so this asks straight away rather than in a minute.
+      {State.assign(state, :mode, :watched), [{:tick, :check}, timer(:watched)]}
+    end
   end
+
+  defp reconsider(state) do
+    mode = current_mode(state)
+
+    if mode == State.get(state, :mode) do
+      {state, []}
+    else
+      {State.assign(state, :mode, mode), [timer(mode)]}
+    end
+  end
+
+  defp current_mode(state) do
+    if PubSub.health_watched?(device_id(state)), do: :watched, else: :idle
+  end
+
+  # Replaces whatever is armed under `:check`; see `NervesHubWeb.Channels.Effects`.
+  defp timer(:watched) do
+    {:start_timer, :check, to_timeout(second: ui_polling_seconds())}
+  end
+
+  defp timer(:idle) do
+    interval = to_timeout(minute: health_interval_minutes())
+
+    {:start_timer, :check, Jitter.start_delay(interval), interval}
+  end
+
+  defp device_id(state), do: state.device_info.device_id
 
   defp health_interval_minutes() do
-    extension_config = Application.get_env(:nerves_hub, :extension_config, [])
-
-    case get_in(extension_config, [:health, :interval_minutes]) do
+    case config([:health, :interval_minutes]) do
       i when is_integer(i) and i > 0 -> i
       _ -> @default_interval_minutes
     end
+  end
+
+  defp ui_polling_seconds() do
+    case config([:health, :ui_polling_seconds]) do
+      i when is_integer(i) and i > 0 -> i
+      _ -> @default_ui_polling_seconds
+    end
+  end
+
+  defp config(path) do
+    :nerves_hub
+    |> Application.get_env(:extension_config, [])
+    |> get_in(path)
   end
 end

--- a/lib/nerves_hub/extensions/pub_sub.ex
+++ b/lib/nerves_hub/extensions/pub_sub.ex
@@ -17,16 +17,22 @@ defmodule NervesHub.Extensions.PubSub do
 
   ## web -> device: `Phoenix.PubSub`
 
-  `health:check`, `attach` and `detach` are published by a UI button and by
-  per-device extension toggles. They are *rare*, and the consumer -- the
-  device's own `ExtensionsChannel` -- exists for as long as the device is
-  connected. Putting that side on `:group` would mean a cluster-replicated join
-  on every device connect and a leave on every disconnect, plus a row per online
-  device on every node, to target a handful of operator-triggered messages. That
-  is the same trade this module already declines for `product:<id>:extensions`
-  below, and it is a worse one here because the churn scales with the fleet
-  rather than with the number of open pages. A `Phoenix.PubSub` subscribe is
-  node-local and costs nothing to hold.
+  `attach` and `detach` are published by per-device extension toggles. They are
+  *rare*, and the consumer -- the device's own `ExtensionsChannel` -- exists for
+  as long as the device is connected. Putting that side on `:group` would mean a
+  cluster-replicated join on every device connect and a leave on every
+  disconnect, plus a row per online device on every node, to target a handful of
+  operator-triggered messages. That is the same trade this module already
+  declines for `product:<id>:extensions` below, and it is a worse one here
+  because the churn scales with the fleet rather than with the number of open
+  pages. A `Phoenix.PubSub` subscribe is node-local and costs nothing to hold.
+
+  `device:health/<id>` is the one exception, and it earns it: `Health` needs a
+  message from an open page (see `watch_health/1`), and there is no
+  `Phoenix.PubSub` topic that reaches one device's connection without every node
+  in the cluster hearing about it. The join is per *attached extension* rather
+  than per connection, and it buys targeted delivery for something that would
+  otherwise be fleet-wide fan-out.
 
   Reports are delivered as `%Phoenix.Socket.Broadcast{}` structs identical to
   what `Phoenix.PubSub` delivered, so existing `handle_info(%Broadcast{...})` /
@@ -64,12 +70,12 @@ defmodule NervesHub.Extensions.PubSub do
   constraint there: the struct fails to expand and the call warns as undefined,
   so the module cannot be built at all. Recording therefore belongs with
   whatever produced the message, which is on a web node in every case -- see
-  `NervesHub.Extensions.broadcast_extension_event/3` and
-  `NervesHub.Extensions.Health.request_health_check/1`.
+  `NervesHub.Extensions.broadcast_extension_event/3`.
 
   `NervesHub.Consoles.PubSub` is the same shape for the same reason.
   """
 
+  alias NervesHub.Extensions.Health
   alias Phoenix.Channel.Server, as: ChannelServer
   alias Phoenix.Socket.Broadcast
 
@@ -111,6 +117,55 @@ defmodule NervesHub.Extensions.PubSub do
     Group.dispatch(@group, reports_key(device_id), message)
   end
 
+  # -- Health: who is watching a device right now -----------------------------
+
+  @doc """
+  The group key the device's extensions channel joins while `Health` is
+  attached, so an open page can tell it to report more often.
+
+  Public because the join cannot happen here: `Group.join/4` joins the calling
+  process, and the process that has to be a member is the one holding the
+  device's connection. `Health` therefore returns a `{:group_join, key}` effect
+  and lets the connection carry it out -- the same reason
+  `NervesHub.Consoles.PubSub.local_shell_key/1` is public.
+  """
+  @spec health_key(integer()) :: String.t()
+  def health_key(device_id), do: "device:health/#{device_id}"
+
+  @doc """
+  Watch a device's health from the calling process (a device Show LiveView).
+
+  Two things happen, and they answer different questions.
+
+  The join is the standing answer to "is anybody still watching?", which is what
+  `Health` reads when it decides to *slow back down*. Membership is the right
+  shape for that: a page closing, a browser tab going away and a LiveView
+  crashing all look the same, and none of them can send a message on the way
+  out. It is also why there is no matching unwatch -- the membership lasts
+  exactly as long as the process that took it, which is exactly as long as
+  somebody is looking.
+
+  The dispatch is what makes the *speed up* immediate. `Health` could read the
+  membership instead, but that read runs wherever the extension runs, which is
+  not necessarily the node this join was made on, and group state is eventually
+  consistent -- a read in that gap would miss the page that just opened and
+  nothing further would arrive to correct it. Announcing needs no read at all.
+  """
+  @spec watch_health(integer()) :: :ok
+  def watch_health(device_id) do
+    :ok = Group.join(@group, health_watchers_key(device_id), %{})
+
+    # The extensions channel routes `{module, msg}` to the matching attached
+    # extension, so the tuple has to carry the module.
+    Group.dispatch(@group, health_key(device_id), {Health, :watching})
+  end
+
+  @doc "Is anybody watching this device's health right now?"
+  @spec health_watched?(integer()) :: boolean()
+  def health_watched?(device_id) do
+    Group.members(@group, health_watchers_key(device_id)) != []
+  end
+
   # -- Product-wide extension config (stays on Phoenix.PubSub) -----------------
 
   @doc """
@@ -132,8 +187,9 @@ defmodule NervesHub.Extensions.PubSub do
     ChannelServer.broadcast_from!(NervesHub.PubSub, self(), product_topic(product_id), event, payload)
   end
 
-  # Group key ("/" is Group's hierarchy separator).
+  # Group keys ("/" is Group's hierarchy separator).
   defp reports_key(device_id), do: "device:extensions:reports/#{device_id}"
+  defp health_watchers_key(device_id), do: "device:health:watchers/#{device_id}"
 
   # Preserved as the previous `Phoenix.PubSub` topic strings.
   defp topic(device_id), do: "device:#{device_id}:extensions"

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -107,8 +107,6 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   end
 
   def render(assigns) do
-    assigns = Map.put(assigns, :auto_refresh_health, !!assigns.health_check_timer)
-
     ~H"""
     <div
       id="details-tab"
@@ -139,36 +137,11 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
               <div class="text-base-50 leading-6 font-medium">Health</div>
               <HealthStatus.render device_id={@device.id} health={@device.latest_health} tooltip_position="right" />
             </div>
-            <div class="flex items-center gap-2">
-              <div class="text-base-500 text-xs tracking-wide">
-                <span>Last updated: </span>
-                <time id="health-last-updated" phx-hook="UpdatingTimeAgo" datetime={String.replace(DateTime.to_string(DateTime.truncate(@latest_metrics["timestamp"], :second)), " ", "T")}>
-                  {Timex.from_now(@latest_metrics["timestamp"])}
-                </time>
-              </div>
-              <div class="text-base-300 text-xs tracking-wide">Auto refresh</div>
-              <div>
-                <button
-                  type="button"
-                  phx-click="toggle-health-check-auto-refresh"
-                  class={[
-                    "border-1.5 focus:ring-focus-ring relative inline-flex h-3.5 w-6 shrink-0 cursor-pointer items-center rounded-full border-transparent transition-colors duration-200 ease-in-out focus:ring-1 focus:ring-offset-2 focus:outline-none",
-                    (@auto_refresh_health && "bg-primary") || "bg-gray-200"
-                  ]}
-                  role="switch"
-                  aria-checked="false"
-                >
-                  <span class="sr-only">Auto refresh health information</span>
-                  <span
-                    aria-hidden="true"
-                    class={[
-                      "pointer-events-none inline-block size-3",
-                      (@auto_refresh_health && "translate-x-3") || "translate-x-0",
-                      "transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                    ]}
-                  ></span>
-                </button>
-              </div>
+            <div class="text-base-500 text-xs tracking-wide">
+              <span>Last updated: </span>
+              <time id="health-last-updated" phx-hook="UpdatingTimeAgo" datetime={String.replace(DateTime.to_string(DateTime.truncate(@latest_metrics["timestamp"], :second)), " ", "T")}>
+                {Timex.from_now(@latest_metrics["timestamp"])}
+              </time>
             </div>
           </div>
           <div class="flex flex-wrap items-center justify-items-stretch gap-2 px-4 pt-2 pb-4">
@@ -709,20 +682,6 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     |> halt()
   end
 
-  def hooked_event("toggle-health-check-auto-refresh", _value, socket) do
-    if timer_ref = socket.assigns.health_check_timer do
-      _ = Process.cancel_timer(timer_ref)
-
-      socket
-      |> assign(:health_check_timer, nil)
-      |> halt()
-    else
-      socket
-      |> schedule_health_check_timer()
-      |> halt()
-    end
-  end
-
   def hooked_event("clear-manual-location-information", _, socket) do
     {:ok, device} =
       Devices.update_device(socket.assigns.device, %{
@@ -1050,21 +1009,6 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     |> assign(:support_script_running, false)
     |> assign(:recently_run_support_script_output, output)
     |> halt()
-  end
-
-  defp schedule_health_check_timer(socket) do
-    %{device: device, product: product} = socket.assigns
-
-    if connected?(socket) and health_extension_enabled?(product, device) do
-      timer_ref = Process.send_after(self(), :check_health_interval, 500)
-      assign(socket, :health_check_timer, timer_ref)
-    else
-      assign(socket, :health_check_timer, nil)
-    end
-  end
-
-  defp health_extension_enabled?(product, device) do
-    product.extensions.health and device.extensions.health
   end
 
   # TODO: this is duplicated code, find a new way to reuse it

--- a/lib/nerves_hub_web/live/devices/show.ex
+++ b/lib/nerves_hub_web/live/devices/show.ex
@@ -10,7 +10,6 @@ defmodule NervesHubWeb.Live.Devices.Show do
   alias NervesHub.Devices.PubSub
   alias NervesHub.Devices.Updates
   alias NervesHub.Extensions
-  alias NervesHub.Extensions.Health
   alias NervesHub.FirmwareUpdates
   alias NervesHub.Products
   alias NervesHub.Tracker
@@ -62,7 +61,7 @@ defmodule NervesHubWeb.Live.Devices.Show do
     |> sidebar_tab(:devices)
     |> selected_tab()
     |> general_assigns(device)
-    |> schedule_health_check_timer()
+    |> watch_health()
     |> load_inprogress_firmware_update()
     |> assign(:pinned?, Pinning.device_pinned?(user.id, device.id))
     |> setup_presence_tracking()
@@ -163,16 +162,6 @@ defmodule NervesHubWeb.Live.Devices.Show do
     socket
     |> assign(:firmware_update_progress, nil)
     |> assign(:firmware_update_stage, stage)
-    |> noreply()
-  end
-
-  def handle_info(:check_health_interval, socket) do
-    timer_ref = Process.send_after(self(), :check_health_interval, health_polling_seconds())
-
-    Health.request_health_check(socket.assigns.device)
-
-    socket
-    |> assign(:health_check_timer, timer_ref)
     |> noreply()
   end
 
@@ -381,15 +370,22 @@ defmodule NervesHubWeb.Live.Devices.Show do
     end
   end
 
-  defp schedule_health_check_timer(socket) do
+  # Tells the device's extensions channel that somebody is looking, which is the
+  # whole of the page's involvement in health reporting: the pace, and the
+  # `health:check` itself, belong to `NervesHub.Extensions.Health`. Every open
+  # page used to run its own timer and ask the device directly, so two people on
+  # one device meant two extra streams of requests on top of the platform's.
+  #
+  # There is nothing to give up again: watching lasts as long as this process,
+  # and the reporting slows back down once the last page has closed.
+  defp watch_health(socket) do
     %{device: device, product: product} = socket.assigns
 
     if connected?(socket) and health_extension_enabled?(product, device) do
-      timer_ref = Process.send_after(self(), :check_health_interval, 500)
-      assign(socket, :health_check_timer, timer_ref)
-    else
-      assign(socket, :health_check_timer, nil)
+      :ok = Extensions.PubSub.watch_health(device.id)
     end
+
+    socket
   end
 
   defp health_extension_enabled?(product, device) do
@@ -441,12 +437,6 @@ defmodule NervesHubWeb.Live.Devices.Show do
 
   def selected_tab(socket) do
     assign(socket, :tab, socket.assigns.live_action || :details)
-  end
-
-  defp health_polling_seconds() do
-    Application.get_env(:nerves_hub, :extension_config, [])
-    |> get_in([:health, :ui_polling_seconds])
-    |> :timer.seconds()
   end
 
   def render_tab(assigns) do

--- a/test/nerves_hub/extensions/health_test.exs
+++ b/test/nerves_hub/extensions/health_test.exs
@@ -1,0 +1,167 @@
+defmodule NervesHub.Extensions.HealthTest do
+  @moduledoc """
+  The pace at which a device is asked for health reports.
+
+  Only this module asks. Everything below is about how it settles on how often,
+  and about the asymmetry that makes it work: a page opening says so, a page
+  closing says nothing and is noticed on the next check.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Extensions.Health
+  alias NervesHub.Extensions.PubSub
+  alias NervesHub.Extensions.State
+
+  # Both default to 60 in config, so the units are what tells the two timers
+  # apart: a minute while watched, an hour while nobody is looking.
+  @watched_ms to_timeout(minute: 1)
+  @idle_ms to_timeout(hour: 1)
+
+  setup do
+    device_id = System.unique_integer([:positive])
+
+    %{device_id: device_id, state: State.new(%DeviceInfo{device_id: device_id})}
+  end
+
+  describe "attaching" do
+    test "asks straight away and settles into the platform interval", %{device_id: device_id, state: state} do
+      {state, effects} = Health.attach(state)
+
+      assert State.get(state, :mode) == :idle
+      assert {:group_join, "device:health/#{device_id}"} in effects
+      assert {:tick, :check} in effects
+      assert {:start_timer, :check, first_ms, @idle_ms} = timer(effects)
+
+      # Offset so a fleet attaching together does not answer together.
+      assert first_ms in 1..@idle_ms
+    end
+
+    test "picks up a page that was already open", %{device_id: device_id, state: state} do
+      :ok = PubSub.watch_health(device_id)
+
+      {state, effects} = Health.attach(state)
+
+      assert State.get(state, :mode) == :watched
+      assert {:start_timer, :check, @watched_ms} = timer(effects)
+    end
+
+    test "detaching gives up the timer and the group", %{device_id: device_id, state: state} do
+      {state, _effects} = Health.attach(state)
+
+      {state, effects} = Health.detach(state)
+
+      assert State.get(state, :mode) == nil
+      assert {:cancel_timer, :check} in effects
+      assert {:group_leave, "device:health/#{device_id}"} in effects
+    end
+  end
+
+  describe "a page opening" do
+    test "speeds the reporting up and asks now", %{state: state} do
+      {state, _effects} = Health.attach(state)
+
+      {state, effects} = Health.handle_info(:watching, state)
+
+      assert State.get(state, :mode) == :watched
+      assert {:tick, :check} in effects
+      assert {:start_timer, :check, @watched_ms} = timer(effects)
+    end
+
+    test "a second page changes nothing", %{device_id: device_id, state: state} do
+      :ok = PubSub.watch_health(device_id)
+      {state, _effects} = Health.attach(state)
+
+      # What the device would otherwise pay for every extra person looking at it.
+      assert {state, []} = Health.handle_info(:watching, state)
+      assert State.get(state, :mode) == :watched
+    end
+  end
+
+  describe "checking" do
+    test "asks the device, and nothing more while the pace is right", %{device_id: device_id, state: state} do
+      :ok = PubSub.watch_health(device_id)
+      {state, _effects} = Health.attach(state)
+
+      assert {_state, [{:push, "health:check", %{}}]} = Health.handle_info(:check, state)
+    end
+
+    test "slows back down once the last page has closed", %{device_id: device_id, state: state} do
+      watcher = watch_from_another_process(device_id)
+      {state, _effects} = Health.attach(state)
+      assert State.get(state, :mode) == :watched
+
+      # Nothing announces this: the page is gone, and with it any chance of it
+      # saying so. The next check is where that gets noticed.
+      close(watcher, device_id)
+
+      {state, effects} = Health.handle_info(:check, state)
+
+      assert State.get(state, :mode) == :idle
+      assert {:push, "health:check", %{}} in effects
+      assert {:start_timer, :check, first_ms, @idle_ms} = timer(effects)
+      assert first_ms in 1..@idle_ms
+    end
+
+    test "picks up a watcher whose announcement never arrived", %{device_id: device_id, state: state} do
+      {state, _effects} = Health.attach(state)
+      assert State.get(state, :mode) == :idle
+
+      # A join this node had not replicated when the page announced itself would
+      # leave the announcement landing nowhere. Reading membership on every
+      # check means that heals, rather than lasting the life of the connection.
+      :ok = PubSub.watch_health(device_id)
+
+      {state, effects} = Health.handle_info(:check, state)
+
+      assert State.get(state, :mode) == :watched
+      assert {:start_timer, :check, @watched_ms} = timer(effects)
+    end
+  end
+
+  defp timer(effects) do
+    Enum.find(effects, &match?({:start_timer, :check, _}, &1)) ||
+      Enum.find(effects, &match?({:start_timer, :check, _, _}, &1))
+  end
+
+  # A watcher the test can kill, since the test process itself cannot stand in
+  # for a page that closes.
+  defp watch_from_another_process(device_id) do
+    test = self()
+
+    pid =
+      spawn(fn ->
+        :ok = PubSub.watch_health(device_id)
+        send(test, :watching)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :watching, 500
+    pid
+  end
+
+  defp close(pid, device_id) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 500
+
+    # Membership is given up by the group noticing the exit, not by the exit
+    # itself, so the read has to wait for the group rather than the process.
+    wait_until(fn -> not PubSub.health_watched?(device_id) end)
+  end
+
+  defp wait_until(fun, attempts \\ 50) do
+    cond do
+      fun.() ->
+        :ok
+
+      attempts == 0 ->
+        flunk("the watcher never left the group")
+
+      true ->
+        Process.sleep(20)
+        wait_until(fun, attempts - 1)
+    end
+  end
+end

--- a/test/nerves_hub/extensions/pub_sub_test.exs
+++ b/test/nerves_hub/extensions/pub_sub_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHub.Extensions.PubSubTest do
   use ExUnit.Case, async: true
 
+  alias NervesHub.Extensions.Health
   alias NervesHub.Extensions.PubSub
   alias Phoenix.Socket.Broadcast
 
@@ -59,6 +60,83 @@ defmodule NervesHub.Extensions.PubSubTest do
     :ok = PubSub.subscribe_device(device_id)
 
     assert Group.members(NervesHub.Group, "device:extensions/#{device_id}") == []
+  end
+
+  describe "health watchers" do
+    test "watching announces itself to the device's extensions channel", %{device_id: device_id} do
+      # Standing in for the extensions channel, which joins this group for as
+      # long as the health extension is attached.
+      :ok = Group.join(NervesHub.Group, PubSub.health_key(device_id), %{})
+
+      task = Task.async(fn -> PubSub.watch_health(device_id) end)
+      :ok = Task.await(task)
+
+      # Tagged with the module because that is how the channel routes it to the
+      # extension that asked.
+      assert_receive {Health, :watching}, 500
+    end
+
+    test "watching is also a standing membership, for the slowdown", %{device_id: device_id} do
+      refute PubSub.health_watched?(device_id)
+
+      :ok = PubSub.watch_health(device_id)
+
+      assert PubSub.health_watched?(device_id)
+    end
+
+    test "the page closing is what gives the membership up", %{device_id: device_id} do
+      page = watching_page(device_id)
+      assert PubSub.health_watched?(device_id)
+
+      # Nothing is sent on the way out -- a closed tab cannot -- so this is the
+      # only thing that ends a watch.
+      close(page)
+
+      assert eventually(fn -> not PubSub.health_watched?(device_id) end)
+    end
+
+    test "one page closing does not stop the others being watched", %{device_id: device_id} do
+      page = watching_page(device_id)
+      :ok = PubSub.watch_health(device_id)
+
+      close(page)
+
+      # This test process is still a member, so the device keeps reporting at
+      # the faster pace for whoever is left.
+      assert PubSub.health_watched?(device_id)
+    end
+  end
+
+  # A watcher that can be closed, since the test process cannot stand in for a
+  # page going away.
+  defp watching_page(device_id) do
+    test = self()
+
+    pid =
+      spawn(fn ->
+        :ok = PubSub.watch_health(device_id)
+        send(test, :watching)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :watching, 500
+    pid
+  end
+
+  defp close(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 500
+  end
+
+  # Membership is given up by the group noticing the exit, not by the exit
+  # itself, so the read has to wait for the group rather than the process.
+  defp eventually(fun, attempts \\ 50) do
+    cond do
+      fun.() -> true
+      attempts == 0 -> false
+      true -> Process.sleep(20) && eventually(fun, attempts - 1)
+    end
   end
 
   describe "product-wide events (Phoenix.PubSub)" do

--- a/test/nerves_hub_web/channels/device_message_recording_test.exs
+++ b/test/nerves_hub_web/channels/device_message_recording_test.exs
@@ -17,7 +17,6 @@ defmodule NervesHubWeb.DeviceMessageRecordingTest do
   alias NervesHub.Devices.DeviceMessage
   alias NervesHub.Devices.DeviceMessages
   alias NervesHub.Extensions
-  alias NervesHub.Extensions.Health
   alias NervesHub.Fixtures
   alias NervesHubWeb.DeviceChannel
   alias NervesHubWeb.DeviceSocket
@@ -80,17 +79,6 @@ defmodule NervesHubWeb.DeviceMessageRecordingTest do
     # `Extensions.PubSub`, which stays free of the database so the connection
     # layer can be duplicated onto a node that has none. Which means a caller
     # can forget, and only a test would say so.
-    test "records a health check requested from the web", %{tmp_dir: tmp_dir} do
-      %{device: device, channel: channel} = join_device(tmp_dir)
-
-      :ok = Health.request_health_check(device)
-
-      assert %{direction: "sent", topic: "extensions", event: "health:check"} =
-               find(recorded(device), "health:check")
-
-      close_cleanly(channel)
-    end
-
     test "records an extension being attached and detached", %{tmp_dir: tmp_dir} do
       %{device: device, channel: channel} = join_device(tmp_dir)
 

--- a/test/nerves_hub_web/channels/extensions_channel_test.exs
+++ b/test/nerves_hub_web/channels/extensions_channel_test.exs
@@ -380,6 +380,38 @@ defmodule NervesHubWeb.ExtensionsChannelTest do
     assert_push("health:check", _)
   end
 
+  test "a page opening asks the attached health extension for a report", %{tmp_dir: tmp_dir} do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, dir: tmp_dir)
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, _, socket} =
+      subscribe_and_join_with_default_device_api_version(socket, DeviceChannel, "device:#{device.id}")
+
+    assert_push("extensions:get", _extensions)
+
+    assert {:ok, ["health"], socket} =
+             subscribe_and_join_with_default_device_api_version(
+               socket,
+               ExtensionsChannel,
+               "extensions",
+               %{"health" => "0.0.1"}
+             )
+
+    push(socket, "health:attached")
+    assert_push("health:check", _)
+
+    # What the device Show LiveView does on mount. The whole point of the round
+    # trip is that the device is asked by the channel, so a second page opening
+    # adds nothing to what the device is already being sent.
+    :ok = PubSub.watch_health(device.id)
+
+    assert_push("health:check", _)
+  end
+
   test "attached geo extension will receive request for location update", %{tmp_dir: tmp_dir} do
     user = Fixtures.user_fixture()
     {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, dir: tmp_dir)

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -654,6 +654,25 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
   end
 
   describe "device health" do
+    test "opening the page is the whole of its part in health reporting", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      refute PubSub.health_watched?(device.id)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+
+      # The page used to run a timer and ask the device for a report itself,
+      # once per open page, on top of the interval the platform already had.
+      # Now it says it is watching and `NervesHub.Extensions.Health` does the
+      # asking -- once, however many people are looking.
+      assert PubSub.health_watched?(device.id)
+    end
+
     test "no device health", %{conn: conn, org: org, product: product, device: device} do
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")


### PR DESCRIPTION
## The problem

The device Show page ran its own health check timer. Every mount scheduled `:check_health_interval` and called `Health.request_health_check/1`, which broadcast `health:check` straight through the extensions channel to the device, on top of the interval `NervesHub.Extensions.Health` was already running.

That timer was per page, not per device. Two people with the same device open meant two extra streams of requests overlapping the platform's own, none of them aligned, each answer costing the device a report plus two database writes.

## What changed

`health:check` now leaves one place: the extensions channel, on one timer per connection. The timer has two paces, tracked in the extension's `:mode` assign.

- `:idle` when nobody is looking. `interval_minutes` (an hour by default), first fire jittered as before.
- `:watched` when at least one Show page is open. `ui_polling_seconds` (a minute by default).

The two transitions are asymmetric on purpose, because a page opening can say so and a page closing cannot.

Speeding up is announced. The LiveView joins `device:health:watchers/<id>` and dispatches `{Health, :watching}` to `device:health/<id>`, a group the channel joins while the extension is attached. The extension switches to the fast timer and asks once, straight away. A second viewer lands on the already-`:watched` branch and produces nothing.

Slowing down is discovered. Every `:check` re-reads the watchers group, which while watched is once a minute, so the last page closing costs the device one extra report. That read also heals a `:watching` that landed nowhere because the group join had not replicated yet, which a membership monitor could not.

## The auto refresh toggle is gone

It claimed to control refreshing, but once the pace belonged to the channel it only controlled whether your page was counted among the watchers. With someone else's page open it changed nothing visible; with nobody else's it stopped a refresh the page was still perfectly willing to display.

## Also removed

`Health.request_health_check/1`. The LiveView was its only caller, and leaving a "the web sends a check directly" path in place would contradict the rule the rest of this change establishes.
