### PR TITLE
Send emails from a background job

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -114,6 +114,7 @@ config :nerves_hub, Oban,
   ],
   queues: [
     default: 1,
+    email: 5,
     firmware: 5,
     delete_file: 3,
     cleanup: 2,

--- a/lib/nerves_hub/accounts.ex
+++ b/lib/nerves_hub/accounts.ex
@@ -158,12 +158,12 @@ defmodule NervesHub.Accounts do
   end
 
   @doc ~S"""
-  Delivers an email confirming that a users password has been updated.
+  Queues an email confirming that a users password has been updated.
 
   ## Examples
 
       iex> deliver_user_password_updated(user, &url(~p"/reset-password/#{&1}"))
-      {:ok, %{to: ..., body: ...}}
+      {:ok, %Oban.Job{}}
 
   """
   def deliver_user_password_updated(%User{} = user, reset_url_fun) when is_function(reset_url_fun, 1) do
@@ -961,12 +961,12 @@ defmodule NervesHub.Accounts do
   ## Confirmation
 
   @doc ~S"""
-  Delivers the confirmation email instructions to the given user.
+  Queues the confirmation email instructions for the given user.
 
   ## Examples
 
       iex> deliver_user_confirmation_instructions(user, &url(~p"/confirm/#{&1}"))
-      {:ok, %{to: ..., body: ...}}
+      {:ok, %Oban.Job{}}
 
       iex> deliver_user_confirmation_instructions(confirmed_user, &url(~p"/confirm/#{&1}"))
       {:error, :already_confirmed}
@@ -1010,12 +1010,12 @@ defmodule NervesHub.Accounts do
   ## Reset password
 
   @doc ~S"""
-  Delivers the reset password email to the given user, unless they have logged in with Google auth.
+  Queues the reset password email for the given user, unless they have logged in with Google auth.
 
   ## Examples
 
       iex> deliver_user_reset_password_instructions(user, &url(~p"/password-reset/#{&1}"))
-      {:ok, %{to: ..., body: ...}}
+      {:ok, %Oban.Job{}}
 
   """
   def deliver_user_reset_password_instructions(%User{google_id: google_id} = user, _reset_password_url_fun, login_url)

--- a/lib/nerves_hub/accounts/user_notifier.ex
+++ b/lib/nerves_hub/accounts/user_notifier.ex
@@ -1,4 +1,17 @@
 defmodule NervesHub.Accounts.UserNotifier do
+  @moduledoc """
+  The emails NervesHub sends to its users.
+
+  Every `deliver_*` function queues a `NervesHub.Workers.SendEmail` job rather
+  than talking to the mail server itself, so a slow or unreachable SMTP relay
+  can't stall a web request or a LiveView event. A job carries the recipient, a
+  template key and that template's assigns; `render_and_deliver/3` turns those
+  back into a message when the job runs.
+
+  They return whatever `Oban.insert/1` or `Oban.insert_all/1` returned, so a
+  successful call means the email is queued, not that it has been delivered.
+  """
+
   import Swoosh.Email
 
   alias NervesHub.Accounts
@@ -16,218 +29,226 @@ defmodule NervesHub.Accounts.UserNotifier do
   alias NervesHub.Emails.UserInviteTemplate
   alias NervesHub.Emails.WelcomeTemplate
   alias NervesHub.SwooshMailer, as: Mailer
+  alias NervesHub.Workers.SendEmail
   alias Phoenix.HTML.Safe
 
   def deliver_confirmation_instructions(user, confirmation_url) do
-    assigns = %{
-      user_name: user.name,
-      confirmation_url: confirmation_url,
-      platform_name: platform_name()
-    }
-
-    {html, text} = render(ConfirmationTemplate, assigns)
-
-    send_email(user, "#{platform_name()}: Confirm your account", html, text)
+    Oban.insert(
+      job("confirmation", user, %{
+        user_name: user.name,
+        confirmation_url: confirmation_url
+      })
+    )
   end
 
   def deliver_password_updated(user, reset_url) do
-    assigns = %{
-      user_name: user.name,
-      reset_url: reset_url,
-      platform_name: platform_name()
-    }
-
-    {html, text} = render(PasswordUpdatedTemplate, assigns)
-
-    send_email(user, "#{platform_name()}: Your password has been updated", html, text)
+    Oban.insert(job("password_updated", user, %{user_name: user.name, reset_url: reset_url}))
   end
 
   def deliver_login_with_google_reminder(user, login_url) do
-    assigns = %{
-      user_name: user.name,
-      login_url: login_url,
-      platform_name: platform_name()
-    }
-
-    {html, text} = render(LoginWithGoogleReminderTemplate, assigns)
-
-    send_email(user, "#{platform_name()}: Login with Google", html, text)
+    Oban.insert(job("login_with_google_reminder", user, %{user_name: user.name, login_url: login_url}))
   end
 
   def deliver_reset_password_instructions(user, reset_url) do
-    assigns = %{
-      user_name: user.name,
-      reset_url: reset_url,
-      platform_name: platform_name()
-    }
-
-    {html, text} = render(PasswordResetTemplate, assigns)
-
-    send_email(user, "#{platform_name()}: Reset your password", html, text)
+    Oban.insert(job("password_reset", user, %{user_name: user.name, reset_url: reset_url}))
   end
 
   def deliver_reset_password_confirmation(user) do
-    assigns = %{
-      user_name: user.name,
-      platform_name: platform_name()
-    }
-
-    {html, text} = render(PasswordResetConfirmationTemplate, assigns)
-
-    send_email(user, "#{platform_name()}: Your password has been reset", html, text)
+    Oban.insert(job("password_reset_confirmation", user, %{user_name: user.name}))
   end
 
   def deliver_welcome_email(user) do
-    assigns = %{user_name: user.name, platform_name: platform_name()}
-
-    {html, text} = render(WelcomeTemplate, assigns)
-
-    send_email(user, "#{platform_name()}: Welcome #{user.name}!", html, text)
+    Oban.insert(job("welcome", user, %{user_name: user.name}))
   end
 
   def deliver_user_invite(email, org, invited_by, invite_url) do
-    assigns = %{
-      org_name: org.name,
-      platform_name: platform_name(),
-      invited_by_name: invited_by.name,
-      invite_url: invite_url
-    }
-
-    {html, text} = render(UserInviteTemplate, assigns)
-
-    send_email(
-      email,
-      "#{platform_name()}: You have been invited to join #{org.name}",
-      html,
-      text
+    Oban.insert(
+      job("user_invite", email, %{
+        org_name: org.name,
+        invited_by_name: invited_by.name,
+        invite_url: invite_url
+      })
     )
   end
 
   def deliver_org_user_added(org, user, invited_by) do
-    assigns = %{
-      user_name: user.name,
-      invited_by_name: invited_by.name,
-      org_name: org.name
-    }
-
-    {html, text} = render(OrgUserAddedTemplate, assigns)
-
-    send_email(
-      user,
-      "#{platform_name()}: You have been added to #{org.name}",
-      html,
-      text
+    Oban.insert(
+      job("org_user_added", user, %{
+        user_name: user.name,
+        invited_by_name: invited_by.name,
+        org_name: org.name
+      })
     )
   end
 
   def deliver_all_tell_org_user_invited(org, instigator, new_user_email) do
-    admins = Accounts.get_org_admins(org)
-
-    for admin <- admins do
-      deliver_tell_org_user_invited(org, admin, instigator, new_user_email)
-    end
+    org
+    |> Accounts.get_org_admins()
+    |> Enum.map(&tell_org_user_invited_job(org, &1, instigator, new_user_email))
+    |> Oban.insert_all()
   end
 
   def deliver_tell_org_user_invited(org, admin, instigator, new_user_email) do
-    assigns = %{
+    org
+    |> tell_org_user_invited_job(admin, instigator, new_user_email)
+    |> Oban.insert()
+  end
+
+  def deliver_all_tell_org_user_added(org, instigator, new_user) do
+    org
+    |> Accounts.get_org_admins()
+    |> Enum.reject(&(&1.id == instigator.id))
+    |> Enum.map(&tell_org_user_added_job(org, &1, instigator, new_user))
+    |> Oban.insert_all()
+  end
+
+  def deliver_tell_org_user_added(org, admin, instigator, new_user) do
+    org
+    |> tell_org_user_added_job(admin, instigator, new_user)
+    |> Oban.insert()
+  end
+
+  def deliver_all_tell_org_user_removed(org, instigator, user) do
+    org
+    |> Accounts.get_org_admins()
+    |> Enum.reject(&(&1.id == instigator.id))
+    |> Enum.map(&tell_org_user_removed_job(org, &1, instigator, user))
+    |> Oban.insert_all()
+  end
+
+  def deliver_tell_org_user_removed(org, admin, instigator, removed_user) do
+    org
+    |> tell_org_user_removed_job(admin, instigator, removed_user)
+    |> Oban.insert()
+  end
+
+  def deliver_all_tell_org_user_removed_themself(org, user) do
+    org
+    |> Accounts.get_org_admins()
+    |> Enum.map(&tell_org_user_removed_themself_job(org, &1, user))
+    |> Oban.insert_all()
+  end
+
+  def deliver_tell_org_user_removed_themself(org, admin, removed_user) do
+    org
+    |> tell_org_user_removed_themself_job(admin, removed_user)
+    |> Oban.insert()
+  end
+
+  @doc """
+  Renders and delivers one email.
+
+  Called by `NervesHub.Workers.SendEmail` when a job runs. To send an email use
+  one of the `deliver_*` functions, which queue the job that lands here.
+  """
+  @spec render_and_deliver(String.t(), String.t(), map()) ::
+          {:ok, Swoosh.Email.t()} | {:error, term()}
+  def render_and_deliver(template, recipient, assigns) do
+    assigns =
+      assigns
+      |> atomize_keys()
+      |> Map.put(:platform_name, platform_name())
+
+    {html, text} = render(template_module(template), assigns)
+
+    email =
+      new()
+      |> to(recipient)
+      |> from(from_address())
+      |> subject(subject_for(template, assigns))
+      |> html_body(html)
+      |> text_body(text)
+
+    with {:ok, _metadata} <- Mailer.deliver(email) do
+      {:ok, email}
+    end
+  end
+
+  defp tell_org_user_invited_job(org, admin, instigator, new_user_email) do
+    job("tell_org_user_invited", admin, %{
       user_name: admin.name,
       new_user_email: new_user_email,
       invited_by_name: instigator.name,
       org_name: org.name
-    }
-
-    {html, text} = render(TellOrgUserInvitedTemplate, assigns)
-
-    send_email(
-      admin,
-      "#{platform_name()}: #{new_user_email} has been invited to #{org.name}",
-      html,
-      text
-    )
+    })
   end
 
-  def deliver_all_tell_org_user_added(org, instigator, new_user) do
-    admins =
-      Accounts.get_org_admins(org)
-      |> Enum.reject(&(&1.id == instigator.id))
-
-    Enum.map(admins, fn admin ->
-      deliver_tell_org_user_added(org, admin, instigator, new_user)
-    end)
-  end
-
-  def deliver_tell_org_user_added(org, admin, instigator, new_user) do
-    assigns = %{
+  defp tell_org_user_added_job(org, admin, instigator, new_user) do
+    job("tell_org_user_added", admin, %{
       user_name: admin.name,
       new_user_name: new_user.name,
       invited_by_name: instigator.name,
       org_name: org.name
-    }
-
-    {html, text} = render(TellOrgUserAddedTemplate, assigns)
-
-    send_email(
-      admin,
-      "#{platform_name()}: #{new_user.name} has been added to #{org.name}",
-      html,
-      text
-    )
+    })
   end
 
-  def deliver_all_tell_org_user_removed(org, instigator, user) do
-    admins =
-      Accounts.get_org_admins(org)
-      |> Enum.reject(&(&1.id == instigator.id))
-
-    Enum.map(admins, fn admin ->
-      deliver_tell_org_user_removed(org, admin, instigator, user)
-    end)
-  end
-
-  def deliver_all_tell_org_user_removed_themself(org, user) do
-    admins = Accounts.get_org_admins(org)
-
-    Enum.map(admins, fn admin ->
-      deliver_tell_org_user_removed_themself(org, admin, user)
-    end)
-  end
-
-  def deliver_tell_org_user_removed(org, admin, instigator, removed_user) do
-    assigns = %{
+  defp tell_org_user_removed_job(org, admin, instigator, removed_user) do
+    job("tell_org_user_removed", admin, %{
       user_name: admin.name,
       removed_user_name: removed_user.name,
       instigator_name: instigator.name,
       org_name: org.name
-    }
-
-    {html, text} = render(TellOrgUserRemovedTemplate, assigns)
-
-    send_email(
-      admin,
-      "#{platform_name()}: #{removed_user.name} has been removed from #{org.name}",
-      html,
-      text
-    )
+    })
   end
 
-  def deliver_tell_org_user_removed_themself(org, admin, removed_user) do
-    assigns = %{
+  defp tell_org_user_removed_themself_job(org, admin, removed_user) do
+    job("tell_org_user_removed_themself", admin, %{
       user_name: admin.name,
       removed_user_name: removed_user.name,
       org_name: org.name
-    }
-
-    {html, text} = render(TellOrgUserRemovedThemselfTemplate, assigns)
-
-    send_email(
-      admin,
-      "#{platform_name()}: #{removed_user.name} has been removed from #{org.name}",
-      html,
-      text
-    )
+    })
   end
 
-  def render(module, assigns) do
+  defp job(template, %User{} = user, assigns), do: job(template, user.email, assigns)
+
+  defp job(template, recipient, assigns) when is_binary(recipient) do
+    SendEmail.new(%{template: template, to: recipient, assigns: assigns})
+  end
+
+  defp template_module("confirmation"), do: ConfirmationTemplate
+  defp template_module("login_with_google_reminder"), do: LoginWithGoogleReminderTemplate
+  defp template_module("org_user_added"), do: OrgUserAddedTemplate
+  defp template_module("password_reset"), do: PasswordResetTemplate
+  defp template_module("password_reset_confirmation"), do: PasswordResetConfirmationTemplate
+  defp template_module("password_updated"), do: PasswordUpdatedTemplate
+  defp template_module("tell_org_user_added"), do: TellOrgUserAddedTemplate
+  defp template_module("tell_org_user_invited"), do: TellOrgUserInvitedTemplate
+  defp template_module("tell_org_user_removed"), do: TellOrgUserRemovedTemplate
+  defp template_module("tell_org_user_removed_themself"), do: TellOrgUserRemovedThemselfTemplate
+  defp template_module("user_invite"), do: UserInviteTemplate
+  defp template_module("welcome"), do: WelcomeTemplate
+
+  defp subject_for("confirmation", _assigns), do: "#{platform_name()}: Confirm your account"
+
+  defp subject_for("login_with_google_reminder", _assigns), do: "#{platform_name()}: Login with Google"
+
+  defp subject_for("org_user_added", %{org_name: org_name}),
+    do: "#{platform_name()}: You have been added to #{org_name}"
+
+  defp subject_for("password_reset", _assigns), do: "#{platform_name()}: Reset your password"
+
+  defp subject_for("password_reset_confirmation", _assigns), do: "#{platform_name()}: Your password has been reset"
+
+  defp subject_for("password_updated", _assigns), do: "#{platform_name()}: Your password has been updated"
+
+  defp subject_for("tell_org_user_added", %{new_user_name: new_user_name, org_name: org_name}),
+    do: "#{platform_name()}: #{new_user_name} has been added to #{org_name}"
+
+  defp subject_for("tell_org_user_invited", %{new_user_email: new_user_email, org_name: org_name}),
+    do: "#{platform_name()}: #{new_user_email} has been invited to #{org_name}"
+
+  defp subject_for("tell_org_user_removed", %{removed_user_name: removed_user_name, org_name: org_name}),
+    do: "#{platform_name()}: #{removed_user_name} has been removed from #{org_name}"
+
+  defp subject_for("tell_org_user_removed_themself", %{removed_user_name: removed_user_name, org_name: org_name}),
+    do: "#{platform_name()}: #{removed_user_name} has been removed from #{org_name}"
+
+  defp subject_for("user_invite", %{org_name: org_name}),
+    do: "#{platform_name()}: You have been invited to join #{org_name}"
+
+  defp subject_for("welcome", %{user_name: user_name}), do: "#{platform_name()}: Welcome #{user_name}!"
+
+  defp render(module, assigns) do
     html = module.render(assigns)
 
     text =
@@ -238,22 +259,11 @@ defmodule NervesHub.Accounts.UserNotifier do
     {html, text}
   end
 
-  defp send_email(%User{} = user, subject, html, text) do
-    send_email(user.email, subject, html, text)
-  end
-
-  defp send_email(user_email, subject, html, text) do
-    email =
-      new()
-      |> to(user_email)
-      |> from(from_address())
-      |> subject(subject)
-      |> html_body(html)
-      |> text_body(text)
-
-    with {:ok, _metadata} <- Mailer.deliver(email) do
-      {:ok, email}
-    end
+  # Oban args round-trip through JSON, so the assigns arrive with string keys.
+  # Every one of them is written literally in a `deliver_*` clause above, so the
+  # atoms are guaranteed to exist by the time a job runs.
+  defp atomize_keys(assigns) do
+    Map.new(assigns, fn {key, value} -> {String.to_existing_atom(key), value} end)
   end
 
   defp from_address() do

--- a/lib/nerves_hub/accounts/user_notifier.ex
+++ b/lib/nerves_hub/accounts/user_notifier.ex
@@ -71,7 +71,7 @@ defmodule NervesHub.Accounts.UserNotifier do
     )
   end
 
-  def deliver_org_user_added(org, user, invited_by) do
+  def deliver_org_user_added(org, invited_by, user) do
     Oban.insert(
       job("org_user_added", user, %{
         user_name: user.name,

--- a/lib/nerves_hub/workers/send_email.ex
+++ b/lib/nerves_hub/workers/send_email.ex
@@ -1,0 +1,24 @@
+defmodule NervesHub.Workers.SendEmail do
+  @moduledoc """
+  Renders and delivers one email.
+
+  The job carries the recipient, a template key and that template's assigns
+  rather than a rendered message, so both the rendering and the SMTP
+  conversation happen here instead of in the web request that asked for the
+  email. See `NervesHub.Accounts.UserNotifier` for the functions that queue
+  these jobs.
+  """
+
+  use Oban.Worker,
+    queue: :email,
+    max_attempts: 5
+
+  alias NervesHub.Accounts.UserNotifier
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"template" => template, "to" => recipient, "assigns" => assigns}}) do
+    with {:ok, _email} <- UserNotifier.render_and_deliver(template, recipient, assigns) do
+      :ok
+    end
+  end
+end

--- a/test/nerves_hub/accounts/user_notifier_test.exs
+++ b/test/nerves_hub/accounts/user_notifier_test.exs
@@ -1,18 +1,33 @@
 defmodule NervesHub.Accounts.UserNotifierTest do
   use NervesHub.DataCase, async: true
 
+  import NervesHub.Support.Emails
   import Swoosh.X.TestAssertions
 
   alias NervesHub.Accounts
   alias NervesHub.Accounts.User
   alias NervesHub.Accounts.UserNotifier
   alias NervesHub.Fixtures
+  alias NervesHub.Workers.SendEmail
+
+  test "emails are queued rather than sent" do
+    user = %User{name: "Tony", email: "tony@salami.com"}
+
+    {:ok, _job} = UserNotifier.deliver_welcome_email(user)
+
+    assert_enqueued(worker: SendEmail, args: %{template: "welcome", to: user.email})
+    refute_email_sent()
+
+    send_queued_emails()
+
+    assert_email_sent(to: user.email, subject: "NervesHub: Welcome Tony!")
+  end
 
   test "invite email" do
     invite = %{email: "foo@bar.com", token: "token"}
     org = %{name: "My Org Name"}
 
-    {:ok, email} =
+    {:ok, _job} =
       UserNotifier.deliver_user_invite(
         invite.email,
         org,
@@ -20,9 +35,13 @@ defmodule NervesHub.Accounts.UserNotifierTest do
         "/invite/token"
       )
 
-    assert email.to == [{"", invite.email}]
-    assert email.html_body =~ org.name
-    assert email.html_body =~ "/invite/#{invite.token}"
+    send_queued_emails()
+
+    assert_email_sent(fn email ->
+      assert email.to == [{"", invite.email}]
+      assert email.html_body =~ org.name
+      assert email.html_body =~ "/invite/#{invite.token}"
+    end)
   end
 
   test "forgot_password email" do
@@ -33,17 +52,19 @@ defmodule NervesHub.Accounts.UserNotifierTest do
 
     password_reset_token = "ultrarandomresettoken"
 
-    {:ok, email} =
+    {:ok, _job} =
       UserNotifier.deliver_reset_password_instructions(
         user,
         "/password-reset/#{password_reset_token}"
       )
 
-    assert email.to == [{"", user.email}]
-    assert email.html_body =~ user.name
+    send_queued_emails()
 
-    assert email.html_body =~
-             "/password-reset/#{password_reset_token}"
+    assert_email_sent(fn email ->
+      assert email.to == [{"", user.email}]
+      assert email.html_body =~ user.name
+      assert email.html_body =~ "/password-reset/#{password_reset_token}"
+    end)
   end
 
   test "org user created email" do
@@ -59,17 +80,21 @@ defmodule NervesHub.Accounts.UserNotifierTest do
       email: "baloney@curedmeats.com"
     }
 
-    {:ok, email} =
+    {:ok, _job} =
       UserNotifier.deliver_org_user_added(
         org,
         user,
         invited_by
       )
 
-    assert email.to == [{"", "tony@salami.com"}]
+    send_queued_emails()
 
-    assert email.html_body =~
-             "You've been added to the <strong>My Org Name</strong> organization by <strong>Baloney</strong>."
+    assert_email_sent(fn email ->
+      assert email.to == [{"", "tony@salami.com"}]
+
+      assert email.html_body =~
+               "You've been added to the <strong>My Org Name</strong> organization by <strong>Baloney</strong>."
+    end)
   end
 
   test "tell org about new user" do
@@ -87,6 +112,8 @@ defmodule NervesHub.Accounts.UserNotifierTest do
     tony = Fixtures.user_fixture(name: "Tony", email: "tony@salami.com")
 
     UserNotifier.deliver_all_tell_org_user_added(the_band, paul, tony)
+
+    send_queued_emails()
 
     assert_email_sent(to: john.email, subject: "NervesHub: Tony has been added to TheBeatles")
     assert_email_sent(to: ringo.email, subject: "NervesHub: Tony has been added to TheBeatles")
@@ -110,6 +137,8 @@ defmodule NervesHub.Accounts.UserNotifierTest do
     tony = Fixtures.user_fixture(name: "Tony", email: "tony@salami.com")
 
     UserNotifier.deliver_all_tell_org_user_removed(the_band, paul, tony)
+
+    send_queued_emails()
 
     assert_email_sent(to: john.email, subject: "NervesHub: Tony has been removed from TheBeatles")
 

--- a/test/nerves_hub/accounts/user_notifier_test.exs
+++ b/test/nerves_hub/accounts/user_notifier_test.exs
@@ -83,8 +83,8 @@ defmodule NervesHub.Accounts.UserNotifierTest do
     {:ok, _job} =
       UserNotifier.deliver_org_user_added(
         org,
-        user,
-        invited_by
+        invited_by,
+        user
       )
 
     send_queued_emails()

--- a/test/nerves_hub_web/controllers/account_controller_test.exs
+++ b/test/nerves_hub_web/controllers/account_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.AccountControllerTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts
@@ -41,6 +42,8 @@ defmodule NervesHubWeb.AccountControllerTest do
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
 
+      send_queued_emails()
+
       assert_email_sent(fn email ->
         assert email.subject == "#{platform_name}: Confirm your account"
         assert to_string(email.text_body) =~ "Thanks for creating an account with NervesHub."
@@ -60,6 +63,8 @@ defmodule NervesHubWeb.AccountControllerTest do
       |> submit()
       |> assert_path(~p"/register")
       |> assert_has("p", with: "can't be blank", times: 3)
+
+      send_queued_emails()
 
       refute_email_sent()
     end
@@ -83,6 +88,8 @@ defmodule NervesHubWeb.AccountControllerTest do
       |> assert_path(~p"/orgs")
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
+
+      send_queued_emails()
 
       assert_email_sent(fn email ->
         assert email.subject == "#{platform_name}: Welcome Sgt Pepper!"
@@ -122,6 +129,8 @@ defmodule NervesHubWeb.AccountControllerTest do
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
 
+      send_queued_emails()
+
       assert_email_sent(fn email ->
         assert email.subject == "#{platform_name}: Confirm your account"
         assert to_string(email.text_body) =~ "Please use the link below to confirm your account:"
@@ -146,6 +155,8 @@ defmodule NervesHubWeb.AccountControllerTest do
       |> assert_path(~p"/orgs")
       |> assert_has("h1", with: "Welcome to NervesHub!")
       |> assert_has("div", with: org.name)
+
+      send_queued_emails()
 
       # don't send email to admin who added the user
       refute_email_sent(subject: "NervesHub: Sgt Pepper has been added to Jeff")

--- a/test/nerves_hub_web/controllers/api/org_user_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/org_user_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.API.OrgUserControllerTest do
   use NervesHubWeb.APIConnCase, async: true
 
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts
@@ -64,6 +65,8 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
       conn = get(conn, Routes.api_org_user_path(conn, :show, org.name, user2.email))
       assert json_response(conn, 200)["data"]["name"] == user2.name
 
+      send_queued_emails()
+
       # don't send email to admin who added the user
       refute_email_sent()
     end
@@ -78,6 +81,8 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
       org_user = %{"email" => "bogus@example.com", "role" => "manage"}
       conn = post(conn, Routes.api_org_user_path(conn, :add, org.name), org_user)
       assert response(conn, 204)
+
+      send_queued_emails()
 
       assert_email_sent()
     end
@@ -107,6 +112,8 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
       org_user = %{"email" => "bogus@example.com", "role" => "manage"}
       conn = post(conn, Routes.api_org_user_path(conn, :invite, org.name), org_user)
       assert response(conn, 204)
+
+      send_queued_emails()
 
       assert_email_sent()
     end
@@ -150,6 +157,8 @@ defmodule NervesHubWeb.API.OrgUserControllerTest do
 
       conn = delete(conn, Routes.api_org_user_path(conn, :remove, org.name, user.email))
       assert response(conn, 204)
+
+      send_queued_emails()
 
       # don't send email to admin who added the user
       refute_email_sent()

--- a/test/nerves_hub_web/controllers/oauth_controller_test.exs
+++ b/test/nerves_hub_web/controllers/oauth_controller_test.exs
@@ -2,6 +2,7 @@ defmodule NervesHubWeb.OAuthControllerTest do
   use NervesHubWeb.ConnCase.Browser, async: true
   use Mimic
 
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts.User
@@ -37,6 +38,8 @@ defmodule NervesHubWeb.OAuthControllerTest do
       |> assert_path("/orgs")
       |> assert_has("div", with: "Welcome back!")
 
+      send_queued_emails()
+
       assert_email_sent(subject: "NervesHub: Welcome Jane Person!")
     end
 
@@ -66,6 +69,8 @@ defmodule NervesHubWeb.OAuthControllerTest do
       |> submit()
       |> assert_path(~p"/password-reset")
       |> assert_has("h1", with: "Time to check your email")
+
+      send_queued_emails()
 
       assert_email_sent(subject: "NervesHub: Login with Google")
     end

--- a/test/nerves_hub_web/controllers/password_reset_controller_test.exs
+++ b/test/nerves_hub_web/controllers/password_reset_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.PasswordResetControllerTest do
   use NervesHubWeb.ConnCase, async: true
 
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts
@@ -25,6 +26,8 @@ defmodule NervesHubWeb.PasswordResetControllerTest do
 
       assert html_response(reset_conn, 200) =~
                "If your email is recognized, you will receive instructions to reset your password shortly."
+
+      send_queued_emails()
 
       assert_email_sent(subject: "NervesHub: Reset your password")
     end

--- a/test/nerves_hub_web/controllers/session_controller_test.exs
+++ b/test/nerves_hub_web/controllers/session_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.SessionControllerTest do
   use NervesHubWeb.ConnCase.Browser, async: false
 
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts
@@ -28,6 +29,8 @@ defmodule NervesHubWeb.SessionControllerTest do
       |> assert_path(~p"/orgs")
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
+
+      send_queued_emails()
 
       assert_email_sent(fn email ->
         assert email.subject == "#{platform_name}: Welcome Sgt Pepper!"
@@ -66,6 +69,8 @@ defmodule NervesHubWeb.SessionControllerTest do
       )
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
+
+      send_queued_emails()
 
       assert_email_sent(fn email ->
         assert email.subject == "#{platform_name}: Confirm your account"

--- a/test/nerves_hub_web/live/account_test.exs
+++ b/test/nerves_hub_web/live/account_test.exs
@@ -1,6 +1,7 @@
 defmodule NervesHubWeb.Live.AccountTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts
@@ -85,6 +86,8 @@ defmodule NervesHubWeb.Live.AccountTest do
       end)
       |> assert_path("/account")
       |> assert_has("div", text: "Account updated")
+
+      send_queued_emails()
 
       assert_email_sent(subject: "NervesHub: Your password has been updated")
     end

--- a/test/nerves_hub_web/live/org/users_test.exs
+++ b/test/nerves_hub_web/live/org/users_test.exs
@@ -2,6 +2,7 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
   import Ecto.Query, only: [where: 3]
+  import NervesHub.Support.Emails
   import Swoosh.TestAssertions
 
   alias NervesHub.Accounts
@@ -105,6 +106,8 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       |> assert_path("/org/#{org.name}/settings/users")
       |> assert_has("div", text: "User removed")
 
+      send_queued_emails()
+
       # don't send email to admin who added the user
       refute_email_sent()
     end
@@ -122,6 +125,8 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       |> assert_has("h2", text: "Outstanding Invites")
       |> assert_has("td", text: "josh@mrjosh.com")
 
+      send_queued_emails()
+
       assert_email_sent(subject: "NervesHub: You have been invited to join Jeff")
     end
 
@@ -137,6 +142,8 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       |> assert_has("div", text: "User has been added to #{org.name}")
       |> refute_has("h1", text: "Outstanding Invites")
       |> assert_has("td", text: josh_again.email)
+
+      send_queued_emails()
 
       # don't send email to admin who added the user
       refute_email_sent(subject: "NervesHub: Josh Again has been added to")
@@ -169,6 +176,8 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       |> assert_has("p", text: "Something went wrong, please check the errors below.")
       |> assert_has("span", text: "is already member")
 
+      send_queued_emails()
+
       refute_email_sent()
     end
 
@@ -194,6 +203,8 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       |> click_button("Rescind")
       |> refute_has("td", text: "josh@mrjosh.com")
       |> assert_has("div", text: "Invite couldn't be rescinded as the invite has been accepted.")
+
+      send_queued_emails()
 
       refute_email_sent()
     end

--- a/test/nerves_hub_web/live/org/users_test.exs
+++ b/test/nerves_hub_web/live/org/users_test.exs
@@ -130,7 +130,7 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       assert_email_sent(subject: "NervesHub: You have been invited to join Jeff")
     end
 
-    test "adds user if they are already registered", %{conn: conn, org: org} do
+    test "adds user if they are already registered", %{conn: conn, org: org, user: user} do
       josh_again = Fixtures.user_fixture(%{name: "Josh Again"})
 
       conn
@@ -146,9 +146,15 @@ defmodule NervesHubWeb.Live.Org.UsersTest do
       send_queued_emails()
 
       # don't send email to admin who added the user
-      refute_email_sent(subject: "NervesHub: Josh Again has been added to")
+      tell_org_subject = "NervesHub: Josh Again has been added to #{org.name}"
+      refute_email_sent(subject: ^tell_org_subject)
 
-      assert_email_sent(subject: "NervesHub: You have been added to #{org.name}")
+      # the "you're in" email goes to the added user, and names the admin who added them
+      assert_email_sent(fn email ->
+        assert email.subject == "NervesHub: You have been added to #{org.name}"
+        assert email.to == [{"", josh_again.email}]
+        assert email.html_body =~ "organization by <strong>#{user.name}</strong>"
+      end)
     end
 
     test "rescind unaccepted invite", %{conn: conn, org: org, user: user} do

--- a/test/support/emails.ex
+++ b/test/support/emails.ex
@@ -1,0 +1,14 @@
+defmodule NervesHub.Support.Emails do
+  @moduledoc """
+  Emails are delivered from `NervesHub.Workers.SendEmail` jobs, and the test
+  environment runs Oban in `:manual` mode, so queueing one doesn't send it.
+
+  Call `send_queued_emails/0` between the code under test and any
+  `assert_email_sent/1`. It drains the queue in the calling process, which is
+  what puts the message in the test's mailbox for the Swoosh assertions to find.
+  """
+
+  def send_queued_emails() do
+    Oban.drain_queue(queue: :email)
+  end
+end


### PR DESCRIPTION
Emails were sent inline. Every `UserNotifier.deliver_*` call ran `Swoosh.Mailer.deliver/1` in the calling process, so in production the whole SMTP conversation (connect, TLS handshake, AUTH, DATA) happened on the web request or LiveView event that asked for the email.

The `deliver_all_tell_*` fan-outs made it worse: they loop over an org's admins with a separate blocking send each, so inviting someone into a ten-admin org is eleven sequential round-trips before the page comes back. Dev uses the Local adapter and test uses the Test adapter, so the latency only shows up in production.

Emails are now queued as `NervesHub.Workers.SendEmail` jobs on their own `email` queue. The job carries the recipient, a template key and that template's assigns rather than a rendered message, so the rendering happens in the job too; the fan-outs build one job per admin and enqueue them with a single `insert_all`.

Two things fall out of the move:

- Delivery failures were discarded by `_ =` at most call sites, and hard-matched at two (`accounts.ex` raised a `MatchError` after the user row was already inserted during Google OAuth signup). A failed send now fails the job and retries with backoff, up to five attempts.
- `deliver_*` returns whatever `Oban.insert/1` and `Oban.insert_all/1` return, so the existing `{:ok, _}` call sites still match. They mean "queued" now, not "delivered", and the three `Accounts` docstrings that promised an email struct say so.

The second commit fixes a separate bug I hit while moving this code. `deliver_org_user_added/3` took `(org, user, invited_by)`, but its only call site passed `(org, invited_by, org_user.user)`, so the "You have been added to <org>" email went to the admin doing the inviting, and the body named the new member as the person who added them. The parameters are reordered to match `deliver_all_tell_org_user_added/3` next door, so both calls in the `send_invite` handler now read the same. The swap survived because the test only asserted the subject, which is identical either way.

Closes #2078 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
