### PR TITLE
Take back the notice that a workflow stopped, once it has not

### DIFF
--- a/lib/nerves_hub/managed_deployments/workflows.ex
+++ b/lib/nerves_hub/managed_deployments/workflows.ex
@@ -35,7 +35,9 @@ defmodule NervesHub.ManagedDeployments.Workflows do
   alias NervesHub.Devices.Device
   alias NervesHub.FirmwareUpdates
   alias NervesHub.ManagedDeployments.DeploymentGroup
+  alias NervesHub.ManagedDeployments.DeploymentRelease
   alias NervesHub.ManagedDeployments.DeploymentWorkflowStep
+  alias NervesHub.ProductNotifications
   alias NervesHub.Repo
   alias Phoenix.Channel.Server, as: PhoenixChannelServer
 
@@ -339,7 +341,11 @@ defmodule NervesHub.ManagedDeployments.Workflows do
   """
   @spec approve_step(DeploymentWorkflowStep.t(), User.t()) :: DeploymentWorkflowStep.t()
   def approve_step(step, user) do
-    transition(step, approved_at: now(), approved_by_id: user.id)
+    step = transition(step, approved_at: now(), approved_by_id: user.id)
+
+    :ok = resolve_halt_notification(step)
+
+    step
   end
 
   @doc """
@@ -383,7 +389,11 @@ defmodule NervesHub.ManagedDeployments.Workflows do
     if skippable?(step) do
       _ = release_claimed_devices(step)
 
-      {:ok, transition(step, status: :skipped, skipped_at: now(), skipped_by_id: user.id)}
+      step = transition(step, status: :skipped, skipped_at: now(), skipped_by_id: user.id)
+
+      :ok = resolve_halt_notification(step)
+
+      {:ok, step}
     else
       {:error, :not_skippable}
     end
@@ -407,6 +417,8 @@ defmodule NervesHub.ManagedDeployments.Workflows do
         |> exclude(:order_by)
         |> Repo.update_all(set: [updates_blocked_until: nil, update_attempts: []])
 
+      :ok = resolve_halt_notification(step, deployment_group)
+
       Logger.info("Workflow step retried",
         deployment_id: deployment_group.id,
         step_number: step.number,
@@ -418,6 +430,34 @@ defmodule NervesHub.ManagedDeployments.Workflows do
     else
       {:error, :not_retryable}
     end
+  end
+
+  # A workflow that has stopped raises a notification, since nothing else would
+  # say so. Starting again takes it back: the list is what needs attention now,
+  # not everything that ever did.
+  defp resolve_halt_notification(step, deployment_group \\ nil)
+
+  defp resolve_halt_notification(step, nil) do
+    case deployment_group_ids(step) do
+      nil -> :ok
+      {product_id, deployment_group_id} -> resolve_halt_notification(step, {product_id, deployment_group_id})
+    end
+  end
+
+  defp resolve_halt_notification(step, %DeploymentGroup{} = deployment_group) do
+    resolve_halt_notification(step, {deployment_group.product_id, deployment_group.id})
+  end
+
+  defp resolve_halt_notification(step, {product_id, deployment_group_id}) do
+    ProductNotifications.resolve_workflow_halted_notification!(product_id, deployment_group_id, step.id)
+  end
+
+  defp deployment_group_ids(step) do
+    DeploymentRelease
+    |> where([r], r.id == ^step.deployment_release_id)
+    |> join(:inner, [r], dg in assoc(r, :deployment_group), as: :deployment_group)
+    |> select([deployment_group: dg], {dg.product_id, dg.id})
+    |> Repo.one()
   end
 
   defp release_claimed_devices(step) do

--- a/lib/nerves_hub/product_notifications.ex
+++ b/lib/nerves_hub/product_notifications.ex
@@ -235,7 +235,7 @@ defmodule NervesHub.ProductNotifications do
       },
       # Keyed to the step rather than the deployment group, so a workflow that
       # stops twice at different stages says so twice.
-      event_key: "workflow_halted-#{deployment_group.id}-#{step.id}"
+      event_key: workflow_halted_key(deployment_group.id, step.id)
     })
     |> insert_and_notify!()
   end
@@ -265,6 +265,41 @@ defmodule NervesHub.ProductNotifications do
       event_key: "too_many_metrics-#{device_info.device_identifier}"
     })
     |> insert_and_notify!()
+  end
+
+  @doc """
+  Take back the notice that a workflow had stopped.
+
+  Raised when a workflow stops and cleared when it starts again, so the list
+  reflects what needs attention now rather than everything that ever did. The
+  same key the notice was raised under finds it, whether it was raised once or
+  coalesced from several.
+  """
+  @spec resolve_workflow_halted_notification!(pos_integer(), pos_integer(), pos_integer()) :: :ok
+  def resolve_workflow_halted_notification!(product_id, deployment_group_id, step_id) do
+    resolve!(product_id, workflow_halted_key(deployment_group_id, step_id))
+  end
+
+  defp resolve!(product_id, event_key) do
+    {deleted, _} =
+      Notification
+      |> where([n], n.product_id == ^product_id and n.event_key == ^event_key)
+      |> Repo.delete_all()
+
+    if deleted > 0 do
+      _ =
+        Group.dispatch(NervesHub.Group, key(product_id), %Broadcast{
+          topic: topic(product_id),
+          event: "resolved",
+          payload: %{}
+        })
+    end
+
+    :ok
+  end
+
+  defp workflow_halted_key(deployment_group_id, step_id) do
+    "workflow_halted-#{deployment_group_id}-#{step_id}"
   end
 
   defp workflow_halted_copy(deployment_group, step, {:failed, failed_count}) do

