### PR TITLE
Don't mistake an unloaded deployment_group for a real one

### DIFF
--- a/lib/nerves_hub/audit_logs/templates/device_templates.ex
+++ b/lib/nerves_hub/audit_logs/templates/device_templates.ex
@@ -80,17 +80,7 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
   end
 
   @spec audit_firmware_upgrade_ignored(Device.t(), DeploymentGroup.t() | nil, String.t() | nil) :: :ok
-  def audit_firmware_upgrade_ignored(device, nil, reason) do
-    reason = truncate_reason(reason)
-
-    description = """
-    Device #{device.identifier} ignored the manual firmware upgrade request#{reason && " because of \"#{reason}\""}.
-    """
-
-    AuditLogs.audit!(device, device, description)
-  end
-
-  def audit_firmware_upgrade_ignored(device, deployment_group, reason) do
+  def audit_firmware_upgrade_ignored(device, %DeploymentGroup{} = deployment_group, reason) do
     reason = truncate_reason(reason)
 
     description = """
@@ -99,6 +89,16 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     """
 
     AuditLogs.audit!(deployment_group, device, description)
+  end
+
+  def audit_firmware_upgrade_ignored(device, _deployment_group, reason) do
+    reason = truncate_reason(reason)
+
+    description = """
+    Device #{device.identifier} ignored the manual firmware upgrade request#{reason && " because of \"#{reason}\""}.
+    """
+
+    AuditLogs.audit!(device, device, description)
   end
 
   @spec audit_firmware_upgrade_blocked(DeploymentGroup.t(), Device.t()) :: :ok
@@ -113,23 +113,7 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
 
   @spec audit_firmware_upgrade_rescheduled(Device.t(), NaiveDateTime.t(), String.t() | nil) :: :ok
   def audit_firmware_upgrade_rescheduled(
-        %{inflight_update: %{deployment_group: deployment_group}} = device,
-        blocked_until,
-        reason
-      )
-      when is_nil(deployment_group) do
-    reason = truncate_reason(reason)
-
-    description = """
-    During a manual firmware update request, device #{device.identifier} requested firmware upgrades be rescheduled #{Timex.from_now(blocked_until)} time #{reason && "because \"#{reason}\""}.
-    The update will not be automatically retried.
-    """
-
-    AuditLogs.audit!(device, device, description)
-  end
-
-  def audit_firmware_upgrade_rescheduled(
-        %{inflight_update: %{deployment_group: deployment_group}} = device,
+        %{inflight_update: %{deployment_group: %DeploymentGroup{} = deployment_group}} = device,
         blocked_until,
         reason
       ) do
@@ -142,21 +126,25 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     AuditLogs.audit!(deployment_group, device, description)
   end
 
-  @spec audit_firmware_upgrade_failed(Device.t(), String.t() | nil, Keyword.t()) :: :ok
-  def audit_firmware_upgrade_failed(device, reason, opts \\ [])
-
-  def audit_firmware_upgrade_failed(%{inflight_update: %{deployment_group: deployment_group}} = device, reason, _)
-      when is_nil(deployment_group) do
+  def audit_firmware_upgrade_rescheduled(device, blocked_until, reason) do
     reason = truncate_reason(reason)
 
     description = """
-    Device #{device.identifier} reported an error #{reason && "(\"#{reason}\") "}while trying to update its firmware.
+    During a manual firmware update request, device #{device.identifier} requested firmware upgrades be rescheduled #{Timex.from_now(blocked_until)} time #{reason && "because \"#{reason}\""}.
+    The update will not be automatically retried.
     """
 
     AuditLogs.audit!(device, device, description)
   end
 
-  def audit_firmware_upgrade_failed(%{inflight_update: %{deployment_group: deployment_group}} = device, reason, opts) do
+  @spec audit_firmware_upgrade_failed(Device.t(), String.t() | nil, Keyword.t()) :: :ok
+  def audit_firmware_upgrade_failed(device, reason, opts \\ [])
+
+  def audit_firmware_upgrade_failed(
+        %{inflight_update: %{deployment_group: %DeploymentGroup{} = deployment_group}} = device,
+        reason,
+        opts
+      ) do
     reason = truncate_reason(reason)
 
     description = """
@@ -164,6 +152,16 @@ defmodule NervesHub.AuditLogs.DeviceTemplates do
     """
 
     AuditLogs.audit!(deployment_group, device, description)
+  end
+
+  def audit_firmware_upgrade_failed(device, reason, _opts) do
+    reason = truncate_reason(reason)
+
+    description = """
+    Device #{device.identifier} reported an error #{reason && "(\"#{reason}\") "}while trying to update its firmware.
+    """
+
+    AuditLogs.audit!(device, device, description)
   end
 
   @spec audit_firmware_updated(Device.t()) :: :ok

--- a/lib/nerves_hub/firmware_updates.ex
+++ b/lib/nerves_hub/firmware_updates.ex
@@ -67,16 +67,18 @@ defmodule NervesHub.FirmwareUpdates do
       "ignored",
       %{reason: info["reason"]},
       fn device ->
