### PR TITLE
Send a device only the signing keys its update tool can use

### DIFF
--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -540,13 +540,18 @@ defmodule NervesHub.Accounts do
   end
 
   @doc """
-  Fetch the org's firmware signing keys for the given device.
+  Fetch the org's firmware signing keys of one scheme for the given device.
+
+  Keys of different schemes are different formats — an fwup Ed25519 key, an
+  ESP-IDF RSA key and a RAUC certificate have nothing in common — so a caller
+  always wants exactly one scheme, never the org's whole keyring.
   """
-  def fetch_firmware_signing_keys(device_id) do
+  @spec fetch_firmware_signing_keys(integer(), OrgKey.scheme()) :: [OrgKey.t()]
+  def fetch_firmware_signing_keys(device_id, scheme) do
     OrgKey
     |> join(:inner, [ok], d in assoc(ok, :org))
     |> join(:inner, [ok, o], d in assoc(o, :devices))
-    |> where([ok, o, d], d.id == ^device_id)
+    |> where([ok, o, d], d.id == ^device_id and ok.scheme == ^scheme)
     |> Repo.all()
   end
 

--- a/lib/nerves_hub/accounts/org_key.ex
+++ b/lib/nerves_hub/accounts/org_key.ex
@@ -9,6 +9,7 @@ defmodule NervesHub.Accounts.OrgKey do
   alias NervesHub.Firmwares.Firmware
 
   @type t :: %__MODULE__{}
+  @type scheme :: :ed25519 | :secure_boot_v2_rsa | :x509_certificate
 
   @required_params [:org_id, :created_by_id, :name, :key]
   @optional_params [:scheme]
@@ -70,7 +71,7 @@ defmodule NervesHub.Accounts.OrgKey do
   @doc """
   The signature schemes a key may use.
   """
-  @spec schemes() :: [:ed25519 | :secure_boot_v2_rsa, ...]
+  @spec schemes() :: [scheme(), ...]
   def schemes(), do: @schemes
 
   # `validate_change/3` only runs when `:key` changes, and it cannot see other

--- a/lib/nerves_hub/device_link.ex
+++ b/lib/nerves_hub/device_link.ex
@@ -22,6 +22,8 @@ defmodule NervesHub.DeviceLink do
   alias NervesHub.Extensions
   alias NervesHub.Extensions.Dispatch, as: ExtensionDispatch
   alias NervesHub.Firmwares
+  alias NervesHub.Firmwares.UpdateTool
+  alias NervesHub.Firmwares.UpdateTool.Fwup
   alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments
   alias NervesHub.ProductNotifications
@@ -29,8 +31,6 @@ defmodule NervesHub.DeviceLink do
   alias Phoenix.Socket.Broadcast
 
   require Logger
-
-  @public_key_types ["fwup_public_keys", "archive_public_keys"]
 
   # The device API version that introduced device-managed updates. Devices below
   # it have no handler for `update_mode` and would only log it as unknown, so it
@@ -818,22 +818,26 @@ defmodule NervesHub.DeviceLink do
     |> Map.put(:deployment_group, nil)
   end
 
+  # A device may ask for its signing keys on join. Which keys those are follows
+  # its update tool: an fwup device wants Ed25519 keys, an ESP-IDF device Secure
+  # Boot RSA keys, a RAUC device certificates. The org's keys of the other
+  # schemes are a different format entirely — a PEM handed to `fwup
+  # --public-key` can never match — so they are never sent. Archives are always
+  # fwup-signed, whatever tool the firmware uses.
   defp maybe_send_public_keys(device_info, params) do
-    signing_keys =
-      if Enum.any?(@public_key_types, fn type -> params[type] == "on_connect" end) do
-        Accounts.fetch_firmware_signing_keys(device_info.device_id)
-      else
-        []
-      end
+    tool = UpdateTool.for_device_metadata(params)
 
