### PR TITLE
Add firmware validation status to the devices filter and advanced query

### DIFF
--- a/lib/nerves_hub/devices/advanced_query/compiler.ex
+++ b/lib/nerves_hub/devices/advanced_query/compiler.ex
@@ -168,6 +168,25 @@ defmodule NervesHub.Devices.AdvancedQuery.Compiler do
 
   defp comparison_dynamic("architecture", "!=", value), do: dynamic([d], d.firmware_metadata["architecture"] != ^value)
 
+  # Whether the device reported its running firmware as validated. The column is
+  # nullable, and a device that has never reported reads as "unknown" - so the
+  # null is folded in rather than left to drop out of both sides of the compare.
+  defp comparison_dynamic("firmware_validation_status", "=", "unknown"),
+    do: dynamic([d], d.firmware_validation_status == :unknown or is_nil(d.firmware_validation_status))
+
+  defp comparison_dynamic("firmware_validation_status", "!=", "unknown"),
+    do: dynamic([d], not is_nil(d.firmware_validation_status) and d.firmware_validation_status != :unknown)
+
+  defp comparison_dynamic("firmware_validation_status", "=", value) do
+    status = String.to_existing_atom(value)
+    dynamic([d], d.firmware_validation_status == ^status)
+  end
+
+  defp comparison_dynamic("firmware_validation_status", "!=", value) do
+    status = String.to_existing_atom(value)
+    dynamic([d], is_nil(d.firmware_validation_status) or d.firmware_validation_status != ^status)
+  end
+
   # The sentinel value matches devices with no tags. `array_length` returns NULL
   # for both a NULL column and an empty array, so COALESCE treats both as 0.
   defp comparison_dynamic("tags", "contains", @not_set_value),

--- a/lib/nerves_hub/devices/advanced_query/schema.ex
+++ b/lib/nerves_hub/devices/advanced_query/schema.ex
@@ -59,6 +59,12 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
       operators: ["=", "!="],
       values: &Devices.architectures/1
     },
