### PR TITLE
Make the generated OpenAPI document valid

### DIFF
--- a/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
+++ b/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
@@ -39,7 +39,6 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
       properties: %{
         advanced_query: %OpenApiSpex.Schema{
           type: :string,
-          required: false,
           description: """
           A query in the device list's advanced query language, the same one the
           web UI's search bar uses. Values are quoted; expressions combine with
@@ -57,26 +56,24 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
           """,
           example: ~s|metric:cpu_temp > 70 and connection = "connected"|
         },
-        alarm: %OpenApiSpex.Schema{type: :string, required: false, example: "SomeAlarm"},
-        alarm_status: %OpenApiSpex.Schema{type: :string, required: false, enum: ["with", "without"]},
-        connection: %OpenApiSpex.Schema{type: :string, required: false, enum: ["connected", "disconnected", "not_seen"]},
-        deployment_id: %OpenApiSpex.Schema{type: :string, required: false, example: "12"},
-        display_deleted: %OpenApiSpex.Schema{type: :string, required: false, enum: ["include", "exclude", "only"]},
-        firmware_version: %OpenApiSpex.Schema{type: :string, required: false, example: "1.10.0"},
-        has_no_tags: %OpenApiSpex.Schema{type: :string, required: false, enum: ["true", "false"]},
+        alarm: %OpenApiSpex.Schema{type: :string, example: "SomeAlarm"},
+        alarm_status: %OpenApiSpex.Schema{type: :string, enum: ["with", "without"]},
+        connection: %OpenApiSpex.Schema{type: :string, enum: ["connected", "disconnected", "not_seen"]},
+        deployment_id: %OpenApiSpex.Schema{type: :string, example: "12"},
+        display_deleted: %OpenApiSpex.Schema{type: :string, enum: ["include", "exclude", "only"]},
+        firmware_version: %OpenApiSpex.Schema{type: :string, example: "1.10.0"},
+        has_no_tags: %OpenApiSpex.Schema{type: :string, enum: ["true", "false"]},
         health_status: %OpenApiSpex.Schema{
           type: :string,
-          required: false,
           enum: ["healthy", "unhealthy", "warning", "unknown"]
         },
-        identifier: %OpenApiSpex.Schema{type: :string, required: false, example: "sn123"},
-        only_updating: %OpenApiSpex.Schema{type: :string, required: false, enum: ["true", "false"]},
-        platform: %OpenApiSpex.Schema{type: :string, required: false, example: "rpi4"},
-        search: %OpenApiSpex.Schema{type: :string, required: false, example: "sn123"},
-        tags: %OpenApiSpex.Schema{type: :string, required: false, example: "prod,staging"},
+        identifier: %OpenApiSpex.Schema{type: :string, example: "sn123"},
+        only_updating: %OpenApiSpex.Schema{type: :string, enum: ["true", "false"]},
+        platform: %OpenApiSpex.Schema{type: :string, example: "rpi4"},
+        search: %OpenApiSpex.Schema{type: :string, example: "sn123"},
+        tags: %OpenApiSpex.Schema{type: :string, example: "prod,staging"},
         updates: %OpenApiSpex.Schema{
           type: :string,
-          required: false,
           enum: ["enabled", "disabled", "automatic", "device-managed", "penalty-box"]
         }
       }
@@ -150,7 +147,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
     opts = @path_structures[:short]
 
     path_items = %OpenApiSpex.PathItem{
-      get: show_device_action(@path_structures[:short])
+      get: show_device_action(@path_structures[:short], :short)
     }
 
     updated_paths = Map.put(openapi.paths, opts.path_prefix, path_items)
@@ -162,7 +159,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
     opts = @path_structures[:long]
 
     add_to_paths(openapi, opts.path_prefix, %OpenApiSpex.PathItem{
-      get: show_device_action(@path_structures[:long]),
+      get: show_device_action(@path_structures[:long], :long),
       delete: delete_device_action(@path_structures[:long]),
       put: update_device_action(@path_structures[:long]),
       post: create_device_action(@path_structures[:long])
@@ -193,8 +190,9 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
     )
   end
 
-  def show_device_action(opts) do
+  def show_device_action(opts, path_structure) do
     device_operation("Show a Device", :show, opts.parameters, opts.tags,
+      path_structure: path_structure,
       response: Map.merge(@device_response, @not_found_error)
     )
   end
@@ -278,6 +276,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :code,
         opts.parameters,
         opts.tags,
+        path_structure: path_structure,
         request_body: request_body,
         response: Map.merge(@no_content_response, @not_found_error)
       )
@@ -315,6 +314,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :move,
         opts.parameters ++ query_parameters,
         opts.tags,
+        path_structure: path_structure,
         response: Map.merge(@device_response, @not_found_error)
       )
 
