### PR TITLE
Clear the rate limit bucket after the tests that fill it

### DIFF
--- a/test/nerves_hub/rate_limit_test.exs
+++ b/test/nerves_hub/rate_limit_test.exs
@@ -3,8 +3,13 @@ defmodule NervesHub.RateLimitTest do
 
   alias NervesHub.RateLimit
 
+  # The bucket is global and keyed by the current second, and these tests
+  # deliberately fill it past the limit. Clearing it on the way out as well as
+  # on the way in keeps the next test in the same second from being rejected by
+  # `NervesHub.DeviceSSLTransport`, which reads the same counter.
   setup do
     :ets.delete_all_objects(:nerves_hub_rate_limit)
+    on_exit(fn -> :ets.delete_all_objects(:nerves_hub_rate_limit) end)
     :ok
   end
 


### PR DESCRIPTION
`NervesHub.RateLimit` counts device connections into one global ETS bucket keyed by the current second, and `NervesHub.DeviceSSLTransport.handshake/1` returns `{:error, :closed}` as soon as that count passes the limit, which is 100 under test.

`RateLimitTest` fills the bucket past the limit on purpose, and cleared it only on the way in. So it finished with the current second already poisoned. It and `DeviceSSLTransportTest` are both `async: false`, and when the seed runs them back to back inside the same second, every handshake the transport test makes is rejected before it starts. Five of its six tests fail, all with `{:error, :closed}` or `{:error, :enotconn}`, and the sixth passes because it was expecting an error anyway.

Seed 195461 reproduces it, which is the seed CI drew on nerves-hub/nerves_hub_web#3015:

```
mix test test/nerves_hub/rate_limit_test.exs test/nerves_hub/device_ssl_transport_test.exs --seed 195461
```

Clearing the bucket in `on_exit` as well leaves the counter where the next test expects to find it. The tests keep clearing it on the way in, so they are still protected from anything that ran before them.

Nothing outside the test env is affected. The transport is only wired into the endpoint in dev and prod config, so `DeviceSSLTransportTest` is the only thing reading that counter during a test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
