### PR TITLE
Return 404 for missing records in the web UI

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -271,25 +271,38 @@ defmodule NervesHub.Devices do
     |> Repo.fetch()
   end
 
-  defp get_by_identifier_query(%Scope{org: org}, identifier, preload_assoc) when not is_nil(org) do
+  defp get_by_identifier_query(%Scope{org: org} = scope, identifier, preload_assoc) when not is_nil(org) do
     Device
     |> join(:left, [d], o in assoc(d, :org), as: :org)
     |> where(identifier: ^identifier)
     |> where(org_id: ^org.id)
+    |> scope_to_product(scope)
     |> preload([org: o], org: o)
     |> join_and_preload_deployment_group_and_current_release()
     |> join_and_preload(preload_assoc)
   end
 
-  defp get_by_identifier_query(%Scope{user: user}, identifier, preload_assoc) when not is_nil(user) do
+  defp get_by_identifier_query(%Scope{user: user} = scope, identifier, preload_assoc) when not is_nil(user) do
     Device
     |> join(:left, [d], o in assoc(d, :org), as: :org)
     |> join(:left, [d, o], u in assoc(o, :users), as: :users)
     |> where(identifier: ^identifier)
     |> where([users: u], u.id == ^user.id)
+    |> scope_to_product(scope)
     |> preload([org: o], org: o)
     |> join_and_preload_deployment_group_and_current_release()
     |> join_and_preload(preload_assoc)
