### PR TITLE
Filter devices by the firmware versions they are running

### DIFF
--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -761,6 +761,29 @@ defmodule NervesHub.Devices do
   end
 
   @doc """
+  Get distinct firmware versions currently reported by the product's devices,
+  newest first.
+
+  This is the set of versions actually in use, which is a subset of the
+  firmware uploaded to the product.
+  """
+  def firmware_versions(product_id) do
+    Device
+    |> where([d], d.product_id == ^product_id)
+    |> where([d], not is_nil(fragment("?->>'version'", d.firmware_metadata)))
+    # `SELECT DISTINCT` requires the sort expression in the select list, so the
+    # semver key comes back alongside the version and is dropped afterwards.
+    |> select([d], %{
+      version: fragment("?->>'version'", d.firmware_metadata),
+      sort_key: fragment(~s|semver_sort_key(?->>'version') COLLATE "C"|, d.firmware_metadata)
+    })
+    |> distinct(true)
+    |> order_by([d], fragment(~s|semver_sort_key(?->>'version') COLLATE "C" DESC NULLS LAST|, d.firmware_metadata))
+    |> Repo.all()
+    |> Enum.map(& &1.version)
+  end
+
+  @doc """
   Get distinct tags currently used across devices in the product
   """
   def distinct_tags(product_id) do

--- a/lib/nerves_hub/firmwares.ex
+++ b/lib/nerves_hub/firmwares.ex
@@ -194,19 +194,6 @@ defmodule NervesHub.Firmwares do
   end
 
   @doc """
-  Get only version numbers for a product, sorted highest first
-  """
-  def get_firmware_versions_by_product(product_id) do
-    Firmware
-    |> where([f], f.product_id == ^product_id)
-    |> select([f], %{version: f.version, sort_key: fragment(~s|semver_sort_key(?) COLLATE "C"|, f.version)})
-    |> distinct(true)
-    |> order_by([f], fragment(~s|semver_sort_key(?) COLLATE "C" DESC NULLS LAST|, f.version))
-    |> Repo.all()
-    |> Enum.map(& &1.version)
-  end
-
-  @doc """
   The product's firmwares as `%{version, uuid}` maps, newest version first.
   """
   def firmware_versions_and_uuids(product_id) do

--- a/lib/nerves_hub_web/components/filter_sidebar.ex
+++ b/lib/nerves_hub_web/components/filter_sidebar.ex
@@ -12,6 +12,7 @@ defmodule NervesHubWeb.Components.FilterSidebar do
     attr(:label, :string, required: true)
     attr(:type, :atom, required: true)
     attr(:values, :list)
+    attr(:hint, :string, doc: "Explanatory text shown in a tooltip beside the label")
   end
 
   def render(assigns) do
@@ -51,7 +52,16 @@ defmodule NervesHubWeb.Components.FilterSidebar do
           <div class="flex flex-1 flex-col pb-4">
             <form id="filter-form" class="grow px-4" phx-change={@on_update}>
               <div :for={filter <- @filter} class="mt-6">
-                <label class="sidebar-label" for={"input_#{filter.attr}"}>{filter.label}</label>
+                <div class="flex items-center justify-between gap-2">
+                  <label class="sidebar-label" for={"input_#{filter.attr}"}>{filter.label}</label>
+                  <div :if={filter[:hint]} class="relative z-20 flex items-center" id={"filter-hint-#{filter.attr}"} phx-hook="ToolTip" data-placement="left">
+                    <.icon name="info" class="stroke-base-400" />
+                    <div class="bg-surface-muted border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden w-max max-w-56 rounded border px-2 py-1.5 text-xs">
+                      {filter.hint}
+                      <div class="bg-surface-muted border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
+                    </div>
+                  </div>
+                </div>
                 <%= case filter.type do %>
                   <% :text -> %>
                     <input class="sidebar-text-input" type="text" name={filter.attr} id={"input_#{filter.attr}"} value={@current_filters[filter.attr]} phx-debounce="500" />

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -65,7 +65,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:current_sort, "identifier")
     |> assign(:sort_direction, "asc")
     |> assign(:paginate_opts, @default_pagination)
