### PR TITLE
Configureable health profiles

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -11,6 +11,8 @@
   {"lib/nerves_hub/devices/network_identities.ex", :call_without_opaque},
   {"lib/nerves_hub/devices/alarms.ex", :call_without_opaque},
   {"lib/nerves_hub/devices/updates.ex", :call_without_opaque},
+  {"lib/nerves_hub/products.ex", :call_without_opaque},
+  {"lib/nerves_hub/products/health_profiles.ex", :call_without_opaque},
   {"lib/nerves_hub_web/components/layouts.ex", :call},
   {"lib/nerves_hub_web/components/layouts.ex", :no_return}
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,9 @@ when adding or removing one.
   `Distributed.Orchestrator` (one per deployment).
 - `firmwares.ex` / `firmwares/` and `archives.ex` / `archives/` — firmware and
   archive artifacts, uploads, and firmware **delta** building.
-- `products.ex` / `products/` — products and product settings.
+- `products.ex` / `products/` — products and product settings, including
+  health profiles (the per-product thresholds behind device health status,
+  evaluated in `devices/health_evaluation.ex`).
 - `extensions.ex` / `extensions/` — the device **extension framework**
   (`health`, `geo`, `local_shell`, `logging`, `network_identity`,
   `error_reports`); extensions attach per-device and exchange messages over the

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -287,6 +287,13 @@
     rgba(245, 158, 11, 0.04) 81.25%
   );
 }