-    Enum.each(["fwup_public_keys", "archive_public_keys"], fn key_type ->
-      with "on_connect" <- params[key_type],
-           org_keys when is_list(org_keys) and org_keys != [] <- signing_keys do
-        broadcast(device_info, key_type, %{keys: Enum.map(org_keys, & &1.key)})
-      else
-        _ -> :ok
+    Enum.each(
+      [{"fwup_public_keys", tool.key_scheme()}, {"archive_public_keys", Fwup.key_scheme()}],
+      fn {topic, scheme} ->
+        with "on_connect" <- params[topic],
+             [_ | _] = org_keys <- Accounts.fetch_firmware_signing_keys(device_info.device_id, scheme) do
+          broadcast(device_info, topic, %{keys: Enum.map(org_keys, & &1.key)})
+        else
+          _ -> :ok
+        end
       end
-    end)
+    )
 
     :ok
   end

--- a/lib/nerves_hub/firmwares/update_tool.ex
+++ b/lib/nerves_hub/firmwares/update_tool.ex
@@ -141,6 +141,16 @@ defmodule NervesHub.Firmwares.UpdateTool do
               {:ok, OrgKey.t() | nil} | {:error, term()}
 
   @doc """
+  The `NervesHub.Accounts.OrgKey` scheme this tool's signatures verify against.
+
+  An org's keyring mixes formats — fwup Ed25519 keys, ESP-IDF Secure Boot RSA
+  keys, RAUC certificates — and only one of them means anything to a given
+  tool. This is what `c:verify_signature/2` filters on, and what decides which
+  keys a device running this tool is sent when it asks for them on join.
+  """
+  @callback key_scheme() :: OrgKey.scheme()
+
+  @doc """
   Retrieves metadata from a firmware file.
   """
   @callback get_firmware_metadata_from_file(String.t()) ::

--- a/lib/nerves_hub/firmwares/update_tool/atom_vm.ex
+++ b/lib/nerves_hub/firmwares/update_tool/atom_vm.ex
@@ -143,6 +143,9 @@ defmodule NervesHub.Firmwares.UpdateTool.AtomVM do
   def file_extension(), do: ".avm"
 
   @impl UpdateTool
+  def key_scheme(), do: :ed25519
+
+  @impl UpdateTool
   def recognises?(filepath) do
     case File.open(filepath, [:read, :binary], &IO.binread(&1, @magic_size)) do
       {:ok, @magic} -> true
@@ -180,7 +183,7 @@ defmodule NervesHub.Firmwares.UpdateTool.AtomVM do
 
   defp verify_payload(signed, <<"NH1", @signature_version::8, signature::binary-size(64)>>, keys) do
     keys
-    |> Enum.filter(&(&1.scheme == :ed25519))
+    |> Enum.filter(&(&1.scheme == key_scheme()))
     |> Enum.find(&verifies?(signed, signature, &1))
     |> case do
       nil -> {:error, :invalid_signature}

--- a/lib/nerves_hub/firmwares/update_tool/esp_idf.ex
+++ b/lib/nerves_hub/firmwares/update_tool/esp_idf.ex
@@ -127,6 +127,9 @@ defmodule NervesHub.Firmwares.UpdateTool.EspIdf do
   def file_extension(), do: ".bin"
 
   @impl UpdateTool
+  def key_scheme(), do: :secure_boot_v2_rsa
+
+  @impl UpdateTool
   def recognises?(filepath) do
     case read_header(filepath) do
       {:ok, <<@image_magic, _::binary-size(0x1F), @app_desc_magic::little-32, _::binary>>} -> true
@@ -375,7 +378,7 @@ defmodule NervesHub.Firmwares.UpdateTool.EspIdf do
   # Ed25519 key. Keys of another scheme are not candidates.
   defp match_org_key(%{version: @sig_version_rsa} = block, keys) do
     keys