+    # Whether the device reported its running firmware as validated. Devices
+    # that don't report validation (or haven't reported yet) are "unknown".
+    "firmware_validation_status" => %{
+      operators: ["=", "!="],
+      values: &__MODULE__.firmware_validation_status_values/1
+    },
     "connection" => %{
       operators: ["=", "!="],
       values: &__MODULE__.connection_values/1
@@ -210,6 +216,9 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
 
   @doc false
   def health_status_values(_product_id), do: ["unknown", "healthy", "warning", "unhealthy"]
+
+  @doc false
+  def firmware_validation_status_values(_product_id), do: ["validated", "not_validated", "unknown"]
 
   @doc false
   def connection_type_values(_product_id), do: ["cellular", "ethernet", "wifi", "unknown"]

--- a/lib/nerves_hub/devices/device_filtering.ex
+++ b/lib/nerves_hub/devices/device_filtering.ex
@@ -13,6 +13,7 @@ defmodule NervesHub.Devices.DeviceFiltering do
     connection: "",
     connection_type: "",
     firmware_version: "",
+    firmware_validation_status: "",
     platform: "",
     healthy: "",
     health_status: "",
@@ -37,6 +38,7 @@ defmodule NervesHub.Devices.DeviceFiltering do
     connection: :string,
     connection_type: :string,
     firmware_version: :string,
+    firmware_validation_status: :string,
     platform: :string,
     healthy: :string,
     health_status: :string,
@@ -176,6 +178,11 @@ defmodule NervesHub.Devices.DeviceFiltering do
   # this stays a direct comparison.
   def filter(query, _filters, :firmware_version, value) do
     where(query, [d], d.firmware_metadata["version"] == ^value)
+  end
+
+  def filter(query, _filters, :firmware_validation_status, value)
+      when value in ["validated", "not_validated", "unknown"] do
+    advanced(query, "firmware_validation_status", "=", value)
   end
 
   def filter(query, _filters, :platform, "Unknown") do

--- a/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
+++ b/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
@@ -53,6 +53,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
           * `connection = "connected" and tags contains "prod"`
           * `health_status != "healthy" or alarm_status = "with"`
           * `metric:battery_soc < 20 and updates = "enabled"`
+          * `firmware_validation_status = "not_validated"`
           """,
           example: ~s|metric:cpu_temp > 70 and connection = "connected"|
         },
@@ -61,6 +62,10 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
         connection: %OpenApiSpex.Schema{type: :string, enum: ["connected", "disconnected", "not_seen"]},
         deployment_id: %OpenApiSpex.Schema{type: :string, example: "12"},
         display_deleted: %OpenApiSpex.Schema{type: :string, enum: ["include", "exclude", "only"]},
+        firmware_validation_status: %OpenApiSpex.Schema{
+          type: :string,
+          enum: ["validated", "not_validated", "unknown"]
+        },
         firmware_version: %OpenApiSpex.Schema{type: :string, example: "1.10.0"},
         has_no_tags: %OpenApiSpex.Schema{type: :string, enum: ["true", "false"]},
         health_status: %OpenApiSpex.Schema{

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -764,6 +764,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
         "last_seen" => AdvancedQuery.Schema.last_seen_values(nil),
         "tags" => assigns.advanced_query_tags ++ [AdvancedQuery.Schema.not_set_value()],
         "health_status" => AdvancedQuery.Schema.health_status_values(nil),
+        "firmware_validation_status" => AdvancedQuery.Schema.firmware_validation_status_values(nil),
         "connection_type" => AdvancedQuery.Schema.connection_type_values(nil),
         "updates" => AdvancedQuery.Schema.updates_values(nil),
         "alarm_status" => AdvancedQuery.Schema.alarm_status_values(nil),

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -410,7 +410,7 @@
       label="Firmware"
       type={:select}
       values={[{"All", ""} | Enum.map(@firmware_versions, &{&1, &1})] ++ [{"Unknown", "Unknown"}]}
-      hint="Only versions currently running on devices in this product are listed. Uploaded firmware which no device is running won't appear." 
+      hint="Only versions currently running on devices in this product are listed. Uploaded firmware which no device is running won't appear."
     />
     <:filter
       attr="firmware_validation_status"

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -406,6 +406,17 @@
       ]}
     />
     <:filter attr="firmware_version" label="Firmware" type={:select} values={[{"All", ""} | Enum.map(@firmware_versions, &{&1, &1})]} />
+    <:filter
+      attr="firmware_validation_status"
+      label="Firmware Validation"
+      type={:select}
+      values={[
+        {"All", ""},
+        {"Validated", "validated"},
+        {"Not validated", "not_validated"},
+        {"Unknown", "unknown"}
+      ]}
+    />
     <:filter attr="platform" label="Platform" type={:select} values={[{"All", ""} | Enum.map(@platforms, &{if(&1, do: &1, else: "Unknown"), &1})]} />
     <:filter attr="tags" label="Tags" type={:text} />
     <:filter attr="has_no_tags" label="Untagged" type={:select} values={[{"All", "false"}, {"Only untagged", "true"}]} />

--- a/test/nerves_hub/devices/advanced_query/compiler_test.exs
+++ b/test/nerves_hub/devices/advanced_query/compiler_test.exs
@@ -28,6 +28,11 @@ defmodule NervesHub.Devices.AdvancedQuery.CompilerTest do
     |> Enum.sort()
   end
 
+  defp set_validation_status(device, status) do
+    {1, _} = Repo.update_all(where(Device, id: ^device.id), set: [firmware_validation_status: status])
+    :ok
+  end
+
   describe "apply_query/2" do
     test "platform equality", %{product: product, platform: platform} do
       assert run(product, ~s|platform = "#{platform}"|) == ["connected", "never_connected", "tagged", "untagged"]
@@ -192,6 +197,44 @@ defmodule NervesHub.Devices.AdvancedQuery.CompilerTest do
 
     test "health_status inequality includes devices with no health record", %{product: product} do
       assert run(product, ~s|health_status != "healthy"|) == ["connected", "never_connected", "untagged"]
+    end
+
+    test "firmware_validation_status matches the device's reported validation", %{
+      product: product,
+      tagged: tagged,
+      untagged: untagged
+    } do
+      set_validation_status(tagged, :validated)
+      set_validation_status(untagged, :not_validated)
+
+      assert run(product, ~s|firmware_validation_status = "validated"|) == ["tagged"]
+      assert run(product, ~s|firmware_validation_status = "not_validated"|) == ["untagged"]
+      assert run(product, ~s|firmware_validation_status != "validated"|) == ["connected", "never_connected", "untagged"]
+    end
+
+    test "firmware_validation_status unknown matches devices that never reported", %{
+      product: product,
+      tagged: tagged
+    } do
+      set_validation_status(tagged, :validated)
+
+      # The rest keep the schema default of :unknown.
+      assert run(product, ~s|firmware_validation_status = "unknown"|) == ["connected", "never_connected", "untagged"]
+      assert run(product, ~s|firmware_validation_status != "unknown"|) == ["tagged"]
+    end
+
+    test "firmware_validation_status treats a null column as unknown", %{product: product, tagged: tagged} do
+      # The column is nullable, so a null has to read the same way a device that
+      # never reported does - on both sides of the comparison.
+      {1, _} = Repo.update_all(where(Device, id: ^tagged.id), set: [firmware_validation_status: nil])
+
+      assert run(product, ~s|firmware_validation_status = "unknown"|) ==
+               ["connected", "never_connected", "tagged", "untagged"]
+
+      assert run(product, ~s|firmware_validation_status != "unknown"|) == []
+
+      assert run(product, ~s|firmware_validation_status != "validated"|) ==
+               ["connected", "never_connected", "tagged", "untagged"]
     end
 
     test "connection_type equality matches the latest connection's network interface", %{product: product} do

--- a/test/nerves_hub/devices/advanced_query/schema_test.exs
+++ b/test/nerves_hub/devices/advanced_query/schema_test.exs
@@ -28,6 +28,7 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
       assert Schema.operators("connection_type") == ["=", "!="]
       assert Schema.operators("tags") == ["contains", "not_contains"]
       assert Schema.operators("update_status") == ["is", "is not"]
+      assert Schema.operators("firmware_validation_status") == ["=", "!="]
       assert Schema.operators("identifier") == ["like", "not like"]
       assert Schema.operators("search") == ["like", "not like"]
     end
@@ -63,6 +64,14 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
       refute Schema.value?("identifier", "", 1)
       assert Schema.value?("search", "%anything%", 1)
       refute Schema.value?("search", "", 1)
+    end
+
+    test "firmware_validation_status accepts the device's validation states" do
+      for value <- ["validated", "not_validated", "unknown"] do
+        assert Schema.value?("firmware_validation_status", value, 1)
+      end
+
+      refute Schema.value?("firmware_validation_status", "bogus", 1)
     end
 
     test "connection_type accepts the network interfaces and unknown" do

--- a/test/nerves_hub/devices/device_filtering_test.exs
+++ b/test/nerves_hub/devices/device_filtering_test.exs
@@ -319,6 +319,11 @@ defmodule NervesHub.Devices.DeviceFilteringTest do
       })
   end
 
+  defp set_validation_status(device, status) do
+    {1, _} = Repo.update_all(where(Device, id: ^device.id), set: [firmware_validation_status: status])
+    :ok
+  end
+
   describe "filter/4 :health_status" do
     test "filters devices by health status", %{org: org, product: product, firmware: firmware} do
       healthy = Fixtures.device_fixture(org, product, firmware)
@@ -346,6 +351,40 @@ defmodule NervesHub.Devices.DeviceFilteringTest do
       result = DeviceFiltering.filter(query, %{}, :health_status, "unknown") |> identifiers()
       assert no_health.identifier in result
       refute healthy.identifier in result
+    end
+  end
+
+  describe "filter/4 :firmware_validation_status" do
+    test "filters devices by reported validation status", %{org: org, product: product, firmware: firmware} do
+      validated = Fixtures.device_fixture(org, product, firmware)
+      not_validated = Fixtures.device_fixture(org, product, firmware)
+      set_validation_status(validated, :validated)
+      set_validation_status(not_validated, :not_validated)
+
+      query = base_query(product)
+      result = DeviceFiltering.filter(query, %{}, :firmware_validation_status, "validated") |> identifiers()
+      assert validated.identifier in result
+      refute not_validated.identifier in result
+    end
+
+    test "unknown matches devices that have never reported", %{org: org, product: product, firmware: firmware} do
+      never_reported = Fixtures.device_fixture(org, product, firmware)
+      validated = Fixtures.device_fixture(org, product, firmware)
+      set_validation_status(validated, :validated)
+
+      query = base_query(product)
+      result = DeviceFiltering.filter(query, %{}, :firmware_validation_status, "unknown") |> identifiers()
+      assert never_reported.identifier in result
+      refute validated.identifier in result
+    end
+
+    test "unknown value returns query unchanged", %{org: org, product: product, firmware: firmware} do
+      device = Fixtures.device_fixture(org, product, firmware)
+      set_validation_status(device, :validated)
+
+      query = base_query(product)
+      result = DeviceFiltering.filter(query, %{}, :firmware_validation_status, "bogus") |> identifiers()
+      assert device.identifier in result
     end
   end
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -677,6 +677,30 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> refute_has("div a", text: device2.identifier)
     end
 
+    test "by firmware validation status", %{conn: conn, fixture: fixture} do
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
+
+      validated = Fixtures.device_fixture(org, product, firmware, %{})
+      not_validated = Fixtures.device_fixture(org, product, firmware, %{})
+
+      set_validation_status(validated, :validated)
+      set_validation_status(not_validated, :not_validated)
+
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("#device-count", text: "3", timeout: 1000)
+      |> select("Firmware Validation", option: "Validated")
+      |> assert_has("#device-count", text: "1", timeout: 1_000)
+      |> assert_has("div a", text: validated.identifier)
+      |> select("Firmware Validation", option: "Not validated")
+      |> assert_has("#device-count", text: "1", timeout: 1_000)
+      |> assert_has("div a", text: not_validated.identifier)
+      # the fixture device has never reported, so it reads as unknown
+      |> select("Firmware Validation", option: "Unknown")
+      |> assert_has("#device-count", text: "1", timeout: 1_000)
+      |> assert_has("div a", text: device.identifier)
+    end
+
     test "by several tags", %{conn: conn, fixture: fixture} do
       %{device: device, firmware: firmware, org: org, product: product} = fixture
 
@@ -1795,6 +1819,23 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> refute_has("div a", text: device.identifier)
     end
 
+    test "a firmware validation query filters the device list", %{conn: conn, fixture: fixture} do
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
+
+      not_validated = Fixtures.device_fixture(org, product, firmware, %{})
+      set_validation_status(not_validated, :not_validated)
+
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("#device-count", text: "2", timeout: 1000)
+      |> unwrap(fn view ->
+        render_hook(view, "apply-advanced-query", %{"query" => ~s|firmware_validation_status = "not_validated"|})
+      end)
+      |> assert_has("#device-count", text: "1", timeout: 1000)
+      |> assert_has("div a", text: not_validated.identifier)
+      |> refute_has("div a", text: device.identifier)
+    end
+
     test "an invalid query shows an inline error and does not change the filter", %{conn: conn, fixture: fixture} do
       %{device: device} = fixture
 
@@ -1873,5 +1914,10 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
     }
 
     {:ok, _stored} = Metrics.record(device_info, metrics, timestamp)
+  end
+
+  defp set_validation_status(device, status) do
+    {1, _} = Repo.update_all(where(Device, id: ^device.id), set: [firmware_validation_status: status])
+    :ok
   end
 end


### PR DESCRIPTION
Devices report whether their running firmware was validated, and the device page shows it, but there was no way to find the devices that never validated without opening them one at a time.

## Sidebar filter

A "Firmware Validation" select on the device list: All / Validated / Not validated / Unknown. It goes through the same filter map as every other sidebar filter, so `filters[firmware_validation_status]` works on the device list API too. The OpenAPI spec documents it.

The filter is guarded on the three valid values, so an old bookmark carrying a junk value is ignored instead of raising.

## Advanced query

A `firmware_validation_status` column supporting `=` and `!=`:

```
firmware_validation_status = "not_validated"
firmware_validation_status != "validated" and connection = "connected"
```

Autosuggest picks the column up from the schema whitelist, and the live view hands its values to the editor in the schema JSON.

## The nullable column

`devices.firmware_validation_status` is nullable, so the compiler folds NULL into `unknown` on both sides of the comparison. Without that, `!= "validated"` would silently drop any NULL row. It's the same treatment `health_status` already gets.

## Not included

The device page also shows "Revert detected", which is the separate `firmware_auto_revert_detected` boolean. That could be its own column and filter later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