+@utility health-alert {
+  background-image: linear-gradient(
+    180deg,
+    rgba(239, 68, 68, 0) 18.75%,
+    rgba(239, 68, 68, 0.04) 81.25%
+  );
+}
 @utility health-neutral {
   background-image: linear-gradient(
     180deg,

--- a/assets/js/hooks/chart.js
+++ b/assets/js/hooks/chart.js
@@ -20,15 +20,41 @@ export default {
       max = this.el.dataset.max
     }
 
+    // The device's health profile thresholds for this metric, when it has
+    // any: dots breaching them are colored by the level they breach. Judged
+    // per dot (instantaneous), independent of the windowed median that
+    // decides the device's status.
+    let thresholds = null
+    if (this.el.dataset.thresholds && this.el.dataset.thresholds !== "null") {
+      thresholds = JSON.parse(this.el.dataset.thresholds)
+    }
+
+    const breachLevel = (y) => {
+      if (!thresholds || y == null) return null
+      const breaches = (t) => (thresholds.operator === "lte" ? y <= t : y >= t)
+      if (breaches(thresholds.alert)) return "alert"
+      if (breaches(thresholds.warning)) return "warning"
+      return null
+    }
+
+    const pointColor = (ctx) => {
+      const level = breachLevel(ctx.raw && ctx.raw.y)
+      if (level === "alert") return "rgb(239, 68, 68)"
+      if (level === "warning") return "rgb(245, 158, 11)"
+      return "rgb(97, 95, 255)"
+    }
+
+    const pointRadius = (ctx) => (breachLevel(ctx.raw && ctx.raw.y) ? 3 : 2)
+
     const areaChartDataset = {
       type: "scatter",
       data: {
         datasets: [
           {
-            radius: 2,
+            radius: pointRadius,
             data: metrics,
-            pointBackgroundColor: "rgb(97, 95, 255)",
-            pointBorderColor: "rgb(97, 95, 255)",
+            pointBackgroundColor: pointColor,
+            pointBorderColor: pointColor,
             parsing: false,
           },
         ],

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -5,6 +5,7 @@ defmodule NervesHub.Application do
   alias NervesHub.DeviceLink.Handlers
   alias NervesHub.Devices.DeviceAlarmHistory
   alias NervesHub.Devices.DeviceConnectionHistory
+  alias NervesHub.Devices.DeviceHealthHistory
   alias NervesHub.Devices.DeviceMessage
   alias NervesHub.Devices.DeviceMetric
   alias NervesHub.Devices.LogLine
@@ -182,6 +183,7 @@ defmodule NervesHub.Application do
         Buffer.child_spec([schema: ErrorReport] ++ opts),
         Buffer.child_spec([schema: DeviceMetric] ++ opts),
         Buffer.child_spec([schema: DeviceAlarmHistory] ++ opts),
+        Buffer.child_spec([schema: DeviceHealthHistory] ++ opts),
         # Writes PostgreSQL, not ClickHouse, and is here anyway: it is the other
         # half of the same write path, and the extension that feeds it is gated
         # on the same flag. Started without a ClickHouse to pair with, it would

--- a/lib/nerves_hub/application.ex
+++ b/lib/nerves_hub/application.ex
@@ -12,6 +12,7 @@ defmodule NervesHub.Application do
   alias NervesHub.ErrorReports.GroupBuffer
   alias NervesHub.ManagedDeployments.OrchestratorRegistration
   alias NervesHub.PlugAttack.Storage, as: PlugAttackStorage
+  alias NervesHub.Products.HealthProfiles.Cache
   alias NervesHub.RateLimit.ErrorReports, as: ErrorReportLimit
   alias NervesHub.RateLimit.LogLines
   alias NervesHub.RateLimit.Metrics, as: MetricsLimit
@@ -43,6 +44,9 @@ defmodule NervesHub.Application do
         ecto_repos() ++
         [
           {Phoenix.PubSub, name: NervesHub.PubSub},
+          # Reads the profile every metric report needs; see the module for why
+          # this cache is not the state health evaluation does without.
+          Cache,
           # Ahead of the group tree: `RateLimitPubSub` applies peer throttle
           # increments into this storage the moment it joins its group.
           {PlugAttackEts, name: PlugAttackStorage, clean_period: 60_000},

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -27,6 +27,37 @@ defmodule NervesHub.Devices do
   alias NervesHub.Products.Product
   alias NervesHub.Repo
 
+  @doc """
+  Pair counted analytics results with their devices, in the order given.
+
+  Analytics tables hold device ids, not devices, so a "top N devices by
+  something" read comes back as `[%{device_id: _, count: _}]` and needs the
+  devices fetched from PostgreSQL. The analytics ordering is preserved, and an
+  id with no matching device — deleted, or belonging to another product — is
+  dropped rather than rendered as a hole.
+  """
+  @spec with_counts([%{device_id: pos_integer(), count: non_neg_integer()}], Product.t()) ::
+          [{Device.t(), non_neg_integer()}]
+  def with_counts([], _product), do: []
+
+  def with_counts(counted, %Product{id: product_id}) do
+    device_ids = Enum.map(counted, & &1.device_id)
+
+    devices =
+      Device
+      |> where(product_id: ^product_id)
+      |> where([d], d.id in ^device_ids)
+      |> Repo.all()
+      |> Map.new(&{&1.id, &1})
+
+    Enum.flat_map(counted, fn %{device_id: device_id, count: count} ->
+      case Map.get(devices, device_id) do
+        nil -> []
+        device -> [{device, count}]
+      end
+    end)
+  end
+
   def get_device(device_id) when is_integer(device_id) do
     Repo.get(Device, device_id)
   end

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -411,6 +411,34 @@ defmodule NervesHub.Devices.Connections do
     :ok
   end
 
+  @doc """
+  How many times the device disconnected during each of two trailing
+  windows, as `{count_in_first, count_in_second}` — one query for both.
+
+  Backs the "disconnects" built-in health profile metric (a warning and an
+  alert window per judgement); callers are expected to check that analytics
+  is enabled first.
+  """
+  @spec disconnection_counts(pos_integer(), pos_integer(), pos_integer(), {pos_integer(), pos_integer()}) ::
+          {non_neg_integer(), non_neg_integer()}
+  def disconnection_counts(org_id, product_id, device_id, {first_seconds, second_seconds}) do
+    now = DateTime.utc_now()
+    first_cutoff = DateTime.shift(now, second: -first_seconds)
+    second_cutoff = DateTime.shift(now, second: -second_seconds)
+    widest = if DateTime.before?(first_cutoff, second_cutoff), do: first_cutoff, else: second_cutoff
+
+    DeviceConnectionHistory
+    |> where([dc], dc.org_id == ^org_id and dc.product_id == ^product_id and dc.device_id == ^device_id)
+    |> where([dc], not is_nil(dc.disconnected_at))
+    |> where([dc], dc.disconnected_at >= ^widest)
+    |> select(
+      [dc],
+      {fragment("countIf(disconnected_at >= ?)", ^first_cutoff),
+       fragment("countIf(disconnected_at >= ?)", ^second_cutoff)}
+    )
+    |> AnalyticsRepo.one(settings: [final: 1])
+  end
+
   def flapping_connections(%Product{} = product) do
     DeviceConnectionHistory
     |> where([dc], dc.org_id == ^product.org_id and dc.product_id == ^product.id)

--- a/lib/nerves_hub/devices/connections.ex
+++ b/lib/nerves_hub/devices/connections.ex
@@ -6,7 +6,7 @@ defmodule NervesHub.Devices.Connections do
 
   alias NervesHub.Analytics.Buffer
   alias NervesHub.AnalyticsRepo
-  alias NervesHub.Devices.Device
+  alias NervesHub.Devices
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceConnectionHistory
   alias NervesHub.Products.Product
@@ -448,29 +448,6 @@ defmodule NervesHub.Devices.Connections do
     |> having([dc], fragment("count > 10"))
     |> order_by(desc: fragment("count"))
     |> AnalyticsRepo.all(settings: [final: 1])
-    |> case do
-      [] -> []
-      results -> fetch_devices_and_transform(results, product)
-    end
-  end
-
-  defp fetch_devices_and_transform(results, product) do
-    device_ids = Enum.map(results, & &1.device_id)
-
-    devices =
-      Device
-      |> where(product_id: ^product.id)
-      |> where([d], d.id in ^device_ids)
-      |> NervesHub.Repo.all()
-      |> Map.new(fn device -> {device.id, device} end)
-
-    # Preserve the "most flapping first" ordering from the analytics query;
-    # drop any ids without a matching device (e.g. deleted devices).
-    Enum.flat_map(results, fn %{device_id: device_id, count: count} ->
-      case Map.get(devices, device_id) do
-        nil -> []
-        device -> [{device, count}]
-      end
-    end)
+    |> Devices.with_counts(product)
   end
 end

--- a/lib/nerves_hub/devices/device_health_history.ex
+++ b/lib/nerves_hub/devices/device_health_history.ex
@@ -1,0 +1,78 @@
+defmodule NervesHub.Devices.DeviceHealthHistory do
+  @moduledoc """
+  One health verdict transition on one device.
+
+  Rows are batched into ClickHouse by `NervesHub.Analytics.Buffer`. Where
+  `NervesHub.Devices.DeviceHealth` answers "what is this device's status now",
+  this answers "what was it, and when did it change" — how long a level held
+  is the gap to the next row, a window function rather than a row this has to
+  keep mutable.
+
+  Only transitions are written, never the steady state. A device reports every
+  few minutes and its status changes far more rarely than that, so the volume
+  is a fraction of `device_metrics` even though rows are kept three times as
+  long.
+
+  ## Why this exists rather than recomputing
+
+  A status is derived from the profile's thresholds and the stored readings,
+  so it looks like something that can simply be recomputed. It cannot, for
+  two reasons.
+
+  Thresholds are per product and editable (`NervesHub.Products.HealthProfiles`).
+  Recomputing a past status applies today's thresholds to yesterday's
+  readings, which answers "would we call that unhealthy now" rather than "did
+  we call it unhealthy then" — the wrong question for a deployment gate or an
+  audit. `status_reasons` is carried on the row for the same reason: it names
+  the threshold and the period that were in force, so a row stays true after
+  somebody edits the profile.
+
+  And the readings themselves expire before these rows do. Past the
+  `device_metrics` TTL there is nothing left to recompute from, so this table
+  is the only thing that can still say what a device's status was.
+
+  ## What it does not record
+
+  Transitions are observed from reports, so a device that stops reporting
+  keeps its last verdict and writes nothing further. A range query that means
+  "how much of the fleet was healthy" should narrow on connection status
+  rather than assume every device was reporting throughout.
+
+  Rows also ride `NervesHub.Analytics.Buffer`, which sheds its oldest rows if
+  ClickHouse stays unreachable. Like every other analytics write, this is a
+  faithful record of what the platform saw rather than a ledger that cannot
+  lose an entry.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  schema "device_health_history" do
+    field(:timestamp, Ch, type: "DateTime64(6, 'UTC')")
+
+    field(:org_id, Ch, type: "UInt64")
+    field(:product_id, Ch, type: "UInt64")
+    field(:device_id, Ch, type: "UInt64")
+
+    field(:status, Ch, type: "LowCardinality(String)")
+
+    # The `status_reasons` map as JSON; empty when no level is engaged.
+    field(:status_reasons, Ch, type: "String", default: "")
+  end
+
+  @doc """
+  Builds a row for `NervesHub.Analytics.Buffer` to batch.
+
+  Changes the struct directly rather than casting, as `DeviceAlarmHistory`
+  does: the caller is holding a verdict the database has already accepted, so
+  there is nothing left to validate. The buffer flattens the changeset back
+  through the struct to fill in untouched fields, since `insert_all` builds
+  one statement per batch and every row has to carry the same columns.
+  """
+  @spec changeset(map()) :: Ecto.Changeset.t()
+  def changeset(attrs), do: change(%__MODULE__{}, attrs)
+end

--- a/lib/nerves_hub/devices/health.ex
+++ b/lib/nerves_hub/devices/health.ex
@@ -18,16 +18,44 @@ defmodule NervesHub.Devices.Health do
 
   One statement: the row is the device's current verdict, so a second report
   overwrites the first rather than appending to it.
+
+  The update carries a `WHERE`, so a report that agrees with the stored
+  verdict writes nothing — which is most of them, since a device's status
+  changes far more rarely than it reports. That case answers `{:ok,
+  :unchanged}`.
   """
   @spec save_device_health(health_report :: map()) ::
-          {:ok, DeviceHealth.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, DeviceHealth.t()} | {:ok, :unchanged} | {:error, Ecto.Changeset.t()}
   def save_device_health(device_status) do
     device_status
     |> DeviceHealth.save()
     |> Repo.insert(
-      on_conflict: {:replace, [:status, :status_reasons, :updated_at]},
+      on_conflict: replace_when_changed(),
       conflict_target: [:device_id],
       returning: true
+    )
+  rescue
+    # `ON CONFLICT DO UPDATE ... WHERE` returns no row when the verdict is
+    # unchanged, and Ecto reads "no row came back" as a stale entry. Here it
+    # is the answer rather than an error.
+    Ecto.StaleEntryError -> {:ok, :unchanged}
+  end
+
+  # `IS DISTINCT FROM` rather than `!=` because either side can be NULL:
+  # `status_reasons` is null whenever no level is engaged, which is the
+  # common case, and `NULL != NULL` is null, not true.
+  defp replace_when_changed() do
+    from(h in DeviceHealth,
+      where:
+        fragment("? IS DISTINCT FROM ?", h.status, fragment("EXCLUDED.status")) or
+          fragment("? IS DISTINCT FROM ?", h.status_reasons, fragment("EXCLUDED.status_reasons")),
+      update: [
+        set: [
+          status: fragment("EXCLUDED.status"),
+          status_reasons: fragment("EXCLUDED.status_reasons"),
+          updated_at: fragment("EXCLUDED.updated_at")
+        ]
+      ]
     )
   end
 

--- a/lib/nerves_hub/devices/health.ex
+++ b/lib/nerves_hub/devices/health.ex
@@ -9,9 +9,19 @@ defmodule NervesHub.Devices.Health do
 
   import Ecto.Query
 
+  alias NervesHub.AnalyticsRepo
+  alias NervesHub.Devices
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceHealth
+  alias NervesHub.Devices.DeviceHealthHistory
+  alias NervesHub.Products.Product
   alias NervesHub.Repo
+
+  # More than five moves into a warning or unhealthy verdict in an hour. Only
+  # levels that engaged count: settling back to healthy is the recovery, not
+  # the symptom.
+  @flapping_threshold 5
+  @flapping_statuses ["warning", "unhealthy"]
 
   @doc """
   Record the device's current health status, replacing whatever it had.
@@ -57,6 +67,34 @@ defmodule NervesHub.Devices.Health do
         ]
       ]
     )
+  end
+
+  @doc """
+  The product's devices whose health has been flapping: those with more than
+  `@flapping_threshold` moves into a warning or unhealthy verdict in the last
+  hour, worst first, capped at ten.
+
+  Only transitions are recorded, so a count here is that many genuine changes
+  of mind about the device rather than that many reports. A device sitting
+  steadily unhealthy contributes one; a device crossing its threshold back and
+  forth contributes one each time, which is the behaviour worth surfacing.
+
+  Reads ClickHouse (`NervesHub.Devices.DeviceHealthHistory`); callers are
+  expected to check that analytics is enabled first.
+  """
+  @spec flapping_health(Product.t()) :: [{Device.t(), non_neg_integer()}]
+  def flapping_health(%Product{} = product) do
+    DeviceHealthHistory
+    |> where([h], h.org_id == ^product.org_id and h.product_id == ^product.id)
+    |> where([h], h.timestamp >= fragment("now() - INTERVAL 1 HOUR"))
+    |> where([h], h.status in ^@flapping_statuses)
+    |> group_by([h], h.device_id)
+    |> having([h], fragment("count() > ?", ^@flapping_threshold))
+    |> select([h], %{device_id: h.device_id, count: fragment("count()")})
+    |> order_by([h], desc: fragment("count()"))
+    |> limit(10)
+    |> AnalyticsRepo.all()
+    |> Devices.with_counts(product)
   end
 
   def health_status_count(product, status) do

--- a/lib/nerves_hub/devices/health_evaluation.ex
+++ b/lib/nerves_hub/devices/health_evaluation.ex
@@ -1,0 +1,307 @@
+defmodule NervesHub.Devices.HealthEvaluation do
+  @moduledoc """
+  Judges a device's health against its product's profile, as each metric
+  report arrives — on the `metrics` extension or the `health` extension,
+  both of which store through `NervesHub.Devices.Metrics.record/3` and
+  judge through here. Stateless, per report, in the channel process: no
+  cache, no process, no state anywhere.
+
+  ## The counting semantic
+
+  Status never needs a median's value, only which side of a threshold it
+  sits, and "median >= T" is "at least half the window's samples are at or
+  over T". So a level engages when its window holds at least one sample and
+  at least half of them breach the threshold in the metric's unhealthy
+  direction — the discrete-median reading of "the median reaches the
+  threshold", which keeps the median's robustness: one absurd glitch
+  reading is one vote, not a value that can drag anything. Windows are
+  judged on minute buckets (unix time div 60), the evaluation granularity;
+  measurement periods round up to whole minutes.
+
+  Counting is ClickHouse's home turf, so the store is never asked for raw
+  readings: `Metrics.health_breach_counts/3` returns, per metric and level,
+  how many samples the window holds and how many breach — one aggregate
+  query per evaluation. The judgement over those counts is a handful of
+  pure functions here.
+
+  ## Readings in hand
+
+  `record/3` buffers its ClickHouse write, so the freshest samples are the
+  ones the store cannot serve yet. The report's own readings are therefore
+  counted in hand (`count_samples/3`) and merged with the stored counts —
+  do not reintroduce "write then read back". Batched readings carry device
+  timestamps and are bucketed where they belong, so a device reporting late
+  lands its catch-up data in the right minutes.
+
+  Without ClickHouse there is no history to window, so evaluation falls
+  back to the legacy instantaneous check against the report itself, in
+  `NervesHub.Devices.HealthStatus` — as does a device whose product has no
+  profile (backfill not run).
+  """
+
+  alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.Health
+  alias NervesHub.Devices.HealthStatus
+  alias NervesHub.Devices.Metrics
+  alias NervesHub.Extensions.PubSub, as: ExtensionsPubSub
+  alias NervesHub.Helpers.Logging
+  alias NervesHub.Products.HealthProfile
+  alias NervesHub.Products.HealthProfileMetric
+  alias NervesHub.Products.HealthProfiles
+
+  require Logger
+
+  @type status() :: :unknown | :healthy | :warning | :unhealthy
+  @type reasons() :: %{warning: map(), unhealthy: map()} | nil
+
+  @typedoc "A reading in hand: not yet readable from the store."
+  @type sample() :: {key :: String.t(), DateTime.t(), value :: number()}
+
+  @typedoc "Per metric key and level: samples in the window, samples breaching the threshold."
+  @type counts() :: %{
+          optional(String.t()) => %{
+            warning: {non_neg_integer(), non_neg_integer()},
+            alert: {non_neg_integer(), non_neg_integer()}
+          }
+        }
+
+  @type judgement() :: :unknown | :healthy | {:warning | :unhealthy, key :: String.t(), reason :: map()}
+
+  @doc """
+  Health status and reasons for the device described by `device_info` (a
+  `NervesHub.DeviceLink.DeviceInfo`), judging the stored history plus the
+  `in_hand_samples` that just arrived and are still in the write buffer.
+  """
+  @spec evaluate(struct() | map(), [sample()]) :: {status(), reasons()}
+  def evaluate(device_info, in_hand_samples) do
+    with true <- Application.get_env(:nerves_hub, :analytics_enabled, false),
+         %HealthProfile{} = profile <- HealthProfiles.resolve(device_info) do
+      now_minute = minute(DateTime.utc_now())
+      regular = Enum.reject(profile.metrics, & &1.built_in)
+
+      counts =
+        merge_counts(
+          Metrics.health_breach_counts(device_info, regular, now_minute),
+          count_samples(regular, in_hand_samples, now_minute)
+        )
+
+      regular
+      |> judge_metrics(counts)
+      |> Enum.concat(built_in_judgements(profile, device_info))
+      |> summarize()
+    else
+      _no_clickhouse_or_no_profile -> legacy(in_hand_samples)
+    end
+  end
+
+  @doc """
+  Evaluate, then persist the verdict as the device's `device_health` row and
+  broadcast it. The row is the current verdict alone — one per device,
+  replaced in place; alarms and metadata went to their own homes, and the
+  readings live in ClickHouse.
+  """
+  @spec evaluate_and_save(struct() | map(), [sample()]) :: :ok | :error
+  def evaluate_and_save(device_info, in_hand_samples) do
+    {status, reasons} = evaluate(device_info, in_hand_samples)
+
+    device_health = %{
+      "device_id" => device_info.device_id,
+      "status" => status,
+      "status_reasons" => reasons
+    }
+
+    case Health.save_device_health(device_health) do
+      {:ok, _health} ->
+        :ok = ExtensionsPubSub.broadcast_report(device_info.device_id, "health_check_report", %{})
+
+      {:error, error} ->
+        Logger.warning("Failed to save health check data: #{inspect(error)}")
+        Logging.log_to_sentry(device_info, "[HealthEvaluation] Failed to save health check data.")
+        :error
+    end
+  end
+
+  @doc "The minute bucket for a point in time."
+  @spec minute(DateTime.t()) :: integer()
+  def minute(%DateTime{} = at), do: at |> DateTime.to_unix() |> div(60)
+
+  @doc """
+  Count in-hand samples into the same shape the store reports: per metric
+  and level, samples in the window and samples breaching. Only the given
+  (regular) metrics are counted — other keys carry no thresholds — and only
+  samples whose minute bucket falls inside the level's window.
+  """
+  @spec count_samples([HealthProfileMetric.t()], [sample()], integer()) :: counts()
+  def count_samples(metrics, samples, now_minute) do
+    by_key = Map.new(metrics, &{&1.key, &1})
+
+    Enum.reduce(samples, %{}, fn {key, at, value}, counts ->
+      with %HealthProfileMetric{} = metric <- by_key[key],
+           true <- is_number(value) do
+        merge_counts(counts, %{key => sample_counts(metric, value, minute(at), now_minute)})
+      else
+        _unknown_key_or_not_a_number -> counts
+      end
+    end)
+  end
+
+  # One sample's contribution: a vote in each level whose window holds its
+  # minute, breaching or not.
+  defp sample_counts(metric, value, sample_minute, now_minute) do
+    Map.new(
+      [
+        warning: {metric.warning_threshold, metric.warning_period_seconds},
+        alert: {metric.alert_threshold, metric.alert_period_seconds}
+      ],
+      fn {level, {threshold, period_seconds}} ->
+        if in_window?(sample_minute, now_minute, span(period_seconds)) do
+          {level, {1, boolint(breaches?(value, threshold, metric.operator))}}
+        else
+          {level, {0, 0}}
+        end
+      end
+    )
+  end
+
+  @doc "Merge two count maps by adding their per-level counts."
+  @spec merge_counts(counts(), counts()) :: counts()
+  def merge_counts(a, b) do
+    Map.merge(a, b, fn _key, left, right ->
+      Map.merge(left, right, fn _level, {n1, k1}, {n2, k2} -> {n1 + n2, k1 + k2} end)
+    end)
+  end
+
+  @doc """
+  Judge every metric against its counts: alert engages before warning, any
+  observed sample beats no data. Returns judgements `summarize/1` folds, so
+  callers can append built-in judgements before summarizing.
+  """
+  @spec judge_metrics([HealthProfileMetric.t()], counts()) :: [judgement()]
+  def judge_metrics(metrics, counts) do
+    Enum.map(metrics, fn metric ->
+      %{warning: {n_warning, k_warning}, alert: {n_alert, k_alert}} =
+        Map.get(counts, metric.key, %{warning: {0, 0}, alert: {0, 0}})
+
+      cond do
+        engaged?(n_alert, k_alert) ->
+          {:unhealthy, metric.key,
+           share_reason(k_alert, n_alert, metric, metric.alert_threshold, metric.alert_period_seconds)}
+
+        engaged?(n_warning, k_warning) ->
+          {:warning, metric.key,
+           share_reason(k_warning, n_warning, metric, metric.warning_threshold, metric.warning_period_seconds)}
+
+        n_warning > 0 or n_alert > 0 ->
+          :healthy
+
+        true ->
+          :unknown
+      end
+    end)
+  end
+
+  @doc """
+  Fold judgements into `{status, reasons}` in the shape `device_health`
+  stores: alert (`:unhealthy`) wins over warning, any healthy metric beats
+  no data, reasons name every engaged metric.
+  """
+  @spec summarize([judgement()]) :: {status(), reasons()}
+  def summarize(judgements) do
+    reasons =
+      Enum.reduce(judgements, %{warning: %{}, unhealthy: %{}}, fn
+        {level, key, reason}, acc -> put_in(acc, [level, key], reason)
+        _healthy_or_unknown, acc -> acc
+      end)
+
+    cond do
+      reasons.unhealthy != %{} -> {:unhealthy, reasons}
+      reasons.warning != %{} -> {:warning, reasons}
+      Enum.any?(judgements, &(&1 == :healthy)) -> {:healthy, nil}
+      true -> {:unknown, nil}
+    end
+  end
+
+  # At least one sample, and at least half of them breaching the threshold in
+  # the metric's unhealthy direction: the counting form of "the (discrete)
+  # median reaches the threshold".
+  defp engaged?(n, k), do: n > 0 and 2 * k >= n
+
+  # Which side of the threshold is unhealthy. `nil` (structs built before the
+  # column existed) reads as :gte, the historical behavior.
+  defp breaches?(value, threshold, :lte), do: value <= threshold
+  defp breaches?(value, threshold, _gte_or_nil), do: value >= threshold
+
+  defp share_reason(k, n, metric, threshold, period_seconds) do
+    %{
+      value: round(100 * k / n),
+      threshold: threshold,
+      operator: metric.operator || :gte,
+      period_seconds: period_seconds,
+      aggregation: :share
+    }
+  end
+
+  # The window over the last `span` minutes is the buckets
+  # (now - span, now] — the current, still-filling minute counts, and a
+  # bucket exactly `span` minutes old has fallen out.
+  defp in_window?(minute, now_minute, span), do: minute > now_minute - span
+
+  # Periods are stored in seconds; evaluation granularity is a minute.
+  defp span(period_seconds), do: div(period_seconds + 59, 60)
+
+  defp boolint(true), do: 1
+  defp boolint(false), do: 0
+
+  # Built-ins move independently of what the device reports — each has its
+  # own query.
+  defp built_in_judgements(%HealthProfile{} = profile, device_info) do
+    for metric <- profile.metrics, metric.built_in do
+      judge_built_in(metric, device_info)
+    end
+  end
+
+  # Only reached with analytics enabled: `evaluate/2` gates on it before
+  # anything is judged.
+  defp judge_built_in(%{key: "disconnects"} = metric, device_info) do
+    {warning_count, alert_count} =
+      Connections.disconnection_counts(
+        device_info.org_id,
+        device_info.product_id,
+        device_info.device_id,
+        {metric.warning_period_seconds, metric.alert_period_seconds}
+      )
+
+    cond do
+      alert_count >= metric.alert_threshold ->
+        {:unhealthy, metric.key, count_reason(alert_count, metric.alert_threshold, metric.alert_period_seconds)}
+
+      warning_count >= metric.warning_threshold ->
+        {:warning, metric.key, count_reason(warning_count, metric.warning_threshold, metric.warning_period_seconds)}
+
+      true ->
+        :healthy
+    end
+  end
+
+  # A built-in this release doesn't know how to evaluate: rows written by a
+  # newer node during a rolling deploy. No opinion beats a wrong one.
+  defp judge_built_in(_metric, _device_info), do: :unknown
+
+  defp count_reason(count, threshold, period_seconds) do
+    %{value: count, threshold: threshold, period_seconds: period_seconds, aggregation: :count}
+  end
+
+  # The latest in-hand value per key, judged instantaneously — all the
+  # legacy check ever looked at.
+  defp legacy(in_hand_samples) do
+    metrics =
+      in_hand_samples
+      |> Enum.sort_by(fn {_key, timestamp, _value} -> timestamp end, DateTime)
+      |> Map.new(fn {key, _timestamp, value} -> {key, value} end)
+
+    case HealthStatus.calculate_metrics_status(metrics) do
+      {status, reasons} -> {status, reasons}
+      status -> {status, nil}
+    end
+  end
+end

--- a/lib/nerves_hub/devices/health_evaluation.ex
+++ b/lib/nerves_hub/devices/health_evaluation.ex
@@ -39,7 +39,10 @@ defmodule NervesHub.Devices.HealthEvaluation do
   profile (backfill not run).
   """
 
+  alias NervesHub.Analytics.Buffer
   alias NervesHub.Devices.Connections
+  alias NervesHub.Devices.DeviceHealth
+  alias NervesHub.Devices.DeviceHealthHistory
   alias NervesHub.Devices.Health
   alias NervesHub.Devices.HealthStatus
   alias NervesHub.Devices.Metrics
@@ -115,11 +118,16 @@ defmodule NervesHub.Devices.HealthEvaluation do
     }
 
     case Health.save_device_health(device_health) do
-      # Broadcast either way: this says a report landed, not that the verdict
-      # moved. It is what refreshes the readings, the charts and the metadata
-      # on an open device page, and those change on every report even when
-      # the status does not.
-      {:ok, _health_or_unchanged} ->
+      {:ok, saved} ->
+        # A row rather than `:unchanged` means the verdict actually moved, or
+        # this is the device's first — which is exactly the edge the history
+        # records.
+        :ok = record_transition(device_info, saved)
+
+        # Broadcast either way: this says a report landed, not that the verdict
+        # moved. It is what refreshes the readings, the charts and the metadata
+        # on an open device page, and those change on every report even when
+        # the status does not.
         :ok = ExtensionsPubSub.broadcast_report(device_info.device_id, "health_check_report", %{})
 
       {:error, error} ->
@@ -259,6 +267,34 @@ defmodule NervesHub.Devices.HealthEvaluation do
 
   defp boolint(true), do: 1
   defp boolint(false), do: 0
+
+  # Gated explicitly rather than relying on a cast to a missing buffer quietly
+  # succeeding, the same way `NervesHub.Devices.Alarms` gates its history: a
+  # deployment without analytics is a decision this code made.
+  defp record_transition(_device_info, :unchanged), do: :ok
+
+  defp record_transition(device_info, %DeviceHealth{} = health) do
+    if Application.get_env(:nerves_hub, :analytics_enabled) do
+      Buffer.insert(
+        DeviceHealthHistory,
+        DeviceHealthHistory.changeset(%{
+          # The moment the verdict was recorded, taken from the row itself so
+          # the two stores agree rather than nearly agree.
+          timestamp: health.updated_at,
+          org_id: device_info.org_id,
+          product_id: device_info.product_id,
+          device_id: device_info.device_id,
+          status: to_string(health.status),
+          status_reasons: encode_reasons(health.status_reasons)
+        })
+      )
+    end
+
+    :ok
+  end
+
+  defp encode_reasons(nil), do: ""
+  defp encode_reasons(reasons), do: Jason.encode!(reasons)
 
   # Built-ins move independently of what the device reports — each has its
   # own query.

--- a/lib/nerves_hub/devices/health_evaluation.ex
+++ b/lib/nerves_hub/devices/health_evaluation.ex
@@ -99,6 +99,10 @@ defmodule NervesHub.Devices.HealthEvaluation do
   broadcast it. The row is the current verdict alone — one per device,
   replaced in place; alarms and metadata went to their own homes, and the
   readings live in ClickHouse.
+
+  A verdict that has not moved since the last report writes nothing: the
+  steady state, which is nearly every report, costs one statement that
+  touches no rows.
   """
   @spec evaluate_and_save(struct() | map(), [sample()]) :: :ok | :error
   def evaluate_and_save(device_info, in_hand_samples) do
@@ -111,7 +115,11 @@ defmodule NervesHub.Devices.HealthEvaluation do
     }
 
     case Health.save_device_health(device_health) do
-      {:ok, _health} ->
+      # Broadcast either way: this says a report landed, not that the verdict
+      # moved. It is what refreshes the readings, the charts and the metadata
+      # on an open device page, and those change on every report even when
+      # the status does not.
+      {:ok, _health_or_unchanged} ->
         :ok = ExtensionsPubSub.broadcast_report(device_info.device_id, "health_check_report", %{})
 
       {:error, error} ->

--- a/lib/nerves_hub/devices/health_status.ex
+++ b/lib/nerves_hub/devices/health_status.ex
@@ -9,7 +9,8 @@ defmodule NervesHub.Devices.HealthStatus do
   @default_thresholds %{
     "cpu_usage_percent" => %{unhealthy: 90, warning: 80},
     "mem_used_percent" => %{unhealthy: 80, warning: 70},
-    "disk_used_percentage" => %{unhealthy: 90, warning: 80}
+    "disk_used_percentage" => %{unhealthy: 90, warning: 80},
+    "load_15min" => %{unhealthy: 10, warning: 8}
   }
 
   def default_thresholds(), do: @default_thresholds

--- a/lib/nerves_hub/devices/metrics.ex
+++ b/lib/nerves_hub/devices/metrics.ex
@@ -138,6 +138,124 @@ defmodule NervesHub.Devices.Metrics do
   end
 
   @doc """
+  What the fleet's history says about each metric key, across the product's
+  devices and ClickHouse's retention (30 days), as
+
+      %{key => %{min: _, max: _, q1: _, q3: _, samples: _, oldest: _}}
+
+  One grouped query; the quartiles (`quantile(0.25)`/`quantile(0.75)`) are
+  computed by ClickHouse alongside the range. The health profiles page shows
+  the range so thresholds get picked against real units rather than guesses,
+  and feeds the quartiles to `NervesHub.Products.HealthProfiles.suggested_thresholds/1`
+  — `samples` and `oldest` are what it gates on. Callers are expected to
+  check that analytics is enabled first.
+  """
+  def observed_stats(product_id) do
+    DeviceMetric
+    |> where([dm], dm.product_id == ^product_id)
+    |> group_by([dm], dm.key)
+    |> select(
+      [dm],
+      {dm.key,
+       %{
+         min: min(dm.value),
+         max: max(dm.value),
+         q1: fragment("quantile(0.25)(?)", dm.value),
+         q3: fragment("quantile(0.75)(?)", dm.value),
+         samples: count(dm.value),
+         oldest: min(dm.timestamp)
+       }}
+    )
+    |> AnalyticsRepo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  How many stored readings each health-profile metric has in its measurement
+  windows, and how many of those breach its thresholds — counted by
+  ClickHouse, so no raw readings cross the wire. What health evaluation
+  judges; the counting semantics are documented on
+  `NervesHub.Devices.HealthEvaluation`.
+
+  Takes the profile's regular (non-built-in) metrics and returns
+  `%{key => %{warning: {samples, breaching}, alert: {samples, breaching}}}`,
+  one map entry per metric, `{0, 0}` where the store holds nothing. Window
+  membership is judged on minute buckets (`unix time div 60`), matching the
+  evaluation granularity, with `now_minute` the current bucket.
+
+  One query per evaluation, built entirely from Ecto dynamics — a pair of
+  `countIf`s per metric level in an interpolated select map — over one scan
+  of the device's rows in the longest window, pruned by the table's
+  `(product_id, device_id, key, timestamp)` sort key. ClickHouse: callers
+  are expected to check that analytics is enabled first.
+  """
+  @spec health_breach_counts(DeviceInfo.t() | map(), [struct()], integer()) ::
+          %{
+            optional(String.t()) => %{
+              warning: {non_neg_integer(), non_neg_integer()},
+              alert: {non_neg_integer(), non_neg_integer()}
+            }
+          }
+  def health_breach_counts(_device_info, [] = _metrics, _now_minute), do: %{}
+
+  def health_breach_counts(device_info, metrics, now_minute) do
+    selects =
+      metrics
+      |> Enum.flat_map(fn metric ->
+        for {level, threshold, period_seconds} <- [
+              {"warning", metric.warning_threshold, metric.warning_period_seconds},
+              {"alert", metric.alert_threshold, metric.alert_period_seconds}
+            ] do
+          cutoff = now_minute - minute_span(period_seconds)
+
+          in_window =
+            dynamic(
+              [dm],
+              dm.key == ^metric.key and fragment("intDiv(toUnixTimestamp(?), 60)", dm.timestamp) > ^cutoff
+            )
+
+          breach = breach_condition(metric.operator, threshold)
+
+          [
+            {"#{metric.key}:#{level}:n", dynamic([dm], fragment("countIf(?)", ^in_window))},
+            {"#{metric.key}:#{level}:k", dynamic([dm], fragment("countIf(? AND ?)", ^in_window, ^breach))}
+          ]
+        end
+      end)
+      |> List.flatten()
+      |> Map.new()
+
+    longest_period = metrics |> Enum.flat_map(&[&1.warning_period_seconds, &1.alert_period_seconds]) |> Enum.max()
+    # Scan pruning only; the per-metric bucket conditions above decide
+    # membership. The oldest reachable bucket starts at this instant.
+    oldest = DateTime.from_unix!((now_minute - minute_span(longest_period)) * 60)
+
+    row =
+      DeviceMetric
+      |> where([dm], dm.product_id == ^device_info.product_id and dm.device_id == ^device_info.device_id)
+      |> where([dm], dm.key in ^Enum.map(metrics, & &1.key))
+      |> where([dm], dm.timestamp >= ^oldest)
+      |> select([dm], ^selects)
+      |> AnalyticsRepo.one()
+
+    Map.new(metrics, fn metric ->
+      {metric.key,
+       %{
+         warning: {row["#{metric.key}:warning:n"], row["#{metric.key}:warning:k"]},
+         alert: {row["#{metric.key}:alert:n"], row["#{metric.key}:alert:k"]}
+       }}
+    end)
+  end
+
+  # Which side of the threshold is unhealthy. `nil` (rows from before the
+  # operator column existed) reads as :gte, the historical behavior.
+  defp breach_condition(:lte, threshold), do: dynamic([dm], dm.value <= ^threshold)
+  defp breach_condition(_gte_or_nil, threshold), do: dynamic([dm], dm.value >= ^threshold)
+
+  # Periods are stored in seconds; evaluation granularity is a minute.
+  defp minute_span(period_seconds), do: div(period_seconds + 59, 60)
+
+  @doc """
   The longest metric name that will be stored, in bytes.
   """
   def max_key_bytes(), do: @max_key_bytes

--- a/lib/nerves_hub/extensions/health.ex
+++ b/lib/nerves_hub/extensions/health.ex
@@ -28,13 +28,11 @@ defmodule NervesHub.Extensions.Health do
 
   alias NervesHub.Devices.Alarms
   alias NervesHub.Devices.Connections
-  alias NervesHub.Devices.Health
-  alias NervesHub.Devices.HealthStatus
+  alias NervesHub.Devices.HealthEvaluation
   alias NervesHub.Devices.Metrics
   alias NervesHub.Extensions.Jitter
   alias NervesHub.Extensions.PubSub
   alias NervesHub.Extensions.State
-  alias NervesHub.Helpers.Logging
 
   require Logger
 
@@ -78,28 +76,15 @@ defmodule NervesHub.Extensions.Health do
   def handle_in("report", %{"value" => device_report}, state) do
     device_info = state.device_info
 
-    # Get metrics from health report to store in metrics table and calculate status
     metrics = device_report["metrics"] || %{}
-
-    # Get device status together with reasons, if any.
-    {status, reasons} =
-      case HealthStatus.calculate_metrics_status(metrics) do
-        {status, reasons} -> {status, reasons}
-        status -> {status, nil}
-      end
-
-    device_health = %{
-      "device_id" => device_info.device_id,
-      "status" => status,
-      "status_reasons" => reasons
-    }
 
     now = DateTime.utc_now()
 
     # Metrics first, and not inside the health report's failure handling:
     # `Metrics.record/3` buffers rather than writing, so there is no failure
     # here to report, and a health row that will not save is no reason to throw
-    # away readings that would.
+    # away readings that would. The buffered write is also why the judgement
+    # takes the readings in hand rather than reading them back.
     {:ok, _stored} = Metrics.record(device_info, metrics, now)
 
     # The report carries the device's whole current alarm set; `sync/3` works
@@ -114,18 +99,9 @@ defmodule NervesHub.Extensions.Health do
     # the timer).
     :ok = merge_metadata(device_info, device_report["metadata"])
 
-    case Health.save_device_health(device_health) do
-      {:ok, _health} ->
-        :ok = PubSub.broadcast_report(device_info.device_id, "health_check_report", %{})
+    in_hand = for {key, value} <- metrics, is_number(value), do: {key, now, value}
 
-      {:error, err} ->
-        Logger.warning("Failed to save health check data: #{inspect(err)}")
-
-        Logging.log_to_sentry(
-          device_info,
-          "[DeviceChannel] Failed to save health check data."
-        )
-    end
+    _ = HealthEvaluation.evaluate_and_save(device_info, in_hand)
 
     {state, []}
   end

--- a/lib/nerves_hub/extensions/metrics.ex
+++ b/lib/nerves_hub/extensions/metrics.ex
@@ -59,6 +59,7 @@ defmodule NervesHub.Extensions.Metrics do
   @behaviour NervesHub.Extensions
 
   alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices.HealthEvaluation
   alias NervesHub.Devices.Metrics, as: Store
   alias NervesHub.Extensions.Jitter
   alias NervesHub.Extensions.PubSub
@@ -122,9 +123,15 @@ defmodule NervesHub.Extensions.Metrics do
 
   def handle_in("report", %{"reports" => reports}, state) when is_list(reports) do
     if allow?(state.device_info) do
-      reports
-      |> Enum.take(@max_reports_per_message)
-      |> Enum.each(&record(state.device_info, &1))
+      reports = Enum.take(reports, @max_reports_per_message)
+
+      Enum.each(reports, &record(state.device_info, &1))
+
+      # The readings just recorded are still in the write buffer, so the
+      # health judgement takes them in hand rather than expecting to read
+      # them back. One judgement per message, however many batched reports
+      # it carried.
+      _ = HealthEvaluation.evaluate_and_save(state.device_info, in_hand_samples(reports))
     end
 
     {state, []}
@@ -194,6 +201,18 @@ defmodule NervesHub.Extensions.Metrics do
   # failing its neighbours: a device that gets one report wrong should not lose
   # the rest of the batch.
   defp record(_device_info, _report), do: :ok
+
+  # The batch as `{key, timestamp, value}` readings, filtered the way
+  # `record/2` filters — a report without a usable timestamp or a value that
+  # is not a number contributes nothing to the judgement either.
+  defp in_hand_samples(reports) do
+    for %{"metrics" => metrics} = report <- reports,
+        is_map(metrics),
+        {:ok, timestamp} <- [timestamp(report)],
+        {key, value} <- metrics,
+        is_number(value),
+        do: {key, timestamp, value}
+  end
 
   # A reading is only worth what its timestamp is worth. A device whose clock
   # has not caught up with NTP yet would otherwise write a chart that stretches

--- a/lib/nerves_hub/products.ex
+++ b/lib/nerves_hub/products.ex
@@ -5,6 +5,7 @@ defmodule NervesHub.Products do
 
   import Ecto.Query, warn: false
 
+  alias Ecto.Multi
   alias NervesHub.Accounts.Org
   alias NervesHub.Accounts.OrgUser
   alias NervesHub.Accounts.Scope
@@ -12,6 +13,7 @@ defmodule NervesHub.Products do
   alias NervesHub.Devices.Device
   alias NervesHub.Extensions
   alias NervesHub.Products.CustomHealthMetricsLabel
+  alias NervesHub.Products.HealthProfiles
   alias NervesHub.Products.Product
   alias NervesHub.Products.SharedSecretAuth
   alias NervesHub.Repo
@@ -180,12 +182,34 @@ defmodule NervesHub.Products do
   end
 
   @doc """
-  Creates a product.
+  Creates a product, along with its default health profile.
   """
   @spec create_product(map()) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()}
   def create_product(params) do
-    Product.changeset(%Product{}, params)
-    |> Repo.insert()
+    Multi.new()
+    |> Multi.insert(:product, Product.changeset(%Product{}, params))
+    |> Multi.run(:health_profile, fn _repo, %{product: product} ->
+      HealthProfiles.create_default_profile(product.id)
+    end)
+    |> Repo.transact()
+    |> case do
+      {:ok, %{product: product}} ->
+        {:ok, product}
+
+      {:error, :product, changeset, _} ->
+        {:error, changeset}
+
+      {:error, _profile_step, _profile_changeset, _} ->
+        # Callers render this changeset's errors on the product form, so a
+        # failure from the profile seeding must not leak a changeset of the
+        # wrong schema.
+        changeset =
+          %Product{}
+          |> Product.changeset(params)
+          |> Ecto.Changeset.add_error(:base, "could not create the default health profile")
+
+        {:error, changeset}
+    end
   end
 
   @doc """

--- a/lib/nerves_hub/products/health_profile.ex
+++ b/lib/nerves_hub/products/health_profile.ex
@@ -1,0 +1,43 @@
+defmodule NervesHub.Products.HealthProfile do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Products.HealthProfileMetric
+  alias NervesHub.Products.Product
+
+  @type t :: %__MODULE__{}
+
+  schema "health_profiles" do
+    belongs_to(:product, Product)
+
+    # nil means this is the product's default profile; a value scopes the
+    # profile to devices whose firmware reports that platform.
+    field(:platform, :string)
+
+    has_many(:metrics, HealthProfileMetric, preload_order: [asc: :key])
+
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:product_id, :platform])
+    |> validate_required([:product_id])
+    |> update_change(:platform, &trim_to_nil/1)
+    |> foreign_key_constraint(:product_id)
+    |> unique_constraint(:platform,
+      name: :health_profiles_product_id_platform_index,
+      message: "already has a health profile"
+    )
+  end
+
+  defp trim_to_nil(nil), do: nil
+
+  defp trim_to_nil(platform) do
+    case String.trim(platform) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+end

--- a/lib/nerves_hub/products/health_profile_metric.ex
+++ b/lib/nerves_hub/products/health_profile_metric.ex
@@ -1,0 +1,103 @@
+defmodule NervesHub.Products.HealthProfileMetric do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias NervesHub.Products.HealthProfile
+
+  @type t :: %__MODULE__{}
+
+  @required [
+    :health_profile_id,
+    :key,
+    :warning_threshold,
+    :warning_period_seconds,
+    :alert_threshold,
+    :alert_period_seconds
+  ]
+
+  # A measurement period is a window over recent samples: at least a minute
+  # (the evaluation granularity), at most 24 hours — idle devices report once
+  # an hour, so day-scale windows are what gives their medians more than a
+  # sample or two to work with. Stored in seconds so the granularity can
+  # change without a schema migration.
+  @max_period_seconds 24 * 3600
+
+  schema "health_profile_metrics" do
+    belongs_to(:health_profile, HealthProfile)
+
+    field(:key, :string)
+
+    # A built-in metric is not read from `device_metrics`: its key names a
+    # platform-provided signal (see `HealthProfiles.built_in_metrics/0`) that is
+    # evaluated with its own query, e.g. "disconnects" counts connectivity
+    # events. The flag is explicit so a device reporting a metric that happens
+    # to share a built-in's name can never change what an existing row means.
+    field(:built_in, :boolean, default: false)
+
+    # Featured metrics are the ones surfaced at the top of the device details
+    # page; the rest still count toward health but only show on the health tab.
+    field(:featured, :boolean, default: false)
+
+    # Which direction is unhealthy: `:gte` engages at or above the thresholds
+    # (temperatures, usage), `:lte` at or below (frame rates, readings per
+    # interval — values that going low is the problem).
+    field(:operator, Ecto.Enum, values: [:gte, :lte], default: :gte)
+
+    field(:warning_threshold, :float)
+    field(:warning_period_seconds, :integer)
+    field(:alert_threshold, :float)
+    field(:alert_period_seconds, :integer)
+
+    timestamps()
+  end
+
+  def max_period_seconds(), do: @max_period_seconds
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, @required ++ [:built_in, :featured, :operator])
+    |> validate_required(@required)
+    |> update_change(:key, &String.trim/1)
+    |> validate_length(:key, min: 1, max: 255)
+    |> validate_number(:warning_period_seconds,
+      greater_than_or_equal_to: 60,
+      less_than_or_equal_to: @max_period_seconds,
+      message: "must be between 1 minute and 24 hours"
+    )
+    |> validate_number(:alert_period_seconds,
+      greater_than_or_equal_to: 60,
+      less_than_or_equal_to: @max_period_seconds,
+      message: "must be between 1 minute and 24 hours"
+    )
+    |> validate_alert_beyond_warning()
+    |> foreign_key_constraint(:health_profile_id)
+    |> unique_constraint(:key,
+      name: :health_profile_metrics_health_profile_id_key_index,
+      message: "is already in this profile"
+    )
+  end
+
+  # The alert threshold must sit at or beyond the warning threshold in the
+  # unhealthy direction — an alert the median reaches before the warning
+  # would make the warning level unreachable.
+  defp validate_alert_beyond_warning(changeset) do
+    warning = get_field(changeset, :warning_threshold)
+    alert = get_field(changeset, :alert_threshold)
+    operator = get_field(changeset, :operator) || :gte
+
+    cond do
+      !(is_number(warning) and is_number(alert)) ->
+        changeset
+
+      operator == :gte and alert < warning ->
+        add_error(changeset, :alert_threshold, "must be at or above the warning threshold when high is unhealthy")
+
+      operator == :lte and alert > warning ->
+        add_error(changeset, :alert_threshold, "must be at or below the warning threshold when low is unhealthy")
+
+      true ->
+        changeset
+    end
+  end
+end

--- a/lib/nerves_hub/products/health_profiles.ex
+++ b/lib/nerves_hub/products/health_profiles.ex
@@ -1,0 +1,328 @@
+defmodule NervesHub.Products.HealthProfiles do
+  @moduledoc """
+  Health profiles: per-product (optionally per-platform) thresholds that decide
+  whether a device is healthy.
+
+  Every product owns a default profile (`platform: nil`), created with the
+  product and backfilled for existing products by a data migration. A platform
+  profile overrides the default for devices whose firmware reports that
+  platform, so hardware differences can carry different thresholds.
+
+  A profile holds any number of metrics, each with a warning and an alert
+  level: a level engages when the metric's median over that level's
+  measurement period (a minute to 24 hours) reaches the level's threshold.
+  Most metrics read the values devices report; a metric flagged `built_in`
+  is a virtual one evaluated with its own query (e.g. "disconnects" counts
+  connectivity events). Evaluation happens as reports arrive, in
+  `NervesHub.Devices.HealthEvaluation`.
+
+  A metric can also be flagged `featured`, which is about display rather than
+  status: featured metrics are the ones surfaced at the top of the device
+  details page.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias NervesHub.Devices.HealthStatus
+  alias NervesHub.Products.HealthProfile
+  alias NervesHub.Products.HealthProfileMetric
+  alias NervesHub.Products.Product
+  alias NervesHub.Repo
+
+  @default_period_seconds 3600
+
+  @built_in_metrics %{
+    "disconnects" => %{
+      label: "Disconnects",
+      description: "How many times the device disconnected during the measurement period."
+    }
+  }
+
+  @doc """
+  The virtual metrics a profile can include besides device-reported ones, as
+  `%{key => %{label: ..., description: ...}}`.
+  """
+  @spec built_in_metrics() :: %{optional(String.t()) => %{label: String.t(), description: String.t()}}
+  def built_in_metrics(), do: @built_in_metrics
+
+  @doc """
+  The metrics a brand-new default profile starts with.
+
+  Thresholds come from `NervesHub.Devices.HealthStatus.default_thresholds/0`
+  — the previously hardcoded trio plus a 15-minute load average at 8/10 —
+  measured over an hour (one idle-paced report) so behaviour stays close to
+  the old latest-value check. Featuring these defaults keeps the old
+  CPU / Memory / Load device-details tiles and adds a Disk one.
+  """
+  @spec default_metric_attrs() :: [map()]
+  def default_metric_attrs() do
+    HealthStatus.default_thresholds()
+    |> Enum.map(fn {key, %{warning: warning, unhealthy: alert}} ->
+      %{
+        key: key,
+        built_in: false,
+        featured: true,
+        operator: :gte,
+        warning_threshold: warning / 1,
+        warning_period_seconds: @default_period_seconds,
+        alert_threshold: alert / 1,
+        alert_period_seconds: @default_period_seconds
+      }
+    end)
+    |> Enum.sort_by(& &1.key)
+  end
+
+  @doc """
+  All profiles for a product, default first, then platforms alphabetically.
+  """
+  @spec all_for_product(Product.t()) :: [HealthProfile.t()]
+  def all_for_product(%Product{id: product_id}) do
+    HealthProfile
+    |> where(product_id: ^product_id)
+    |> order_by([p], asc_nulls_first: p.platform)
+    |> preload(:metrics)
+    |> Repo.all()
+  end
+
+  @spec get_profile!(Product.t(), pos_integer()) :: HealthProfile.t()
+  def get_profile!(%Product{id: product_id}, id) do
+    HealthProfile
+    |> where(product_id: ^product_id, id: ^id)
+    |> preload(:metrics)
+    |> Repo.one!()
+  end
+
+  @doc """
+  The profile that applies to a device: the profile of the platform its
+  firmware reports, when one exists, the product default otherwise. Takes
+  anything shaped like a device — a `Device`, a `DeviceLink.DeviceInfo` —
+  or a product id and a platform.
+
+  `nil` only for products that predate health profiles without the backfill
+  having run, or when the default profile has been removed directly in the
+  database; callers fall back to the legacy hardcoded thresholds.
+  """
+  @spec resolve(%{:product_id => pos_integer(), optional(atom()) => any()}) :: HealthProfile.t() | nil
+  def resolve(%{product_id: product_id} = device), do: resolve(product_id, platform(device))
+
+  @spec resolve(pos_integer(), String.t() | nil) :: HealthProfile.t() | nil
+  def resolve(product_id, platform) do
+    HealthProfile
+    |> where(product_id: ^product_id)
+    |> platform_or_default(platform)
+    # A platform match (platform not null) sorts before the default.
+    |> order_by([p], asc: is_nil(p.platform))
+    |> limit(1)
+    |> preload(:metrics)
+    |> Repo.one()
+  end
+
+  defp platform_or_default(query, nil), do: where(query, [p], is_nil(p.platform))
+  defp platform_or_default(query, platform), do: where(query, [p], is_nil(p.platform) or p.platform == ^platform)
+
+  defp platform(%{firmware_metadata: %{platform: platform}}), do: platform
+  defp platform(%{firmware_metadata: %{"platform" => platform}}), do: platform
+  defp platform(_device), do: nil
+
+  @doc """
+  Keys of the featured metrics in the device's profile — the metrics
+  surfaced at the top of the device details page. Built-ins are left out:
+  they have no reported value to put in a tile. `nil` when the product has
+  no profile, so the caller can fall back to the legacy fixed tiles.
+  """
+  @spec featured_keys(%{:product_id => pos_integer(), optional(atom()) => any()}) :: [String.t()] | nil
+  def featured_keys(device) do
+    case resolve(device) do
+      nil ->
+        nil
+
+      profile ->
+        for metric <- profile.metrics, metric.featured, !metric.built_in, do: metric.key
+    end
+  end
+
+  # Enough history to have seen a full week cycle (weekday vs weekend
+  # behavior), and enough samples for the quartiles to mean something.
+  @suggestion_minimum_days 7
+  @suggestion_minimum_samples 100
+
+  @doc """
+  Threshold suggestions derived from a metric's observed fleet history (the
+  per-key stats of `NervesHub.Devices.Metrics.observed_stats/1`), or `nil`
+  when the history cannot support one.
+
+  Uses Tukey's fences — warning at `Q3 + 1.5 * IQR`, alert at `Q3 + 3 * IQR`
+  (mirrored below `Q1` for the `lte` direction) — the boxplot outlier rule.
+  Not standard deviations: those assume roughly bell-shaped data and are
+  themselves dragged by the freak readings device metrics produce, the same
+  reason evaluation judges a median and not a mean. Quartiles ignore the
+  extreme tails entirely, so one glitch in the history cannot move the
+  suggestion, and the fences scale with the metric's own normal spread.
+
+  `nil` when the history spans less than #{@suggestion_minimum_days} days
+  (a threshold suggested before a full week cycle has been seen would read
+  weekend behavior as an anomaly), holds fewer than
+  #{@suggestion_minimum_samples} samples, or has zero spread between the
+  quartiles (the fences would sit on the median itself, where half of all
+  normal samples already "breach").
+
+  Values are rounded to three significant digits: they are suggestions to
+  adjust, not measurements.
+  """
+  @spec suggested_thresholds(map() | nil) ::
+          %{gte: %{warning: float(), alert: float()}, lte: %{warning: float(), alert: float()}} | nil
+  def suggested_thresholds(%{q1: q1, q3: q3, samples: samples, oldest: oldest}) do
+    iqr = q3 - q1
+    week_ago = DateTime.add(DateTime.utc_now(), -@suggestion_minimum_days, :day)
+
+    if samples >= @suggestion_minimum_samples and DateTime.before?(oldest, week_ago) and iqr > 0 do
+      %{
+        gte: %{warning: round_sig(q3 + 1.5 * iqr), alert: round_sig(q3 + 3 * iqr)},
+        lte: %{warning: round_sig(q1 - 1.5 * iqr), alert: round_sig(q1 - 3 * iqr)}
+      }
+    end
+  end
+
+  def suggested_thresholds(_no_stats), do: nil
+
+  @sig_digits 3
+
+  defp round_sig(value) when value == 0, do: 0.0
+
+  defp round_sig(value) do
+    magnitude = value |> abs() |> :math.log10() |> :math.floor() |> trunc()
+    factor = :math.pow(10, @sig_digits - 1 - magnitude)
+    round(value * factor) / factor
+  end
+
+  @doc """
+  Creates the product's default profile, seeded with `default_metric_attrs/0`.
+
+  Runs inside product creation (see `NervesHub.Products.create_product/1`);
+  also the backstop for older products that somehow missed the backfill.
+  """
+  @spec create_default_profile(pos_integer()) :: {:ok, HealthProfile.t()} | {:error, Ecto.Changeset.t()}
+  def create_default_profile(product_id) do
+    create_profile_with_metrics(product_id, nil, default_metric_attrs())
+  end
+
+  @doc """
+  Creates a platform-scoped profile, seeded from the product's default profile
+  so it starts as a copy to adjust rather than a blank slate.
+  """
+  @spec create_platform_profile(Product.t(), String.t()) ::
+          {:ok, HealthProfile.t()} | {:error, Ecto.Changeset.t()}
+  def create_platform_profile(%Product{id: product_id}, platform) do
+    metrics =
+      case resolve(product_id, nil) do
+        nil ->
+          default_metric_attrs()
+
+        default ->
+          Enum.map(
+            default.metrics,
+            &Map.take(&1, [
+              :key,
+              :built_in,
+              :featured,
+              :operator,
+              :warning_threshold,
+              :warning_period_seconds,
+              :alert_threshold,
+              :alert_period_seconds
+            ])
+          )
+      end
+
+    create_profile_with_metrics(product_id, platform, metrics)
+  end
+
+  defp create_profile_with_metrics(product_id, platform, metric_attrs) do
+    Multi.new()
+    |> Multi.insert(:profile, HealthProfile.changeset(%HealthProfile{}, %{product_id: product_id, platform: platform}))
+    |> Multi.merge(fn %{profile: profile} ->
+      metric_attrs
+      |> Enum.with_index()
+      |> Enum.reduce(Multi.new(), fn {attrs, index}, multi ->
+        changeset =
+          HealthProfileMetric.changeset(%HealthProfileMetric{}, Map.put(attrs, :health_profile_id, profile.id))
+
+        Multi.insert(multi, {:metric, index}, changeset)
+      end)
+    end)
+    |> Repo.transact()
+    |> case do
+      {:ok, %{profile: profile}} ->
+        {:ok, Repo.preload(profile, :metrics)}
+
+      {:error, _step, changeset, _} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  Deletes a platform profile; the default profile cannot be deleted, since
+  every product is expected to keep one.
+  """
+  @spec delete_profile(HealthProfile.t()) :: {:ok, HealthProfile.t()} | {:error, :cannot_delete_default}
+  def delete_profile(%HealthProfile{platform: nil}), do: {:error, :cannot_delete_default}
+
+  def delete_profile(%HealthProfile{} = profile) do
+    {:ok, Repo.delete!(profile)}
+  end
+
+  @doc """
+  Adds a metric to a profile. `built_in` is decided here from the key, never
+  taken from the caller: a key is a built-in exactly when it is registered in
+  `built_in_metrics/0`.
+  """
+  @spec add_metric(HealthProfile.t(), map()) ::
+          {:ok, HealthProfileMetric.t()} | {:error, Ecto.Changeset.t()}
+  def add_metric(%HealthProfile{id: profile_id}, attrs) do
+    built_in? = Map.has_key?(@built_in_metrics, String.trim(attrs["key"] || ""))
+
+    attrs =
+      attrs
+      |> Map.put("health_profile_id", profile_id)
+      |> Map.put("built_in", built_in?)
+
+    # A built-in defines its own unhealthy direction (a disconnect count only
+    # goes bad high), so the operator is not the caller's to choose.
+    attrs = if built_in?, do: Map.put(attrs, "operator", "gte"), else: attrs
+
+    %HealthProfileMetric{}
+    |> HealthProfileMetric.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a metric's thresholds and periods. The key (and with it the
+  built-in flag) is fixed once added; remove and re-add to change it.
+  """
+  @spec update_metric(HealthProfileMetric.t(), map()) ::
+          {:ok, HealthProfileMetric.t()} | {:error, Ecto.Changeset.t()}
+  def update_metric(%HealthProfileMetric{} = metric, attrs) do
+    fixed =
+      if metric.built_in,
+        do: ["key", "built_in", "health_profile_id", "operator"],
+        else: ["key", "built_in", "health_profile_id"]
+
+    metric
+    |> HealthProfileMetric.changeset(Map.drop(attrs, fixed))
+    |> Repo.update()
+  end
+
+  @spec get_metric!(HealthProfile.t(), pos_integer()) :: HealthProfileMetric.t()
+  def get_metric!(%HealthProfile{id: profile_id}, id) do
+    HealthProfileMetric
+    |> where(health_profile_id: ^profile_id, id: ^id)
+    |> Repo.one!()
+  end
+
+  @spec delete_metric(HealthProfileMetric.t()) :: :ok
+  def delete_metric(%HealthProfileMetric{} = metric) do
+    Repo.delete!(metric)
+    :ok
+  end
+end

--- a/lib/nerves_hub/products/health_profiles.ex
+++ b/lib/nerves_hub/products/health_profiles.ex
@@ -27,6 +27,7 @@ defmodule NervesHub.Products.HealthProfiles do
   alias NervesHub.Devices.HealthStatus
   alias NervesHub.Products.HealthProfile
   alias NervesHub.Products.HealthProfileMetric
+  alias NervesHub.Products.HealthProfiles.Cache
   alias NervesHub.Products.Product
   alias NervesHub.Repo
 
@@ -108,6 +109,10 @@ defmodule NervesHub.Products.HealthProfiles do
 
   @spec resolve(pos_integer(), String.t() | nil) :: HealthProfile.t() | nil
   def resolve(product_id, platform) do
+    Cache.fetch({product_id, platform}, fn -> load(product_id, platform) end)
+  end
+
+  defp load(product_id, platform) do
     HealthProfile
     |> where(product_id: ^product_id)
     |> platform_or_default(platform)
@@ -254,6 +259,7 @@ defmodule NervesHub.Products.HealthProfiles do
     |> Repo.transact()
     |> case do
       {:ok, %{profile: profile}} ->
+        :ok = Cache.invalidate(product_id)
         {:ok, Repo.preload(profile, :metrics)}
 
       {:error, _step, changeset, _} ->
@@ -269,7 +275,10 @@ defmodule NervesHub.Products.HealthProfiles do
   def delete_profile(%HealthProfile{platform: nil}), do: {:error, :cannot_delete_default}
 
   def delete_profile(%HealthProfile{} = profile) do
-    {:ok, Repo.delete!(profile)}
+    deleted = Repo.delete!(profile)
+    :ok = Cache.invalidate(profile.product_id)
+
+    {:ok, deleted}
   end
 
   @doc """
@@ -279,7 +288,7 @@ defmodule NervesHub.Products.HealthProfiles do
   """
   @spec add_metric(HealthProfile.t(), map()) ::
           {:ok, HealthProfileMetric.t()} | {:error, Ecto.Changeset.t()}
-  def add_metric(%HealthProfile{id: profile_id}, attrs) do
+  def add_metric(%HealthProfile{id: profile_id, product_id: product_id}, attrs) do
     built_in? = Map.has_key?(@built_in_metrics, String.trim(attrs["key"] || ""))
 
     attrs =
@@ -294,6 +303,7 @@ defmodule NervesHub.Products.HealthProfiles do
     %HealthProfileMetric{}
     |> HealthProfileMetric.changeset(attrs)
     |> Repo.insert()
+    |> tap_ok(product_id)
   end
 
   @doc """
@@ -311,6 +321,7 @@ defmodule NervesHub.Products.HealthProfiles do
     metric
     |> HealthProfileMetric.changeset(Map.drop(attrs, fixed))
     |> Repo.update()
+    |> tap_ok(product_id_of(metric))
   end
 
   @spec get_metric!(HealthProfile.t(), pos_integer()) :: HealthProfileMetric.t()
@@ -322,7 +333,26 @@ defmodule NervesHub.Products.HealthProfiles do
 
   @spec delete_metric(HealthProfileMetric.t()) :: :ok
   def delete_metric(%HealthProfileMetric{} = metric) do
+    product_id = product_id_of(metric)
     Repo.delete!(metric)
-    :ok
+
+    Cache.invalidate(product_id)
   end
+
+  # A metric knows its profile, not its product; the cache is keyed by
+  # product. One query on an admin action, never on a report.
+  defp product_id_of(%HealthProfileMetric{health_profile_id: profile_id}) do
+    HealthProfile
+    |> where(id: ^profile_id)
+    |> select([p], p.product_id)
+    |> Repo.one!()
+  end
+
+  # Drop the product's cached profiles when a write succeeded, and only then.
+  defp tap_ok({:ok, _} = result, product_id) do
+    :ok = Cache.invalidate(product_id)
+    result
+  end
+
+  defp tap_ok({:error, _} = result, _product_id), do: result
 end

--- a/lib/nerves_hub/products/health_profiles/cache.ex
+++ b/lib/nerves_hub/products/health_profiles/cache.ex
@@ -1,0 +1,118 @@
+defmodule NervesHub.Products.HealthProfiles.Cache do
+  @moduledoc """
+  Caches resolved health profiles, keyed by `{product_id, platform}`.
+
+  A device's profile is read on every metric report — hundreds a second on a
+  large fleet — and changes only when somebody edits one, so resolving it
+  from the database each time re-reads the same handful of rows over and
+  over. Entries are read straight out of ETS by the calling process, so a
+  read costs no message and serialises against nothing.
+
+  An edit drops the product's entries on the spot and tells the other nodes
+  to do the same; the TTL is the backstop for a node that was not there to
+  hear it, or that joined afterwards.
+
+  This is configuration, not device state. An entry is derivable from the
+  database at any moment, so an empty table costs a query and a briefly
+  stale one costs a few seconds of a superseded threshold. Nothing here has
+  to survive a restart, a redeployment, or a device moving between nodes —
+  which is what keeps it a cache rather than the state this evaluation
+  deliberately does without.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+  @topic "health_profiles:changed"
+  @default_ttl_ms to_timeout(second: 30)
+
+  @typedoc "Product and the platform its firmware reports; `nil` platform is the product default."
+  @type key() :: {pos_integer(), String.t() | nil}
+
+  @doc """
+  The cached value for `key`, or `fun.()` — stored under it and returned.
+
+  `nil` is cached like anything else: a product with no profile is the case
+  that would otherwise pay for a query on every report to learn nothing.
+  """
+  @spec fetch(key(), (-> value)) :: value when value: term()
+  def fetch(key, fun) do
+    now = System.monotonic_time(:millisecond)
+
+    case :ets.lookup(@table, key) do
+      [{^key, value, expires_at}] when expires_at > now ->
+        value
+
+      _miss_or_expired ->
+        value = fun.()
+        true = :ets.insert(@table, {key, value, now + ttl_ms()})
+        value
+    end
+  rescue
+    # The table exists only once the cache has started. Without it every read
+    # is a miss, which is a slower answer rather than a wrong one.
+    ArgumentError -> fun.()
+  end
+
+  @doc """
+  Forget everything cached for the product, here and on every other node.
+
+  Called by `NervesHub.Products.HealthProfiles` after any change to a
+  product's profiles or their metrics. The local drop is synchronous, so a
+  read that follows an edit in the same process — the page reloading itself
+  after a save — never sees the value it just replaced.
+  """
+  @spec invalidate(pos_integer()) :: :ok
+  def invalidate(product_id) do
+    :ok = drop(product_id)
+    _ = Phoenix.PubSub.broadcast(NervesHub.PubSub, @topic, {:health_profiles_changed, product_id})
+    :ok
+  end
+
+  @doc "Empty the cache. For tests, where the database is rolled back beneath it."
+  @spec reset() :: :ok
+  def reset() do
+    true = :ets.delete_all_objects(@table)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl GenServer
+  def init(_opts) do
+    _ =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    :ok = Phoenix.PubSub.subscribe(NervesHub.PubSub, @topic)
+
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info({:health_profiles_changed, product_id}, state) do
+    :ok = drop(product_id)
+
+    {:noreply, state}
+  end
+
+  # This process owns a table and a subscription and nothing else; an
+  # unrecognised message is not a reason to drop either.
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp drop(product_id) do
+    true = :ets.match_delete(@table, {{product_id, :_}, :_, :_})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp ttl_ms(), do: Application.get_env(:nerves_hub, :health_profile_cache_ttl_ms, @default_ttl_ms)
+end

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -13,6 +13,7 @@ defmodule NervesHub.Products.Product do
   alias NervesHub.Firmwares.UpdateTool
   alias NervesHub.ManagedDeployments.DeploymentGroup
   alias NervesHub.Products.CustomHealthMetricsLabel
+  alias NervesHub.Products.HealthProfile
   alias NervesHub.Products.Notification
   alias NervesHub.Products.SharedSecretAuth
   alias NervesHub.Scripts.Script
@@ -32,6 +33,7 @@ defmodule NervesHub.Products.Product do
     has_many(:update_stats, UpdateStat, on_delete: :nilify_all)
     has_many(:notifications, Notification, on_delete: :delete_all)
     has_many(:custom_health_metrics_labels, CustomHealthMetricsLabel, on_delete: :delete_all)
+    has_many(:health_profiles, HealthProfile, on_delete: :delete_all)
 
     has_many(:shared_secret_auths, SharedSecretAuth, preload_order: [desc: :deactivated_at, asc: :id])
 

--- a/lib/nerves_hub_web/components/device_health/health_status.ex
+++ b/lib/nerves_hub_web/components/device_health/health_status.ex
@@ -1,6 +1,8 @@
 defmodule NervesHubWeb.Components.HealthStatus do
   use NervesHubWeb, :component
 
+  alias NervesHubWeb.Components.Utils
+
   attr(:device_id, :integer)
   attr(:health, :map, default: %{status: :unknown, status_reasons: nil})
   attr(:tooltip_position, :string, default: "bottom")
@@ -47,11 +49,36 @@ defmodule NervesHubWeb.Components.HealthStatus do
             {key_parts, ""}
           end
 
-        "#{Enum.join(key_parts, " ")}: #{reasons["value"]}#{delimiter} (threshold is #{reasons["threshold"]}#{delimiter})"
+        name = Enum.join(key_parts, " ")
+
+        # A share reason's value is how much of the window breached the
+        # threshold, not a reading of the metric itself, so it gets its own
+        # sentence shape.
+        case reasons do
+          %{"aggregation" => "share"} ->
+            "#{name}: #{direction_word(reasons)} #{Utils.format_number(reasons["threshold"])}#{delimiter} for #{reasons["value"]}% of #{Utils.format_period(reasons["period_seconds"])}"
+
+          _ ->
+            "#{name}: #{Utils.format_number(reasons["value"])}#{delimiter}#{window_phrase(reasons)} (threshold is #{Utils.format_number(reasons["threshold"])}#{delimiter})"
+        end
       end)
 
     if Enum.any?(reasons) do
       "#{String.capitalize(status)}:  #{key_strings}"
     end
   end
+
+  # A reason judged by a health profile carries the measurement period (a
+  # count reason names the window it counted over); one from the legacy
+  # instantaneous check carries neither.
+  defp window_phrase(%{"aggregation" => "count", "period_seconds" => seconds}) when is_integer(seconds) do
+    " in #{Utils.format_period(seconds)}"
+  end
+
+  defp window_phrase(_reasons), do: ""
+
+  # Which side of the threshold the metric breached; reasons written before
+  # operators existed read as the historical at-or-over.
+  defp direction_word(%{"operator" => "lte"}), do: "at or under"
+  defp direction_word(_reasons), do: "at or over"
 end

--- a/lib/nerves_hub_web/components/device_health/metric_labels.ex
+++ b/lib/nerves_hub_web/components/device_health/metric_labels.ex
@@ -1,0 +1,54 @@
+defmodule NervesHubWeb.Components.DeviceHealth.MetricLabels do
+  @moduledoc """
+  One place to turn a health metric key into what the UI calls it, so the
+  device health tab, the device details tiles, and the health profiles page
+  all agree.
+
+  A built-in health-profile metric carries its own label; otherwise a custom
+  label set on the product wins; a well-known nerves_hub_health key gets its
+  hand-written title; anything else is humanized from the key.
+  """
+
+  alias NervesHub.Products.HealthProfiles
+
+  # Also the display order for the health tab's charts.
+  @default_titles [
+    {"load_1min", "Load Average 1 Min"},
+    {"load_5min", "Load Average 5 Min"},
+    {"load_15min", "Load Average 15 Min"},
+    {"mem_used_mb", "Memory Usage (MB)"},
+    {"mem_used_percent", "Memory Usage (%)"},
+    {"disk_used_percentage", "Disk Usage (%)"},
+    {"cpu_usage_percent", "CPU Usage (%)"},
+    {"cpu_temp", "CPU Temperature (°C)"}
+  ]
+
+  @doc "The well-known keys with their titles, in chart display order."
+  @spec default_titles() :: [{String.t(), String.t()}]
+  def default_titles(), do: @default_titles
+
+  @doc """
+  The display label for `key`: a built-in's own label, else the product's
+  custom label when one is set, else the derived title.
+  """
+  @spec label(String.t(), %{optional(String.t()) => String.t()} | nil) :: String.t()
+  def label(key, custom_labels \\ %{}) do
+    case HealthProfiles.built_in_metrics() do
+      %{^key => %{label: label}} -> label
+      _ -> Map.get(custom_labels || %{}, key) || title(key)
+    end
+  end
+
+  defp title(key) do
+    case List.keyfind(@default_titles, key, 0) do
+      {_, title} ->
+        title
+
+      nil ->
+        key
+        |> String.replace("_", " ")
+        |> String.capitalize()
+    end
+    |> String.replace(~r/mb$/, "MB")
+  end
+end

--- a/lib/nerves_hub_web/components/device_page/details_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/details_tab.ex
@@ -13,10 +13,14 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   alias NervesHub.Devices.Updates
   alias NervesHub.Firmwares
   alias NervesHub.ManagedDeployments
+  alias NervesHub.Products
+  alias NervesHub.Products.HealthProfiles
   alias NervesHub.Scripts
+  alias NervesHubWeb.Components.DeviceHealth.MetricLabels
   alias NervesHubWeb.Components.DeviceLocation
   alias NervesHubWeb.Components.DeviceNetworkIdentities
   alias NervesHubWeb.Components.HealthStatus
+  alias NervesHubWeb.Components.Utils
   alias Phoenix.Socket.Broadcast
 
   require Logger
@@ -40,7 +44,7 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
     |> assign_support_scripts()
     |> assign(:firmwares, Firmwares.get_firmware_for_device(device))
     |> assign(:update_information, Updates.resolve_update(device))
-    |> assign(:latest_metrics, Metrics.get_latest_metric_set(device.id))
+    |> assign_health_display(device)
     |> assign(:alarms, Alarms.current_alarms_for_device(device))
     |> assign(:extension_overrides, extension_overrides(device, device.product))
     |> assign(:delta_available?, false)
@@ -52,6 +56,24 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   end
 
   def cleanup(), do: @keys_to_cleanup
+
+  # The health card only renders when the extension is enabled for both the
+  # product and the device, so nothing health-shaped is read otherwise — no
+  # metrics, no labels, no profile resolution. An install that leaves the
+  # health extension off pays none of its query load on this page.
+  defp assign_health_display(socket, device) do
+    if device.product.extensions.health && device.extensions.health do
+      socket
+      |> assign(:latest_metrics, Metrics.get_latest_metric_set(device.id))
+      |> assign(:custom_labels, Products.custom_health_metrics_labels(device.product))
+      |> assign(:featured_keys, featured_keys(device))
+    else
+      socket
+      |> assign(:latest_metrics, %{})
+      |> assign(:custom_labels, %{})
+      |> assign(:featured_keys, nil)
+    end
+  end
 
   defp assign_metadata(%{assigns: %{device: device}} = socket) do
     metadata =
@@ -144,54 +166,23 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
               </time>
             </div>
           </div>
+          <div :if={engaged_reasons(@device.latest_health) != []} class="flex flex-wrap items-center justify-items-stretch gap-2 px-4 pt-2">
+            <.engaged_tile
+              :for={{level, key, reason} <- engaged_reasons(@device.latest_health)}
+              level={level}
+              metric_key={key}
+              reason={reason}
+              latest_metrics={@latest_metrics}
+              custom_labels={@custom_labels}
+            />
+          </div>
           <div class="flex flex-wrap items-center justify-items-stretch gap-2 px-4 pt-2 pb-4">
-            <div class="border-success health-good flex h-16 grow flex-col rounded border-b px-3 py-2">
-              <span class="text-base-400 text-xs tracking-wide">CPU</span>
-              <div :if={@latest_metrics["cpu_usage_percent"] && @latest_metrics["cpu_temp"]} class="flex items-end justify-between">
-                <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_usage_percent"])}%</span>
-                <span class="text-success text-base">{round(@latest_metrics["cpu_temp"])}°</span>
-              </div>
-              <div :if={@latest_metrics["cpu_usage_percent"] && !@latest_metrics["cpu_temp"]}>
-                <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_usage_percent"])}</span>
-                <span class="text-base-50 text-lg leading-[30px]">%</span>
-              </div>
-              <div :if={!@latest_metrics["cpu_usage_percent"] && @latest_metrics["cpu_temp"]} class="flex items-end justify-between">
-                <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_temp"])}°</span>
-              </div>
-              <span :if={!@latest_metrics["cpu_usage_percent"] && !@latest_metrics["cpu_temp"]} class="text-base-500 text-xl leading-[30px]">NA</span>
-            </div>
-            <div class="border-warning health-warning flex h-16 grow flex-col rounded border-b px-3 py-2">
-              <span class="text-base-400 text-xs tracking-wide">Memory used</span>
-              <div :if={@latest_metrics["mem_used_mb"]} class="flex items-end justify-between">
-                <div>
-                  <span class="text-base-50 text-xl leading-[30px]">{number_to_delimited(@latest_metrics["mem_used_mb"], precision: 0)}</span>
-                  <span class="text-base-50 text-sm leading-[30px]">MB</span>
-                </div>
-                <div>
-                  <span class="text-warning text-base">{round(@latest_metrics["mem_used_percent"])}</span>
-                  <span class="text-warning text-sm">%</span>
-                </div>
-              </div>
-              <div :if={!@latest_metrics["mem_used_mb"]} class="flex items-end justify-between">
-                <span class="text-base-500 text-xl leading-[30px]">Not reported</span>
-              </div>
-            </div>
-            <div class="border-notice health-neutral flex h-16 grow flex-col rounded border-b px-3 py-2">
-              <span class="text-base-400 text-xs tracking-wide">Load avg</span>
-              <div :if={@latest_metrics["load_1min"] || @latest_metrics["load_5min"] || @latest_metrics["load_15min"]} class="flex items-center justify-between">
-                <span :if={@latest_metrics["load_1min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_1min"]}</span>
-                <span :if={!@latest_metrics["load_1min"]} class="text-base-500 text-xl leading-[30px]">NA</span>
-                <span class="bg-base-700 h-4 w-px"></span>
-                <span :if={@latest_metrics["load_5min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_5min"]}</span>
-                <span :if={!@latest_metrics["load_5min"]} class="text-base-500 text-xl leading-[30px]">NA</span>
-                <span class="bg-base-700 h-4 w-px"></span>
-                <span :if={@latest_metrics["load_15min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_15min"]}</span>
-                <span :if={!@latest_metrics["load_15min"]} class="text-base-500 text-xl leading-[30px]">NA</span>
-              </div>
-              <div :if={!@latest_metrics["load_1min"] && !@latest_metrics["load_5min"] && !@latest_metrics["load_15min"]} class="flex items-center">
-                <span class="text-base-500 text-xl leading-[30px]">Not reported</span>
-              </div>
-            </div>
+            <.featured_tile
+              :for={tile <- featured_tiles(@featured_keys, engaged_keys(@device.latest_health))}
+              tile={tile}
+              latest_metrics={@latest_metrics}
+              custom_labels={@custom_labels}
+            />
           </div>
           <div class="text-base-400 px-4 pb-4 text-xs font-normal">
             Learn more about
@@ -1076,4 +1067,177 @@ defmodule NervesHubWeb.Components.DevicePage.DetailsTab do
   defp update_mode_label(:automatic), do: "automatic"
   defp update_mode_label(:device_managed), do: "device managed"
   defp update_mode_label(:off), do: "off"
+
+  defp featured_keys(device) do
+    HealthProfiles.featured_keys(device)
+  end
+
+  # The engaged metrics of the latest evaluation — the row pinned above the
+  # featured tiles, alert level first. Reasons come back from jsonb with
+  # string keys.
+  defp engaged_reasons(%{status_reasons: %{} = reasons}) do
+    for level <- ["unhealthy", "warning"],
+        {key, reason} <- Enum.sort(Map.get(reasons, level) || %{}),
+        do: {level, key, reason}
+  end
+
+  defp engaged_reasons(_no_health_or_reasons), do: []
+
+  defp engaged_keys(latest_health) do
+    MapSet.new(engaged_reasons(latest_health), fn {_level, key, _reason} -> key end)
+  end
+
+  # A tile per featured metric of the device's health profile. Keys the
+  # hand-designed composite tiles cover collapse into their tile — featuring
+  # cpu_usage_percent or cpu_temp gives the CPU tile — and any other featured
+  # key gets a plain value tile, unless it is already pinned in the engaged
+  # row above. An engaged key belonging to a composite shows in both places
+  # on purpose: the engaged tile carries the reason, the composite keeps its
+  # companion readings (CPU keeps its temperature). With no profile, the
+  # pre-profile fixed trio.
+  defp featured_tiles(nil, _engaged_keys), do: [:cpu, :memory, :load]
+
+  defp featured_tiles(featured_keys, engaged_keys) do
+    featured_keys
+    |> Enum.map(fn
+      key when key in ["cpu_usage_percent", "cpu_temp"] -> :cpu
+      key when key in ["mem_used_percent", "mem_used_mb", "mem_size_mb"] -> :memory
+      "load_" <> _rest -> :load
+      key -> {:metric, key}
+    end)
+    |> Enum.reject(fn
+      {:metric, key} -> MapSet.member?(engaged_keys, key)
+      _composite -> false
+    end)
+    |> Enum.uniq()
+  end
+
+  # An engaged metric's tile: the level's tile treatment (colored bottom
+  # border and tint), the current value, and how the level engaged.
+  attr(:level, :string, required: true, values: ["warning", "unhealthy"])
+  attr(:metric_key, :string, required: true)
+  attr(:reason, :map, required: true)
+  attr(:latest_metrics, :map, required: true)
+  attr(:custom_labels, :map, required: true)
+
+  defp engaged_tile(assigns) do
+    ~H"""
+    <div class={[
+      "flex h-16 grow flex-col rounded border-b px-3 py-2",
+      @level == "unhealthy" && "border-alert health-alert",
+      @level == "warning" && "border-warning health-warning"
+    ]}>
+      <span class="text-base-400 text-xs tracking-wide">{MetricLabels.label(@metric_key, @custom_labels)}</span>
+      <div class="flex items-end justify-between gap-3">
+        <span class="text-base-50 text-xl leading-[30px]">{engaged_value(@metric_key, @reason, @latest_metrics)}</span>
+        <span class={["pb-1 text-xs", @level == "unhealthy" && "text-alert", @level == "warning" && "text-warning"]}>
+          {engaged_detail(@reason)}
+        </span>
+      </div>
+    </div>
+    """
+  end
+
+  # A count reason's value is the observation itself; a share reason's main
+  # number is the metric's latest reading.
+  defp engaged_value(_key, %{"aggregation" => "count", "value" => count}, _latest_metrics), do: count
+
+  defp engaged_value(key, _reason, latest_metrics) do
+    case latest_metrics[key] do
+      value when is_number(value) -> Utils.nice_round(value)
+      _ -> "NA"
+    end
+  end
+
+  defp engaged_detail(%{"aggregation" => "count"} = reason) do
+    "threshold #{Utils.format_number(reason["threshold"])} in #{Utils.format_period(reason["period_seconds"])}"
+  end
+
+  defp engaged_detail(%{"aggregation" => "share"} = reason) do
+    direction = if reason["operator"] == "lte", do: "at or under", else: "at or over"
+
+    "#{direction} #{Utils.format_number(reason["threshold"])} for #{reason["value"]}% of #{Utils.format_period(reason["period_seconds"])}"
+  end
+
+  defp engaged_detail(reason), do: "threshold #{Utils.format_number(reason["threshold"])}"
+
+  defp featured_tile(%{tile: :cpu} = assigns) do
+    ~H"""
+    <div class="border-success health-good flex h-16 grow flex-col rounded border-b px-3 py-2">
+      <span class="text-base-400 text-xs tracking-wide">CPU</span>
+      <div :if={@latest_metrics["cpu_usage_percent"] && @latest_metrics["cpu_temp"]} class="flex items-end justify-between">
+        <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_usage_percent"])}%</span>
+        <span class="text-success text-base">{round(@latest_metrics["cpu_temp"])}°</span>
+      </div>
+      <div :if={@latest_metrics["cpu_usage_percent"] && !@latest_metrics["cpu_temp"]}>
+        <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_usage_percent"])}</span>
+        <span class="text-base-50 text-lg leading-[30px]">%</span>
+      </div>
+      <div :if={!@latest_metrics["cpu_usage_percent"] && @latest_metrics["cpu_temp"]} class="flex items-end justify-between">
+        <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["cpu_temp"])}°</span>
+      </div>
+      <span :if={!@latest_metrics["cpu_usage_percent"] && !@latest_metrics["cpu_temp"]} class="text-base-500 text-xl leading-[30px]">NA</span>
+    </div>
+    """
+  end
+
+  defp featured_tile(%{tile: :memory} = assigns) do
+    ~H"""
+    <div class="border-warning health-warning flex h-16 grow flex-col rounded border-b px-3 py-2">
+      <span class="text-base-400 text-xs tracking-wide">Memory used</span>
+      <div :if={@latest_metrics["mem_used_mb"]} class="flex items-end justify-between">
+        <div>
+          <span class="text-base-50 text-xl leading-[30px]">{number_to_delimited(@latest_metrics["mem_used_mb"], precision: 0)}</span>
+          <span class="text-base-50 text-sm leading-[30px]">MB</span>
+        </div>
+        <div>
+          <span class="text-warning text-base">{round(@latest_metrics["mem_used_percent"])}</span>
+          <span class="text-warning text-sm">%</span>
+        </div>
+      </div>
+      <div :if={!@latest_metrics["mem_used_mb"] && @latest_metrics["mem_used_percent"]} class="flex items-end justify-between">
+        <div>
+          <span class="text-base-50 text-xl leading-[30px]">{round(@latest_metrics["mem_used_percent"])}</span>
+          <span class="text-base-50 text-sm leading-[30px]">%</span>
+        </div>
+      </div>
+      <div :if={!@latest_metrics["mem_used_mb"] && !@latest_metrics["mem_used_percent"]} class="flex items-end justify-between">
+        <span class="text-base-500 text-xl leading-[30px]">Not reported</span>
+      </div>
+    </div>
+    """
+  end
+
+  defp featured_tile(%{tile: :load} = assigns) do
+    ~H"""
+    <div class="border-notice health-neutral flex h-16 grow flex-col rounded border-b px-3 py-2">
+      <span class="text-base-400 text-xs tracking-wide">Load avg</span>
+      <div :if={@latest_metrics["load_1min"] || @latest_metrics["load_5min"] || @latest_metrics["load_15min"]} class="flex items-center justify-between">
+        <span :if={@latest_metrics["load_1min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_1min"]}</span>
+        <span :if={!@latest_metrics["load_1min"]} class="text-base-500 text-xl leading-[30px]">NA</span>
+        <span class="bg-base-700 h-4 w-px"></span>
+        <span :if={@latest_metrics["load_5min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_5min"]}</span>
+        <span :if={!@latest_metrics["load_5min"]} class="text-base-500 text-xl leading-[30px]">NA</span>
+        <span class="bg-base-700 h-4 w-px"></span>
+        <span :if={@latest_metrics["load_15min"]} class="text-base-50 text-xl leading-[30px]">{@latest_metrics["load_15min"]}</span>
+        <span :if={!@latest_metrics["load_15min"]} class="text-base-500 text-xl leading-[30px]">NA</span>
+      </div>
+      <div :if={!@latest_metrics["load_1min"] && !@latest_metrics["load_5min"] && !@latest_metrics["load_15min"]} class="flex items-center">
+        <span class="text-base-500 text-xl leading-[30px]">Not reported</span>
+      </div>
+    </div>
+    """
+  end
+
+  defp featured_tile(%{tile: {:metric, key}} = assigns) do
+    assigns = assign(assigns, :key, key)
+
+    ~H"""
+    <div class="health-plain flex h-16 grow flex-col rounded border-b border-neutral-500 px-3 py-2">
+      <span class="text-base-400 text-xs tracking-wide">{MetricLabels.label(@key, @custom_labels)}</span>
+      <span :if={@latest_metrics[@key]} class="text-base-50 text-xl leading-[30px]">{Utils.nice_round(@latest_metrics[@key])}</span>
+      <span :if={!@latest_metrics[@key]} class="text-base-500 text-xl leading-[30px]">Not reported</span>
+    </div>
+    """
+  end
 end

--- a/lib/nerves_hub_web/components/device_page/health_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/health_tab.ex
@@ -3,6 +3,9 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
 
   alias NervesHub.Devices.Metrics
   alias NervesHub.Products
+  alias NervesHub.Products.HealthProfiles
+  alias NervesHubWeb.Components.DeviceHealth.MetricLabels
+  alias NervesHubWeb.Components.Utils
   alias Phoenix.LiveView.AsyncResult
 
   @time_frame_opts [
@@ -11,19 +14,6 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     {"day", 7}
   ]
   @default_time_frame {"hour", 3}
-
-  # Metric types with belonging titles to display as default.
-  # Also sets order of charts.
-  @default_metrics [
-    {"load_1min", "Load Average 1 Min"},
-    {"load_5min", "Load Average 5 Min"},
-    {"load_15min", "Load Average 15 Min"},
-    {"mem_used_mb", "Memory Usage (MB)"},
-    {"mem_used_percent", "Memory Usage (%)"},
-    {"disk_used_percentage", "Disk Usage (%)"},
-    {"cpu_usage_percent", "CPU Usage (%)"},
-    {"cpu_temp", "CPU Temperature (°C)"}
-  ]
 
   @manual_metrics [
     "cpu_temp",
@@ -55,6 +45,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     # the charts say why they are empty.
     |> assign(:analytics_enabled, analytics_enabled?())
     |> assign(:latest_metrics, Metrics.get_latest_metric_set(socket.assigns.device.id))
+    |> assign(:threshold_specs, threshold_specs(socket.assigns.device))
     |> assign(:custom_health_labels, Products.custom_health_metrics_labels(socket.assigns.product))
     |> assign(:editing_label_key, nil)
     |> assign(:chart_data, %{})
@@ -268,7 +259,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
               </div>
             </div>
             <div :for={{key, value} <- custom_metrics(@latest_metrics)} class="health-plain flex h-16 grow flex-col rounded border-b border-neutral-500 px-3 py-2">
-              <span class="text-base-400 text-xs tracking-wide">{key_label(key)}</span>
+              <span class="text-base-400 text-xs tracking-wide">{label_for(key, @custom_health_labels)}</span>
               <span class="text-base-50 text-xl leading-[30px]">{nice_round(value)}</span>
             </div>
           </div>
@@ -359,6 +350,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
                   phx-update="ignore"
                   data-key={key}
                   data-metrics={Jason.encode!(chart_data)}
+                  data-thresholds={Jason.encode!(@threshold_specs[key])}
                   data-title=""
                   data-max={suggested_max(key)}
                   data-mintime={Jason.encode!(@charts_from_timestamp)}
@@ -502,10 +494,6 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     end)
   end
 
-  defp chart_title(key) do
-    String.replace(key, ~r/mb$/, "MB")
-  end
-
   defp metrics_to_chart(latest_metrics) do
     latest_metrics
     |> Map.keys()
@@ -513,8 +501,8 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
       k == "timestamp" or String.downcase(k) in @no_chart_metrics
     end)
     |> Enum.sort_by(fn key ->
-      # Sorts list by @default_metrics order
-      Enum.find_index(@default_metrics, fn {default_type, _} ->
+      # Sorts list by the well-known chart order
+      Enum.find_index(MetricLabels.default_titles(), fn {default_type, _} ->
         default_type == key
       end)
     end)
@@ -529,26 +517,7 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
     end
   end
 
-  # The custom label set on the product takes precedence over the default title.
-  defp label_for(key, custom_labels) do
-    case Map.get(custom_labels || %{}, key) do
-      nil -> title(key)
-      label -> label
-    end
-  end
-
-  defp title(type) do
-    case Enum.find(@default_metrics, fn {default_type, _} -> default_type == type end) do
-      {_, title} ->
-        title
-
-      nil ->
-        type
-        |> String.replace("_", " ")
-        |> String.capitalize()
-    end
-    |> chart_title()
-  end
+  defp label_for(key, custom_labels), do: MetricLabels.label(key, custom_labels)
 
   # `tab_params/3` runs from a `:handle_params` hook, so it fires again every
   # time the user navigates back onto this tab. A tick left over from an earlier
@@ -570,18 +539,27 @@ defmodule NervesHubWeb.Components.DevicePage.HealthTab do
   defp get_time_unit({"day", 1}), do: "hour"
   defp get_time_unit({"day", _}), do: "day"
 
+  # The thresholds the device's resolved profile holds for each regular
+  # metric, handed to the chart hook so it can color the dots that breach
+  # them. Dots are judged instantaneously — a colored dot is a sample beyond
+  # a threshold, whether or not the windowed median engaged the level.
+  defp threshold_specs(device) do
+    case HealthProfiles.resolve(device) do
+      nil ->
+        %{}
+
+      profile ->
+        for metric <- profile.metrics, !metric.built_in, into: %{} do
+          {metric.key, %{operator: metric.operator, warning: metric.warning_threshold, alert: metric.alert_threshold}}
+        end
+    end
+  end
+
   defp custom_metrics(metrics) do
     Enum.reject(metrics, &(elem(&1, 0) in @manual_metrics))
   end
 
-  defp nice_round(val) when is_float(val), do: Float.round(val, 1)
-  defp nice_round(val), do: val
-
-  defp key_label(key) do
-    key
-    |> String.replace("_", " ")
-    |> String.capitalize()
-  end
+  defp nice_round(val), do: Utils.nice_round(val)
 
   # Charts are keyed by metric name, and metric names come from the device --
   # `Extensions.Health` stores whatever keys a report carries. Deriving an

--- a/lib/nerves_hub_web/components/layouts.ex
+++ b/lib/nerves_hub_web/components/layouts.ex
@@ -24,6 +24,17 @@ defmodule NervesHubWeb.Layouts do
 
   embed_templates("layouts/*")
 
+  @doc """
+  How a tab links to its path.
+
+  Tabs patch by default, which is what a page whose tabs are `live_action`s of
+  one LiveView wants — the device and deployment group pages. A tab whose
+  target is a *different* LiveView cannot be patched to, so it opts into
+  `navigate` by setting `navigate: true` on the slot.
+  """
+  def tab_target(%{navigate: true} = nav), do: %{navigate: nav.path}
+  def tab_target(nav), do: %{patch: nav.path}
+
   def toggle_product_picker(js \\ %JS{}) do
     JS.toggle(js,
       to: "#product-picker",

--- a/lib/nerves_hub_web/components/layouts/sidebar.html.heex
+++ b/lib/nerves_hub_web/components/layouts/sidebar.html.heex
@@ -170,7 +170,16 @@
       {if(assigns[:top_bar], do: render_slot(@top_bar))}
     </div>
 
-    <div :if={assigns[:header]} id="header" class="border-base-700 h-header flex items-center gap-4 border-b px-6 text-sm font-medium">
+    <%!-- The tab bar draws the line under the header when there is one, the
+          way `big_header` leaves it to. Two borders read as a double rule. --%>
+    <div
+      :if={assigns[:header]}
+      id="header"
+      class={[
+        "border-base-700 h-header flex items-center gap-4 px-6 text-sm font-medium",
+        !assigns[:tabbed_nav] && "border-b"
+      ]}
+    >
       {render_slot(@header)}
     </div>
 
@@ -184,7 +193,7 @@
           :for={nav <- @tabbed_nav}
           data-selected={nav.selected}
           class="data-selected:border-primary data-selected:tab-selected data-selected:text-base-300 hover:border-primary text-base-50 relative -bottom-px h-11 px-6 py-2 text-sm font-normal hover:border-b data-selected:border-b"
-          patch={nav.path}
+          {tab_target(nav)}
         >
           {nav.label}
         </.link>

--- a/lib/nerves_hub_web/components/utils.ex
+++ b/lib/nerves_hub_web/components/utils.ex
@@ -10,6 +10,46 @@ defmodule NervesHubWeb.Components.Utils do
         do: {String.capitalize(value), key}
   end
 
+  @doc """
+  A number for display. Elixir's default float rendering flips to scientific
+  notation at 10^4 (9000.0 prints as "9.0e3"), which is wrong everywhere a
+  threshold or metric value faces a person. Whole floats print as integers,
+  fractions keep up to four decimals. Anything that is not a number — a
+  jsonb value that predates validation — passes through untouched, so a
+  template can render whatever is there.
+  """
+  def format_number(number) when is_integer(number), do: Integer.to_string(number)
+
+  def format_number(number) when is_float(number) do
+    if number == trunc(number) do
+      number |> trunc() |> Integer.to_string()
+    else
+      number
+      |> :erlang.float_to_binary(decimals: 4)
+      |> String.trim_trailing("0")
+      |> String.trim_trailing(".")
+    end
+  end
+
+  def format_number(not_a_number), do: not_a_number
+
+  @doc """
+  A metric reading for display: floats rounded to one decimal, formatted by
+  `format_number/1`; anything else untouched.
+  """
+  def nice_round(value) when is_float(value), do: format_number(Float.round(value, 1))
+  def nice_round(value), do: format_number(value)
+
+  @doc """
+  A measurement period in seconds as a compact human string: "45s", "30m",
+  "6h", "1d", "1m 30s".
+  """
+  def format_period(seconds) when seconds < 60, do: "#{seconds}s"
+  def format_period(seconds) when rem(seconds, 86_400) == 0, do: "#{div(seconds, 86_400)}d"
+  def format_period(seconds) when rem(seconds, 3600) == 0, do: "#{div(seconds, 3600)}h"
+  def format_period(seconds) when rem(seconds, 60) == 0, do: "#{div(seconds, 60)}m"
+  def format_period(seconds), do: "#{div(seconds, 60)}m #{rem(seconds, 60)}s"
+
   def format_serial(big_long_integer) when is_integer(big_long_integer) do
     big_long_integer
     |> Integer.to_string(16)

--- a/lib/nerves_hub_web/live/product/health_profiles.ex
+++ b/lib/nerves_hub_web/live/product/health_profiles.ex
@@ -1,0 +1,394 @@
+defmodule NervesHubWeb.Live.Product.HealthProfiles do
+  use NervesHubWeb, :live_view
+
+  alias NervesHub.Devices.Metrics
+  alias NervesHub.Firmwares
+  alias NervesHub.Products
+  alias NervesHub.Products.HealthProfiles
+  alias NervesHubWeb.Components.DeviceHealth.MetricLabels
+  alias NervesHubWeb.Components.Utils
+
+  def mount(_params, _session, socket) do
+    product = socket.assigns.current_scope.product
+
+    socket
+    |> assign(:page_title, "#{product.name} Health Profiles")
+    |> sidebar_tab(:settings)
+    |> assign(:product, product)
+    |> assign(:custom_labels, Products.custom_health_metrics_labels(product))
+    |> assign_observed(product)
+    |> assign_profiles()
+    |> ok()
+  end
+
+  # Flipping the operator is page state until the row is saved: the flipped
+  # thresholds usually need adjusting before they validate, so nothing is
+  # persisted on the click itself. On an add-metric form with a suggestion
+  # pending, the pre-filled thresholds follow the flip (the suggestion has a
+  # value per direction).
+  def handle_event("flip-operator", %{"target" => target, "operator" => current}, socket) do
+    flipped = if current == "gte", do: "lte", else: "gte"
+
+    {:noreply, update(socket, :pending_operators, &Map.put(&1, target, flipped))}
+  end
+
+  # Picking a metric in an add form pre-fills its thresholds with the fleet
+  # suggestion (page state until Add). The form's phx-change also fires for
+  # the other inputs; only the picker matters here.
+  def handle_event("suggest-thresholds", %{"_target" => ["metric", "key"]} = params, socket) do
+    %{"profile_id" => profile_id, "metric" => %{"key" => key}} = params
+    suggestion = HealthProfiles.suggested_thresholds(socket.assigns.observed_stats[key])
+
+    {:noreply, update(socket, :pending_suggestions, &Map.put(&1, "new-#{profile_id}", suggestion))}
+  end
+
+  def handle_event("suggest-thresholds", _other_input, socket), do: {:noreply, socket}
+
+  def handle_event("create-platform-profile", %{"platform" => platform}, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    case HealthProfiles.create_platform_profile(socket.assigns.product, platform) do
+      {:ok, profile} ->
+        socket
+        |> assign_profiles()
+        |> put_flash(:info, "A health profile for #{profile.platform} was created, seeded from the default profile.")
+        |> noreply()
+
+      {:error, changeset} ->
+        socket
+        |> put_flash(:error, "Could not create the profile: #{first_error(changeset)}")
+        |> noreply()
+    end
+  end
+
+  def handle_event("delete-profile", %{"profile_id" => profile_id}, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    profile = HealthProfiles.get_profile!(socket.assigns.product, profile_id)
+
+    case HealthProfiles.delete_profile(profile) do
+      {:ok, _} ->
+        socket
+        |> assign_profiles()
+        |> put_flash(
+          :info,
+          "The #{profile.platform} health profile was deleted. Its devices use the default profile again."
+        )
+        |> noreply()
+
+      {:error, :cannot_delete_default} ->
+        socket
+        |> put_flash(:error, "The default health profile cannot be deleted.")
+        |> noreply()
+    end
+  end
+
+  def handle_event("add-metric", %{"profile_id" => profile_id, "metric" => attrs}, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    profile = HealthProfiles.get_profile!(socket.assigns.product, profile_id)
+
+    case HealthProfiles.add_metric(profile, normalize_periods(attrs)) do
+      {:ok, metric} ->
+        socket
+        |> assign_profiles()
+        |> put_flash(:info, "#{metric.key} was added to the profile.")
+        |> noreply()
+
+      {:error, changeset} ->
+        socket
+        |> put_flash(:error, "Could not add the metric: #{first_error(changeset)}")
+        |> noreply()
+    end
+  end
+
+  def handle_event("update-metric", %{"profile_id" => profile_id, "metric_id" => metric_id, "metric" => attrs}, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    profile = HealthProfiles.get_profile!(socket.assigns.product, profile_id)
+    metric = HealthProfiles.get_metric!(profile, metric_id)
+
+    case HealthProfiles.update_metric(metric, normalize_periods(attrs)) do
+      {:ok, metric} ->
+        socket
+        |> assign_profiles()
+        |> put_flash(:info, "#{metric.key} was updated.")
+        |> noreply()
+
+      {:error, changeset} ->
+        socket
+        |> put_flash(:error, "Could not update the metric: #{first_error(changeset)}")
+        |> noreply()
+    end
+  end
+
+  def handle_event("delete-metric", %{"profile_id" => profile_id, "metric_id" => metric_id}, socket) do
+    authorized!(:"product:update", socket.assigns.current_scope)
+
+    profile = HealthProfiles.get_profile!(socket.assigns.product, profile_id)
+    metric = HealthProfiles.get_metric!(profile, metric_id)
+
+    :ok = HealthProfiles.delete_metric(metric)
+
+    socket
+    |> assign_profiles()
+    |> put_flash(:info, "#{metric.key} no longer affects health for this profile.")
+    |> noreply()
+  end
+
+  defp assign_profiles(socket) do
+    profiles = HealthProfiles.all_for_product(socket.assigns.product)
+
+    taken = profiles |> Enum.map(& &1.platform) |> Enum.reject(&is_nil/1)
+
+    platforms =
+      socket.assigns.product
+      |> Firmwares.get_unique_platforms()
+      |> Enum.reject(&(is_nil(&1) or &1 in taken))
+      |> Enum.sort()
+
+    socket
+    |> assign(:profiles, profiles)
+    |> assign(:available_platforms, platforms)
+    |> assign(:pending_operators, %{})
+    |> assign(:pending_suggestions, %{})
+  end
+
+  # One pass over the product's stored metrics feeds the picker (its keys,
+  # padded with the well-known nerves_hub_health defaults so a fresh product
+  # isn't looking at an empty list), the observed value ranges shown beside
+  # each metric, and the threshold suggestions derived from the quartiles —
+  # thresholds get picked against real units and real behavior.
+  defp assign_observed(socket, product) do
+    observed_stats =
+      if Application.get_env(:nerves_hub, :analytics_enabled, false) do
+        Metrics.observed_stats(product.id)
+      else
+        %{}
+      end
+
+    reported_keys =
+      (Metrics.default_metrics() ++ Map.keys(observed_stats))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    socket
+    |> assign(:observed_stats, observed_stats)
+    |> assign(:reported_keys, reported_keys)
+  end
+
+  # What the fleet has actually reported for this key, over the retention
+  # window; nil when nothing has (built-ins, defaults never reported).
+  defp seen_range(observed_stats, key) do
+    case observed_stats do
+      %{^key => %{min: min, max: max}} ->
+        "seen #{Utils.format_number(min)} – #{Utils.format_number(max)}"
+
+      _ ->
+        nil
+    end
+  end
+
+  # "suggested 82 / 91" for the direction the metric points, or nil when the
+  # history can't support a suggestion (see HealthProfiles.suggested_thresholds/1).
+  defp suggested(observed_stats, key, operator) do
+    direction = if operator in [:lte, "lte"], do: :lte, else: :gte
+
+    case HealthProfiles.suggested_thresholds(observed_stats[key]) do
+      %{^direction => %{warning: warning, alert: alert}} ->
+        "suggested #{Utils.format_number(warning)} / #{Utils.format_number(alert)}"
+
+      nil ->
+        nil
+    end
+  end
+
+  # The pre-fill for an add form's threshold input: the pending suggestion
+  # for the operator currently shown on that form, if a picked metric has one.
+  defp suggested_threshold(assigns, target, level) do
+    operator = shown_operator(assigns.pending_operators, target, :gte)
+    direction = if operator in [:lte, "lte"], do: :lte, else: :gte
+
+    case assigns.pending_suggestions[target] do
+      %{^direction => levels} -> Map.fetch!(levels, level)
+      nil -> nil
+    end
+  end
+
+  defp metric_options(assigns, profile) do
+    taken = MapSet.new(profile.metrics, & &1.key)
+
+    built_in =
+      for {key, %{label: label}} <- Enum.sort(HealthProfiles.built_in_metrics()),
+          key not in taken,
+          do: {label, key}
+
+    regular =
+      for key <- assigns.reported_keys,
+          not MapSet.member?(taken, key) do
+        label = MetricLabels.label(key, assigns.custom_labels)
+
+        annotations =
+          [seen_range(assigns.observed_stats, key), suggested(assigns.observed_stats, key, :gte)]
+          |> Enum.reject(&is_nil/1)
+
+        case annotations do
+          [] -> {label, key}
+          _ -> {"#{label} — #{Enum.join(annotations, ", ")}", key}
+        end
+      end
+
+    [{"Built-in", built_in}, {"Health metrics", regular}]
+  end
+
+  # The operator sits between the metric and its thresholds and flips on
+  # click: `>=` when high is unhealthy, `<=` when low is (a frame rate goes
+  # bad low).
+  attr(:target, :string, required: true)
+  attr(:operator, :any, required: true)
+  attr(:disabled, :boolean, default: false)
+
+  defp operator_flip(assigns) do
+    ~H"""
+    <input type="hidden" name="metric[operator]" value={to_string(@operator)} />
+    <button
+      type="button"
+      phx-click="flip-operator"
+      phx-value-target={@target}
+      phx-value-operator={to_string(@operator)}
+      title={operator_title(@operator)}
+      disabled={@disabled}
+      class="bg-base-900 border-base-600 hover:border-base-400 text-base-50 flex size-9 shrink-0 items-center justify-center rounded border font-mono text-lg hover:cursor-pointer disabled:cursor-not-allowed"
+    >
+      {operator_glyph(@operator)}
+    </button>
+    """
+  end
+
+  defp operator_glyph(operator) when operator in [:gte, "gte"], do: "≥"
+  defp operator_glyph(_lte), do: "≤"
+
+  defp operator_title(operator) when operator in [:gte, "gte"],
+    do: "Unhealthy at or above the thresholds — click to flip"
+
+  defp operator_title(_lte), do: "Unhealthy at or below the thresholds — click to flip"
+
+  defp shown_operator(pending_operators, target, fallback) do
+    Map.get(pending_operators, target) || fallback
+  end
+
+  # One section per level, warning and alert each with their own threshold
+  # and measurement period, styled like the health tiles on device details:
+  # a colored bottom border with a matching tint. Sections sit side by side
+  # when there is room and stack on narrow screens (half-width windows,
+  # tablets).
+  attr(:level, :string, required: true, values: ["warning", "alert"])
+  attr(:threshold, :any, default: nil)
+  attr(:period_seconds, :integer, required: true)
+  attr(:disabled, :boolean, default: false)
+
+  defp level_fields(assigns) do
+    ~H"""
+    <div class={[
+      "flex min-w-56 grow basis-56 flex-col gap-2 rounded border-b p-3",
+      @level == "warning" && "border-warning health-warning",
+      @level == "alert" && "border-alert health-alert"
+    ]}>
+      <div class={[
+        "text-xs font-semibold tracking-wide uppercase",
+        @level == "warning" && "text-warning",
+        @level == "alert" && "text-alert"
+      ]}>
+        {@level}
+      </div>
+      <div class="flex flex-wrap items-end gap-3">
+        <label class="text-base-400 flex flex-col gap-1 text-xs">
+          Threshold
+          <input
+            type="number"
+            step="any"
+            required
+            name={"metric[#{@level}_threshold]"}
+            value={@threshold && NervesHubWeb.Components.Utils.format_number(@threshold)}
+            disabled={@disabled}
+            class="bg-base-900 border-base-600 focus:border-base-400 text-base-400 block w-28 rounded border px-2 py-1 focus:ring-0 sm:text-sm"
+          />
+        </label>
+        <label class="text-base-400 flex flex-col gap-1 text-xs">
+          Median over
+          <div class="flex gap-2">
+            <input
+              type="number"
+              min="1"
+              step="1"
+              required
+              name={"metric[#{@level}_period_value]"}
+              value={period_value(@period_seconds)}
+              disabled={@disabled}
+              class="bg-base-900 border-base-600 focus:border-base-400 text-base-400 block w-20 rounded border px-2 py-1 focus:ring-0 sm:text-sm"
+            />
+            <select
+              name={"metric[#{@level}_period_unit]"}
+              disabled={@disabled}
+              class="bg-base-900 border-base-600 focus:border-base-400 text-base-400 block rounded border px-2 py-1 focus:ring-0 sm:text-sm"
+            >
+              {Phoenix.HTML.Form.options_for_select([{"minutes", "minutes"}, {"hours", "hours"}], period_unit(@period_seconds))}
+            </select>
+          </div>
+        </label>
+      </div>
+    </div>
+    """
+  end
+
+  @period_units %{"minutes" => 60, "hours" => 3600}
+
+  # The form takes each period as a value plus a unit (so people aren't locked
+  # into a preset list); the schema stores seconds. An unparseable value is
+  # passed through untouched so the changeset reports it instead of a crash.
+  defp normalize_periods(attrs) do
+    attrs
+    |> normalize_period("warning")
+    |> normalize_period("alert")
+  end
+
+  defp normalize_period(attrs, level) do
+    value = attrs["#{level}_period_value"]
+    unit = attrs["#{level}_period_unit"]
+
+    # A forged unit must fail validation, not be quietly reinterpreted.
+    seconds =
+      with {n, ""} <- Integer.parse(to_string(value)),
+           {:ok, multiplier} <- Map.fetch(@period_units, unit) do
+        n * multiplier
+      else
+        _unparseable_or_unknown_unit -> "invalid period"
+      end
+
+    attrs
+    |> Map.put("#{level}_period_seconds", seconds)
+    |> Map.drop(["#{level}_period_value", "#{level}_period_unit"])
+  end
+
+  # Stored seconds rendered back into the value + unit pair, preferring the
+  # largest unit that divides evenly (3600 seconds shows as 1 hour). The form
+  # only offers minutes and hours, so a stored sub-minute remainder (only
+  # reachable via console/API today) floors to minutes — re-saving such a
+  # row rewrites 90s to 60s.
+  defp period_value(seconds) when is_integer(seconds) and rem(seconds, 3600) == 0, do: div(seconds, 3600)
+  defp period_value(seconds) when is_integer(seconds), do: div(seconds, 60)
+  defp period_value(seconds), do: seconds
+
+  defp period_unit(seconds) when is_integer(seconds) and rem(seconds, 3600) == 0, do: "hours"
+  defp period_unit(_seconds), do: "minutes"
+
+  defp first_error(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+    |> Enum.map_join("; ", fn {field, messages} -> "#{field} #{Enum.join(messages, ", ")}" end)
+  end
+end

--- a/lib/nerves_hub_web/live/product/health_profiles.ex
+++ b/lib/nerves_hub_web/live/product/health_profiles.ex
@@ -14,6 +14,7 @@ defmodule NervesHubWeb.Live.Product.HealthProfiles do
     socket
     |> assign(:page_title, "#{product.name} Health Profiles")
     |> sidebar_tab(:settings)
+    |> assign(:tab, :health)
     |> assign(:product, product)
     |> assign(:custom_labels, Products.custom_health_metrics_labels(product))
     |> assign_observed(product)

--- a/lib/nerves_hub_web/live/product/health_profiles.html.heex
+++ b/lib/nerves_hub_web/live/product/health_profiles.html.heex
@@ -1,0 +1,212 @@
+<NervesHubWeb.Layouts.sidebar flash={@flash} current_scope={@current_scope} sidebar_tab={@sidebar_tab}>
+  <:header>
+    <h1 class="text-base-50 text-xl leading-[30px] font-semibold">Health Profiles</h1>
+  </:header>
+
+  <div class="h-0 flex-1 overflow-y-auto">
+    <div class="flex flex-col items-start justify-between gap-4 p-6">
+      <div :for={profile <- @profiles} class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
+        <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
+          <div class="text-base-50 text-base font-medium">
+            <%= if profile.platform do %>
+              Platform: {profile.platform}
+            <% else %>
+              Default profile
+            <% end %>
+          </div>
+          <.button
+            :if={profile.platform}
+            style="danger"
+            type="button"
+            phx-click="delete-profile"
+            phx-value-profile_id={profile.id}
+            data-confirm={"Delete the #{profile.platform} profile? Its devices will use the default profile."}
+            disabled={!authorized?(:"product:update", @current_scope)}
+          >
+            Delete profile
+          </.button>
+        </div>
+
+        <div class="flex flex-col gap-3 p-6">
+          <p :if={is_nil(profile.platform)} class="text-base-400 w-2/3 text-sm">
+            A metric engages its warning (orange) or alert (red) level when its median over the measurement period crosses the
+            threshold in the direction the operator points. This profile applies to every device without a platform profile.
+            Featured metrics are shown at the top of the device details page.
+          </p>
+          <div :if={profile.metrics == []} class="text-base-400 text-sm">
+            This profile has no metrics, so its devices always report an unknown health status.
+          </div>
+
+          <form
+            :for={metric <- profile.metrics}
+            id={"metric-#{metric.id}"}
+            phx-submit="update-metric"
+            class="border-base-700 flex flex-col gap-3 rounded border p-3"
+          >
+            <input type="hidden" name="profile_id" value={profile.id} />
+            <input type="hidden" name="metric_id" value={metric.id} />
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div class="flex flex-col">
+                <span class="text-base-300 text-sm font-medium">{MetricLabels.label(metric.key, @custom_labels)}</span>
+                <span :if={metric.built_in} class="text-base-500 text-xs">built-in</span>
+                <span :if={!metric.built_in && MetricLabels.label(metric.key, @custom_labels) != metric.key} class="text-base-500 text-xs">{metric.key}</span>
+                <span :if={seen_range(@observed_stats, metric.key)} class="text-base-500 text-xs" title="Lowest and highest value reported across this product's devices, over the retention window">
+                  {seen_range(@observed_stats, metric.key)}
+                  <span
+                    :if={suggested(@observed_stats, metric.key, metric.operator)}
+                    title="Statistical outlier fences from at least a week of this fleet's history: values this far outside the middle half of readings are unusual for this fleet"
+                  >
+                    · {suggested(@observed_stats, metric.key, metric.operator)}
+                  </span>
+                </span>
+              </div>
+              <div class="flex items-center gap-3">
+                <label class="text-base-400 flex items-center gap-2 text-xs" title="Featured metrics are shown at the top of the device details page">
+                  <input type="hidden" name="metric[featured]" value="false" />
+                  <input
+                    type="checkbox"
+                    name="metric[featured]"
+                    value="true"
+                    checked={metric.featured}
+                    disabled={!authorized?(:"product:update", @current_scope)}
+                    class="border-base-700 checked:bg-primary text-base-400 rounded focus:ring-0"
+                  /> Featured
+                </label>
+                <button
+                  type="submit"
+                  title="Save changes"
+                  disabled={!authorized?(:"product:update", @current_scope)}
+                  class="hover:bg-base-700 rounded p-1.5 hover:cursor-pointer disabled:cursor-not-allowed"
+                >
+                  <span class="lucide-save--light text-base-400 size-4"></span>
+                </button>
+                <button
+                  type="button"
+                  title="Remove metric"
+                  phx-click="delete-metric"
+                  phx-value-profile_id={profile.id}
+                  phx-value-metric_id={metric.id}
+                  data-confirm={"Remove #{metric.key} from this profile?"}
+                  disabled={!authorized?(:"product:update", @current_scope)}
+                  class="hover:bg-base-700 rounded p-1.5 hover:cursor-pointer disabled:cursor-not-allowed"
+                >
+                  <span class="lucide-trash-2--light text-alert size-4"></span>
+                </button>
+              </div>
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+              <span
+                :if={metric.built_in}
+                title="A count only goes bad high"
+                class="text-base-500 flex size-9 shrink-0 items-center justify-center font-mono text-lg"
+              >
+                ≥
+              </span>
+              <.operator_flip
+                :if={!metric.built_in}
+                target={"metric-#{metric.id}"}
+                operator={shown_operator(@pending_operators, "metric-#{metric.id}", metric.operator)}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+              <.level_fields
+                level="warning"
+                threshold={metric.warning_threshold}
+                period_seconds={metric.warning_period_seconds}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+              <.level_fields
+                level="alert"
+                threshold={metric.alert_threshold}
+                period_seconds={metric.alert_period_seconds}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+            </div>
+          </form>
+
+          <form
+            id={"add-metric-#{profile.id}"}
+            phx-submit="add-metric"
+            phx-change="suggest-thresholds"
+            class="border-base-700 mt-2 flex flex-col gap-3 rounded border border-dashed p-3"
+          >
+            <input type="hidden" name="profile_id" value={profile.id} />
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <select
+                name="metric[key]"
+                required
+                disabled={!authorized?(:"product:update", @current_scope)}
+                class="bg-base-900 border-base-600 focus:border-base-400 text-base-400 block w-64 rounded border px-2 py-1 focus:ring-0 sm:text-sm"
+              >
+                <option value="">Add a metric...</option>
+                {Phoenix.HTML.Form.options_for_select(metric_options(assigns, profile), nil)}
+              </select>
+              <div class="flex items-center gap-3">
+                <label class="text-base-400 flex items-center gap-2 text-xs" title="Featured metrics are shown at the top of the device details page">
+                  <input type="hidden" name="metric[featured]" value="false" />
+                  <input
+                    type="checkbox"
+                    name="metric[featured]"
+                    value="true"
+                    disabled={!authorized?(:"product:update", @current_scope)}
+                    class="border-base-700 checked:bg-primary text-base-400 rounded focus:ring-0"
+                  /> Featured
+                </label>
+                <.button style="secondary" type="submit" disabled={!authorized?(:"product:update", @current_scope)}>
+                  Add
+                </.button>
+              </div>
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+              <.operator_flip
+                target={"new-#{profile.id}"}
+                operator={shown_operator(@pending_operators, "new-#{profile.id}", :gte)}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+              <.level_fields
+                level="warning"
+                threshold={suggested_threshold(assigns, "new-#{profile.id}", :warning)}
+                period_seconds={3600}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+              <.level_fields
+                level="alert"
+                threshold={suggested_threshold(assigns, "new-#{profile.id}", :alert)}
+                period_seconds={3600}
+                disabled={!authorized?(:"product:update", @current_scope)}
+              />
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
+        <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
+          <div class="text-base-50 text-base font-medium">Add a platform profile</div>
+        </div>
+        <div class="flex flex-col gap-3 p-6">
+          <p class="w-2/3 text-sm">
+            A platform profile starts as a copy of the default profile and overrides it for devices on that platform. Platforms are
+            taken from the firmware uploaded to this product.
+          </p>
+          <form :if={@available_platforms != []} phx-submit="create-platform-profile" class="flex items-center gap-3">
+            <select
+              name="platform"
+              required
+              disabled={!authorized?(:"product:update", @current_scope)}
+              class="bg-base-900 border-base-600 focus:border-base-400 text-base-400 block w-64 rounded border px-2 py-1 focus:ring-0 sm:text-sm"
+            >
+              <option value="">Choose a platform...</option>
+              {Phoenix.HTML.Form.options_for_select(@available_platforms, nil)}
+            </select>
+            <.button style="secondary" type="submit" disabled={!authorized?(:"product:update", @current_scope)}>
+              Create profile
+            </.button>
+          </form>
+          <p :if={@available_platforms == []} class="text-base-400 text-sm">
+            Every platform seen in this product's firmware already has a profile, or no firmware has been uploaded yet.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</NervesHubWeb.Layouts.sidebar>

--- a/lib/nerves_hub_web/live/product/health_profiles.html.heex
+++ b/lib/nerves_hub_web/live/product/health_profiles.html.heex
@@ -1,7 +1,21 @@
 <NervesHubWeb.Layouts.sidebar flash={@flash} current_scope={@current_scope} sidebar_tab={@sidebar_tab}>
   <:header>
-    <h1 class="text-base-50 text-xl leading-[30px] font-semibold">Health Profiles</h1>
+    <h1 class="text-base-50 text-xl leading-[30px] font-semibold">Product Settings</h1>
   </:header>
+
+  <%!-- Separate LiveViews rather than actions of one, so these navigate. --%>
+  <:tabbed_nav
+    path={~p"/org/#{@current_scope.org}/#{@current_scope.product}/settings"}
+    selected={@tab == :general}
+    navigate={true}
+    label="General"
+  />
+  <:tabbed_nav
+    path={~p"/org/#{@current_scope.org}/#{@current_scope.product}/settings/health"}
+    selected={@tab == :health}
+    navigate={true}
+    label="Device Health"
+  />
 
   <div class="h-0 flex-1 overflow-y-auto">
     <div class="flex flex-col items-start justify-between gap-4 p-6">

--- a/lib/nerves_hub_web/live/product/insights.ex
+++ b/lib/nerves_hub_web/live/product/insights.ex
@@ -20,6 +20,7 @@ defmodule NervesHubWeb.Live.Product.Insights do
     |> fleet_health_information()
     |> assign_notifications()
     |> maybe_assign_flapping_connections()
+    |> maybe_assign_flapping_health()
     |> assign(:page_title, "#{scope.product.name} Insights")
     |> sidebar_tab(:insights)
     |> ok()
@@ -137,6 +138,16 @@ defmodule NervesHubWeb.Live.Product.Insights do
     case DateTime.now(time_zone) do
       {:ok, now} -> {time_zone, now}
       {:error, _} -> {"Etc/UTC", DateTime.utc_now()}
+    end
+  end
+
+  defp maybe_assign_flapping_health(%{assigns: %{current_scope: scope}} = socket) do
+    if Application.get_env(:nerves_hub, :analytics_enabled) do
+      socket
+      |> assign(:flapping_health, Health.flapping_health(scope.product))
+      |> assign(:flapping_health_enabled, true)
+    else
+      assign(socket, :flapping_health_enabled, false)
     end
   end
 

--- a/lib/nerves_hub_web/live/product/insights.html.heex
+++ b/lib/nerves_hub_web/live/product/insights.html.heex
@@ -237,6 +237,40 @@
             </div>
           </div>
         </div>
+        <div :if={@flapping_health_enabled} class="bg-surface-raised border-base-700 shadow-device-details-content flex flex-col gap-5 rounded border p-5">
+          <div class="flex justify-between">
+            <div class="text-base-50 flex items-center leading-6 font-medium">
+              Flapping Health
+            </div>
+            <div class="relative z-20 ml-4" id="flapping-health-tooltip" phx-hook="ToolTip" data-placement="top">
+              <span class="lucide-info--light size-4" />
+              <div class="bg-surface-muted border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden w-max rounded border px-2 py-1.5 text-xs">
+                <p class="pb-2">Devices whose health has crossed into warning or unhealthy more than 5 times in the last hour.</p>
+                <p>
+                  A device sitting steadily unhealthy is not here — these are the ones <br />changing their mind, which usually means a
+                  threshold sits right where <br />the metric normally runs.
+                </p>
+                <div class="bg-surface-muted border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
+              </div>
+            </div>
+          </div>
+          <div class="divide-b-subtle flex flex-col divide-y">
+            <.link
+              :for={{device, change_count} <- @flapping_health}
+              :if={Enum.any?(@flapping_health)}
+              navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/devices/#{device.identifier}/health"}
+            >
+              <div class="group flex items-center gap-3 py-3">
+                <span class="text-content-body flex-1 font-mono text-sm group-hover:underline">{device.identifier}</span>
+                <span class="text-content-strong text-right font-mono text-sm">{change_count} p/hour</span>
+              </div>
+            </.link>
+            <div :if={Enum.empty?(@flapping_health)} class="inline-flex h-20 items-center justify-center">
+              <span class="text-content-faint font-mono">No flapping health detected</span>
+            </div>
+          </div>
+        </div>
+
         <%!-- <div class="bg-surface-raised border-base-700 shadow-device-details-content flex h-[132px] flex-col rounded border">
           <div class="text-base-50 flex h-14 items-center pr-3 pl-4 leading-6 font-medium">
             Device Alarms

--- a/lib/nerves_hub_web/live/product/settings.ex
+++ b/lib/nerves_hub_web/live/product/settings.ex
@@ -46,6 +46,7 @@ defmodule NervesHubWeb.Live.Product.Settings do
       socket
       |> assign(:page_title, "#{product.name} Settings")
       |> sidebar_tab(:settings)
+      |> assign(:tab, :general)
       |> assign(:product, product)
       |> assign(:shared_secrets, product.shared_secret_auths)
       |> assign(:shared_auth_enabled, DeviceLink.shared_secrets_enabled?())

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -63,6 +63,21 @@
 
       <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
         <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
+          <div class="text-base-50 text-base font-medium">Device Health</div>
+          <.button type="link" style="secondary" navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/settings/health"}>
+            Manage health profiles
+          </.button>
+        </div>
+        <div class="flex flex-col gap-3 p-6">
+          <p class="w-2/3 text-sm">
+            Health profiles set the thresholds that decide when a device counts as unhealthy — per product, or per platform when
+            hardware differences call for different values.
+          </p>
+        </div>
+      </div>
+
+      <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
+        <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
           <div class="text-base-50 text-base font-medium">Firmware</div>
         </div>
 

--- a/lib/nerves_hub_web/live/product/settings.html.heex
+++ b/lib/nerves_hub_web/live/product/settings.html.heex
@@ -3,6 +3,20 @@
     <h1 class="text-base-50 text-xl leading-[30px] font-semibold">Product Settings</h1>
   </:header>
 
+  <%!-- Separate LiveViews rather than actions of one, so these navigate. --%>
+  <:tabbed_nav
+    path={~p"/org/#{@current_scope.org}/#{@current_scope.product}/settings"}
+    selected={@tab == :general}
+    navigate={true}
+    label="General"
+  />
+  <:tabbed_nav
+    path={~p"/org/#{@current_scope.org}/#{@current_scope.product}/settings/health"}
+    selected={@tab == :health}
+    navigate={true}
+    label="Device Health"
+  />
+
   <div class="h-0 flex-1 overflow-y-auto">
     <div class="flex flex-col items-start justify-between gap-4 p-6">
       <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
@@ -58,21 +72,6 @@
               </div>
             </div>
           </div>
-        </div>
-      </div>
-
-      <div class="bg-surface-raised border-base-700 flex w-full flex-col rounded border">
-        <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
-          <div class="text-base-50 text-base font-medium">Device Health</div>
-          <.button type="link" style="secondary" navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/settings/health"}>
-            Manage health profiles
-          </.button>
-        </div>
-        <div class="flex flex-col gap-3 p-6">
-          <p class="w-2/3 text-sm">
-            Health profiles set the thresholds that decide when a device counts as unhealthy — per product, or per platform when
-            hardware differences call for different values.
-          </p>
         </div>
       </div>
 

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -16,6 +16,7 @@ defmodule NervesHubWeb.Router do
   alias Live.Orgs.New
   alias Live.Product.ErrorGroup
   alias Live.Product.Errors
+  alias Live.Product.HealthProfiles
   alias Live.Product.Insights
   alias Live.Product.Notifications
   alias Live.SupportScripts.Edit
@@ -438,6 +439,7 @@ defmodule NervesHubWeb.Router do
       live("/org/:org_name/:product_name/notifications", Notifications)
 
       live("/org/:org_name/:product_name/settings", Live.Product.Settings)
+      live("/org/:org_name/:product_name/settings/health", HealthProfiles)
     end
   end
 

--- a/priv/analytics_repo/migrations/20260906010000_add_device_health_history_table.exs
+++ b/priv/analytics_repo/migrations/20260906010000_add_device_health_history_table.exs
@@ -1,0 +1,43 @@
+defmodule NervesHub.AnalyticsRepo.Migrations.AddDeviceHealthHistoryTable do
+  use Ecto.Migration
+
+  def change() do
+    options = [
+      partition_by: "toDate(timestamp)",
+      # A device's health timeline is the read: "this device, in order" gives
+      # the transitions, and how long a level held is the gap to the next row.
+      # Product leads because every read is product-scoped, as with
+      # `device_metrics` and `device_alarm_history`.
+      order_by: "(product_id, device_id, timestamp)",
+      # Matching `device_alarm_history` rather than the thirty days
+      # `device_metrics` keeps. Only transitions are written, so a quarter of
+      # health history costs less than a day of readings — and outliving the
+      # readings is the point: past the metrics TTL this table is the only
+      # thing that can still say what a device's status was.
+      ttl: "toDateTime(timestamp) + toIntervalDay(90)"
+    ]
+
+    create table(:device_health_history,
+             primary_key: false,
+             engine: "MergeTree",
+             options: options
+           ) do
+      add(:timestamp, :"DateTime64(6, 'UTC')")
+
+      add(:org_id, :UInt64)
+      add(:product_id, :UInt64)
+      add(:device_id, :UInt64)
+
+      # "unknown", "healthy", "warning" or "unhealthy" — four values for the
+      # life of the table, which is what LowCardinality is for.
+      add(:status, :"LowCardinality(String)")
+
+      # The engaged levels and what engaged them, as the JSON stored on
+      # `device_health.status_reasons`; empty when no level is engaged. Kept
+      # rather than recomputed because it names the threshold and period in
+      # force at the time, which is what makes a row still true after somebody
+      # edits the profile.
+      add(:status_reasons, :String)
+    end
+  end
+end

--- a/priv/repo/migrations/20260901090000_create_health_profiles.exs
+++ b/priv/repo/migrations/20260901090000_create_health_profiles.exs
@@ -1,0 +1,97 @@
+defmodule NervesHub.Repo.Migrations.CreateHealthProfiles do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  # The thresholds that were hardcoded in NervesHub.Devices.HealthStatus until
+  # now, measured over an hour (one idle-paced report). Duplicated here rather
+  # than read from the module so the migration stays frozen.
+  @default_metrics [
+    {"cpu_usage_percent", 80.0, 90.0},
+    {"disk_used_percentage", 80.0, 90.0},
+    {"load_15min", 8.0, 10.0},
+    {"mem_used_percent", 70.0, 80.0}
+  ]
+  @default_period_seconds 3600
+
+  def up() do
+    create table(:health_profiles) do
+      add(:product_id, references(:products, on_delete: :delete_all), null: false)
+      add(:platform, :string)
+
+      timestamps()
+    end
+
+    # One profile per platform, and `nulls_distinct: false` makes the NULL
+    # platform (the product default) unique per product too. Requires
+    # PostgreSQL 15+ (the README recommends 18).
+    create(
+      unique_index(:health_profiles, [:product_id, :platform],
+        name: :health_profiles_product_id_platform_index,
+        nulls_distinct: false
+      )
+    )
+
+    create table(:health_profile_metrics) do
+      add(:health_profile_id, references(:health_profiles, on_delete: :delete_all), null: false)
+      add(:key, :string, null: false)
+      add(:built_in, :boolean, null: false, default: false)
+      add(:featured, :boolean, null: false, default: false)
+      # Which direction is unhealthy: "gte" engages at or above the
+      # thresholds, "lte" at or below (frame rates go bad low).
+      add(:operator, :string, null: false, default: "gte")
+      add(:warning_threshold, :float, null: false)
+      add(:warning_period_seconds, :integer, null: false)
+      add(:alert_threshold, :float, null: false)
+      add(:alert_period_seconds, :integer, null: false)
+
+      timestamps()
+    end
+
+    create(unique_index(:health_profile_metrics, [:health_profile_id, :key]))
+
+    flush()
+
+    # Every existing product gets a default profile carrying the previously
+    # hardcoded thresholds plus a 15-minute load average at 8/10, with each
+    # metric featured. The one display change this brings to existing
+    # device-details pages: they gain a Disk tile alongside the old
+    # CPU / Memory / Load trio, since disk always had default thresholds.
+    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+
+    product_ids = repo().all(from(p in "products", where: is_nil(p.deleted_at), select: p.id))
+
+    profiles =
+      Enum.map(product_ids, fn product_id ->
+        %{product_id: product_id, platform: nil, inserted_at: now, updated_at: now}
+      end)
+
+    if profiles != [] do
+      {_count, profile_rows} = repo().insert_all("health_profiles", profiles, returning: [:id])
+
+      metrics =
+        for %{id: profile_id} <- profile_rows, {key, warning, alert} <- @default_metrics do
+          %{
+            health_profile_id: profile_id,
+            key: key,
+            built_in: false,
+            featured: true,
+            operator: "gte",
+            warning_threshold: warning,
+            warning_period_seconds: @default_period_seconds,
+            alert_threshold: alert,
+            alert_period_seconds: @default_period_seconds,
+            inserted_at: now,
+            updated_at: now
+          }
+        end
+
+      repo().insert_all("health_profile_metrics", metrics)
+    end
+  end
+
+  def down() do
+    drop(table(:health_profile_metrics))
+    drop(table(:health_profiles))
+  end
+end

--- a/test/nerves_hub/devices/device_health_history_test.exs
+++ b/test/nerves_hub/devices/device_health_history_test.exs
@@ -9,6 +9,7 @@ defmodule NervesHub.Devices.DeviceHealthHistoryTest do
   alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Devices.DeviceHealthHistory
   alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Devices.Health
   alias NervesHub.Devices.HealthEvaluation
   alias NervesHub.Devices.Metrics
   alias NervesHub.Fixtures
@@ -39,7 +40,7 @@ defmodule NervesHub.Devices.DeviceHealthHistoryTest do
       firmware_metadata: device.firmware_metadata
     }
 
-    {:ok, %{org: org, product: product, device: device, device_info: device_info}}
+    {:ok, %{org: org, product: product, firmware: firmware, device: device, device_info: device_info}}
   end
 
   # Readings land the way production writes them, flushed so the judgement
@@ -136,6 +137,84 @@ defmodule NervesHub.Devices.DeviceHealthHistoryTest do
       end
 
       assert ["healthy", "warning", "unhealthy", "healthy"] = Enum.map(history(device), & &1.status)
+    end
+  end
+
+  describe "flapping_health/1" do
+    # Straight into the history, so what is under test is the read rather than
+    # a long march of readings through the judgement.
+    defp record(device, status, minutes_ago) do
+      Buffer.insert(
+        DeviceHealthHistory,
+        DeviceHealthHistory.changeset(%{
+          timestamp: DateTime.add(DateTime.utc_now(), -minutes_ago, :minute),
+          org_id: device.org_id,
+          product_id: device.product_id,
+          device_id: device.id,
+          status: status,
+          status_reasons: ""
+        })
+      )
+    end
+
+    defp flapping(product) do
+      :ok = Buffer.flush(DeviceHealthHistory)
+      Health.flapping_health(product)
+    end
+
+    test "lists devices with more than five engaged verdicts in the last hour", %{
+      product: product,
+      device: device
+    } do
+      for _ <- 1..6, do: record(device, "warning", 10)
+
+      assert [{listed, 6}] = flapping(product)
+      assert listed.id == device.id
+    end
+
+    test "five is not yet flapping", %{product: product, device: device} do
+      for _ <- 1..5, do: record(device, "warning", 10)
+
+      assert flapping(product) == []
+    end
+
+    test "settling back to healthy is not counted", %{product: product, device: device} do
+      for _ <- 1..4, do: record(device, "unhealthy", 10)
+      for _ <- 1..4, do: record(device, "healthy", 10)
+
+      assert flapping(product) == []
+    end
+
+    test "warning and unhealthy count together", %{product: product, device: device} do
+      for _ <- 1..3, do: record(device, "warning", 10)
+      for _ <- 1..3, do: record(device, "unhealthy", 10)
+
+      assert [{_device, 6}] = flapping(product)
+    end
+
+    test "transitions older than an hour do not count", %{product: product, device: device} do
+      for _ <- 1..6, do: record(device, "warning", 90)
+
+      assert flapping(product) == []
+    end
+
+    test "the worst come first, capped at ten", %{org: org, product: product, firmware: firmware, device: device} do
+      devices =
+        for n <- 1..11 do
+          other = Fixtures.device_fixture(org, product, firmware, %{identifier: "flapper-#{n}"})
+          for _ <- 1..(5 + n), do: record(other, "warning", 10)
+          other
+        end
+
+      for _ <- 1..6, do: record(device, "warning", 10)
+
+      listed = flapping(product)
+
+      assert length(listed) == 10
+      assert [{first, 16} | _] = listed
+      assert first.id == List.last(devices).id
+      # The busiest ten crowd out the six-count device entirely.
+      refute device.id in Enum.map(listed, fn {d, _} -> d.id end)
     end
   end
 

--- a/test/nerves_hub/devices/device_health_history_test.exs
+++ b/test/nerves_hub/devices/device_health_history_test.exs
@@ -1,0 +1,157 @@
+defmodule NervesHub.Devices.DeviceHealthHistoryTest do
+  # Not async: reads and writes the AnalyticsRepo (ClickHouse), which no
+  # sandbox rolls back.
+  use NervesHub.DataCase, async: false
+
+  alias NervesHub.Analytics.Buffer
+  alias NervesHub.AnalyticsRepo
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices.DeviceHealth
+  alias NervesHub.Devices.DeviceHealthHistory
+  alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Devices.HealthEvaluation
+  alias NervesHub.Devices.Metrics
+  alias NervesHub.Fixtures
+  alias NervesHub.Products.HealthProfiles
+
+  setup %{tmp_dir: tmp_dir} do
+    for table <- ["device_metrics", "device_health_history"] do
+      AnalyticsRepo.query!("TRUNCATE TABLE #{table}")
+    end
+
+    on_exit(fn ->
+      for table <- ["device_metrics", "device_health_history"] do
+        AnalyticsRepo.query!("TRUNCATE TABLE #{table}")
+      end
+    end)
+
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    device_info = %{
+      device_id: device.id,
+      product_id: device.product_id,
+      org_id: device.org_id,
+      firmware_metadata: device.firmware_metadata
+    }
+
+    {:ok, %{org: org, product: product, device: device, device_info: device_info}}
+  end
+
+  # Readings land the way production writes them, flushed so the judgement
+  # reads them back rather than only counting them in hand.
+  defp store_reading(device, key, value) do
+    device_info = %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id
+    }
+
+    {:ok, 1} = Metrics.record(device_info, %{key => value})
+    :ok = Buffer.flush(DeviceMetric)
+  end
+
+  defp history(device) do
+    :ok = Buffer.flush(DeviceHealthHistory)
+
+    DeviceHealthHistory
+    |> where(device_id: ^device.id)
+    |> order_by([h], asc: h.timestamp)
+    |> AnalyticsRepo.all()
+  end
+
+  defp reading(key, value), do: [{key, DateTime.utc_now(), value}]
+
+  describe "recording transitions" do
+    test "a device's first verdict is recorded", %{org: org, product: product, device: device, device_info: info} do
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 20.0))
+
+      assert [row] = history(device)
+      assert row.status == "healthy"
+      assert row.status_reasons == ""
+      assert row.device_id == device.id
+      assert row.product_id == product.id
+      assert row.org_id == org.id
+    end
+
+    test "the row carries the moment the verdict was stored", %{device: device, device_info: info} do
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 20.0))
+
+      assert [row] = history(device)
+      stored = Repo.get_by(DeviceHealth, device_id: device.id)
+
+      assert DateTime.diff(row.timestamp, stored.updated_at, :millisecond) == 0
+    end
+
+    test "a verdict that has not moved records nothing further", %{device: device, device_info: info} do
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 20.0))
+      store_reading(device, "cpu_usage_percent", 20.0)
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 21.0))
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 22.0))
+
+      assert [%{status: "healthy"}] = history(device)
+    end
+
+    test "a move to unhealthy records the reasons that engaged it", %{device: device, device_info: info} do
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 20.0))
+
+      # Enough breaching readings in the window to carry the majority.
+      for _ <- 1..3, do: store_reading(device, "cpu_usage_percent", 95.0)
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 95.0))
+
+      assert [%{status: "healthy"}, %{status: "unhealthy", status_reasons: reasons}] = history(device)
+
+      # Stored as JSON, naming the threshold and period in force at the time —
+      # which is what keeps the row true after somebody edits the profile.
+      assert %{"unhealthy" => %{"cpu_usage_percent" => reason}} = Jason.decode!(reasons)
+      assert reason["threshold"] == 90.0
+      assert reason["period_seconds"] == 3600
+    end
+
+    test "each further move is its own row", %{product: product, device: device, device_info: info} do
+      profile = HealthProfiles.resolve(product.id, nil)
+      cpu = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+
+      # A one-minute window, so a step's own readings are the whole window
+      # once the previous step's have been cleared out of it. Three of them
+      # each time, so the majority is carried rather than decided by a single
+      # reading.
+      {:ok, _} =
+        HealthProfiles.update_metric(cpu, %{
+          "warning_period_seconds" => "60",
+          "alert_period_seconds" => "60"
+        })
+
+      for value <- [20.0, 85.0, 95.0, 20.0] do
+        # The window has moved on: what came before is no longer in it.
+        AnalyticsRepo.query!("TRUNCATE TABLE device_metrics")
+        for _ <- 1..3, do: store_reading(device, "cpu_usage_percent", value)
+
+        :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", value))
+      end
+
+      assert ["healthy", "warning", "unhealthy", "healthy"] = Enum.map(history(device), & &1.status)
+    end
+  end
+
+  describe "without analytics" do
+    setup do
+      Application.put_env(:nerves_hub, :analytics_enabled, false)
+      on_exit(fn -> Application.put_env(:nerves_hub, :analytics_enabled, true) end)
+    end
+
+    test "nothing is recorded, and the verdict still saves", %{device: device, device_info: info} do
+      :ok = HealthEvaluation.evaluate_and_save(info, reading("cpu_usage_percent", 95.0))
+
+      # The legacy instantaneous check still ran and stored its verdict.
+      assert Repo.get_by(DeviceHealth, device_id: device.id).status == :unhealthy
+
+      assert history(device) == []
+    end
+  end
+end