-    |> assign(:firmware_versions, firmware_versions(product.id))
+    |> assign(:firmware_versions, [])
     |> assign(:platforms, [])
     |> assign(:architectures, [])
     |> assign(:advanced_query_tags, [])
@@ -722,6 +722,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
         current_alarms: Alarms.get_current_alarm_types(product.id),
         metrics_keys: Enum.sort(Enum.uniq(Metrics.default_metrics() ++ distinct_metric_keys)),
         deployment_groups: ManagedDeployments.get_deployment_groups_by_product(product),
+        firmware_versions: Devices.firmware_versions(product.id),
         platforms: Devices.platforms(product.id),
         architectures: Devices.architectures(product.id),
         advanced_query_tags: Devices.distinct_tags(product.id),
@@ -1043,10 +1044,6 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> then(fn progresses ->
       assign(socket, :progress, progresses)
     end)
-  end
-
-  defp firmware_versions(product_id) do
-    Firmwares.get_firmware_versions_by_product(product_id)
   end
 
   defp maybe_pluralize(count, to_pluralize) do

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -405,7 +405,13 @@
         {"Disabled", "disabled"}
       ]}
     />
-    <:filter attr="firmware_version" label="Firmware" type={:select} values={[{"All", ""} | Enum.map(@firmware_versions, &{&1, &1})]} />
+    <:filter
+      attr="firmware_version"
+      label="Firmware"
+      type={:select}
+      values={[{"All", ""} | Enum.map(@firmware_versions, &{&1, &1})]}
+      hint="Only versions currently running on devices in this product are listed. Uploaded firmware which no device is running won't appear."
+    />
     <:filter attr="platform" label="Platform" type={:select} values={[{"All", ""} | Enum.map(@platforms, &{if(&1, do: &1, else: "Unknown"), &1})]} />
     <:filter attr="tags" label="Tags" type={:text} />
     <:filter attr="has_no_tags" label="Untagged" type={:select} values={[{"All", "false"}, {"Only untagged", "true"}]} />

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -450,6 +450,50 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
+  describe "firmware_versions/1" do
+    setup %{org: org, user: user, firmware: firmware} do
+      product = Fixtures.product_fixture(user, org, %{name: "Firmware Versions Product"})
+
+      running = fn version ->
+        {:ok, metadata} = Firmwares.metadata_from_firmware(firmware)
+
+        Fixtures.device_fixture(org, product, firmware, %{
+          firmware_metadata: Map.put(metadata, :version, version)
+        })
+      end
+
+      %{product: product, running: running}
+    end
+
+    test "returns the distinct versions devices are running, newest first", %{
+      product: product,
+      running: running
+    } do
+      for version <- ["1.9.0", "1.10.0", "1.10.0-rc1", "1.9.0"], do: running.(version)
+
+      assert Devices.firmware_versions(product.id) == ["1.10.0", "1.10.0-rc1", "1.9.0"]
+    end
+
+    test "is scoped to the given product", %{product: product, running: running} do
+      # setup already created three devices in the other product
+      running.("1.9.0")
+
+      assert Devices.firmware_versions(product.id) == ["1.9.0"]
+    end
+
+    test "ignores devices which haven't reported firmware", %{
+      org: org,
+      product: product,
+      firmware: firmware,
+      running: running
+    } do
+      running.("1.9.0")
+      _ = Fixtures.device_fixture(org, product, firmware, %{firmware_metadata: nil})
+
+      assert Devices.firmware_versions(product.id) == ["1.9.0"]
+    end
+  end
+
   describe "disable_updates_for_devices/2" do
     test "can disable updates for multiple devices", %{
       user: user,

--- a/test/nerves_hub/firmwares_test.exs
+++ b/test/nerves_hub/firmwares_test.exs
@@ -288,16 +288,6 @@ defmodule NervesHub.FirmwaresTest do
       assert versions == ["1.10.0", "1.10.0-rc1", "1.9.0", "1.2.0"]
     end
 
-    test "get_firmware_versions_by_product/1 returns distinct versions, newest first", %{
-      product: product,
-      insert: insert
-    } do
-      for v <- ["1.9.0", "1.10.0", "1.10.0-rc1"], do: insert.(v)
-
-      assert Firmwares.get_firmware_versions_by_product(product.id) ==
-               ["1.10.0", "1.10.0-rc1", "1.9.0"]
-    end
-
     test "get_firmwares_by_product_and_platform/2 orders by precedence", %{
       product: product,
       insert: insert

--- a/test/nerves_hub_web/live/devices/index_filter_data_test.exs
+++ b/test/nerves_hub_web/live/devices/index_filter_data_test.exs
@@ -47,7 +47,7 @@ defmodule NervesHubWeb.Live.Devices.IndexFilterDataTest do
       [:nerves_hub, :repo, :query],
       fn _event, _measurements, %{query: query}, _config ->
         cond do
-          # `Devices.distinct_tags/1`, one of the eight filter dropdown queries
+          # `Devices.distinct_tags/1`, one of the nine filter dropdown queries
           String.contains?(query, "DISTINCT unnest") ->
             :counters.add(counter, 2, 1)
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -390,6 +390,25 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> refute_has("a", text: device2.identifier)
     end
 
+    test "the firmware dropdown only lists versions devices are running", %{
+      conn: conn,
+      fixture: fixture,
+      tmp_dir: tmp_dir
+    } do
+      %{device: device, org: org, product: product, user: user} = fixture
+
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+
+      # uploaded to the product, but no device is running it
+      _unused = Fixtures.firmware_fixture(org_key, product, %{version: "9.9.9", dir: tmp_dir})
+
+      conn
+      |> visit("/org/#{org.name}/#{product.name}/devices")
+      |> assert_has("a", text: device.identifier, timeout: 1000)
+      |> assert_has("#input_firmware_version option", text: device.firmware_metadata.version, timeout: 1000)
+      |> refute_has("#input_firmware_version option", text: "9.9.9")
+    end
+
     # `Devices.filter/3` preloads only the columns behind the health icon and its
     # tooltip, so this asserts the tooltip still has what it renders from.
     test "renders the health tooltip from the trimmed preload", %{conn: conn, fixture: fixture} do


### PR DESCRIPTION
The Firmware dropdown in the devices list sidebar was built from every firmware uploaded to the product. On my dev database the SmartKiosk product has 35 uploads covering 34 distinct versions, but its 10 devices are running 7 of them, so 27 of the options matched no devices at all.

This builds the list from `devices.firmware_metadata` instead, so it only offers versions devices are actually running.

Since a version you expected to see can now be missing, the filter label has a hint tooltip explaining why:

> Only versions currently running on devices in this product are listed. Uploaded firmware which no device is running won't appear.

### Notes

- `Devices.firmware_versions/1` sits alongside `platforms/1` and `architectures/1`, which already derive their dropdowns from the devices in the same way. Like them, it doesn't exclude soft-deleted devices. Otherwise the sidebar's "Only deleted devices" option would have nothing to filter by.
- The list moved out of `mount/3` and into the async `assign_filter_data` load with the rest of the dropdown data, so it no longer blocks the first render.
- `Firmwares.get_firmware_versions_by_product/1` had no other callers and is gone.
- `FilterSidebar`'s `:filter` slot takes an optional `hint`. Filters without one render exactly as before.

I couldn't hover the tooltip on a running devices page, so I rendered the same markup against the compiled CSS to confirm it fits inside the sidebar without clipping. The positioning itself comes from the `ToolTip` hook and `data-placement="left"` already used on the Insights page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
