### PR TITLE
Notify a product when a device cannot start an extension

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -63,6 +63,7 @@
     "erpc",
     "espsecure",
     "evenodd",
+    "expty",
     "extn",
     "extralight",
     "featurebase",

--- a/lib/nerves_hub/extensions/dispatch.ex
+++ b/lib/nerves_hub/extensions/dispatch.ex
@@ -19,6 +19,7 @@ defmodule NervesHub.Extensions.Dispatch do
   alias NervesHub.Extensions
   alias NervesHub.Extensions.State
   alias NervesHub.Helpers.Logging
+  alias NervesHub.ProductNotifications
 
   require Logger
 
@@ -69,6 +70,17 @@ defmodule NervesHub.Extensions.Dispatch do
           |> dispatch(key, mod, &mod.detach/1)
 
         "error" ->
+          # The device could not start it at all. Nothing else records this: the
+          # extension is detached below and the device carries on connected, so
+          # without a notification the only trace is a log line and whatever the
+          # device happened to put in its payload.
+          _ =
+            ProductNotifications.create_extension_failure_notification!(
+              device_info(extensions, key),
+              key,
+              reason(payload)
+            )
+
           extensions
           |> put_status(key, :detached)
           |> safe_dispatch(key, mod, &mod.handle_in(event, payload, &1), event)
@@ -161,6 +173,11 @@ defmodule NervesHub.Extensions.Dispatch do
       Logging.log_to_sentry(device_info(extensions, key), error)
       {:ok, extensions, []}
   end
+
+  # `nerves_hub_link` sends `%{reason: ...}`, but an older or third-party client
+  # may not, and a notification is worth having either way.
+  defp reason(%{"reason" => reason}), do: reason
+  defp reason(_payload), do: nil
 
   # Extensions speak in their own tags; callers need something they can send and
   # something they can key a timer by, without knowing which module is involved.

--- a/lib/nerves_hub/extensions/local_shell.ex
+++ b/lib/nerves_hub/extensions/local_shell.ex
@@ -15,6 +15,7 @@ defmodule NervesHub.Extensions.LocalShell do
   @behaviour NervesHub.Extensions
 
   alias NervesHub.Consoles
+  alias NervesHub.ProductNotifications
 
   require Logger
 
@@ -50,6 +51,25 @@ defmodule NervesHub.Extensions.LocalShell do
 
     {state, [{:scrollback_append, data}]}
   end