--- a/test/nerves_hub/devices/health_evaluation_counting_test.exs
+++ b/test/nerves_hub/devices/health_evaluation_counting_test.exs
@@ -1,0 +1,190 @@
+defmodule NervesHub.Devices.HealthEvaluationCountingTest do
+  # The pure counting core of health evaluation: in-hand samples counted into
+  # windows, counts judged against thresholds, judgements summarized. The
+  # same semantics against stored (ClickHouse-counted) readings are pinned in
+  # `NervesHub.Devices.HealthEvaluationTest`.
+  use ExUnit.Case, async: true
+
+  alias NervesHub.Devices.HealthEvaluation
+  alias NervesHub.Products.HealthProfileMetric
+
+  # A fixed minute bucket, so windows are deterministic.
+  @now 29_805_720
+
+  defp metric(attrs \\ []) do
+    struct!(
+      %HealthProfileMetric{
+        key: "cpu",
+        built_in: false,
+        operator: :gte,
+        warning_threshold: 80.0,
+        warning_period_seconds: 3600,
+        alert_threshold: 90.0,
+        alert_period_seconds: 3600
+      },
+      attrs
+    )
+  end
+
+  # A sample `minutes_ago` whole minutes before @now.
+  defp sample(key, value, minutes_ago \\ 0) do
+    {key, DateTime.from_unix!((@now - minutes_ago) * 60), value}
+  end
+
+  defp judge(metrics, samples, now_minute \\ @now) do
+    metrics
+    |> HealthEvaluation.judge_metrics(HealthEvaluation.count_samples(metrics, samples, now_minute))
+    |> HealthEvaluation.summarize()
+  end
+
+  describe "the majority vote" do
+    test "no samples means no opinion" do
+      assert {:unknown, nil} = judge([metric()], [])
+    end
+
+    test "a single healthy sample is healthy" do
+      assert {:healthy, nil} = judge([metric()], [sample("cpu", 20.0)])
+    end
+
+    test "below half the votes nothing engages; at half it does" do
+      below_majority = [sample("cpu", 85.0), sample("cpu", 20.0), sample("cpu", 30.0)]
+      assert {:healthy, nil} = judge([metric()], below_majority)
+
+      at_majority = [sample("cpu", 85.0) | below_majority]
+      assert {:warning, reasons} = judge([metric()], at_majority)
+      assert reasons.warning["cpu"].value == 50
+    end
+
+    test "one absurd glitch reading is one vote, not a poisoned window" do
+      # A mean over this window would sit in the thousands for as long as
+      # the reading stays in it; one vote out of three engages nothing.
+      samples = [sample("cpu", 30.0, 10), sample("cpu", 17_000.0, 5), sample("cpu", 31.0)]
+
+      assert {:healthy, nil} = judge([metric()], samples)
+    end
+
+    test "an alert majority reports :unhealthy with the full reason" do
+      assert {:unhealthy, reasons} = judge([metric()], [sample("cpu", 95.0)])
+
+      assert reasons.unhealthy == %{
+               "cpu" => %{value: 100, threshold: 90.0, operator: :gte, period_seconds: 3600, aggregation: :share}
+             }
+    end
+  end
+
+  describe "windows" do
+    test "a sample outside the measurement period counts for nothing" do
+      assert {:unknown, nil} = judge([metric()], [sample("cpu", 95.0, 90)])
+    end
+
+    test "the current, still-filling minute counts" do
+      assert {:unhealthy, _} = judge([metric()], [sample("cpu", 95.0, 0)])
+    end
+
+    test "old votes age out as the judging minute advances" do
+      samples = [
+        sample("cpu", 20.0, 55),
+        sample("cpu", 20.0, 55),
+        sample("cpu", 20.0, 55),
+        sample("cpu", 85.0, 30),
+        sample("cpu", 85.0, 29)
+      ]
+
+      # Two breaching of five is short of a majority now; once the three low
+      # samples fall out of the hour window, two of two engages — with no new
+      # sample arriving. (This is why an all-clear report is not a safe
+      # reason to skip evaluation.)
+      assert {:healthy, nil} = judge([metric()], samples)
+      assert {:warning, _} = judge([metric()], samples, @now + 26)
+    end
+
+    test "warning and alert windows are separate" do
+      short_alert = metric(alert_period_seconds: 600)
+
+      # In the hour-long warning window but outside the ten-minute alert
+      # window: the sample can only engage the warning level.
+      assert {:warning, _} = judge([short_alert], [sample("cpu", 95.0, 30)])
+    end
+  end
+
+  describe "what gets counted" do
+    test "keys outside the profile and non-number values are ignored" do
+      samples = [sample("other", 100.0), sample("cpu", "hot")]
+
+      assert {:unknown, nil} = judge([metric()], samples)
+    end
+
+    test "each metric is judged on its own samples" do
+      metrics = [metric(), metric(key: "mem", warning_threshold: 70.0, alert_threshold: 80.0)]
+      samples = [sample("cpu", 85.0), sample("mem", 95.0)]
+
+      assert {:unhealthy, reasons} = judge(metrics, samples)
+      assert %{"mem" => _} = reasons.unhealthy
+      assert %{"cpu" => _} = reasons.warning
+    end
+  end
+
+  describe "a low-is-unhealthy metric" do
+    defp fps() do
+      metric(
+        key: "fps",
+        operator: :lte,
+        warning_threshold: 25.0,
+        warning_period_seconds: 3600,
+        alert_threshold: 15.0,
+        alert_period_seconds: 3600
+      )
+    end
+
+    test "engages under the thresholds, not over them" do
+      assert {:healthy, nil} = judge([fps()], [sample("fps", 30.0)])
+      assert {:warning, reasons} = judge([fps()], [sample("fps", 20.0)])
+      assert reasons.warning["fps"].operator == :lte
+
+      assert {:unhealthy, reasons} = judge([fps()], [sample("fps", 10.0)])
+      assert reasons.unhealthy["fps"].threshold == 15.0
+    end
+
+    test "the majority rule flips direction with the operator" do
+      assert {:healthy, nil} = judge([fps()], [sample("fps", 60.0), sample("fps", 0.0), sample("fps", 59.0)])
+
+      low_half = [sample("fps", 20.0), sample("fps", 60.0), sample("fps", 20.0), sample("fps", 60.0)]
+      assert {:warning, _} = judge([fps()], low_half)
+    end
+  end
+
+  describe "merge_counts/2" do
+    test "adds stored counts and in-hand counts per level" do
+      stored = %{"cpu" => %{warning: {3, 1}, alert: {3, 0}}}
+      in_hand = HealthEvaluation.count_samples([metric()], [sample("cpu", 85.0)], @now)
+
+      assert HealthEvaluation.merge_counts(stored, in_hand) ==
+               %{"cpu" => %{warning: {4, 2}, alert: {4, 0}}}
+    end
+
+    test "keys missing on either side pass through" do
+      stored = %{"cpu" => %{warning: {1, 0}, alert: {1, 0}}}
+      in_hand = %{"mem" => %{warning: {1, 1}, alert: {1, 1}}}
+
+      merged = HealthEvaluation.merge_counts(stored, in_hand)
+      assert merged["cpu"] == %{warning: {1, 0}, alert: {1, 0}}
+      assert merged["mem"] == %{warning: {1, 1}, alert: {1, 1}}
+    end
+  end
+
+  describe "summarize/1" do
+    test "alert wins over warning, healthy beats no data, reasons name every engaged metric" do
+      assert {:unknown, nil} = HealthEvaluation.summarize([:unknown, :unknown])
+      assert {:healthy, nil} = HealthEvaluation.summarize([:unknown, :healthy])
+
+      judgements = [
+        :healthy,
+        {:warning, "cpu", %{value: 50}},
+        {:unhealthy, "mem", %{value: 100}}
+      ]
+
+      assert {:unhealthy, reasons} = HealthEvaluation.summarize(judgements)
+      assert reasons == %{warning: %{"cpu" => %{value: 50}}, unhealthy: %{"mem" => %{value: 100}}}
+    end
+  end
+end