--- a/lib/nerves_hub_web/live/product/notifications.ex
+++ b/lib/nerves_hub_web/live/product/notifications.ex
@@ -71,6 +71,14 @@ defmodule NervesHubWeb.Live.Product.Notifications do
     |> noreply()
   end
 
+  # Something that had raised a notification is no longer the case, so the list
+  # changes under the reader with nothing to announce.
+  def handle_info(%Broadcast{event: "resolved"}, socket) do
+    socket
+    |> fetch_notifications(socket.assigns.result_meta.current_page, socket.assigns.result_meta.page_size)
+    |> noreply()
+  end
+
   def handle_info(%Broadcast{event: "dismissed", payload: %{dismissed_by: %{id: user_id, name: name}}}, socket) do
     message =
       if socket.assigns.current_scope.user.id == user_id do

--- a/test/nerves_hub/managed_deployments/workflow_coordinator_test.exs
+++ b/test/nerves_hub/managed_deployments/workflow_coordinator_test.exs
@@ -680,6 +680,90 @@ defmodule NervesHub.ManagedDeployments.WorkflowCoordinatorTest do
     end
   end
 
+  describe "taking back the notice that a workflow stopped" do
+    @needs_approval %{
+      "version" => 1,
+      "steps" => [%{"name" => "Sign-off", "type" => "approval_required"}]
+    }
+
+    # The notice says a workflow needs attention. Once it has had some, it should
+    # stop saying so, or the list becomes a record of everything that ever went
+    # wrong rather than what is wrong now.
+    test "approving clears it", context do
+      %{product: product} = context
+      %{deployment_group: deployment_group, release: release} = release_with(context, @needs_approval)
+
+      _ = WorkflowCoordinator.schedule_updates(deployment_group)
+
+      assert [_notification] = product_notifications(product)
+
+      _ = Workflows.approve_step(step(release, 1), context.user)
+
+      assert product_notifications(product) == []
+    end
+
+    test "skipping clears it", context do
+      canary_device = add_device(context, %{tags: ["canary"]})
+
+      %{product: product} = context
+      %{deployment_group: deployment_group, release: release} = release_with(context, @canary_then_rest)
+
+      _ = WorkflowCoordinator.schedule_updates(deployment_group)
+      _ = fail_device(canary_device)
+      _ = WorkflowCoordinator.schedule_updates(deployment_group)
+
+      assert [_notification] = product_notifications(product)
+
+      {:ok, _} = Workflows.skip_step(step(release, 1), context.user)
+
+      assert product_notifications(product) == []
+    end
+
+    test "retrying clears it", context do
+      canary_device = add_device(context, %{tags: ["canary"]})
+
+      %{product: product} = context
+      %{deployment_group: deployment_group, release: release} = release_with(context, @canary_then_rest)
+
+      _ = WorkflowCoordinator.schedule_updates(deployment_group)
+      _ = fail_device(canary_device)
+      _ = WorkflowCoordinator.schedule_updates(deployment_group)
+
+      assert [_notification] = product_notifications(product)
+
+      {:ok, _} = Workflows.retry_step(deployment_group, step(release, 1), context.user)
+
+      assert product_notifications(product) == []
+    end
+
+    # Two stages stopping are two things to attend to, and clearing one should
+    # not clear the other.
+    test "clearing one step's notice leaves another step's alone", context do
+      %{product: product} = context
+      %{deployment_group: deployment_group, release: release} = release_with(context, @needs_approval)
+
+      approval = step(release, 1)
+      catch_all = step(release, 2)
+
+      _ = WorkflowCoordinator.schedule_updates(deployment_group)
+
+      # Stand in for the catch_all having stopped too.
+      _ =
+        NervesHub.ProductNotifications.create_workflow_halted_notification!(
+          deployment_group,
+          catch_all,
+          :awaiting_approval
+        )
+
+      assert length(product_notifications(product)) == 2
+
+      _ = Workflows.approve_step(approval, context.user)
+
+      assert [remaining] = product_notifications(product)
+      assert remaining.event_key =~ "-#{catch_all.id}"
+    end
+  end
+
   describe "announcing that a workflow has stopped" do
     test "a failed step is measured, recorded, and raised to the product", context do
       canary_device = add_device(context, %{tags: ["canary"]})


### PR DESCRIPTION
A workflow stopping raises a product notification, since nothing else would say so. Nothing took it back. Approving the step the workflow was waiting on, or retrying or skipping the one that failed, started the rollout again and left the notice standing — so the list became a record of everything that had ever needed attention rather than what needs it now. Noticed on production after approving a step.

Each of those three now clears the notice, found by the key it was raised under. Only that step's: two stages stopping are two things to attend to, and clearing one should not clear the other.

Open notification pages hear about it. The existing broadcast says all notifications were dismissed by somebody, which this is not, so a resolved one refreshes the list and says nothing — the reader did not do it, and there is nothing to tell them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
