### PR TITLE
Fix BadMapError when rendering a script with no created_by

### DIFF
--- a/lib/nerves_hub_web/controllers/api/script_json.ex
+++ b/lib/nerves_hub_web/controllers/api/script_json.ex
@@ -30,11 +30,17 @@ defmodule NervesHubWeb.API.ScriptJSON do
       tags: script.tags,
       inserted_at: script.inserted_at,
       updated_at: script.updated_at,
-      created_by: %{
-        id: script.created_by.id,
-        name: script.created_by.name,
-        email: script.created_by.email
-      }
+      created_by: created_by_json(script.created_by)
+    }
+  end
+
+  defp created_by_json(nil), do: nil
+
+  defp created_by_json(user) do
+    %{
+        id: user.id,
+        name: user.name,
+        email: user.email
     }
   end
 end


### PR DESCRIPTION
Add `created_by_json/1` that pattern-matches on `nil` to render an absent `created_by` association as `nil` in the response, instead of assuming the association is always loaded. Fixes #3007