--- a/test/nerves_hub/devices/health_evaluation_test.exs
+++ b/test/nerves_hub/devices/health_evaluation_test.exs
@@ -1,0 +1,287 @@
+defmodule NervesHub.Devices.HealthEvaluationTest do
+  # Not async: the disconnects tests read/write the AnalyticsRepo (ClickHouse).
+  use NervesHub.DataCase, async: false
+
+  alias NervesHub.Analytics.Buffer
+  alias NervesHub.AnalyticsRepo
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices.DeviceConnection
+  alias NervesHub.Devices.DeviceConnectionHistory
+  alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Devices.HealthEvaluation
+  alias NervesHub.Devices.Metrics
+  alias NervesHub.Fixtures
+  alias NervesHub.Products.HealthProfile
+  alias NervesHub.Products.HealthProfileMetric
+  alias NervesHub.Products.HealthProfiles
+
+  setup %{tmp_dir: tmp_dir} do
+    AnalyticsRepo.query!("TRUNCATE TABLE device_metrics")
+    on_exit(fn -> AnalyticsRepo.query!("TRUNCATE TABLE device_metrics") end)
+
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+
+    device_info = %{
+      device_id: device.id,
+      product_id: device.product_id,
+      org_id: device.org_id,
+      firmware_metadata: device.firmware_metadata
+    }
+
+    {:ok, %{user: user, org: org, product: product, firmware: firmware, device: device, device_info: device_info}}
+  end
+
+  # Readings land in ClickHouse the way production writes them: through
+  # `Metrics.record/3`, flushed so the assertions don't race the buffer.
+  defp insert_metric(device, key, value, minutes_ago \\ 0) do
+    device_info = %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id
+    }
+
+    {:ok, 1} = Metrics.record(device_info, %{key => value}, DateTime.add(DateTime.utc_now(), -minutes_ago, :minute))
+    :ok = Buffer.flush(DeviceMetric)
+  end
+
+  describe "against the default profile" do
+    test "no samples means no opinion", %{device_info: device_info} do
+      assert {:unknown, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+
+    test "samples under every threshold are healthy", %{device: device, device_info: device_info} do
+      insert_metric(device, "cpu_usage_percent", 20.0)
+      insert_metric(device, "mem_used_percent", 30.0)
+
+      assert {:healthy, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+
+    test "a warning-level majority engages warning, with the window in the reason", %{
+      device: device,
+      device_info: device_info
+    } do
+      insert_metric(device, "cpu_usage_percent", 85.0)
+
+      assert {:warning, reasons} = HealthEvaluation.evaluate(device_info, [])
+      assert reasons.unhealthy == %{}
+
+      assert reasons.warning == %{
+               "cpu_usage_percent" => %{
+                 value: 100,
+                 threshold: 80.0,
+                 operator: :gte,
+                 period_seconds: 3600,
+                 aggregation: :share
+               }
+             }
+    end
+
+    test "an alert-level majority beats a warning elsewhere", %{device: device, device_info: device_info} do
+      insert_metric(device, "cpu_usage_percent", 85.0)
+      insert_metric(device, "mem_used_percent", 95.0)
+
+      assert {:unhealthy, reasons} = HealthEvaluation.evaluate(device_info, [])
+      assert %{"mem_used_percent" => %{threshold: 80.0}} = reasons.unhealthy
+      assert %{"cpu_usage_percent" => _} = reasons.warning
+    end
+
+    test "a single spike is one vote among many, not a trip", %{device: device, device_info: device_info} do
+      insert_metric(device, "cpu_usage_percent", 100.0, 10)
+      insert_metric(device, "cpu_usage_percent", 10.0, 5)
+      insert_metric(device, "cpu_usage_percent", 10.0)
+
+      assert {:healthy, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+
+    test "one absurd glitch reading doesn't poison the window", %{device: device, device_info: device_info} do
+      # A cheap temperature sensor catching interference: a mean over this
+      # window would sit in the thousands for as long as the reading stays
+      # in it; one vote out of three engages nothing.
+      insert_metric(device, "cpu_usage_percent", 30.0, 10)
+      insert_metric(device, "cpu_usage_percent", 17_000.0, 5)
+      insert_metric(device, "cpu_usage_percent", 31.0)
+
+      assert {:healthy, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+
+    test "samples outside the measurement period are ignored", %{device: device, device_info: device_info} do
+      insert_metric(device, "cpu_usage_percent", 100.0, 90)
+      insert_metric(device, "cpu_usage_percent", 20.0)
+
+      assert {:healthy, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+
+    test "readings still in the write buffer are judged in hand", %{device_info: device_info} do
+      # Nothing stored, nothing flushed: the sample exists only in this call.
+      in_hand = [{"cpu_usage_percent", DateTime.utc_now(), 95.0}]
+
+      assert {:unhealthy, %{unhealthy: %{"cpu_usage_percent" => %{value: 100}}}} =
+               HealthEvaluation.evaluate(device_info, in_hand)
+    end
+
+    test "metrics outside the profile do not affect the status", %{device: device, device_info: device_info} do
+      insert_metric(device, "my_custom_metric", 1_000_000.0)
+
+      assert {:unknown, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+  end
+
+  describe "a low-is-unhealthy metric" do
+    test "a dropping frame rate engages", %{product: product, device: device, device_info: device_info} do
+      {:ok, _} =
+        product.id
+        |> HealthProfiles.resolve(nil)
+        |> HealthProfiles.add_metric(%{
+          "key" => "fps",
+          "operator" => "lte",
+          "warning_threshold" => "25",
+          "warning_period_seconds" => "3600",
+          "alert_threshold" => "15",
+          "alert_period_seconds" => "3600"
+        })
+
+      insert_metric(device, "fps", 12.0)
+
+      assert {:unhealthy, reasons} = HealthEvaluation.evaluate(device_info, [])
+      assert %{"fps" => %{threshold: 15.0, operator: :lte}} = reasons.unhealthy
+    end
+  end
+
+  describe "profile resolution" do
+    test "a platform profile overrides the default for its platform", %{
+      product: product,
+      device: device,
+      device_info: device_info
+    } do
+      {:ok, profile} = HealthProfiles.create_platform_profile(product, device.firmware_metadata.platform)
+      cpu = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+      {:ok, _} = HealthProfiles.update_metric(cpu, %{"warning_threshold" => 10, "alert_threshold" => 15})
+
+      insert_metric(device, "cpu_usage_percent", 20.0)
+
+      assert {:unhealthy, reasons} = HealthEvaluation.evaluate(device_info, [])
+      assert %{"cpu_usage_percent" => %{threshold: 15.0}} = reasons.unhealthy
+    end
+
+    test "without ClickHouse there is no history to window: legacy check on the report", %{
+      device: device,
+      device_info: device_info
+    } do
+      insert_metric(device, "cpu_usage_percent", 20.0)
+
+      original = Application.get_env(:nerves_hub, :analytics_enabled)
+      Application.put_env(:nerves_hub, :analytics_enabled, false)
+      on_exit(fn -> Application.put_env(:nerves_hub, :analytics_enabled, original) end)
+
+      # The stored low readings are invisible; only the report is judged.
+      assert {:unhealthy, reasons} =
+               HealthEvaluation.evaluate(device_info, [{"cpu_usage_percent", DateTime.utc_now(), 95}])
+
+      assert %{"cpu_usage_percent" => %{value: 95, threshold: 90}} = reasons.unhealthy
+    end
+
+    test "a product without any profile falls back to the legacy instantaneous check", %{device_info: device_info} do
+      Repo.delete_all(HealthProfile)
+
+      assert {:unhealthy, reasons} =
+               HealthEvaluation.evaluate(device_info, [{"cpu_usage_percent", DateTime.utc_now(), 95}])
+
+      assert %{"cpu_usage_percent" => %{value: 95, threshold: 90}} = reasons.unhealthy
+    end
+  end
+
+  describe "the disconnects built-in" do
+    setup %{product: product} do
+      AnalyticsRepo.query!("TRUNCATE TABLE device_connection_history")
+      on_exit(fn -> AnalyticsRepo.query!("TRUNCATE TABLE device_connection_history") end)
+
+      profile = HealthProfiles.resolve(product.id, nil)
+
+      {:ok, _} =
+        HealthProfiles.add_metric(profile, %{
+          "key" => "disconnects",
+          "warning_threshold" => "3",
+          "warning_period_seconds" => "3600",
+          "alert_threshold" => "5",
+          "alert_period_seconds" => "3600"
+        })
+
+      :ok
+    end
+
+    # Each row gets a distinct `established_at`: the ReplacingMergeTree dedupes
+    # on (org_id, product_id, device_id, established_at).
+    defp insert_disconnects(device, count, minutes_ago \\ 5) do
+      base = DateTime.add(DateTime.utc_now(), -minutes_ago, :minute)
+
+      for offset <- 1..count do
+        connection = %DeviceConnection{
+          id: UUIDv7.generate(),
+          org_id: device.org_id,
+          product_id: device.product_id,
+          device_id: device.id,
+          established_at: DateTime.add(base, -offset, :second),
+          last_seen_at: base,
+          disconnected_at: base
+        }
+
+        {:ok, _} =
+          connection
+          |> DeviceConnectionHistory.from_device_connection_changeset()
+          |> AnalyticsRepo.insert()
+      end
+
+      :ok
+    end
+
+    test "enough disconnects in the window engage the levels", %{device: device, device_info: device_info} do
+      insert_disconnects(device, 4)
+
+      assert {:warning, reasons} = HealthEvaluation.evaluate(device_info, [])
+
+      assert reasons.warning == %{
+               "disconnects" => %{value: 4, threshold: 3.0, period_seconds: 3600, aggregation: :count}
+             }
+
+      insert_disconnects(device, 2, 10)
+
+      assert {:unhealthy, reasons} = HealthEvaluation.evaluate(device_info, [])
+      assert %{"disconnects" => %{value: 6}} = reasons.unhealthy
+    end
+
+    test "disconnects outside the window are ignored", %{device: device, device_info: device_info} do
+      insert_disconnects(device, 10, 90)
+
+      # Zero disconnects in the window is a real observation, so the metric
+      # counts as healthy rather than as having no opinion.
+      assert {:healthy, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+
+    test "an unknown built-in key contributes no opinion", %{product: product, device_info: device_info} do
+      profile = HealthProfiles.resolve(product.id, nil)
+
+      # A row written by a newer release that knows more built-ins.
+      %HealthProfileMetric{}
+      |> HealthProfileMetric.changeset(%{
+        health_profile_id: profile.id,
+        key: "some_future_built_in",
+        built_in: true,
+        warning_threshold: 1.0,
+        warning_period_seconds: 3600,
+        alert_threshold: 2.0,
+        alert_period_seconds: 3600
+      })
+      |> Repo.insert!()
+
+      # The unknown built-in contributes nothing; the disconnects metric from
+      # the setup still evaluates (zero disconnects -> healthy).
+      assert {:healthy, nil} = HealthEvaluation.evaluate(device_info, [])
+    end
+  end
+end

--- a/test/nerves_hub/devices/health_evaluation_test.exs
+++ b/test/nerves_hub/devices/health_evaluation_test.exs
@@ -7,13 +7,16 @@ defmodule NervesHub.Devices.HealthEvaluationTest do
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices.DeviceConnection
   alias NervesHub.Devices.DeviceConnectionHistory
+  alias NervesHub.Devices.DeviceHealth
   alias NervesHub.Devices.DeviceMetric
   alias NervesHub.Devices.HealthEvaluation
   alias NervesHub.Devices.Metrics
+  alias NervesHub.Extensions.PubSub, as: ExtensionsPubSub
   alias NervesHub.Fixtures
   alias NervesHub.Products.HealthProfile
   alias NervesHub.Products.HealthProfileMetric
   alias NervesHub.Products.HealthProfiles
+  alias Phoenix.Socket.Broadcast
 
   setup %{tmp_dir: tmp_dir} do
     AnalyticsRepo.query!("TRUNCATE TABLE device_metrics")
@@ -193,6 +196,30 @@ defmodule NervesHub.Devices.HealthEvaluationTest do
                HealthEvaluation.evaluate(device_info, [{"cpu_usage_percent", DateTime.utc_now(), 95}])
 
       assert %{"cpu_usage_percent" => %{value: 95, threshold: 90}} = reasons.unhealthy
+    end
+  end
+
+  describe "evaluate_and_save/2" do
+    test "an unchanged verdict still broadcasts, so an open page picks up the readings", %{
+      device: device,
+      device_info: device_info
+    } do
+      :ok = ExtensionsPubSub.subscribe_reports(device.id)
+
+      reading = [{"cpu_usage_percent", DateTime.utc_now(), 20.0}]
+
+      :ok = HealthEvaluation.evaluate_and_save(device_info, reading)
+      assert_receive %Broadcast{event: "health_check_report"}, 500
+      assert Repo.get_by(DeviceHealth, device_id: device.id).status == :healthy
+
+      # Same verdict, so nothing is written — but new readings arrived, and
+      # the charts and tiles on an open device page are drawn from those.
+      before = Repo.get_by(DeviceHealth, device_id: device.id)
+
+      :ok = HealthEvaluation.evaluate_and_save(device_info, reading)
+
+      assert_receive %Broadcast{event: "health_check_report"}, 500
+      assert Repo.get_by(DeviceHealth, device_id: device.id).updated_at == before.updated_at
     end
   end
 

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -1552,6 +1552,45 @@ defmodule NervesHub.DevicesTest do
       assert %{latest_health: %{status: :unhealthy}} = Devices.get_device(device.id, [:latest_health])
       assert Repo.aggregate(where(Devices.DeviceHealth, device_id: ^device.id), :count) == 1
     end
+
+    test "a report that agrees with the stored verdict writes nothing", %{device: device} do
+      verdict = %{
+        "device_id" => device.id,
+        "status" => :warning,
+        "status_reasons" => %{"warning" => %{"cpu_usage_percent" => %{"value" => 60}}}
+      }
+
+      {:ok, %{updated_at: written_at}} = Health.save_device_health(verdict)
+
+      assert {:ok, :unchanged} = Health.save_device_health(verdict)
+
+      # Untouched, not rewritten with the same values.
+      assert %{latest_health: %{updated_at: ^written_at, status: :warning}} =
+               Devices.get_device(device.id, [:latest_health])
+    end
+
+    test "a changed reason writes even when the status is the same", %{device: device} do
+      base = %{"device_id" => device.id, "status" => :warning}
+
+      {:ok, _} = Health.save_device_health(Map.put(base, "status_reasons", %{"warning" => %{"cpu" => 1}}))
+
+      assert {:ok, %Devices.DeviceHealth{}} =
+               Health.save_device_health(Map.put(base, "status_reasons", %{"warning" => %{"cpu" => 2}}))
+    end
+
+    test "moving to and from a nil reason is a change", %{device: device} do
+      {:ok, _} = Health.save_device_health(%{"device_id" => device.id, "status" => :healthy})
+
+      assert {:ok, %Devices.DeviceHealth{}} =
+               Health.save_device_health(%{
+                 "device_id" => device.id,
+                 "status" => :healthy,
+                 "status_reasons" => %{"warning" => %{"cpu" => 1}}
+               })
+
+      assert {:ok, %Devices.DeviceHealth{}} =
+               Health.save_device_health(%{"device_id" => device.id, "status" => :healthy, "status_reasons" => nil})
+    end
   end
 
   describe "update_deployment_group/2" do

--- a/test/nerves_hub/extensions/metrics_test.exs
+++ b/test/nerves_hub/extensions/metrics_test.exs
@@ -43,6 +43,35 @@ defmodule NervesHub.Extensions.MetricsTest do
     %{device: device, device_info: device_info, state: State.new(device_info)}
   end
 
+  describe "health judgement rides the batch" do
+    test "a recorded batch produces a health verdict, no health report needed", %{
+      device: device,
+      state: state
+    } do
+      now = DateTime.utc_now()
+
+      reports = [
+        %{
+          "timestamp" => DateTime.to_iso8601(DateTime.add(now, -3, :minute)),
+          "metrics" => %{"cpu_usage_percent" => 95.0}
+        },
+        %{
+          "timestamp" => DateTime.to_iso8601(DateTime.add(now, -2, :minute)),
+          "metrics" => %{"cpu_usage_percent" => 96.0}
+        },
+        %{"timestamp" => DateTime.to_iso8601(now), "metrics" => %{"cpu_usage_percent" => 20.0}}
+      ]
+
+      {_state, []} = Metrics.handle_in("report", %{"reports" => reports}, state)
+
+      # Two of three readings at or over the alert threshold: the batch's own
+      # readings are judged in hand, before any buffer flush.
+      device = Repo.preload(Repo.reload(device), :latest_health)
+      assert device.latest_health.status == :unhealthy
+      assert %{"cpu_usage_percent" => %{"value" => 67}} = device.latest_health.status_reasons["unhealthy"]
+    end
+  end
+
   describe "attaching" do
     test "asks straight away and settles into the platform interval", %{device: device, state: state} do
       {state, effects} = Metrics.attach(state)

--- a/test/nerves_hub/products/health_profiles/cache_test.exs
+++ b/test/nerves_hub/products/health_profiles/cache_test.exs
@@ -1,0 +1,123 @@
+defmodule NervesHub.Products.HealthProfiles.CacheTest do
+  # Not async: the cache is one ETS table shared by the whole node, and these
+  # tests are about what it holds.
+  use NervesHub.DataCase, async: false
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Products.HealthProfile
+  alias NervesHub.Products.HealthProfiles
+  alias NervesHub.Products.HealthProfiles.Cache
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+
+    {:ok, %{product: product}}
+  end
+
+  describe "resolving through the cache" do
+    test "a second resolve does not query", %{product: product} do
+      profile = HealthProfiles.resolve(product.id, nil)
+      assert %HealthProfile{} = profile
+
+      # Deleted behind the cache's back: a cached answer is the only way this
+      # can still come back with the profile.
+      Repo.delete_all(HealthProfile)
+
+      assert HealthProfiles.resolve(product.id, nil).id == profile.id
+    end
+
+    test "a product with no profile caches the nil too", %{product: product} do
+      Repo.delete_all(HealthProfile)
+      assert HealthProfiles.resolve(product.id, nil) == nil
+
+      # Re-created behind the cache's back; the cached nil still stands.
+      {:ok, _} = HealthProfiles.create_default_profile(product.id)
+      Cache.reset()
+      assert %HealthProfile{} = HealthProfiles.resolve(product.id, nil)
+    end
+
+    test "platform and default are cached separately", %{product: product} do
+      {:ok, _} = HealthProfiles.create_platform_profile(product, "rpi4")
+
+      assert HealthProfiles.resolve(product.id, "rpi4").platform == "rpi4"
+      assert HealthProfiles.resolve(product.id, nil).platform == nil
+      assert HealthProfiles.resolve(product.id, "rpi0").platform == nil
+    end
+  end
+
+  describe "invalidation" do
+    test "editing a metric is visible to the next resolve", %{product: product} do
+      profile = HealthProfiles.resolve(product.id, nil)
+      cpu = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+
+      {:ok, _} = HealthProfiles.update_metric(cpu, %{"warning_threshold" => "42"})
+
+      reloaded = HealthProfiles.resolve(product.id, nil)
+      assert Enum.find(reloaded.metrics, &(&1.key == "cpu_usage_percent")).warning_threshold == 42.0
+    end
+
+    test "adding and removing a metric is visible to the next resolve", %{product: product} do
+      profile = HealthProfiles.resolve(product.id, nil)
+
+      {:ok, metric} =
+        HealthProfiles.add_metric(profile, %{
+          "key" => "water_temp",
+          "warning_threshold" => "50",
+          "warning_period_seconds" => "3600",
+          "alert_threshold" => "90",
+          "alert_period_seconds" => "3600"
+        })
+
+      assert "water_temp" in Enum.map(HealthProfiles.resolve(product.id, nil).metrics, & &1.key)
+
+      :ok = HealthProfiles.delete_metric(metric)
+
+      refute "water_temp" in Enum.map(HealthProfiles.resolve(product.id, nil).metrics, & &1.key)
+    end
+
+    test "deleting a platform profile falls the platform back to the default", %{product: product} do
+      {:ok, platform_profile} = HealthProfiles.create_platform_profile(product, "rpi4")
+      assert HealthProfiles.resolve(product.id, "rpi4").platform == "rpi4"
+
+      {:ok, _} = HealthProfiles.delete_profile(platform_profile)
+
+      assert HealthProfiles.resolve(product.id, "rpi4").platform == nil
+    end
+
+    test "a failed write leaves the cache alone", %{product: product} do
+      profile = HealthProfiles.resolve(product.id, nil)
+      cpu = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+
+      # Alert below warning, with high unhealthy: rejected.
+      {:error, _changeset} = HealthProfiles.update_metric(cpu, %{"alert_threshold" => "1"})
+
+      assert HealthProfiles.resolve(product.id, nil).id == profile.id
+    end
+
+    test "only the edited product is dropped", %{product: product} do
+      other = Fixtures.product_fixture(Fixtures.user_fixture(), Fixtures.org_fixture(Fixtures.user_fixture()))
+
+      _ = HealthProfiles.resolve(other.id, nil)
+      profile = HealthProfiles.resolve(product.id, nil)
+      cpu = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+
+      {:ok, _} = HealthProfiles.update_metric(cpu, %{"warning_threshold" => "42"})
+
+      # The other product's entry survived: deleting its rows cannot change
+      # what a cached resolve answers.
+      other_id = other.id
+      Repo.delete_all(from(p in HealthProfile, where: p.product_id == ^other_id))
+
+      assert %HealthProfile{} = HealthProfiles.resolve(other.id, nil)
+    end
+  end
+
+  describe "a miss" do
+    test "computes and stores the value" do
+      assert Cache.fetch({-1, nil}, fn -> :computed end) == :computed
+      assert Cache.fetch({-1, nil}, fn -> :not_called end) == :computed
+    end
+  end
+end

--- a/test/nerves_hub/products/health_profiles_test.exs
+++ b/test/nerves_hub/products/health_profiles_test.exs
@@ -1,0 +1,308 @@
+defmodule NervesHub.Products.HealthProfilesTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Devices.Device
+  alias NervesHub.Fixtures
+  alias NervesHub.Products
+  alias NervesHub.Products.HealthProfile
+  alias NervesHub.Products.HealthProfiles
+  alias NervesHub.Products.Product
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+
+    {:ok, %{user: user, org: org, product: product}}
+  end
+
+  describe "default profile" do
+    test "creating a product creates its default profile with the default metrics", %{product: product} do
+      assert [profile] = HealthProfiles.all_for_product(product)
+      assert profile.platform == nil
+
+      assert Enum.map(profile.metrics, &{&1.key, &1.warning_threshold, &1.alert_threshold}) == [
+               {"cpu_usage_percent", 80.0, 90.0},
+               {"disk_used_percentage", 80.0, 90.0},
+               {"load_15min", 8.0, 10.0},
+               {"mem_used_percent", 70.0, 80.0}
+             ]
+
+      assert Enum.all?(profile.metrics, &(&1.warning_period_seconds == 3600 and &1.alert_period_seconds == 3600))
+      refute Enum.any?(profile.metrics, & &1.built_in)
+
+      # The starting metrics are the ones the device details page features.
+      assert Enum.all?(profile.metrics, & &1.featured)
+    end
+
+    test "the default profile cannot be deleted", %{product: product} do
+      [profile] = HealthProfiles.all_for_product(product)
+
+      assert {:error, :cannot_delete_default} = HealthProfiles.delete_profile(profile)
+      assert [_profile] = HealthProfiles.all_for_product(product)
+    end
+
+    test "a product cannot get a second default profile", %{product: product} do
+      assert {:error, changeset} = HealthProfiles.create_default_profile(product.id)
+      assert %{platform: ["already has a health profile"]} = errors_on(changeset)
+    end
+  end
+
+  describe "platform profiles" do
+    test "starts as a copy of the default profile", %{product: product} do
+      default = HealthProfiles.resolve(product.id, nil)
+      cpu = Enum.find(default.metrics, &(&1.key == "cpu_usage_percent"))
+
+      {:ok, _} =
+        HealthProfiles.update_metric(cpu, %{"warning_threshold" => 50, "alert_threshold" => 60, "featured" => "false"})
+
+      assert {:ok, profile} = HealthProfiles.create_platform_profile(product, "rpi4")
+
+      assert profile.platform == "rpi4"
+      copied = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+      assert copied.warning_threshold == 50.0
+      assert copied.alert_threshold == 60.0
+      assert copied.featured == false
+    end
+
+    test "one profile per platform", %{product: product} do
+      {:ok, _} = HealthProfiles.create_platform_profile(product, "rpi4")
+
+      assert {:error, changeset} = HealthProfiles.create_platform_profile(product, "rpi4")
+      assert %{platform: ["already has a health profile"]} = errors_on(changeset)
+    end
+
+    test "can be deleted", %{product: product} do
+      {:ok, profile} = HealthProfiles.create_platform_profile(product, "rpi4")
+
+      assert {:ok, _} = HealthProfiles.delete_profile(profile)
+      assert [%{platform: nil}] = HealthProfiles.all_for_product(product)
+    end
+  end
+
+  describe "resolve/2" do
+    test "platform profile wins over the default for its platform", %{product: product} do
+      {:ok, platform_profile} = HealthProfiles.create_platform_profile(product, "rpi4")
+
+      assert HealthProfiles.resolve(product.id, "rpi4").id == platform_profile.id
+      assert HealthProfiles.resolve(product.id, "rpi0").platform == nil
+      assert HealthProfiles.resolve(product.id, nil).platform == nil
+    end
+
+    test "nil for a product without profiles", %{product: product} do
+      Repo.delete_all(HealthProfile)
+
+      assert HealthProfiles.resolve(product.id, "rpi4") == nil
+    end
+  end
+
+  describe "profile metrics" do
+    setup %{product: product} do
+      {:ok, %{profile: HealthProfiles.resolve(product.id, nil)}}
+    end
+
+    test "adding a device-reported metric", %{profile: profile} do
+      attrs = %{
+        "key" => "cpu_temp",
+        "warning_threshold" => "70",
+        "warning_period_seconds" => "1800",
+        "alert_threshold" => "85",
+        "alert_period_seconds" => "300"
+      }
+
+      assert {:ok, metric} = HealthProfiles.add_metric(profile, attrs)
+      assert metric.built_in == false
+      assert metric.featured == false
+      assert metric.warning_threshold == 70.0
+      assert metric.alert_period_seconds == 300
+    end
+
+    test "a metric can be added as featured, and toggled later", %{profile: profile, product: product} do
+      attrs = Map.put(valid_metric_attrs("cpu_temp"), "featured", "true")
+
+      assert {:ok, metric} = HealthProfiles.add_metric(profile, attrs)
+      assert metric.featured == true
+
+      assert {:ok, metric} = HealthProfiles.update_metric(metric, %{"featured" => "false"})
+      assert metric.featured == false
+
+      # featured_keys reports the featured, non-built-in keys of the resolved profile
+      assert HealthProfiles.featured_keys(%{product_id: product.id}) |> Enum.sort() ==
+               ["cpu_usage_percent", "disk_used_percentage", "load_15min", "mem_used_percent"]
+    end
+
+    test "a built-in key is flagged from the registry, not the caller", %{profile: profile} do
+      attrs = %{
+        "key" => "disconnects",
+        # A caller cannot un-flag a built-in.
+        "built_in" => "false",
+        "warning_threshold" => "5",
+        "warning_period_seconds" => "3600",
+        "alert_threshold" => "10",
+        "alert_period_seconds" => "3600"
+      }
+
+      assert {:ok, metric} = HealthProfiles.add_metric(profile, attrs)
+      assert metric.built_in == true
+    end
+
+    test "a low-is-unhealthy metric flips the threshold ordering rule", %{profile: profile} do
+      lte = %{
+        "key" => "fps",
+        "operator" => "lte",
+        "warning_threshold" => "25",
+        "warning_period_seconds" => "3600",
+        "alert_threshold" => "15",
+        "alert_period_seconds" => "3600"
+      }
+
+      assert {:ok, metric} = HealthProfiles.add_metric(profile, lte)
+      assert metric.operator == :lte
+
+      # With low unhealthy, an alert above the warning would engage last.
+      inverted = Map.merge(lte, %{"key" => "fps2", "alert_threshold" => "30"})
+
+      assert {:error, changeset} = HealthProfiles.add_metric(profile, inverted)
+
+      assert %{alert_threshold: ["must be at or below the warning threshold when low is unhealthy"]} =
+               errors_on(changeset)
+    end
+
+    test "a built-in's operator is not the caller's to choose", %{profile: profile} do
+      attrs = %{
+        "key" => "disconnects",
+        "operator" => "lte",
+        "warning_threshold" => "3",
+        "warning_period_seconds" => "3600",
+        "alert_threshold" => "5",
+        "alert_period_seconds" => "3600"
+      }
+
+      assert {:ok, metric} = HealthProfiles.add_metric(profile, attrs)
+      assert metric.operator == :gte
+
+      assert {:ok, metric} = HealthProfiles.update_metric(metric, %{"operator" => "lte"})
+      assert metric.operator == :gte
+    end
+
+    test "a key can only appear once per profile", %{profile: profile} do
+      attrs = valid_metric_attrs("cpu_temp")
+
+      assert {:ok, _} = HealthProfiles.add_metric(profile, attrs)
+      assert {:error, changeset} = HealthProfiles.add_metric(profile, attrs)
+      assert %{key: ["is already in this profile"]} = errors_on(changeset)
+    end
+
+    test "the alert threshold cannot sit below the warning threshold", %{profile: profile} do
+      attrs = Map.merge(valid_metric_attrs("cpu_temp"), %{"warning_threshold" => "80", "alert_threshold" => "70"})
+
+      assert {:error, changeset} = HealthProfiles.add_metric(profile, attrs)
+      assert %{alert_threshold: [error]} = errors_on(changeset)
+      assert error =~ "warning threshold"
+    end
+
+    test "measurement periods stay between 1 minute and 24 hours", %{profile: profile} do
+      over = Map.put(valid_metric_attrs("cpu_temp"), "alert_period_seconds", "#{25 * 3600}")
+
+      assert {:error, changeset} = HealthProfiles.add_metric(profile, over)
+      assert %{alert_period_seconds: ["must be between 1 minute and 24 hours"]} = errors_on(changeset)
+
+      under = Map.put(valid_metric_attrs("cpu_temp"), "warning_period_seconds", "30")
+
+      assert {:error, changeset} = HealthProfiles.add_metric(profile, under)
+      assert %{warning_period_seconds: ["must be between 1 minute and 24 hours"]} = errors_on(changeset)
+    end
+
+    test "updating cannot change the key", %{profile: profile} do
+      {:ok, metric} = HealthProfiles.add_metric(profile, valid_metric_attrs("cpu_temp"))
+
+      assert {:ok, updated} =
+               HealthProfiles.update_metric(metric, %{
+                 "key" => "other",
+                 "warning_threshold" => "10",
+                 "alert_threshold" => "20"
+               })
+
+      assert updated.key == "cpu_temp"
+      assert updated.warning_threshold == 10.0
+    end
+
+    test "deleting a metric", %{profile: profile, product: product} do
+      {:ok, metric} = HealthProfiles.add_metric(profile, valid_metric_attrs("cpu_temp"))
+
+      assert :ok = HealthProfiles.delete_metric(metric)
+
+      refute product.id
+             |> HealthProfiles.resolve(nil)
+             |> Map.fetch!(:metrics)
+             |> Enum.any?(&(&1.key == "cpu_temp"))
+    end
+  end
+
+  test "deleting a product removes its profiles", %{product: product} do
+    {:ok, _} = Products.delete_product(product)
+
+    # Soft delete: profiles stay until the product row goes, but a hard delete
+    # cascades.
+    Repo.delete_all(Device)
+    Repo.delete(%Product{id: product.id})
+
+    assert HealthProfiles.all_for_product(product) == []
+  end
+
+  describe "suggested_thresholds/1" do
+    # A history that clears every gate: over a week old, plenty of samples,
+    # quartiles 20 and 40 (IQR 20).
+    defp stats(overrides \\ []) do
+      Map.merge(
+        %{
+          min: 5.0,
+          max: 60.0,
+          q1: 20.0,
+          q3: 40.0,
+          samples: 200,
+          oldest: DateTime.add(DateTime.utc_now(), -8, :day)
+        },
+        Map.new(overrides)
+      )
+    end
+
+    test "suggests Tukey's fences in both directions" do
+      assert HealthProfiles.suggested_thresholds(stats()) == %{
+               gte: %{warning: 70.0, alert: 100.0},
+               lte: %{warning: -10.0, alert: -40.0}
+             }
+    end
+
+    test "no suggestion without stats, a week of history, enough samples, or any spread" do
+      assert HealthProfiles.suggested_thresholds(nil) == nil
+
+      six_days = DateTime.add(DateTime.utc_now(), -6, :day)
+      assert HealthProfiles.suggested_thresholds(stats(oldest: six_days)) == nil
+
+      assert HealthProfiles.suggested_thresholds(stats(samples: 99)) == nil
+
+      # Zero IQR: the fences would sit on the median, where half of all
+      # normal samples already "breach".
+      assert HealthProfiles.suggested_thresholds(stats(q1: 42.0, q3: 42.0)) == nil
+    end
+
+    test "suggestions are rounded to three significant digits" do
+      %{gte: gte} = HealthProfiles.suggested_thresholds(stats(q1: 10.111, q3: 30.333))
+      assert gte == %{warning: 60.7, alert: 91.0}
+
+      %{gte: big} = HealthProfiles.suggested_thresholds(stats(q1: 1_000_000.0, q3: 2_345_678.0))
+      assert big.warning == 4_360_000.0
+    end
+  end
+
+  defp valid_metric_attrs(key) do
+    %{
+      "key" => key,
+      "warning_threshold" => "70",
+      "warning_period_seconds" => "3600",
+      "alert_threshold" => "85",
+      "alert_period_seconds" => "3600"
+    }
+  end
+end

--- a/test/nerves_hub_web/channels/extensions_health_geo_test.exs
+++ b/test/nerves_hub_web/channels/extensions_health_geo_test.exs
@@ -2,6 +2,8 @@ defmodule NervesHubWeb.Extensions.HealthGeoTest do
   use NervesHubWeb.ChannelCase
   use DefaultMocks
 
+  alias NervesHub.Devices.DeviceHealth
+  alias NervesHub.Devices.Metrics
   alias NervesHub.Devices.PubSub
   alias NervesHub.Extensions.Geo
   alias NervesHub.Extensions.Health
@@ -52,6 +54,40 @@ defmodule NervesHubWeb.Extensions.HealthGeoTest do
   defp attach_extension(ext_channel, name) do
     push(ext_channel, "#{name}:attached", %{})
     :sys.get_state(ext_channel.channel_pid)
+  end
+
+  # ---- Product with the health extension disabled ----
+
+  describe "product with the health extension disabled" do
+    test "attaches nothing health-shaped and stores nothing", %{tmp_dir: tmp_dir} do
+      user = Fixtures.user_fixture()
+      org = Fixtures.org_fixture(user)
+      product = Fixtures.product_fixture(user, org, %{extensions: %{health: false, geo: true}})
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{version: "0.0.1", dir: tmp_dir})
+      device = Fixtures.device_fixture(org, product, firmware, %{tags: ["beta"]})
+      %{db_cert: certificate} = Fixtures.device_certificate_fixture(device)
+
+      {:ok, socket} = connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+      params = %{"device_api_version" => "2.2.0"}
+      {:ok, _, _device_channel} = subscribe_and_join(socket, DeviceChannel, "device:#{device.id}", params)
+      assert_push("extensions:get", _)
+
+      # The device offers health; the server's attach list must not take it.
+      params = Map.merge(%{"device_api_version" => "2.2.0"}, %{"health" => "0.0.1", "geo" => "0.0.1"})
+      {:ok, attach_list, ext_channel} = subscribe_and_join(socket, ExtensionsChannel, "extensions", params)
+
+      refute "health" in attach_list
+
+      # Even a rogue report from an unattached extension is refused untouched:
+      # the server replies "detach" and processes nothing.
+      ref = push(ext_channel, "health:report", %{"value" => %{"metrics" => %{"cpu_usage_percent" => 99.0}}})
+      assert_reply(ref, :error, "detach")
+
+      assert NervesHub.Repo.aggregate(DeviceHealth, :count) == 0
+      assert Metrics.get_latest_metric_set(device.id) == %{}
+    end
   end
 
   # ---- Extensions.Health ----

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -773,6 +773,37 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
     end
   end
 
+  describe "engaged health metrics" do
+    test "are pinned above the featured tiles with their reason, colored by level", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      {:ok, _} = Metrics.record(to_device_info(device), %{"cpu_usage_percent" => 93.0, "mem_used_percent" => 85.0})
+
+      # Reasons as the evaluator writes them; they come back string-keyed.
+      {:ok, _} =
+        Health.save_device_health(%{
+          "device_id" => device.id,
+          "data" => %{},
+          "status" => :unhealthy,
+          "status_reasons" => %{
+            warning: %{"mem_used_percent" => %{value: 60, threshold: 70.0, period_seconds: 3600, aggregation: :share}},
+            unhealthy: %{
+              "cpu_usage_percent" => %{value: 80, threshold: 90.0, period_seconds: 3600, aggregation: :share}
+            }
+          }
+        })
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
+      |> assert_has("h1", text: device.identifier)
+      |> assert_has("div.border-alert span", text: "at or over 90 for 80% of 1h")
+      |> assert_has("div.border-warning span", text: "at or over 70 for 60% of 1h")
+    end
+  end
+
   describe "firmware selection" do
     test "updates when new firmware is available", %{
       conn: conn,

--- a/test/nerves_hub_web/live/org/products_test.exs
+++ b/test/nerves_hub_web/live/org/products_test.exs
@@ -80,6 +80,8 @@ defmodule NervesHubWeb.Live.Org.ProductsTest do
       conn
       |> visit("/org/#{org.name}")
       |> assert_has("a", text: product.name)
+      # The counts load via assign_async and render as "—" until they arrive,
+      # so these assertions need the retry window.
       |> assert_has("span.product-connected-devices-count", text: "1", timeout: 2000)
       |> assert_has("span.product-disconnected-devices-count", text: "3", timeout: 2000)
     end

--- a/test/nerves_hub_web/live/product/health_profiles_test.exs
+++ b/test/nerves_hub_web/live/product/health_profiles_test.exs
@@ -1,0 +1,347 @@
+defmodule NervesHubWeb.Live.Product.HealthProfilesTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  alias NervesHub.Accounts.Org
+  alias NervesHub.Analytics.Buffer
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Devices.DeviceMetric
+  alias NervesHub.Devices.Metrics
+  alias NervesHub.Fixtures
+  alias NervesHub.Products.HealthProfiles
+
+  setup %{user: user, org: org, tmp_dir: tmp_dir} do
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+    {:ok, %{product: product, firmware: firmware}}
+  end
+
+  test "shows the default profile with its metrics", %{conn: conn, org: org, product: product} do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> assert_has("h1", text: "Health Profiles")
+    |> assert_has("div", text: "Default profile")
+    |> assert_has("span", text: "cpu_usage_percent")
+    |> assert_has("span", text: "mem_used_percent")
+    |> assert_has("span", text: "disk_used_percentage")
+  end
+
+  test "shows the observed value range beside metrics the fleet has reported", %{
+    conn: conn,
+    org: org,
+    product: product,
+    firmware: firmware
+  } do
+    device = Fixtures.device_fixture(NervesHub.Repo.get!(Org, product.org_id), product, firmware)
+    {:ok, _} = Metrics.record(device_info(device), %{"cpu_usage_percent" => 10.0, "fps" => 24.0})
+    {:ok, _} = Metrics.record(device_info(device), %{"cpu_usage_percent" => 40.5, "fps" => 61.0})
+    :ok = Buffer.flush(DeviceMetric)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    # Beside the configured metric's name...
+    |> assert_has("span", text: "seen 10 – 40.5")
+    # ...and in the picker for a metric not yet configured.
+    |> assert_has("option", text: "Fps — seen 24 – 61")
+  end
+
+  test "is linked from the product settings page", %{conn: conn, org: org, product: product} do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings")
+    |> click_link("Manage health profiles")
+    |> assert_path("/org/#{org.name}/#{product.name}/settings/health")
+    |> assert_has("h1", text: "Health Profiles")
+  end
+
+  test "adds a metric to the default profile", %{conn: conn, org: org, product: product} do
+    profile = HealthProfiles.resolve(product.id, nil)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      view
+      |> Phoenix.LiveViewTest.form("#add-metric-#{profile.id}", %{
+        "profile_id" => to_string(profile.id),
+        "metric" => %{
+          "key" => "cpu_temp",
+          "warning_threshold" => "70",
+          "warning_period_value" => "1",
+          "warning_period_unit" => "hours",
+          "alert_threshold" => "85",
+          "alert_period_value" => "30",
+          "alert_period_unit" => "minutes",
+          "featured" => "true"
+        }
+      })
+      |> Phoenix.LiveViewTest.render_submit()
+    end)
+    |> assert_has("div", text: "cpu_temp was added to the profile.")
+
+    metric =
+      product.id
+      |> HealthProfiles.resolve(nil)
+      |> Map.fetch!(:metrics)
+      |> Enum.find(&(&1.key == "cpu_temp"))
+
+    assert metric.warning_threshold == 70.0
+    assert metric.warning_period_seconds == 3600
+    assert metric.alert_threshold == 85.0
+    assert metric.alert_period_seconds == 1800
+    assert metric.featured == true
+  end
+
+  test "adds a low-is-unhealthy metric with the operator select", %{
+    conn: conn,
+    org: org,
+    product: product,
+    firmware: firmware
+  } do
+    # The key picker offers reported keys; report an fps sample first.
+    device = Fixtures.device_fixture(NervesHub.Repo.get!(Org, product.org_id), product, firmware)
+    {:ok, _} = Metrics.record(device_info(device), %{"fps" => 60.0})
+    :ok = Buffer.flush(DeviceMetric)
+
+    profile = HealthProfiles.resolve(product.id, nil)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      # Flip the add-form's operator to at-or-below, then submit; the flip is
+      # page state carried by the hidden input.
+      _ =
+        Phoenix.LiveViewTest.render_click(view, "flip-operator", %{"target" => "new-#{profile.id}", "operator" => "gte"})
+
+      view
+      |> Phoenix.LiveViewTest.form("#add-metric-#{profile.id}", %{
+        "profile_id" => to_string(profile.id),
+        "metric" => %{
+          "key" => "fps",
+          "warning_threshold" => "25",
+          "warning_period_value" => "1",
+          "warning_period_unit" => "hours",
+          "alert_threshold" => "15",
+          "alert_period_value" => "1",
+          "alert_period_unit" => "hours",
+          "featured" => "false"
+        }
+      })
+      |> Phoenix.LiveViewTest.render_submit()
+    end)
+    |> assert_has("div", text: "fps was added to the profile.")
+
+    metric =
+      product.id
+      |> HealthProfiles.resolve(nil)
+      |> Map.fetch!(:metrics)
+      |> Enum.find(&(&1.key == "fps"))
+
+    assert metric.operator == :lte
+  end
+
+  test "adding the disconnects built-in flags it", %{conn: conn, org: org, product: product} do
+    profile = HealthProfiles.resolve(product.id, nil)
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      view
+      |> Phoenix.LiveViewTest.form("#add-metric-#{profile.id}", %{
+        "profile_id" => to_string(profile.id),
+        "metric" => %{
+          "key" => "disconnects",
+          "warning_threshold" => "3",
+          "warning_period_value" => "1",
+          "warning_period_unit" => "hours",
+          "alert_threshold" => "6",
+          "alert_period_value" => "1",
+          "alert_period_unit" => "hours",
+          "featured" => "false"
+        }
+      })
+      |> Phoenix.LiveViewTest.render_submit()
+    end)
+    |> assert_has("div", text: "disconnects was added to the profile.")
+    |> assert_has("span", text: "built-in")
+
+    metric =
+      product.id
+      |> HealthProfiles.resolve(nil)
+      |> Map.fetch!(:metrics)
+      |> Enum.find(&(&1.key == "disconnects"))
+
+    assert metric.built_in == true
+  end
+
+  test "updates a metric's thresholds", %{conn: conn, org: org, product: product} do
+    profile = HealthProfiles.resolve(product.id, nil)
+    metric = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      view
+      |> Phoenix.LiveViewTest.form("#metric-#{metric.id}", %{
+        "profile_id" => to_string(profile.id),
+        "metric_id" => to_string(metric.id),
+        "metric" => %{
+          "warning_threshold" => "60",
+          "warning_period_value" => "30",
+          "warning_period_unit" => "minutes",
+          "alert_threshold" => "75",
+          "alert_period_value" => "1",
+          "alert_period_unit" => "hours",
+          "featured" => "false"
+        }
+      })
+      |> Phoenix.LiveViewTest.render_submit()
+    end)
+    |> assert_has("div", text: "cpu_usage_percent was updated.")
+
+    metric = NervesHub.Repo.reload(metric)
+    assert metric.warning_threshold == 60.0
+    assert metric.warning_period_seconds == 1800
+    assert metric.featured == false
+  end
+
+  test "rejects an alert threshold below the warning threshold", %{conn: conn, org: org, product: product} do
+    profile = HealthProfiles.resolve(product.id, nil)
+    metric = Enum.find(profile.metrics, &(&1.key == "cpu_usage_percent"))
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      view
+      |> Phoenix.LiveViewTest.form("#metric-#{metric.id}", %{
+        "profile_id" => to_string(profile.id),
+        "metric_id" => to_string(metric.id),
+        "metric" => %{
+          "warning_threshold" => "80",
+          "warning_period_value" => "1",
+          "warning_period_unit" => "hours",
+          "alert_threshold" => "70",
+          "alert_period_value" => "1",
+          "alert_period_unit" => "hours",
+          "featured" => "true"
+        }
+      })
+      |> Phoenix.LiveViewTest.render_submit()
+    end)
+    |> assert_has("div", text: "Could not update the metric")
+  end
+
+  test "removes a metric", %{conn: conn, org: org, product: product} do
+    profile = HealthProfiles.resolve(product.id, nil)
+    metric = Enum.find(profile.metrics, &(&1.key == "disk_used_percentage"))
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      Phoenix.LiveViewTest.render_click(view, "delete-metric", %{
+        "profile_id" => to_string(profile.id),
+        "metric_id" => to_string(metric.id)
+      })
+    end)
+    |> assert_has("div", text: "disk_used_percentage no longer affects health for this profile.")
+
+    refute product.id
+           |> HealthProfiles.resolve(nil)
+           |> Map.fetch!(:metrics)
+           |> Enum.any?(&(&1.key == "disk_used_percentage"))
+  end
+
+  test "creates and deletes a platform profile", %{conn: conn, org: org, product: product, firmware: firmware} do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      view
+      |> Phoenix.LiveViewTest.form("form[phx-submit=create-platform-profile]", %{"platform" => firmware.platform})
+      |> Phoenix.LiveViewTest.render_submit()
+    end)
+    |> assert_has("div", text: "Platform: #{firmware.platform}")
+
+    profile = HealthProfiles.resolve(product.id, firmware.platform)
+    assert profile.platform == firmware.platform
+
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> unwrap(fn view ->
+      Phoenix.LiveViewTest.render_click(view, "delete-profile", %{"profile_id" => to_string(profile.id)})
+    end)
+    |> assert_has("div", text: "health profile was deleted")
+
+    assert HealthProfiles.resolve(product.id, firmware.platform).platform == nil
+  end
+
+  describe "threshold suggestions" do
+    # Quartiles land inside flat runs of the distribution (80 tens, 80
+    # twenties, 40 thirties: q1 = 10, q3 = 20, IQR = 10), so the suggestion
+    # is deterministic whatever interpolation ClickHouse uses. Tukey's
+    # fences: gte 35 / 50, lte -5 / -20.
+    defp seed_fps_history(product, firmware, days_ago) do
+      device = Fixtures.device_fixture(NervesHub.Repo.get!(Org, product.org_id), product, firmware)
+      at = DateTime.add(DateTime.utc_now(), -days_ago, :day)
+
+      for value <- List.duplicate(10.0, 80) ++ List.duplicate(20.0, 80) ++ List.duplicate(30.0, 40) do
+        {:ok, 1} = Metrics.record(device_info(device), %{"fps" => value}, at)
+      end
+
+      :ok = Buffer.flush(DeviceMetric)
+    end
+
+    test "a week of history suggests thresholds in the picker and pre-fills the add form", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      seed_fps_history(product, firmware, 8)
+      profile = HealthProfiles.resolve(product.id, nil)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/settings/health")
+      |> assert_has("option", text: "Fps — seen 10 – 30, suggested 35 / 50")
+
+      {:ok, view, _html} = live(conn, "/org/#{org.name}/#{product.name}/settings/health")
+
+      # Picking the metric pre-fills the thresholds with the suggestion...
+      html =
+        render_change(view, "suggest-thresholds", %{
+          "_target" => ["metric", "key"],
+          "profile_id" => to_string(profile.id),
+          "metric" => %{"key" => "fps"}
+        })
+
+      assert html =~ ~s(value="35")
+      assert html =~ ~s(value="50")
+
+      # ...and flipping the operator swaps in the low-side fences.
+      html = render_click(view, "flip-operator", %{"target" => "new-#{profile.id}", "operator" => "gte"})
+      assert html =~ ~s(value="-5")
+      assert html =~ ~s(value="-20")
+    end
+
+    test "no suggestion before a full week cycle has been seen", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      seed_fps_history(product, firmware, 2)
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/settings/health")
+      |> assert_has("option", text: "Fps — seen 10 – 30")
+      |> refute_has("option", text: "suggested")
+    end
+  end
+
+  defp device_info(device) do
+    %DeviceInfo{
+      device_id: device.id,
+      device_identifier: device.identifier,
+      org_id: device.org_id,
+      product_id: device.product_id
+    }
+  end
+end