-    |> Enum.filter(&(&1.scheme == :secure_boot_v2_rsa))
+    |> Enum.filter(&(&1.scheme == key_scheme()))
     |> Enum.find(&rsa_signature_valid?(block, &1))
     |> case do
       %OrgKey{} = key -> {:ok, key}

--- a/lib/nerves_hub/firmwares/update_tool/fwup.ex
+++ b/lib/nerves_hub/firmwares/update_tool/fwup.ex
@@ -29,6 +29,9 @@ defmodule NervesHub.Firmwares.UpdateTool.Fwup do
   def file_extension(), do: ".fw"
 
   @impl UpdateTool
+  def key_scheme(), do: :ed25519
+
+  @impl UpdateTool
   def recognises?(filepath) do
     # A .fw archive is a zip, so it starts with the local file header magic.
     case File.open(filepath, [:read, :binary], &IO.binread(&1, 4)) do
@@ -42,7 +45,7 @@ defmodule NervesHub.Firmwares.UpdateTool.Fwup do
     # Only Ed25519 keys are fwup keys. An org may also hold Secure Boot v2 RSA
     # keys, which are PEM and would just be handed to `fwup --verify` as a
     # multi-line argument that can never match.
-    case Enum.filter(keys, &(&1.scheme == :ed25519)) do
+    case Enum.filter(keys, &(&1.scheme == key_scheme())) do
       [] -> {:error, :no_public_keys}
       candidates -> find_signing_key(filepath, candidates)
     end

--- a/lib/nerves_hub/firmwares/update_tool/rauc.ex
+++ b/lib/nerves_hub/firmwares/update_tool/rauc.ex
@@ -142,6 +142,9 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
   def file_extension(), do: ".raucb"
 
   @impl UpdateTool
+  def key_scheme(), do: :x509_certificate
+
+  @impl UpdateTool
   def recognises?(filepath) do
     case File.open(filepath, [:read, :binary], &IO.binread(&1, 4)) do
       {:ok, @squashfs_magic} -> true
@@ -154,7 +157,7 @@ defmodule NervesHub.Firmwares.UpdateTool.Rauc do
     # Only certificates are RAUC trust anchors. An org may also hold fwup
     # Ed25519 keys and ESP secure-boot RSA keys, and handing either to
     # `openssl cms` would fail in a way that reads like a bad bundle.
-    case Enum.filter(keys, &(&1.scheme == :x509_certificate)) do
+    case Enum.filter(keys, &(&1.scheme == key_scheme())) do
       [] -> {:error, :no_public_keys}
       candidates -> find_signing_key(filepath, candidates)
     end

--- a/test/nerves_hub/accounts/accounts_test.exs
+++ b/test/nerves_hub/accounts/accounts_test.exs
@@ -125,6 +125,28 @@ defmodule NervesHub.AccountsTest do
     assert nil == Accounts.find_org_user_with_device(user2, device.id)
   end
 
