### PR TITLE
Say something when a workflow definition will not upload

### DIFF
--- a/lib/nerves_hub_web/components/deployment_group_page/settings.ex
+++ b/lib/nerves_hub_web/components/deployment_group_page/settings.ex
@@ -388,7 +388,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
 
         {:error, _reason} ->
           socket
-          |> put_flash(:error, "That file could not be read as JSON. Check it for a stray comma or bracket.")
+          |> flash(:error, "That file could not be read as JSON. Check it for a stray comma or bracket.")
           |> noreply()
       end
     else
@@ -418,7 +418,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
 
       {:error, changeset} ->
         socket
-        |> put_flash(:error, workflow_definition_error_message(changeset))
+        |> flash(:error, workflow_definition_error_message(changeset))
         |> assign(:form, to_form(changeset))
         |> noreply()
     end
@@ -511,7 +511,7 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
 
       {:error, changeset} ->
         socket
-        |> put_flash(
+        |> flash(
           :error,
           "An error occurred while updating the deployment group. Please check the form for errors."
         )
@@ -533,6 +533,15 @@ defmodule NervesHubWeb.Components.DeploymentGroupPage.Settings do
     |> put_flash(:info, "Deployment group successfully deleted")
     |> push_navigate(to: ~p"/org/#{org}/#{product}/deployment_groups")
     |> noreply()
+  end
+
+  # A flash put on a live component's own socket only ever reaches the page
+  # because a navigation carries it into the next mount. Anything that stays put
+  # has to ask the LiveView to raise it, which is what the other tabs do.
+  defp flash(socket, level, message) do
+    send(self(), {:flash, level, message})
+
+    socket
   end
 
   defp help_message_for(field) do

--- a/test/nerves_hub_web/live/deployment_groups/show/workflow_upload_test.exs
+++ b/test/nerves_hub_web/live/deployment_groups/show/workflow_upload_test.exs
@@ -1,0 +1,125 @@
+defmodule NervesHubWeb.Live.DeploymentGroups.Show.WorkflowUploadTest do
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  alias NervesHub.Fixtures
+  alias NervesHub.ManagedDeployments
+  alias NervesHub.Repo
+
+  setup %{user: user, org_key: org_key, product: product, tmp_dir: tmp_dir} do
+    firmware = Fixtures.firmware_fixture(org_key, product, %{version: "1.0.0", dir: tmp_dir})
+
+    deployment_group =
+      Fixtures.deployment_group_fixture(firmware, %{is_active: true, name: "Workflow Group", user: user})
+
+    %{deployment_group: deployment_group}
+  end
+
+  defp write(tmp_dir, name, contents) do
+    path = Path.join(tmp_dir, name)
+    File.write!(path, contents)
+    path
+  end
+
+  defp settings_path(org, product, deployment_group) do
+    "/org/#{org.name}/#{product.name}/deployment_groups/#{deployment_group.name}/settings"
+  end
+
+  @tag :tmp_dir
+  test "a definition that is not valid JSON says so", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group,
+    tmp_dir: tmp_dir
+  } do
+    # A trailing comma after the tags array: the shape of mistake a person makes
+    # writing one of these by hand.
+    path =
+      write(tmp_dir, "trailing-comma.json", """
+      {
+        "version": 1,
+        "steps": [
+          {
+            "name": "Canary",
+            "matching_conditions": {
+              "tags": ["canary"],
+            }
+          }
+        ]
+      }
+      """)
+
+    conn
+    |> visit(settings_path(org, product, deployment_group))
+    |> upload("Upload Workflow Definition", path)
+    |> assert_has("div", text: "could not be read as JSON")
+
+    refute Repo.reload(deployment_group).workflow_definition
+  end
+
+  @tag :tmp_dir
+  test "a definition the schema rejects says what is wrong", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group,
+    tmp_dir: tmp_dir
+  } do
+    path =
+      write(tmp_dir, "no-name.json", """
+      {"version": 1, "steps": [{"concurrent_updates": 5}]}
+      """)
+
+    conn
+    |> visit(settings_path(org, product, deployment_group))
+    |> upload("Upload Workflow Definition", path)
+    |> assert_has("div", text: "not valid")
+
+    refute Repo.reload(deployment_group).workflow_definition
+  end
+
+  # Driven through LiveViewTest rather than the page helper: a good upload sends
+  # the browser to the deployment group, and the helper carries on talking to the
+  # view it just navigated away from.
+  test "a valid definition is stored, and takes you to the deployment group", %{
+    conn: conn,
+    org: org,
+    product: product,
+    deployment_group: deployment_group
+  } do
+    {:ok, view, _html} = live(conn, settings_path(org, product, deployment_group))
+
+    contents = ~s({"version": 1, "steps": [{"name": "Canary", "matching_conditions": {"tags": ["canary"]}}]})
+
+    upload =
+      file_input(view, "#deployment-form", :workflow_definition, [
+        %{name: "good.json", content: contents, type: "application/json"}
+      ])
+
+    assert {:error, {:live_redirect, %{to: to}}} = render_upload(upload, "good.json")
+    assert to =~ "/deployment_groups/"
+
+    assert %{"steps" => [%{"name" => "Canary"}]} = Repo.reload(deployment_group).workflow_definition
+  end
+
+  @tag :tmp_dir
+  test "an existing definition can be removed", %{
+    conn: conn,
+    org: org,
+    product: product,
+    user: user,
+    deployment_group: deployment_group
+  } do
+    definition = %{"version" => 1, "steps" => [%{"name" => "Canary"}]}
+
+    {:ok, deployment_group} =
+      ManagedDeployments.update_deployment_group(deployment_group, %{workflow_definition: definition}, user)
+
+    conn
+    |> visit(settings_path(org, product, deployment_group))
+    |> click_link("Delete Workflow Definition")
+    |> assert_has("div", text: "removed successfully")
+
+    refute Repo.reload(deployment_group).workflow_definition
+  end
+end


### PR DESCRIPTION
Uploading a workflow definition that could not be used did nothing at all: no error, no change, no sign the file had been read. Found on production, against a definition with a trailing comma in it.

Both refusals put a flash on the component's own socket. A flash put there only reaches the page because a navigation carries it into the next mount, so the paths that navigate — a definition that uploaded, one that was deleted — looked fine, and the paths that stay put, which are all the ones with something to say, said nothing. They ask the LiveView to raise it instead, which is what the other tabs on this page already do.

The same shape, and the same silence, was already there for the deployment group form: submitting an invalid one re-rendered with no explanation. Fixed alongside, being one line and the same bug.

Covered by uploading the kinds of file a person actually produces: one with a trailing comma, and one the schema turns down. Both fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