--- a/test/nerves_hub_web/live/product/health_profiles_test.exs
+++ b/test/nerves_hub_web/live/product/health_profiles_test.exs
@@ -20,7 +20,7 @@ defmodule NervesHubWeb.Live.Product.HealthProfilesTest do
   test "shows the default profile with its metrics", %{conn: conn, org: org, product: product} do
     conn
     |> visit("/org/#{org.name}/#{product.name}/settings/health")
-    |> assert_has("h1", text: "Health Profiles")
+    |> assert_has("h1", text: "Product Settings")
     |> assert_has("div", text: "Default profile")
     |> assert_has("span", text: "cpu_usage_percent")
     |> assert_has("span", text: "mem_used_percent")
@@ -46,12 +46,20 @@ defmodule NervesHubWeb.Live.Product.HealthProfilesTest do
     |> assert_has("option", text: "Fps — seen 24 – 61")
   end
 
-  test "is linked from the product settings page", %{conn: conn, org: org, product: product} do
+  test "is a tab of the product settings page", %{conn: conn, org: org, product: product} do
     conn
     |> visit("/org/#{org.name}/#{product.name}/settings")
-    |> click_link("Manage health profiles")
+    |> click_link("Device Health")
     |> assert_path("/org/#{org.name}/#{product.name}/settings/health")