+  test "fetch_firmware_signing_keys/2 returns only the org's keys of the requested scheme", %{tmp_dir: tmp_dir} do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    fwup_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+    firmware = Fixtures.firmware_fixture(fwup_key, product, %{dir: tmp_dir})
+    device = Fixtures.device_fixture(org, product, firmware)
+    esp_idf_key = Fixtures.esp_idf_key_fixture(org, user)
+
+    # Another org's keys never belong to this device, whatever their scheme.
+    other_org = Fixtures.org_fixture(user, %{name: "other-org"})
+    _ = Fixtures.org_key_fixture(other_org, user, tmp_dir)
+
+    assert [%OrgKey{id: id}] = Accounts.fetch_firmware_signing_keys(device.id, :ed25519)
+    assert id == fwup_key.id
+
+    assert [%OrgKey{id: id}] = Accounts.fetch_firmware_signing_keys(device.id, :secure_boot_v2_rsa)
+    assert id == esp_idf_key.id
+
+    assert [] = Accounts.fetch_firmware_signing_keys(device.id, :x509_certificate)
+  end
+
   describe "authenticate" do
     setup do
       user_params = %{

--- a/test/nerves_hub/firmwares/update_tool_test.exs
+++ b/test/nerves_hub/firmwares/update_tool_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHub.Firmwares.UpdateToolTest do
   use NervesHub.DataCase, async: true
 
+  alias NervesHub.Firmwares.UpdateTool
   alias NervesHub.Firmwares.UpdateTool.Fwup
   alias NervesHub.Fixtures
 
@@ -771,6 +772,17 @@ defmodule NervesHub.Firmwares.UpdateToolTest do
       # Validate Boot A having been patched to match Boot B
       assert same_fat_files?(dir, {img_a, boot_b_offset}, {img_b, boot_a_offset}, ["first"])
       assert compare_images?({img_a, root_b_offset, root_size}, {img_b, root_a_offset, root_size})
+    end
+  end
+
+  describe "key_scheme/0" do
+    test "every known tool names the scheme its verify_signature/2 filters on" do
+      assert %{
+               "fwup" => :ed25519,
+               "atomvm" => :ed25519,
+               "esp-idf" => :secure_boot_v2_rsa,
+               "rauc" => :x509_certificate
+             } == Map.new(UpdateTool.known(), fn {name, module} -> {name, module.key_scheme()} end)
     end
   end
 

--- a/test/nerves_hub_web/channels/device_channel_test.exs
+++ b/test/nerves_hub_web/channels/device_channel_test.exs
@@ -5,6 +5,8 @@ defmodule NervesHubWeb.DeviceChannelTest do
 
   import TrackerHelper
 
+  alias NervesHub.Accounts
+  alias NervesHub.Accounts.OrgKey
   alias NervesHub.AuditLogs
   alias NervesHub.DeviceEvents
   alias NervesHub.Devices.Connections
@@ -16,6 +18,7 @@ defmodule NervesHubWeb.DeviceChannelTest do
   alias NervesHub.ManagedDeployments
   alias NervesHub.Products.Notification
   alias NervesHub.Repo
+  alias NervesHub.Support.EspIdf
   alias NervesHubWeb.DeviceChannel
   alias NervesHubWeb.DeviceSocket
   alias NervesHubWeb.ExtensionsChannel
@@ -334,13 +337,44 @@ defmodule NervesHubWeb.DeviceChannelTest do
       end
 
     params = Map.put(params, "fwup_public_keys", "on_connect")
+    fwup_key = seed_other_scheme_keys(device, user)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
     {:ok, %{}, device_channel} = subscribe_and_join(socket, DeviceChannel, "device:#{device.id}", params)
 
-    assert_push("fwup_public_keys", %{keys: [_]})
+    assert_push("fwup_public_keys", %{keys: [^fwup_key]})
+
+    assert_online_and_available(device)
+    close_cleanly(device_channel)
+  end
+
+  test "the firmware keys sent follow the device's update tool", %{tmp_dir: tmp_dir} do
+    user = Fixtures.user_fixture()
+    {device, _firmware, _deployment_group} = device_fixture(user, %{identifier: "123"}, tmp_dir)
+    %{db_cert: certificate, cert: _cert} = Fixtures.device_certificate_fixture(device)
+    _fwup_key = seed_other_scheme_keys(device, user)
+    esp_idf_key = EspIdf.signing_public_key()
+
+    # What nerves-hub-link-esp32 sends on join, plus the request for keys.
+    params = %{
+      "device_api_version" => "2.2.0",
+      "update_tool" => "esp-idf",
+      "esp_idf_project_name" => "my_app",
+      "esp_idf_version" => "1.0.0",
+      "esp_idf_app_elf_sha256" => Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
+      "esp_idf_ver" => "v5.2.1",
+      "esp_idf_chip_id" => 9,
+      "fwup_public_keys" => "on_connect"
+    }
+
+    {:ok, socket} =
+      connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
+
+    {:ok, %{}, device_channel} = subscribe_and_join(socket, DeviceChannel, "device:#{device.id}", params)
+
+    assert_push("fwup_public_keys", %{keys: [^esp_idf_key]})
 
     assert_online_and_available(device)
     close_cleanly(device_channel)
@@ -360,13 +394,14 @@ defmodule NervesHubWeb.DeviceChannelTest do
       end
 
     params = Map.put(params, "archive_public_keys", "on_connect")
+    fwup_key = seed_other_scheme_keys(device, user)
 
     {:ok, socket} =
       connect(DeviceSocket, %{}, connect_info: %{peer_data: %{ssl_cert: certificate.der}})
 
     {:ok, %{}, device_channel} = subscribe_and_join(socket, DeviceChannel, "device:#{device.id}", params)
 
-    assert_push("archive_public_keys", %{keys: [_]})
+    assert_push("archive_public_keys", %{keys: [^fwup_key]})
 
     assert_online_and_available(device)
     close_cleanly(device_channel)
@@ -925,6 +960,39 @@ defmodule NervesHubWeb.DeviceChannelTest do
       )
 
     {device, firmware, deployment_group}