+        deployment_group = deployment_group(device)
+
         _ =
-          if device.inflight_update.deployment_group do
-            blocked_for_mins = device.inflight_update.deployment_group.penalty_timeout_minutes
+          if deployment_group do
+            blocked_for_mins = deployment_group.penalty_timeout_minutes
 
             blocked_until = DateTime.utc_now(:second) |> DateTime.add(blocked_for_mins, :minute)
 
             {:ok, _device} = Devices.update_device(device, %{updates_blocked_until: blocked_until})
           end
 
-        DeviceTemplates.audit_firmware_upgrade_ignored(device, device.inflight_update.deployment_group, info["reason"])
+        DeviceTemplates.audit_firmware_upgrade_ignored(device, deployment_group, info["reason"])
 
         clear_inflight_update(device_id)
       end,
@@ -97,7 +99,7 @@ defmodule NervesHub.FirmwareUpdates do
         info["reason"]
       )
 
-      if device.inflight_update.deployment_group do
+      if deployment_group(device) do
         {:ok, _device} = Devices.update_device(device, %{updates_blocked_until: blocked_until})
       end
     end
@@ -113,8 +115,8 @@ defmodule NervesHub.FirmwareUpdates do
       fn device ->
         clear_inflight_update(device_id)
 
-        if device.inflight_update.deployment_group do
-          blocked_for_mins = device.inflight_update.deployment_group.penalty_timeout_minutes
+        if deployment_group = deployment_group(device) do
+          blocked_for_mins = deployment_group.penalty_timeout_minutes
 
           blocked_until = DateTime.utc_now(:second) |> DateTime.add(blocked_for_mins, :minute)
 
@@ -124,7 +126,7 @@ defmodule NervesHub.FirmwareUpdates do
 
           {:ok, _device} = Devices.update_device(device, %{updates_blocked_until: blocked_until})
         else
-          DeviceTemplates.audit_firmware_upgrade_failed(device, nil, info["reason"])
+          DeviceTemplates.audit_firmware_upgrade_failed(device, info["reason"])
         end
       end,
       preload: :deployment
@@ -292,6 +294,9 @@ defmodule NervesHub.FirmwareUpdates do
         inflight_update =
           InflightUpdate.empty_requested_changeset(device.id)
           |> Repo.insert!()
+          # the record was built here rather than by the query above, so the
+          # association is unloaded. It has no deployment_id, so nil is correct.
+          |> Map.put(:deployment_group, nil)
 
         Map.put(device, :inflight_update, inflight_update)
 
@@ -299,6 +304,13 @@ defmodule NervesHub.FirmwareUpdates do
         device
     end
   end
+
+  # Guards against an unloaded association being mistaken for a deployment
+  # group, which is truthy and blows up on the first field access.
+  defp deployment_group(%{inflight_update: %{deployment_group: %DeploymentGroup{} = deployment_group}}),
+    do: deployment_group
+
+  defp deployment_group(_device), do: nil
 
   defp should_persist?(ifu) do
     some_secs_ago = NaiveDateTime.utc_now() |> NaiveDateTime.add(-15, :second)