-    |> assert_has("h1", text: "Health Profiles")
+    |> assert_has("div", text: "Default profile")
+  end
+
+  test "the tab leads back to the general settings", %{conn: conn, org: org, product: product} do
+    conn
+    |> visit("/org/#{org.name}/#{product.name}/settings/health")
+    |> click_link("General")
+    |> assert_path("/org/#{org.name}/#{product.name}/settings")
+    |> assert_has("div", text: "General settings")
   end
 
   test "adds a metric to the default profile", %{conn: conn, org: org, product: product} do

--- a/test/nerves_hub_web/live/product/insights_test.exs
+++ b/test/nerves_hub_web/live/product/insights_test.exs
@@ -3,6 +3,9 @@ defmodule NervesHubWeb.Live.Product.InsightsTest do
 
   import Phoenix.LiveViewTest
 
+  alias NervesHub.Analytics.Buffer
+  alias NervesHub.AnalyticsRepo
+  alias NervesHub.Devices.DeviceHealthHistory
   alias NervesHub.Devices.Health
   alias NervesHub.Fixtures
   alias NervesHub.ProductNotifications
@@ -238,6 +241,52 @@ defmodule NervesHubWeb.Live.Product.InsightsTest do
       render_click(view, "toggle-auto-refresh")
 
       assert :sys.get_state(view.pid).socket.assigns.polling_pid