+  end
+
+  # A route carrying a :product_name segment puts the product on the scope, and
+  # then the URL has to mean what it says: without this, a device was reachable
+  # under any sibling product in the same org. The top-level /api/devices/:identifier
+  # routes carry no product at all, so scoping only when one is present is what
+  # keeps those working.
+  defp scope_to_product(query, %Scope{product: nil}), do: query
+
+  defp scope_to_product(query, %Scope{product: product}) do
+    where(query, product_id: ^product.id)
   end
 
   @doc """

--- a/lib/nerves_hub_web/controllers/deployment_group_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_group_controller.ex
@@ -7,9 +7,16 @@ defmodule NervesHubWeb.DeploymentGroupController do
   plug(:validate_role, org: :view)
 
   def export_audit_logs(%{assigns: %{current_scope: %{org: org, product: product}}} = conn, %{"name" => deployment_name}) do
-    {:ok, deployment_group} =
-      ManagedDeployments.get_deployment_group_by_name(product, deployment_name)
+    case ManagedDeployments.get_deployment_group_by_name(product, deployment_name) do
+      {:ok, deployment_group} ->
+        send_audit_logs(conn, org, product, deployment_group)
 
+      {:error, :not_found} ->
+        raise NervesHubWeb.NotFoundError
+    end
+  end
+
+  defp send_audit_logs(conn, org, product, deployment_group) do
     case AuditLogs.logs_for(deployment_group) do
       [] ->
         conn

--- a/lib/nerves_hub_web/controllers/download_controller.ex
+++ b/lib/nerves_hub_web/controllers/download_controller.ex
@@ -7,17 +7,25 @@ defmodule NervesHubWeb.DownloadController do
   plug(:validate_role, org: :view)
 
   def archive(%{assigns: %{current_scope: scope}} = conn, %{"uuid" => uuid}) do
-    {:ok, archive} = Archives.get(scope.product, uuid)
+    case Archives.get(scope.product, uuid) do
+      {:ok, archive} ->
+        redirect(conn, external: Archives.url(archive))
 
-    redirect(conn, external: Archives.url(archive))
+      {:error, :not_found} ->
+        raise NervesHubWeb.NotFoundError
+    end
   end
 
   def firmware(%{assigns: %{current_scope: scope}} = conn, %{"uuid" => uuid}) do
-    {:ok, firmware} = Firmwares.get_firmware_by_product_and_uuid(scope.product, uuid)
+    case Firmwares.get_firmware_by_product_and_uuid(scope.product, uuid) do
+      {:ok, firmware} ->
+        {:ok, url} = firmware_uploader().download_file(firmware)
 
-    {:ok, url} = firmware_uploader().download_file(firmware)
+        redirect(conn, external: url)
 
-    redirect(conn, external: url)
+      {:error, :not_found} ->
+        raise NervesHubWeb.NotFoundError
+    end
   end
 
   defp firmware_uploader(), do: Application.get_env(:nerves_hub, :firmware_upload)

--- a/test/nerves_hub_web/controllers/api/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/device_controller_test.exs
@@ -461,6 +461,45 @@ defmodule NervesHubWeb.API.DeviceControllerTest do
       |> assert_authorization_error(404)
     end
 
+    test "device from another product in the same org, using nested url", %{
+      conn: conn,
+      user: user,
+      org: org,
+      tmp_dir: tmp_dir
+    } do
+      product = Fixtures.product_fixture(user, org, %{name: "Owning"})
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+      device = Fixtures.device_fixture(org, product, firmware)
+
+      sibling = Fixtures.product_fixture(user, org, %{name: "Sibling"})
+
+      assert_error_sent(404, fn ->
+        get(conn, Routes.api_device_path(conn, :show, org.name, sibling.name, device.identifier))
+      end)
+      |> assert_authorization_error(404)
+    end
+
+    test "short url resolves a device even when the org has other products", %{
+      conn: conn,
+      user: user,
+      org: org,
+      tmp_dir: tmp_dir
+    } do
+      product = Fixtures.product_fixture(user, org, %{name: "Owning"})
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+      device = Fixtures.device_fixture(org, product, firmware)
+
+      # No product in this URL, so nothing to scope to. Guards the conditional
+      # in Devices.scope_to_product/2.
+      _sibling = Fixtures.product_fixture(user, org, %{name: "Sibling"})
+
+      conn = get(conn, Routes.api_device_path(conn, :show, device.identifier))
+
+      assert json_response(conn, 200)["data"]["identifier"] == device.identifier
+    end
+
     test "deleted device can be queried", %{
       conn: conn,
       user: user,

--- a/test/nerves_hub_web/controllers/archive_controller_test.exs
+++ b/test/nerves_hub_web/controllers/archive_controller_test.exs
@@ -19,5 +19,13 @@ defmodule NervesHubWeb.ArchiveControllerTest do
 
       assert redirected_to(conn) == "http://localhost:1234/uploads/archives/#{archive.uuid}.fw"
     end
+
+    test "404s for an archive that does not exist", %{conn: conn, user: user, org: org} do
+      product = Fixtures.product_fixture(user, org)
+
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/archives/#{Ecto.UUID.generate()}/download")
+      end)
+    end
   end
 end

--- a/test/nerves_hub_web/controllers/deployment_group_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_group_controller_test.exs
@@ -44,5 +44,11 @@ defmodule NervesHubWeb.DeploymentGroupControllerTest do
 
       assert response_content_type(conn, :csv) =~ "text/csv"
     end
+
+    test "404s for a deployment group that does not exist", %{conn: conn, org: org, product: product} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/deployment_groups/nope/audit_logs/download")
+      end)
+    end
   end
 end

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -2,11 +2,6 @@ defmodule NervesHubWeb.DeviceControllerTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
   alias NervesHub.Devices.Certificates
-  alias NervesHub.Fixtures
-
-  setup %{user: user, org: org} do
-    [product: Fixtures.product_fixture(user, org)]
-  end
 
   describe "certificates" do
     test "download certificate for device", %{

--- a/test/nerves_hub_web/controllers/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/firmware_controller_test.exs
@@ -18,5 +18,13 @@ defmodule NervesHubWeb.FirmwareControllerTest do
 
       assert redirected_to(conn) == firmware.upload_metadata.public_path
     end
+
+    test "404s for firmware that does not exist", %{conn: conn, user: user, org: org} do
+      product = Fixtures.product_fixture(user, org)
+
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/firmware/#{Ecto.UUID.generate()}/download")
+      end)
+    end
   end
 end

--- a/test/nerves_hub_web/live/not_found_test.exs
+++ b/test/nerves_hub_web/live/not_found_test.exs
@@ -1,0 +1,115 @@
+defmodule NervesHubWeb.Live.NotFoundTest do
+  @moduledoc """
+  The 404 page is reached from two directions: a bang lookup raising
+  `Ecto.NoResultsError`, which `phoenix_ecto` maps to 404, and an explicit
+  `NervesHubWeb.NotFoundError`. Neither is visible at the call site of the page
+  that depends on it, so these assert the status rather than the exception —
+  swapping one mechanism for the other should not break them, but losing the
+  404 should.
+  """
+
+  use NervesHubWeb.ConnCase.Browser, async: true
+
+  alias NervesHub.Fixtures
+
+  describe "an org or product that does not exist" do
+    test "unknown org", %{conn: conn} do
+      assert_error_sent(404, fn -> get(conn, ~p"/org/nope") end)
+    end
+
+    test "unknown product", %{conn: conn, org: org} do
+      assert_error_sent(404, fn -> get(conn, ~p"/org/#{org}/nope/devices") end)
+    end
+
+    test "an org the user is not a member of", %{conn: conn} do
+      other_user = Fixtures.user_fixture(%{name: "Somebody Else"})
+      other_org = Fixtures.org_fixture(other_user, %{name: "SomebodyElseCorp"})
+
+      assert_error_sent(404, fn -> get(conn, ~p"/org/#{other_org}") end)
+    end
+
+    test "a product belonging to another org", %{conn: conn, org: org} do
+      other_user = Fixtures.user_fixture(%{name: "Somebody Else"})
+      other_org = Fixtures.org_fixture(other_user, %{name: "SomebodyElseCorp"})
+      other_product = Fixtures.product_fixture(other_user, other_org, %{name: "Theirs"})
+
+      # Asked for under an org the user *can* see, so this is the scoping in
+      # Products.get_by_name!/2 doing the work rather than the org lookup.
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{other_product.name}/devices")
+      end)
+    end
+  end
+
+  describe "a record that does not exist" do
+    test "unknown device", %{conn: conn, org: org, product: product} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/devices/nope")
+      end)
+    end
+
+    test "unknown firmware", %{conn: conn, org: org, product: product} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/firmware/#{Ecto.UUID.generate()}")
+      end)
+    end
+
+    test "unknown archive", %{conn: conn, org: org, product: product} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/archives/#{Ecto.UUID.generate()}")
+      end)
+    end
+
+    test "unknown deployment group", %{conn: conn, org: org, product: product} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/deployment_groups/nope")
+      end)
+    end
+
+    test "unknown support script", %{conn: conn, org: org, product: product} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{product}/scripts/999999999/edit")
+      end)
+    end
+
+    test "unknown org user", %{conn: conn, org: org} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/settings/users/999999999/edit")
+      end)
+    end
+  end
+
+  describe "a record belonging to another product" do
+    setup %{user: user, org: org} do
+      %{other_product: Fixtures.product_fixture(user, org, %{name: "Another"})}
+    end
+
+    test "firmware", %{conn: conn, org: org, other_product: other_product, firmware: firmware} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{other_product}/firmware/#{firmware.uuid}")
+      end)
+    end
+
+    test "deployment group", %{
+      conn: conn,
+      org: org,
+      other_product: other_product,
+      deployment_group: deployment_group
+    } do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{other_product}/deployment_groups/#{deployment_group.name}")
+      end)
+    end
+  end
+
+  test "a path that matches no route at all", %{conn: conn} do
+    # Unlike the lookups above, this one never raises: the router's own
+    # NoRouteError is turned into a response before the test process sees it.
+    # Asserting the body as well as the status is what proves the branded page
+    # is served rather than Plug's bare "Not Found".
+    conn = get(conn, "/this/does/not/exist")
+
+    assert conn.status == 404
+    assert conn.resp_body =~ "Sorry, the page you are looking can't be found."
+  end
+end

--- a/test/nerves_hub_web/live/not_found_test.exs
+++ b/test/nerves_hub_web/live/not_found_test.exs
@@ -84,6 +84,25 @@ defmodule NervesHubWeb.Live.NotFoundTest do
       %{other_product: Fixtures.product_fixture(user, org, %{name: "Another"})}
     end
 
+    test "device", %{conn: conn, org: org, other_product: other_product, device: device} do
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/org/#{org}/#{other_product}/devices/#{device.identifier}")
+      end)
+    end
+
+    test "device, on a route guarded by Plugs.Device", %{
+      conn: conn,
+      org: org,
+      other_product: other_product,
+      device: device
+    } do
+      # This one renders the 404 itself rather than raising, so there is no
+      # error to assert on — only the response.
+      conn = get(conn, ~p"/org/#{org}/#{other_product}/devices/#{device.identifier}/audit_logs/download")
+
+      assert conn.status == 404
+    end
+
     test "firmware", %{conn: conn, org: org, other_product: other_product, firmware: firmware} do
       assert_error_sent(404, fn ->
         get(conn, ~p"/org/#{org}/#{other_product}/firmware/#{firmware.uuid}")

--- a/test/nerves_hub_web/views/web_error_view_test.exs
+++ b/test/nerves_hub_web/views/web_error_view_test.exs
@@ -9,6 +9,11 @@ defmodule NervesHubWeb.WebErrorViewTest do
              "Sorry, we tried to process your request but something went wrong."
   end
 
+  test "render 404.html" do
+    assert render_to_string(NervesHubWeb.ErrorHTML, "404", "html", []) =~
+             "Sorry, the page you are looking can't be found."
+  end
+
   test "render 400.html" do
     assert render_to_string(NervesHubWeb.ErrorHTML, "400", "html", []) =~
              "Sorry, your request was invalid or corrupted."


### PR DESCRIPTION
Started as a question about whether we test that the 404 page shows up when a record can't be found. The API turned out to be well covered; the web UI was not, and probing it turned up three routes that returned 500 instead.

## Missing download targets returned 500

`DownloadController.archive/2`, `DownloadController.firmware/2` and `DeploymentGroupController.export_audit_logs/2` each matched hard on `{:ok, x} =` against a lookup that returns `{:error, :not_found}`. A bad UUID in a download URL raised a MatchError and served the 500 page. All three had happy-path-only tests, which is how it survived.

They now raise `NervesHubWeb.NotFoundError`, the same way the rest of the app reaches the 404 page.

## Devices ignored the product in their own URL

`Devices.get_by_identifier_query/3` filtered by org but never by product, even on routes carrying a `:product_name` segment. So `/org/acme/ProductB/devices/<id>` returned 200 and rendered a device belonging to ProductA, with ProductB in the page context.

Products are not a permission boundary today, so this is an inconsistency rather than a cross-tenant leak. But firmware and deployment groups are product-scoped and 404 correctly, which left devices as the odd one out.

The scope only carries a product when the route has one to give it, so the filter is conditional and the top-level `/api/devices/:identifier` routes work as before. The two console channels build a scope from the user alone and are unaffected.

One thing reviewers should see: `DeviceControllerTest` was itself depending on the bug. Its setup shadowed the conn case's product with a freshly created one while the device still belonged to another, so its URL paired a device with a product it was not in. It passed only because the lookup ignored the segment. I removed the setup so the test names the device's own product.

## On the new test file

`test/nerves_hub_web/live/not_found_test.exs` asserts the response status rather than the exception type. A 404 gets here two ways (a bang lookup raising `Ecto.NoResultsError`, or `NotFoundError`), and neither is visible from the page that depends on it. Asserting the status means moving a lookup between the two won't break the test, but losing the 404 will.

Web UI coverage before this was three tests across 49 LiveView files, and only one of them asserted a 404 response at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