+
+  # The device answers `request_shell` with how it went. A failure here is not an
+  # attach failure -- the extension is attached, and stays attached, so the shell
+  # looks available right up until nothing happens when it is opened. That is the
+  # case this notification exists for; `:expty` missing from a device's
+  # dependencies is how it was found.
+  def handle_in("request_status", %{"status" => "failed"} = payload, state) do
+    _ =
+      ProductNotifications.create_extension_failure_notification!(
+        state.device_info,
+        "local_shell",
+        payload["reason"]
+      )
+
+    {state, []}
+  end
+
+  # A shell that started needs nothing from us, and is not an unknown message.
+  def handle_in("request_status", _payload, state), do: {state, []}
 
   def handle_in(event, params, state) do
     Logger.warning(

--- a/lib/nerves_hub/product_notifications.ex
+++ b/lib/nerves_hub/product_notifications.ex
@@ -11,6 +11,11 @@ defmodule NervesHub.ProductNotifications do
   alias NervesHub.Repo
   alias Phoenix.Socket.Broadcast
 
+  # Failure reasons arrive in a device's message payload, so they are whatever
+  # the device chose to send. Cap them before they reach a notification the UI
+  # renders, the way `DeviceTemplates` does for audit log descriptions.
+  @reason_max_length 200
+
   @spec subscribe(pos_integer()) :: :ok
   def subscribe(product_id) do
     :ok = Group.join(NervesHub.Group, key(product_id), %{})
@@ -241,6 +246,47 @@ defmodule NervesHub.ProductNotifications do
   end
 
   @doc """
+  A device could not start an extension it was asked to attach.
+
+  Both ways that can happen end up here. `NervesHub.Extensions.Dispatch` reports
+  the device failing to start the extension at all, which detaches it; an
+  extension reports a failure of its own, which does not -- the local shell
+  answering `request_shell` with a reason it has no pty is the case this was
+  written for.
+
+  Either way the extension is enabled and not working, and nothing about the
+  device says so: it stays connected, and the toggle on its settings page stays
+  on. The fix is almost always in the device's firmware, so it needs a person.
+
+  Deduplicated on the device, the extension and the reason. Including the reason
+  looks redundant next to `occurrence_count`, and is not: the conflict clause in
+  `insert_and_notify!/1` updates the count and the timestamp but not the
+  message, so a device that starts failing for a new reason would otherwise
+  keep showing the old one.
+  """
+  @spec create_extension_failure_notification!(DeviceInfo.t(), String.t(), String.t() | nil) ::
+          Notification.t()
+  def create_extension_failure_notification!(%DeviceInfo{} = device_info, extension, reason) do
+    reason = truncate_reason(reason)
+
+    %Product{id: device_info.product_id}
+    |> Notification.new_changeset(%{
+      title: "A device could not start an extension.",
+      message:
+        "The device with the identifier '#{device_info.device_identifier}' could not start the " <>
+          "'#{extension}' extension#{reason_clause(reason)}. It stays enabled in NervesHub and " <>
+          "will not work on this device until the cause is fixed, which is usually in the " <>
+          "device's firmware.",
+      level: :warning,
+      metadata: %{identifier: device_info.device_identifier, extension: extension, reason: reason},
+      # The changeset rejects spaces, and a reason is a sentence, so the reason
+      # is keyed by hash rather than by its text.
+      event_key: "extension_failure-#{extension}-#{device_info.device_identifier}-#{:erlang.phash2(reason)}"
+    })
+    |> insert_and_notify!()
+  end
+
+  @doc """
   A device reported more metrics in one report than will be stored.
 
   The report is kept, trimmed to the first `max_keys` names in sorted order --
@@ -278,6 +324,21 @@ defmodule NervesHub.ProductNotifications do
      "Step #{step.number} ('#{DeploymentWorkflowStep.label(step)}') of the workflow for deployment group '#{deployment_group.name}' needs approving before the rollout continues. No further devices will be updated for this release until it is approved or skipped.",
      :info}
   end
+
+  defp reason_clause(nil), do: ""
+  defp reason_clause(reason), do: ": #{reason}"
+
+  defp truncate_reason(nil), do: nil
+
+  defp truncate_reason(reason) when is_binary(reason) do
+    if String.length(reason) > @reason_max_length do
+      String.slice(reason, 0, @reason_max_length - 1) <> "…"
+    else
+      reason
+    end
+  end
+
+  defp truncate_reason(reason), do: truncate_reason(inspect(reason))
 
   defp insert_and_notify!(changeset) do
     conflict_query =

--- a/test/nerves_hub/extensions/dispatch_test.exs
+++ b/test/nerves_hub/extensions/dispatch_test.exs
@@ -1,0 +1,85 @@
+defmodule NervesHub.Extensions.DispatchTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.DeviceLink.DeviceInfo
+  alias NervesHub.Extensions.Dispatch
+  alias NervesHub.Fixtures
+  alias NervesHub.Products.Notification
+
+  defp product() do
+    user = Fixtures.user_fixture()
+    Fixtures.product_fixture(user, Fixtures.org_fixture(user))
+  end
+
+  defp attached(product, identifier) do
+    device_info = %DeviceInfo{
+      device_id: System.unique_integer([:positive]),
+      device_identifier: identifier,
+      org_id: product.org_id,
+      product_id: product.id,
+      allowed_extensions: [:health, :local_shell]
+    }
+
+    {attach_list, extensions} = Dispatch.join(device_info, %{"local_shell" => "0.0.1"})
+
+    assert "local_shell" in attach_list
+
+    extensions
+  end
+
+  # A device that cannot start an extension says so and carries on connected.
+  # The extension is detached here and nothing else records it, so without this
+  # the only trace is a log line on whichever node serviced the call.
+  describe "an extension the device could not start" do
+    test "is reported to the product" do
+      product = product()
+      extensions = attached(product, "cannot-start-here")
+
+      {:ok, extensions, effects} =
+        Dispatch.message(extensions, "local_shell:error", %{"reason" => "start_failure"})
+
+      assert effects == []
+      assert extensions["local_shell"].status == :detached
+
+      assert [notification] = Repo.all(Notification)
+      assert notification.level == :warning
+      assert notification.message =~ "cannot-start-here"
+      assert notification.message =~ "start_failure"
+      assert notification.metadata["extension"] == "local_shell"
+    end
+
+    test "is reported even when the device names no reason" do
+      # `nerves_hub_link` sends one, but the notification is the point rather
+      # than the reason, and a client that omits it should not be silent.
+      product = product()
+      extensions = attached(product, "quietly-broken")
+
+      {:ok, _extensions, _effects} = Dispatch.message(extensions, "local_shell:error", %{})
+
+      assert [notification] = Repo.all(Notification)
+      assert notification.metadata["reason"] == nil
+      refute notification.message =~ "extension:"
+    end
+
+    test "detaching normally is not a failure" do
+      product = product()
+      extensions = attached(product, "detaches-cleanly")
+
+      {:ok, extensions, _effects} = Dispatch.message(extensions, "local_shell:detached", %{})
+
+      assert extensions["local_shell"].status == :detached
+      assert Repo.all(Notification) == []
+    end
+
+    test "attaching normally is not a failure" do
+      product = product()
+      extensions = attached(product, "attaches-cleanly")
+
+      {:ok, extensions, effects} = Dispatch.message(extensions, "local_shell:attached", %{})
+
+      assert extensions["local_shell"].status == :attached
+      assert {:push, "local_shell:request_shell", %{}} in effects
+      assert Repo.all(Notification) == []
+    end
+  end
+end

--- a/test/nerves_hub/extensions/local_shell_test.exs
+++ b/test/nerves_hub/extensions/local_shell_test.exs
@@ -1,13 +1,29 @@
 defmodule NervesHub.Extensions.LocalShellTest do
-  use ExUnit.Case, async: true
+  use NervesHub.DataCase, async: true
 
   alias NervesHub.Consoles
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Extensions.LocalShell
   alias NervesHub.Extensions.State
+  alias NervesHub.Fixtures
+  alias NervesHub.Products.Notification
 
   defp state(device_id) do
     State.new(%DeviceInfo{device_id: device_id, org_id: 1, product_id: 1})
+  end
+
+  defp state_for(product, identifier) do
+    State.new(%DeviceInfo{
+      device_id: device_id(),
+      device_identifier: identifier,
+      org_id: product.org_id,
+      product_id: product.id
+    })
+  end
+
+  defp product() do
+    user = Fixtures.user_fixture()
+    Fixtures.product_fixture(user, Fixtures.org_fixture(user))
   end
 
   defp device_id(), do: System.unique_integer([:positive])
@@ -44,6 +60,90 @@ defmodule NervesHub.Extensions.LocalShellTest do
 
       assert {:group_leave, Consoles.PubSub.local_shell_key(id)} in effects
       assert {:scrollback_clear} in effects
+    end
+  end
+
+  # The device answers `request_shell` with how it went, and a failure leaves the
+  # extension attached -- so `local_shell_active?/1` stays true and the UI offers
+  # a shell that cannot work. Nothing else records it: before this, the reply hit
+  # the catch-all below and was logged as an unknown message.
+  describe "handle_in/3 request_status" do
+    test "a failure is reported to the product" do
+      product = product()
+      state = state_for(product, "shell-fails-here")
+
+      {_state, effects} =
+        LocalShell.handle_in(
+          "request_status",
+          %{"status" => "failed", "reason" => "`:expty` not included in project dependencies"},
+          state
+        )
+
+      assert effects == []
+
+      assert [notification] = Repo.all(Notification)
+      assert notification.level == :warning
+      assert notification.message =~ "shell-fails-here"
+      assert notification.message =~ "local_shell"
+      assert notification.message =~ ":expty` not included in project dependencies"
+      assert notification.metadata["extension"] == "local_shell"
+    end
+
+    test "the same failure again is counted rather than repeated" do
+      product = product()
+      state = state_for(product, "shell-fails-here")
+
+      payload = %{"status" => "failed", "reason" => "no pty"}
+
+      for _ <- 1..3, do: LocalShell.handle_in("request_status", payload, state)
+
+      assert [notification] = Repo.all(Notification)
+      assert notification.occurrence_count == 3
+    end
+
+    test "a different reason is its own notification, so the message matches it" do
+      product = product()
+      state = state_for(product, "shell-fails-here")
+
+      LocalShell.handle_in("request_status", %{"status" => "failed", "reason" => "no pty"}, state)
+
+      LocalShell.handle_in(
+        "request_status",
+        %{"status" => "failed", "reason" => "permission denied"},
+        state
+      )
+
+      messages = Repo.all(Notification) |> Enum.map(& &1.message)
+
+      assert length(messages) == 2
+      assert Enum.any?(messages, &(&1 =~ "no pty"))
+      assert Enum.any?(messages, &(&1 =~ "permission denied"))
+    end
+
+    test "a shell that started is neither reported nor logged as unknown" do
+      product = product()
+      state = state_for(product, "shell-works-here")
+
+      {_state, effects} =
+        LocalShell.handle_in("request_status", %{"status" => "started"}, state)
+
+      assert effects == []
+      assert Repo.all(Notification) == []
+    end
+
+    test "a reason longer than a notification should carry is cut short" do
+      product = product()
+      state = state_for(product, "shell-fails-here")
+
+      LocalShell.handle_in(
+        "request_status",
+        %{"status" => "failed", "reason" => String.duplicate("a", 500)},
+        state
+      )
+
+      assert [notification] = Repo.all(Notification)
+      assert String.length(notification.metadata["reason"]) == 200
+      assert String.ends_with?(notification.metadata["reason"], "…")
     end
   end
 end


### PR DESCRIPTION
A device that cannot start an extension says so and carries on connected.
Nothing surfaced that.

Found by a device whose firmware was missing `:expty`. The local shell showed
as enabled, opening it did nothing, and the reason was sitting in Data History
where you had to already suspect the answer to go looking:

```json
{"reason": "`:expty` not included in project dependencies", "status": "failed"}
```

## Two paths, and the obvious one is not the one that bit

Covering only "fails to attach" would have missed the case that prompted this.

**`Dispatch.message/3` handling `"<key>:error"`** — the device could not start
the extension at all. `nerves_hub_link` sends this from its attach path when
`start_extension/1` fails. The extension is detached.

**`LocalShell` handling `request_status` with `"status" => "failed"`** — the
extension attached fine, and then the shell would not start. It *stays*
attached, so `local_shell_active?/1` keeps reporting a shell that cannot work.
This is the `:expty` case, and it had no clause at all: the reply fell to the
catch-all and was logged as an unknown message. `"started"` now gets a clause
too, so a working shell stops being logged as unknown.

## On the dedup key

Deduplicated on the device, the extension **and the reason**. The reason is in
the key rather than only in the message because the conflict clause in
`insert_and_notify!/1` updates `occurrence_count` and `last_occurred_at` but not
the message — without it, a device that started failing for a new reason would
keep showing the old one. It is hashed because `new_changeset/2` rejects event
keys containing spaces and a reason is a sentence.

The alternative was to have the conflict clause refresh the message, which is
arguably a latent bug for the existing notification types too. That changes
their behaviour, so it is not in here.

Reasons come off a device's message payload, so they are capped at 200
characters, the way `DeviceTemplates` caps audit log descriptions and for the
reason #2923 gave.

Nothing here needs the device's connection, so it works for a connection held by
a node with no database — the failure reaches a platform node through
`extension_message` before any of this runs.

## What this does not fix

**The settings toggle still lies.** It is bound to `@device.extensions[key]`,
which is intent, not reality. After a failure the notification tells you once;
the device page still says the extension is on, forever. Closing that means
persisting per-extension status from `Dispatch.message/3`, where the platform
already sees every attach, detach and error.

**A failed local shell stays in its group.** `attach/1` has already emitted
`{:group_join, key}` by the time `request_shell` fails, so `local_shell_active?/1`
stays true and the UI keeps offering a shell that cannot work. Leaving the group
on failure would fix that, but it is a behaviour change rather than a
notification, so I have left it out — happy to add it if you want it.

**`"start_failure"` is a coarse reason.** That is all `nerves_hub_link` sends on
the generic path (`extension_message_from_error/1` returns `"start_failure"` or
`"unknown_extension"`), so the notification can only be as specific as the
device is. Worth improving on the device side separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