+    end
+  end
+
+  describe "flapping health" do
+    setup %{org: org, product: product, firmware: firmware} do
+      AnalyticsRepo.query!("TRUNCATE TABLE device_health_history")
+      on_exit(fn -> AnalyticsRepo.query!("TRUNCATE TABLE device_health_history") end)
+
+      %{device: Fixtures.device_fixture(org, product, firmware)}
+    end
+
+    defp record_health(device, status, count) do
+      for _ <- 1..count do
+        Buffer.insert(
+          DeviceHealthHistory,
+          DeviceHealthHistory.changeset(%{
+            timestamp: DateTime.utc_now(),
+            org_id: device.org_id,
+            product_id: device.product_id,
+            device_id: device.id,
+            status: status,
+            status_reasons: ""
+          })
+        )
+      end
+
+      :ok = Buffer.flush(DeviceHealthHistory)
+    end
+
+    test "lists a device that keeps changing its mind", %{conn: conn, org: org, product: product, device: device} do
+      record_health(device, "warning", 6)
+
+      conn
+      |> visit(insights_path(org, product))
+      |> assert_has("div", text: "Flapping Health")
+      |> assert_has("span", text: device.identifier)
+      |> assert_has("span", text: "6 p/hour")
+    end
+
+    test "says so when nothing is flapping", %{conn: conn, org: org, product: product, device: device} do
+      record_health(device, "warning", 2)
+
+      conn
+      |> visit(insights_path(org, product))
+      |> assert_has("span", text: "No flapping health detected")
+      |> refute_has("span", text: device.identifier)
     end
   end
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -16,6 +16,7 @@ defmodule NervesHubWeb.ChannelCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox, as: SQLSandbox
+  alias NervesHub.Products.HealthProfiles.Cache
 
   using do
     quote do