@@ -332,6 +332,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :reboot,
         opts.parameters,
         opts.tags,
+        path_structure: path_structure,
         response: Map.merge(@no_content_response, @not_found_error)
       )
 
@@ -349,6 +350,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :reconnect,
         opts.parameters,
         opts.tags,
+        path_structure: path_structure,
         response: Map.merge(@no_content_response, @not_found_error)
       )
 
@@ -374,6 +376,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :upgrade,
         opts.parameters,
         opts.tags,
+        path_structure: path_structure,
         request_body: request_body,
         response: Map.merge(@no_content_response, Map.merge(@not_found_error, @validation_error))
       )
@@ -392,6 +395,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :penalty,
         opts.parameters,
         opts.tags,
+        path_structure: path_structure,
         response: Map.merge(@no_content_response, @not_found_error)
       )
 
@@ -439,6 +443,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         :send,
         opts.parameters ++ additional_parameters,
         opts.tags,
+        path_structure: path_structure,
         response: response
       )
 
@@ -475,11 +480,17 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
     )
   end
 
+  # An operation published under both the short and long URL structures needs a
+  # distinct operationId for each, since OpenAPI requires them to be unique
+  # document-wide.
+  defp operation_id(controller, action, nil), do: "#{controller}.#{action}"
+  defp operation_id(controller, action, path_structure), do: "#{controller}.#{action}.#{path_structure}"
+
   defp device_operation(summary, operation_id, parameters, tags, opts) do
     %OpenApiSpex.Operation{
       tags: tags,
       summary: summary,
-      operationId: "NervesHubWeb.API.DevicesController.#{operation_id}",
+      operationId: operation_id("NervesHubWeb.API.DevicesController", operation_id, opts[:path_structure]),
       parameters: parameters,
       requestBody: opts[:request_body],
       responses: Map.merge(@common_errors, opts[:response] || %{}),
@@ -493,7 +504,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
     %OpenApiSpex.Operation{
       tags: tags,
       summary: summary,
-      operationId: "NervesHubWeb.API.ScriptController.#{operation_id}",
+      operationId: operation_id("NervesHubWeb.API.ScriptController", operation_id, opts[:path_structure]),
       parameters: parameters,
       requestBody: opts[:request_body],
       responses: Map.merge(@common_errors, opts[:response] || %{}),


### PR DESCRIPTION
`/api/openapi` currently fails OpenAPI 3.0 validation, so anything that validates before using it rejects the document outright. Found it while pointing the docs site at the spec — Mintlify refused it — but the same applies to Postman, Insomnia and client generators.

Two defects, both in `device_controller_specs.ex`.

## Boolean `required` on schema properties

The `filters` parameter set `required: false` on fifteen of its property schemas:

```elixir
alarm: %OpenApiSpex.Schema{type: :string, required: false, example: "SomeAlarm"},
```

In OpenAPI 3.x, `required` on a **Schema Object** is an array of property names on the parent object. A boolean per property is the Swagger 2.0 form, and OpenApiSpex passes it straight through. Properties are optional unless listed, so the flags are removed rather than replaced.

The `required: false` on the `%OpenApiSpex.Parameter{}` structs in the same file is a different field, is correct, and is untouched.

## Duplicate operationIds

Eight ids appeared twice, because every device action is published under both URL structures and reused one id:

```
NervesHubWeb.API.DevicesController.code
  POST /api/devices/{identifier}/code
  POST /api/orgs/{org_name}/products/{product_name}/devices/{identifier}/code
```

Also `show`, `reboot`, `reconnect`, `upgrade`, `move`, `penalty`, and `ScriptController.send`. OpenAPI requires `operationId` to be unique document-wide.

They now carry the path structure, which is what `DeviceLogController` already does:

```elixir
operationId: "NervesHubWeb.API.DeviceLogController.index.#{path_structure}",
```

Each per-structure action passes `path_structure:` through, and a small helper appends it when present so the single-structure operations keep their existing ids unchanged.

## Verification

Regenerated with `mix openapi.spec.json` and checked with `openapi-spec-validator`:

| | Before | After |
| --- | --- | --- |
| OpenAPI 3.0 validation | fails | **passes** |
| operationIds | 69, 8 duplicated | **77, all unique** |
| Boolean `required` in schemas | 15 | **0** |
| Paths / operations | 51 / 77 | 51 / 77 unchanged |

`mix test test/nerves_hub_web/controllers/api/` — 326 passing. Formatting clean; the one Credo note on this file (missing `@moduledoc`) predates the change.

## Note for consumers

The eight ids gain a `.short` / `.long` suffix. Generated clients derive method names from `operationId`, so anyone regenerating a client will see those eight rename. That is unavoidable if they are to be unique, and it matches the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)