--- a/test/nerves_hub/firmware_updates_test.exs
+++ b/test/nerves_hub/firmware_updates_test.exs
@@ -1,0 +1,130 @@
+defmodule NervesHub.FirmwareUpdatesTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.AuditLogs
+  alias NervesHub.Devices
+  alias NervesHub.Devices.InflightUpdate
+  alias NervesHub.FirmwareUpdates
+  alias NervesHub.Fixtures
+  alias NervesHub.ManagedDeployments
+
+  setup %{tmp_dir: tmp_dir} do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    deployment_group = Fixtures.deployment_group_fixture(firmware, %{is_active: true, user: user})
+    device = Fixtures.device_fixture(org, product, firmware, %{status: :provisioned})
+
+    %{deployment_group: deployment_group, device: device}
+  end
+
+  describe "status_update/4 without an inflight update" do
+    # A device can report a terminal update status with no inflight_updates row —
+    # eg. a manual `fwup` run, or after the row expired. `fetch_device/2` builds a
+    # placeholder for those, and its `deployment_group` association must not be
+    # mistaken for a real deployment group.
+
+    test "'failed' doesn't block the device and records a device scoped audit log", %{device: device} do
+      assert :ok = FirmwareUpdates.status_update("failed", device.id, %{"reason" => "fwup error"})
+
+      assert is_nil(Devices.get_device(device.id).updates_blocked_until)
+
+      assert [log] = AuditLogs.logs_for(device)
+      assert_actor(log, device)
+      assert log.description =~ "reported an error (\"fwup error\") while trying to update its firmware."
+      refute log.description =~ "Updates will be blocked"
+    end
+
+    test "'ignored' doesn't block the device and records a device scoped audit log", %{device: device} do
+      assert :ok = FirmwareUpdates.status_update("ignored", device.id, %{"reason" => "busy"})
+
+      assert is_nil(Devices.get_device(device.id).updates_blocked_until)
+
+      assert [log] = AuditLogs.logs_for(device)
+      assert_actor(log, device)
+      assert log.description =~ "ignored the manual firmware upgrade request because of \"busy\""
+    end
+
+    test "'rescheduled' doesn't block the device and records a device scoped audit log", %{device: device} do
+      info = %{"delay_for" => 60_000, "reason" => "on battery"}
+
+      assert :ok = FirmwareUpdates.status_update("rescheduled", device.id, info)
+
+      assert is_nil(Devices.get_device(device.id).updates_blocked_until)
+
+      assert [log] = AuditLogs.logs_for(device)
+      assert_actor(log, device)
+      assert log.description =~ "During a manual firmware update request"
+      assert log.description =~ "on battery"
+    end
+  end
+
+  describe "status_update/4 with a deployment group inflight update" do
+    setup %{deployment_group: deployment_group, device: device} do
+      deployment_group = ManagedDeployments.load_current_release(deployment_group)
+
+      {:ok, _inflight_update} =
+        InflightUpdate.deployment_requested_changeset(deployment_group, device.id, false)
+        |> Repo.insert()
+
+      %{deployment_group: deployment_group}
+    end
+
+    test "'failed' blocks the device for the penalty timeout", %{
+      deployment_group: deployment_group,
+      device: device
+    } do
+      assert :ok = FirmwareUpdates.status_update("failed", device.id, %{"reason" => "fwup error"})
+
+      assert blocked_until = Devices.get_device(device.id).updates_blocked_until
+      assert_blocked_for(blocked_until, deployment_group.penalty_timeout_minutes)
+
+      assert [log] = AuditLogs.logs_for(device)
+      assert_actor(log, deployment_group)
+      assert log.description =~ "Updates will be blocked for #{deployment_group.penalty_timeout_minutes} minutes"
+    end
+
+    test "'ignored' blocks the device for the penalty timeout", %{
+      deployment_group: deployment_group,
+      device: device
+    } do
+      assert :ok = FirmwareUpdates.status_update("ignored", device.id, %{"reason" => "busy"})
+
+      assert blocked_until = Devices.get_device(device.id).updates_blocked_until
+      assert_blocked_for(blocked_until, deployment_group.penalty_timeout_minutes)
+
+      assert [log] = AuditLogs.logs_for(device)
+      assert_actor(log, deployment_group)
+      assert log.description =~ "ignored the scheduled firmware upgrade request"
+    end
+
+    test "'rescheduled' blocks the device until the requested time", %{
+      deployment_group: deployment_group,
+      device: device
+    } do
+      info = %{"delay_for" => 60_000, "reason" => "on battery"}
+
+      assert :ok = FirmwareUpdates.status_update("rescheduled", device.id, info)
+
+      assert blocked_until = Devices.get_device(device.id).updates_blocked_until
+      assert_blocked_for(blocked_until, 1)
+
+      assert [log] = AuditLogs.logs_for(device)
+      assert_actor(log, deployment_group)
+      assert log.description =~ "During an update request from \"#{deployment_group.name}\""
+    end
+  end
+
+  defp assert_actor(log, %type{id: id}) do
+    assert log.actor_type == type
+    assert log.actor_id == id
+  end
+
+  defp assert_blocked_for(blocked_until, minutes) do
+    expected = DateTime.utc_now() |> DateTime.add(minutes, :minute)
+
+    assert_in_delta DateTime.to_unix(blocked_until), DateTime.to_unix(expected), 5
+  end
+end


### PR DESCRIPTION
A device reported a fwup failure while it had no `inflight_updates` row, and the device channel crashed with:

```
KeyError: key :penalty_timeout_minutes not found in:
    #Ecto.Association.NotLoaded<association :deployment_group is not loaded>
```

`fetch_device/2` handles a missing inflight update by inserting a placeholder row and putting the returned struct on the device. That struct comes straight from `Repo.insert!/1`, so its `deployment_group` is `%Ecto.Association.NotLoaded{}` rather than `nil`. It never went through the preload query, so `preload: :deployment` doesn't reach it.

`NotLoaded` is truthy, so `if device.inflight_update.deployment_group do` took the deployment branch and blew up on the first field access.

The same pattern was in all three terminal statuses (`failed`, `ignored` and `rescheduled`), and in the audit templates, which separate the device-scoped and deployment-scoped wording with `when is_nil(deployment_group)`. A `NotLoaded` struct falls through to the deployment clause there too. `failed` is just the one that fired first.

Changes:

- `fetch_device/2` sets `deployment_group: nil` on the placeholder. The row has no `deployment_id`, so `nil` is the accurate value.
- The three status branches read the group through a `deployment_group/1` helper that matches on `%DeploymentGroup{}`, so a missed preload degrades to "no deployment group" instead of a crash.
- The audit templates match `%DeploymentGroup{}` structurally rather than guarding on `is_nil`, for the same reason.
- Fixed the argument order in the manual-update branch of `audit_firmware_upgrade_failed/3`. It was called as `(device, nil, info["reason"])` against a `(device, reason, opts)` signature, so those audit entries silently lost their reason text.

Fixes NERVES-HUB-H4