@@ -62,6 +63,10 @@ defmodule NervesHubWeb.ChannelCase do
   setup do
     # Explicitly get a connection before each test
     :ok = SQLSandbox.checkout(NervesHub.Repo)
+
+    # The profile cache outlives the sandbox transaction that is about to be
+    # rolled back underneath it.
+    :ok = Cache.reset()
   end
 
   setup tags do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,8 @@ defmodule NervesHubWeb.ConnCase do
 
   use ExUnit.CaseTemplate
 
+  alias NervesHub.Products.HealthProfiles.Cache
+
   using do
     quote do
       use NervesHubWeb, :verified_routes
@@ -34,6 +36,10 @@ defmodule NervesHubWeb.ConnCase do
   setup tags do
     # credo:disable-for-next-line
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(NervesHub.Repo)
+
+    # The profile cache outlives the sandbox transaction that is about to be
+    # rolled back underneath it.
+    :ok = Cache.reset()
 
     if !tags[:async] do
       # credo:disable-for-next-line
@@ -62,6 +68,7 @@ defmodule NervesHubWeb.APIConnCase do
   use ExUnit.CaseTemplate
 
   alias NervesHub.Fixtures
+  alias NervesHub.Products.HealthProfiles.Cache
 
   using do
     quote do
@@ -94,6 +101,10 @@ defmodule NervesHubWeb.APIConnCase do
   setup tags do
     # credo:disable-for-next-line
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(NervesHub.Repo)
+
+    # The profile cache outlives the sandbox transaction that is about to be
+    # rolled back underneath it.
+    :ok = Cache.reset()
 
     if !tags[:async] do
       # credo:disable-for-next-line
@@ -144,6 +155,8 @@ defmodule NervesHubWeb.DeviceConnCase do
 
   use ExUnit.CaseTemplate
 
+  alias NervesHub.Products.HealthProfiles.Cache
+
   using do
     quote do
       use NervesHubWeb, :verified_routes
@@ -163,6 +176,10 @@ defmodule NervesHubWeb.DeviceConnCase do
   setup tags do
     # credo:disable-for-next-line
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(NervesHub.Repo)
+
+    # The profile cache outlives the sandbox transaction that is about to be
+    # rolled back underneath it.
+    :ok = Cache.reset()
 
     if !tags[:async] do
       # credo:disable-for-next-line

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -15,6 +15,7 @@ defmodule NervesHub.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox, as: SQLSandbox
+  alias NervesHub.Products.HealthProfiles.Cache
 
   using do
     quote do
@@ -34,6 +35,10 @@ defmodule NervesHub.DataCase do
 
   setup tags do
     :ok = SQLSandbox.checkout(NervesHub.Repo)
+
+    # The profile cache outlives the sandbox transaction that is about to be
+    # rolled back underneath it.
+    :ok = Cache.reset()
 
     if !tags[:async] do
       SQLSandbox.mode(NervesHub.Repo, {:shared, self()})


### PR DESCRIPTION
Health profiles are not used for anything if you do not have the health extension enabled on a product. This entire branch is nothing in that case.

Right now it operates against the health data in Postgres, it tries quite hard to be mindful about the database and tracks some state for the math in memory as a per-node GenServer per product instead. This will be even less of a concern when health metrics move to clickhouse. Like previously it updates the information on the device so other views don't have to re-derive the state.

The feature lets you configure a profile for your device based on a health metric:

Warning level if `CPU% > 50` for `15m`.
Alert level if `CPU% > 90` for `15m`.

This dovetails nicely with Josh's work on deployment workflows which then can have custom criteria about what constitutes a healthy deployment. For the evaluation we use median, rather than average because it protects developers from a random sensor reading going from 1-200 and suddenly sending 17000 and throwing the device into alert.

Another neat thing is that the graphs can be colored according to these levels and what gets pulled to the front page dashboard becomes better.

Devices are completely unaware of this currently. I might bump the health extension protocol or break it apart, to allow passing back information so the device can know it is considered unhealthy.

Most of the code is about managing the state of things and most of that boils away later with clickhouse and becomes a single query. It isn't too hairy now, just a lot to read.

Manage profile:
<img width="3783" height="1826" alt="Screenshot_20260901_162139" src="https://github.com/user-attachments/assets/32d2083c-9d7e-4696-a8b8-28242bb2da71" />

Add new metric and add platform-specific health profile:
<img width="3331" height="672" alt="Screenshot_20260901_162157" src="https://github.com/user-attachments/assets/22b4de0d-240b-43f9-b611-7b5422009428" />

Usage of profile levels:
<img width="3345" height="1345" alt="Screenshot_20260901_162229" src="https://github.com/user-attachments/assets/828cf679-ec4c-4dcf-8c1d-b74454eb73a1" />

<img width="2236" height="1035" alt="Screenshot_20260901_162212" src="https://github.com/user-attachments/assets/ac296eaa-54c3-4eaa-a823-7d1fe7e72155" />