+  end
+
+  # Give the device's org one key of every other scheme, and return the fwup
+  # key it already has. Neither an ESP-IDF RSA key nor a RAUC certificate is
+  # something `fwup --public-key` can use, so neither may reach the device.
+  defp seed_other_scheme_keys(device, user) do
+    %OrgKey{key: fwup_key} = Repo.get_by!(OrgKey, org_id: device.org_id, scheme: :ed25519)
+
+    {:ok, _esp_idf} =
+      Accounts.create_org_key(%{
+        org_id: device.org_id,
+        created_by_id: user.id,
+        name: "esp-idf",
+        key: EspIdf.signing_public_key(),
+        scheme: :secure_boot_v2_rsa
+      })
+
+    certificate =
+      :secp256r1
+      |> X509.PrivateKey.new_ec()
+      |> X509.Certificate.self_signed("CN=rauc")
+      |> X509.Certificate.to_pem()
+
+    {:ok, _rauc} =
+      Accounts.create_org_key(%{
+        org_id: device.org_id,
+        created_by_id: user.id,
+        name: "rauc",
+        key: certificate,
+        scheme: :x509_certificate
+      })
+
+    fwup_key
   end
 
   defp archive_setup(tmp_dir) do


### PR DESCRIPTION
On join, a device that asks for `fwup_public_keys` or `archive_public_keys` was sent every key in its org, whatever the scheme. Now that an org can hold ESP-IDF Secure Boot RSA keys and RAUC certificates alongside fwup keys, a Nerves device was getting PEM blobs it handed to `fwup --public-key`, and an ESP32 or RAUC device would have been sent Ed25519 keys it can't use.

Which keys a device receives now follows its update tool.

- `UpdateTool` gains a `key_scheme/0` callback. fwup and AtomVM return `:ed25519`, ESP-IDF returns `:secure_boot_v2_rsa`, RAUC returns `:x509_certificate`. Each tool's `verify_signature/2` now filters on the callback instead of a hard-coded atom, so upload verification and the join push share one definition.
- `maybe_send_public_keys` resolves the device's tool with `UpdateTool.for_device_metadata/1`, the same way its firmware metadata is read on join. An explicit `update_tool` param wins, otherwise the metadata keys are sniffed. `fwup_public_keys` sends that tool's scheme.
- `archive_public_keys` always sends Ed25519. Archives are fwup-signed regardless of the firmware tool.
- `Accounts.fetch_firmware_signing_keys/2` takes the scheme and filters in the query.

The request topic keeps its `fwup_public_keys` name for every tool, since that is what clients already send. A tool-neutral alias would be a one-line addition to the topic list if we want one later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
