### PR TITLE
Add a firmware version donut to Product Insights

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -118,8 +118,24 @@
  *   • It is a themed box-shadow: Tailwind inlines @theme --shadow-* values into
  *     the generated utility, so a [data-theme] override would be ignored. The
  *     @utility rules below read these at runtime instead.
+ *   • It is a chart series colour: it is only ever read through var() — from an
+ *     interpolated inline style, or by a chart hook off the document root — so
+ *     Tailwind would tree-shake it out of @theme for want of a matching utility.
  */
 :root {
+  /* Categorical chart series — a fixed slot order, assigned by position and
+     never cycled. Stepped for the dark card surface (#1c1c1f); the light
+     overrides below are the same six hues re-stepped for white, not a flip.
+     `chart-other` is the de-emphasis neutral for a folded "Other" slice and is
+     deliberately outside the categorical set. */
+  --color-chart-1: #3987e5;
+  --color-chart-2: #d95926;
+  --color-chart-3: #199e70;
+  --color-chart-4: #c98500;
+  --color-chart-5: #d55181;
+  --color-chart-6: #008300;
+  --color-chart-other: #71717a;
+
   --primary-rgb: 99 102 241;
   --success-rgb: 16 185 129;
   --warning-rgb: 245 158 11;
@@ -176,6 +192,14 @@
   --color-warning-soft: var(--color-amber-100);
   --color-alert-content: var(--color-red-900);
   --color-alert-soft: var(--color-red-50);
+
+  --color-chart-1: #2a78d6;
+  --color-chart-2: #eb6834;
+  --color-chart-3: #1baf7a;
+  --color-chart-4: #eda100;
+  --color-chart-5: #e87ba4;
+  --color-chart-6: #008300;
+  --color-chart-other: #a1a1aa;
 
   /* Semantic roles + neutral veil flip on the light canvas */
   --color-content-strong: var(--color-zinc-900); /* zinc-900 */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,7 @@ import CopyToClipboard from "./hooks/copyToClipboard.js"
 import CrossFadeOnUpdate from "./hooks/crossFadeOnUpdate.js"
 import DeviceLocationMap from "./hooks/deviceLocationMap.js"
 import DeviceLocationMapWithGeocoder from "./hooks/deviceLocationMapWithGeocoder.js"
+import DonutChart from "./hooks/donutChart.js"
 import Flash from "./hooks/flash.js"
 import HighlightCode from "./hooks/highlightCode.js"
 import { LiveFlowHook } from "live_flow"
@@ -68,6 +69,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     CrossFadeOnUpdate,
     DeviceLocationMap,
     DeviceLocationMapWithGeocoder,
+    DonutChart,
     Flash,
     HighlightCode,
     LiveFlow: LiveFlowHook,

--- a/assets/js/hooks/donutChart.js
+++ b/assets/js/hooks/donutChart.js
@@ -1,0 +1,90 @@
+import Chart from "chart.js/auto"
+
+// Reads the categorical chart palette off the document root, so the slice
+// colours come from the same `--color-chart-*` tokens the HTML legend uses and
+// follow the light/dark theme swap.
+function palette(slices) {
+  const styles = getComputedStyle(document.documentElement)
+
+  return slices.map((slice, index) =>
+    styles.getPropertyValue(slice.filter ? `--color-chart-${index + 1}` : "--color-chart-other").trim(),
+  )
+}
+
+// The card surface, used for the gap drawn between slices so they're separated
+// by negative space rather than by a border.
+function surfaceColor() {
+  return getComputedStyle(document.documentElement).getPropertyValue("--color-surface-raised").trim()
+}
+
+export default {
+  mounted() {
+    const slices = JSON.parse(this.el.dataset.slices)
+    const total = slices.reduce((sum, slice) => sum + slice.count, 0)
+
+    this.chart = new Chart(this.el, {
+      type: "doughnut",
+      data: {
+        labels: slices.map((slice) => slice.label),
+        datasets: [
+          {
+            data: slices.map((slice) => slice.count),
+            backgroundColor: palette(slices),
+            borderColor: surfaceColor(),
+            borderWidth: 2,
+            hoverOffset: 4,
+          },
+        ],
+      },
+      options: {
+        cutout: "68%",
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          // Identity is carried by the HTML legend beside the chart, which
+          // also lists the counts, so the canvas doesn't repeat it.
+          legend: { display: false },
+          tooltip: {
+            displayColors: false,
+            callbacks: {
+              label: (context) => {
+                const count = context.parsed
+                const share = total === 0 ? 0 : Math.round((count / total) * 100)
+                return `${count} ${count === 1 ? "device" : "devices"} (${share}%)`
+              },
+            },
+          },
+        },
+        // Only the slices which map to a device filter are clickable; a folded
+        // "Other" slice has no single version to filter on.
+        onClick: (_event, elements) => {
+          if (!elements.length) return
+
+          const slice = slices[elements[0].index]
+          if (!slice.filter) return
+
+          this.pushEvent("view-devices-with-firmware-version", {
+            version: slice.filter,
+          })
+        },
+        onHover: (event, elements) => {
+          const clickable = elements.length > 0 && slices[elements[0].index].filter
+          event.native.target.style.cursor = clickable ? "pointer" : "default"
+        },
+      },
+    })
+
+    this.onThemeUpdated = () => {
+      this.chart.data.datasets[0].backgroundColor = palette(slices)
+      this.chart.data.datasets[0].borderColor = surfaceColor()
+      this.chart.update()
+    }
+
+    window.addEventListener("themeUpdated", this.onThemeUpdated)
+  },
+
+  destroyed() {
+    window.removeEventListener("themeUpdated", this.onThemeUpdated)
+    this.chart?.destroy()
+  },
+}

--- a/assets/js/hooks/toolTip.js
+++ b/assets/js/hooks/toolTip.js
@@ -1,4 +1,4 @@
-import { autoUpdate, computePosition, offset, arrow } from "@floating-ui/dom"
+import { autoUpdate, computePosition, offset, shift, arrow } from "@floating-ui/dom"
 
 export default {
   mounted() {
@@ -20,7 +20,11 @@ export default {
 
       computePosition(this.el, this.content, {
         placement,
-        middleware: [offset(sideOffset), arrow({ element: this.arrow })],
+        // `shift` slides the tooltip back inside the viewport when it would
+        // otherwise overflow — without it a wide tooltip near the right-hand
+        // edge of the page runs off screen. It has to sit before `arrow` so
+        // the arrow is positioned against the shifted box.
+        middleware: [offset(sideOffset), shift({ padding: 8 }), arrow({ element: this.arrow })],
       }).then(({ x, y, middlewareData, placement }) => {
         Object.assign(this.content.style, {
           left: `${x}px`,

--- a/lib/nerves_hub/devices.ex
+++ b/lib/nerves_hub/devices.ex
@@ -890,4 +890,33 @@ defmodule NervesHub.Devices do
     |> Repo.exclude_deleted()
     |> Repo.aggregate(:count)
   end
+
+  @doc """
+  Counts the product's devices by the firmware version they last reported,
+  largest group first, then newest version first for groups of equal size.
+
+  Devices which haven't reported any firmware metadata yet are grouped under a
+  `nil` version.
+
+  Distinct from `firmware_versions/1`, which lists the versions for the devices
+  list's filter dropdown: that one keeps soft-deleted devices so the "Only
+  deleted devices" filter still has options, where this one drops them so the
+  counts add up to the product's fleet size.
+  """
+  @spec firmware_version_counts(Product.t()) :: [%{version: String.t() | nil, count: non_neg_integer()}]
+  def firmware_version_counts(product) do
+    Device
+    |> where(product_id: ^product.id)
+    |> Repo.exclude_deleted()
+    |> group_by([d], fragment("? ->> 'version'", d.firmware_metadata))
+    |> select([d], %{
+      version: fragment("? ->> 'version'", d.firmware_metadata),
+      count: count(d.id)
+    })
+    |> order_by([d], [
+      {:desc, count(d.id)},
+      {:desc_nulls_last, fragment(~s|semver_sort_key(? ->> 'version') COLLATE "C"|, d.firmware_metadata)}
+    ])
+    |> Repo.all()
+  end
 end

--- a/lib/nerves_hub/devices/device_filtering.ex
+++ b/lib/nerves_hub/devices/device_filtering.ex
@@ -172,6 +172,10 @@ defmodule NervesHub.Devices.DeviceFiltering do
     advanced(query, "connection_type", "=", value)
   end
 
+  def filter(query, _filters, :firmware_version, "Unknown") do
+    where(query, [d], is_nil(d.firmware_metadata["version"]))
+  end
+
   # The advanced query's `firmware` column matches by UUID, not version, so
   # this stays a direct comparison.
   def filter(query, _filters, :firmware_version, value) do

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -409,7 +409,7 @@
       attr="firmware_version"
       label="Firmware"
       type={:select}
-      values={[{"All", ""} | Enum.map(@firmware_versions, &{&1, &1})]}
+      values={[{"All", ""} | Enum.map(@firmware_versions, &{&1, &1})] ++ [{"Unknown", "Unknown"}]}
       hint="Only versions currently running on devices in this product are listed. Uploaded firmware which no device is running won't appear."
     />
     <:filter attr="platform" label="Platform" type={:select} values={[{"All", ""} | Enum.map(@platforms, &{if(&1, do: &1, else: "Unknown"), &1})]} />

--- a/lib/nerves_hub_web/live/product/insights.ex
+++ b/lib/nerves_hub_web/live/product/insights.ex
@@ -9,6 +9,10 @@ defmodule NervesHubWeb.Live.Product.Insights do
 
   @graph_periods ~w(twenty_four_hours fourteen_days four_weeks)
 
+  # A donut is only readable at a glance with a handful of colours, so the
+  # long tail of versions is folded into a single "Other" slice past this.
+  @firmware_version_slices 6
+
   @impl Phoenix.LiveView
   def mount(_params, _session, %{assigns: %{current_scope: scope}} = socket) do
     product = Products.load_shared_secret_auth(scope.product)
@@ -17,6 +21,7 @@ defmodule NervesHubWeb.Live.Product.Insights do
     |> assign(:product, product)
     |> update_information()
     |> maybe_assign_device_connections_graph()
+    |> assign_firmware_version_distribution()
     |> fleet_health_information()
     |> assign_notifications()
     |> maybe_assign_flapping_connections()
@@ -51,6 +56,20 @@ defmodule NervesHubWeb.Live.Product.Insights do
     socket
     |> put_flash(:error, "Invalid graph period selected")
     |> noreply()
+  end
+
+  def handle_event(
+        "view-devices-with-firmware-version",
+        %{"version" => version},
+        %{assigns: %{current_scope: scope, firmware_version_slices: slices}} = socket
+      ) do
+    if Enum.any?(slices, &(&1.filter == version)) do
+      socket
+      |> push_navigate(to: ~p"/org/#{scope.org}/#{scope.product}/devices?firmware_version=#{version}")
+      |> noreply()
+    else
+      noreply(socket)
+    end
   end
 
   @impl Phoenix.LiveView
@@ -163,6 +182,43 @@ defmodule NervesHubWeb.Live.Product.Insights do
     end
   end
 
+  defp assign_firmware_version_distribution(%{assigns: %{current_scope: scope}} = socket) do
+    counts = Devices.firmware_version_counts(scope.product)
+    slices = firmware_version_slices(counts)
+
+    socket
+    |> assign(:firmware_version_slices, slices)
+    |> assign(:firmware_version_other, Enum.find(slices, &is_nil(&1.filter)))
+    |> assign(:firmware_version_count, Enum.count(counts, &(&1.version != nil)))
+    |> assign(:firmware_version_total, Enum.sum_by(counts, & &1.count))
+  end
+
+  # Turns the raw per-version counts into the slices the donut draws: at most
+  # `@firmware_version_slices` named versions, with anything past that folded
+  # into a trailing "Other" (`filter: nil`, because there's no single version
+  # to send the devices list). `filter` is otherwise the devices list's
+  # `firmware_version` filter value.
+  defp firmware_version_slices(counts) do
+    slices =
+      Enum.map(counts, fn
+        %{version: nil, count: count} -> %{label: "Unknown", filter: "Unknown", count: count}
+        %{version: version, count: count} -> %{label: version, filter: version, count: count}
+      end)
+
+    case Enum.split(slices, @firmware_version_slices) do
+      {slices, []} ->
+        slices
+
+      # a lone leftover reads better as itself than as an "Other" of one
+      {slices, [only]} ->
+        slices ++ [only]
+
+      {slices, rest} ->
+        folded = %{label: "Other", filter: nil, count: Enum.sum_by(rest, & &1.count), versions: length(rest)}
+        slices ++ [folded]
+    end
+  end
+
   defp fleet_health_information(%{assigns: %{current_scope: scope}} = socket) do
     socket
     |> assign(:healthy_count, Health.health_status_count(scope.product, :healthy))
@@ -189,6 +245,12 @@ defmodule NervesHubWeb.Live.Product.Insights do
   """
   def percentage(_count, total) when total in [0, nil], do: 0
   def percentage(count, total), do: round(count / total * 100)
+
+  @doc """
+  The colour token for the donut slice in position `index`, matching the
+  palette the chart hook reads off the document root.
+  """
+  def firmware_version_color(index), do: "var(--color-chart-#{index + 1})"
 
   defp onboarding_nhl_host() do
     Application.get_env(:nerves_hub, :devices_websocket_url) || URI.parse(NervesHubWeb.Endpoint.url()).host

--- a/lib/nerves_hub_web/live/product/insights.html.heex
+++ b/lib/nerves_hub_web/live/product/insights.html.heex
@@ -278,37 +278,87 @@
         </div> --%>
       </div>
 
-      <div class="bg-surface-raised border-base-700 shadow-device-details-content flex h-fit grow-0 flex-col gap-4.5 rounded border p-5">
-        <div class="flex items-center justify-between">
-          <div class="text-base-50 leading-6 font-medium">
-            Notifications <span class="border-b-default ml-2.5 inline-flex items-center gap-1.5 rounded-full border py-0.5 pr-2.5 pl-2 text-xs/4 tracking-tight">{@notification_count}</span>
+      <div class="flex flex-col gap-4">
+        <div class="bg-surface-raised border-base-700 shadow-device-details-content flex h-fit grow-0 flex-col gap-4.5 rounded border p-5">
+          <div class="flex items-center justify-between">
+            <div class="text-base-50 leading-6 font-medium">
+              Notifications <span class="border-b-default ml-2.5 inline-flex items-center gap-1.5 rounded-full border py-0.5 pr-2.5 pl-2 text-xs/4 tracking-tight">{@notification_count}</span>
+            </div>
+
+            <.link
+              :if={Enum.any?(@notifications)}
+              navigate={~p"/org/#{@current_scope.org}/#{@product}/notifications"}
+              class="text-content-muted flex items-center gap-1.5 text-xs"
+            >
+              All <span class="lucide-chevron-right--light size-4"></span>
+            </.link>
           </div>
 
-          <.link
-            :if={Enum.any?(@notifications)}
-            navigate={~p"/org/#{@current_scope.org}/#{@product}/notifications"}
-            class="text-content-muted flex items-center gap-1.5 text-xs"
-          >
-            All <span class="lucide-chevron-right--light size-4"></span>
-          </.link>
+          <div :if={Enum.empty?(@notifications)} class="text-content-faint flex h-[200px] flex-col items-center justify-center gap-2 font-mono">
+            <div>You have no notifications</div>
+            <div>Nothing to see here</div>
+          </div>
+          <div :if={Enum.any?(@notifications)} class="divide-b-subtle flex flex-col divide-y">
+            <div :for={entry <- @notifications} class="flex items-center gap-2.5 py-2.5">
+              <span data-level={entry.level} class="data-[level=error]:bg-alert data-[level=info]:bg-notice data-[level=warning]:bg-warning/85 size-2 shrink-0 rounded-full"></span>
+              <div class="min-w-0 flex-[1_1_0%]">
+                <div class="truncate font-mono text-sm font-normal">
+                  {entry.title}
+                </div>
+                <div class="text-content-faint font-mono text-xs">
+                  {Number.Delimit.number_to_delimited(entry.occurrence_count, precision: 0)} {if entry.occurrence_count == 1, do: "occurrence", else: "occurrences"}
+                </div>
+              </div>
+              <span class="text-content-muted shrink-0 text-xs">{Timex.from_now(entry.last_occurred_at)}</span>
+            </div>
+          </div>
         </div>
 
-        <div :if={Enum.empty?(@notifications)} class="text-content-faint flex h-[200px] flex-col items-center justify-center gap-2 font-mono">
-          <div>You have no notifications</div>
-          <div>Nothing to see here</div>
-        </div>
-        <div :if={Enum.any?(@notifications)} class="divide-b-subtle flex flex-col divide-y">
-          <div :for={entry <- @notifications} class="flex items-center gap-2.5 py-2.5">
-            <span data-level={entry.level} class="data-[level=error]:bg-alert data-[level=info]:bg-notice data-[level=warning]:bg-warning/85 size-2 shrink-0 rounded-full"></span>
-            <div class="min-w-0 flex-[1_1_0%]">
-              <div class="truncate font-mono text-sm font-normal">
-                {entry.title}
-              </div>
-              <div class="text-content-faint font-mono text-xs">
-                {Number.Delimit.number_to_delimited(entry.occurrence_count, precision: 0)} {if entry.occurrence_count == 1, do: "occurrence", else: "occurrences"}
+        <div class="bg-surface-raised border-base-700 shadow-device-details-content flex h-fit grow-0 flex-col gap-5 rounded border p-5">
+          <div class="flex items-center justify-between">
+            <div class="text-base-50 leading-6 font-medium">
+              Firmware Versions <span class="border-b-default ml-2.5 inline-flex items-center gap-1.5 rounded-full border py-0.5 pr-2.5 pl-2 text-xs/4 tracking-tight">{@firmware_version_count}</span>
+            </div>
+            <div class="relative z-20 ml-4" id="firmware-versions-tooltip" phx-hook="ToolTip" data-placement="top">
+              <span class="lucide-info--light size-4" />
+              <div class="bg-surface-muted border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden w-64 rounded border px-2 py-1.5 text-xs">
+                <p>The firmware version each device last reported, not the version its deployment group is on. Select a version to see those devices.</p>
+                <div class="bg-surface-muted border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
               </div>
             </div>
-            <span class="text-content-muted shrink-0 text-xs">{Timex.from_now(entry.last_occurred_at)}</span>
+          </div>
+
+          <div class="flex items-center gap-6">
+            <div class="size-[168px] shrink-0">
+              <canvas
+                id="firmware-versions-chart"
+                phx-hook="DonutChart"
+                phx-update="ignore"
+                data-slices={Jason.encode!(@firmware_version_slices)}
+              ></canvas>
+            </div>
+
+            <div class="divide-b-subtle flex min-w-0 flex-1 flex-col divide-y">
+              <.link
+                :for={{slice, index} <- Enum.with_index(@firmware_version_slices)}
+                :if={slice.filter}
+                navigate={~p"/org/#{@current_scope.org}/#{@current_scope.product}/devices?firmware_version=#{slice.filter}"}
+              >
+                <div class="group flex items-center gap-3 py-2.5">
+                  <span class="size-2.5 shrink-0 rounded-full" style={"background-color: #{firmware_version_color(index)}"}></span>
+                  <span class="text-content-body min-w-0 flex-1 truncate font-mono text-sm group-hover:underline">{slice.label}</span>
+                  <span class="text-content-strong text-right font-mono text-sm">{slice.count}</span>
+                  <span class="text-content-muted w-12 text-right font-mono text-sm">{percentage(slice.count, @firmware_version_total)}%</span>
+                </div>
+              </.link>
+
+              <div :if={@firmware_version_other} class="flex items-center gap-3 py-2.5">
+                <span class="size-2.5 shrink-0 rounded-full" style="background-color: var(--color-chart-other)"></span>
+                <span class="text-content-muted min-w-0 flex-1 truncate font-mono text-sm">{@firmware_version_other.versions} other versions</span>
+                <span class="text-content-strong text-right font-mono text-sm">{@firmware_version_other.count}</span>
+                <span class="text-content-muted w-12 text-right font-mono text-sm">{percentage(@firmware_version_other.count, @firmware_version_total)}%</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/test/nerves_hub/devices/device_filtering_test.exs
+++ b/test/nerves_hub/devices/device_filtering_test.exs
@@ -76,6 +76,20 @@ defmodule NervesHub.Devices.DeviceFilteringTest do
       assert d2.identifier in v2_ids
       refute d1.identifier in v2_ids
     end
+
+    test "Unknown matches only devices which haven't reported a firmware version", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      unreported = Fixtures.device_fixture(org, product, firmware, %{firmware_metadata: nil})
+      reported = Fixtures.device_fixture(org, product, firmware)
+
+      result = DeviceFiltering.filter(base_query(product), %{}, :firmware_version, "Unknown") |> identifiers()
+
+      assert unreported.identifier in result
+      refute reported.identifier in result
+    end
   end
 
   describe "filter/4 :tags" do

--- a/test/nerves_hub/devices_test.exs
+++ b/test/nerves_hub/devices_test.exs
@@ -3187,6 +3187,81 @@ defmodule NervesHub.DevicesTest do
     end
   end
 
+  describe "firmware_version_counts/1" do
+    test "counts devices by their reported firmware version, largest group first", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      # the setup already puts three devices on the fixture firmware's version
+      device_on_version(org, product, firmware, "2.0.0")
+      device_on_version(org, product, firmware, "2.0.0")
+      device_on_version(org, product, firmware, "1.5.0")
+
+      assert [
+               %{version: setup_version, count: 3},
+               %{version: "2.0.0", count: 2},
+               %{version: "1.5.0", count: 1}
+             ] = Devices.firmware_version_counts(product)
+
+      assert setup_version == firmware.version
+    end
+
+    test "breaks ties on equal counts by version, newest first", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      device_on_version(org, product, firmware, "1.5.0")
+      device_on_version(org, product, firmware, "2.0.0")
+      device_on_version(org, product, firmware, "1.9.0")
+
+      versions =
+        product
+        |> Devices.firmware_version_counts()
+        |> Enum.filter(&(&1.count == 1))
+        |> Enum.map(& &1.version)
+
+      assert versions == ["2.0.0", "1.9.0", "1.5.0"]
+    end
+
+    test "groups devices without firmware metadata under a nil version", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      Fixtures.device_fixture(org, product, firmware, %{firmware_metadata: nil})
+
+      counts = Devices.firmware_version_counts(product)
+
+      assert %{version: nil, count: 1} in counts
+    end
+
+    test "excludes deleted devices", %{org: org, product: product, firmware: firmware} do
+      device = device_on_version(org, product, firmware, "9.9.9")
+      {:ok, _} = Devices.delete_device(device)
+
+      refute Enum.any?(Devices.firmware_version_counts(product), &(&1.version == "9.9.9"))
+    end
+
+    test "is scoped to the product", %{user: user, org: org, tmp_dir: tmp_dir} do
+      other_product = Fixtures.product_fixture(user, org, %{name: "Other Product"})
+      org_key = Fixtures.org_key_fixture(org, user, tmp_dir)
+      other_firmware = Fixtures.firmware_fixture(org_key, other_product, %{dir: tmp_dir})
+      _ = Fixtures.device_fixture(org, other_product, other_firmware)
+
+      assert [%{count: 1}] = Devices.firmware_version_counts(other_product)
+    end
+  end
+
+  defp device_on_version(org, product, firmware, version) do
+    {:ok, metadata} = Firmwares.metadata_from_firmware(firmware)
+
+    Fixtures.device_fixture(org, product, firmware, %{
+      firmware_metadata: %{metadata | version: version}
+    })
+  end
+
   def to_device_info(device) do
     %DeviceInfo{
       device_id: device.id,

--- a/test/nerves_hub_web/live/product/insights_firmware_versions_test.exs
+++ b/test/nerves_hub_web/live/product/insights_firmware_versions_test.exs
@@ -1,0 +1,167 @@
+defmodule NervesHubWeb.Live.Product.InsightsFirmwareVersionsTest do
+  # Not async: mounting the insights page reads the AnalyticsRepo (ClickHouse).
+  use NervesHubWeb.ConnCase.Browser, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias NervesHub.Firmwares
+  alias NervesHub.Fixtures
+
+  setup %{user: user, org: org, org_key: org_key, tmp_dir: tmp_dir} do
+    product = Fixtures.product_fixture(user, org, %{name: "Firmware Versions"})
+    firmware = Fixtures.firmware_fixture(org_key, product, %{dir: tmp_dir})
+
+    %{product: product, firmware: firmware}
+  end
+
+  defp insights_path(org, product), do: ~p"/org/#{org}/#{product}/insights"
+
+  defp device_on_version(org, product, firmware, version) do
+    {:ok, metadata} = Firmwares.metadata_from_firmware(firmware)
+
+    Fixtures.device_fixture(org, product, firmware, %{
+      firmware_metadata: %{metadata | version: version}
+    })
+  end
+
+  describe "the firmware versions donut" do
+    test "renders a slice per version, largest first, with counts and shares", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      for _ <- 1..3, do: device_on_version(org, product, firmware, "1.0.0")
+      device_on_version(org, product, firmware, "0.9.0")
+
+      {:ok, view, html} = live(conn, insights_path(org, product))
+
+      assert html =~ "Firmware Versions"
+      assert html =~ ~s(phx-hook="DonutChart")
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert assigns.firmware_version_slices == [
+               %{label: "1.0.0", filter: "1.0.0", count: 3},
+               %{label: "0.9.0", filter: "0.9.0", count: 1}
+             ]
+
+      assert assigns.firmware_version_count == 2
+      assert assigns.firmware_version_total == 4
+      refute assigns.firmware_version_other
+
+      # the legend carries the counts and shares, so identity is never colour alone
+      assert has_element?(view, "#firmware-versions-chart")
+      assert render(view) =~ "75%"
+      assert render(view) =~ "25%"
+    end
+
+    test "groups devices that haven't reported firmware under Unknown", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      device_on_version(org, product, firmware, "1.0.0")
+      Fixtures.device_fixture(org, product, firmware, %{firmware_metadata: nil})
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert %{label: "Unknown", filter: "Unknown", count: 1} in assigns.firmware_version_slices
+      # "Unknown" isn't a version, so it doesn't count towards the version total
+      assert assigns.firmware_version_count == 1
+    end
+
+    test "folds everything past the sixth version into an Other slice", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      # eight versions, each with a distinct device count so the ordering is stable
+      for {version, count} <- Enum.zip(1..8, 8..1//-1) do
+        for _ <- 1..count, do: device_on_version(org, product, firmware, "#{version}.0.0")
+      end
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert length(assigns.firmware_version_slices) == 7
+      assert Enum.map(assigns.firmware_version_slices, & &1.label) == ~w(1.0.0 2.0.0 3.0.0 4.0.0 5.0.0 6.0.0 Other)
+
+      # versions 7 and 8, with 2 and 1 devices
+      assert assigns.firmware_version_other == %{label: "Other", filter: nil, count: 3, versions: 2}
+      assert assigns.firmware_version_count == 8
+
+      assert render(view) =~ "2 other versions"
+    end
+
+    test "keeps a lone seventh version as itself rather than an Other of one", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      for {version, count} <- Enum.zip(1..7, 7..1//-1) do
+        for _ <- 1..count, do: device_on_version(org, product, firmware, "#{version}.0.0")
+      end
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      assigns = :sys.get_state(view.pid).socket.assigns
+
+      assert Enum.map(assigns.firmware_version_slices, & &1.label) == ~w(1.0.0 2.0.0 3.0.0 4.0.0 5.0.0 6.0.0 7.0.0)
+      refute assigns.firmware_version_other
+    end
+  end
+
+  describe "filtering the device list from a slice" do
+    test "the legend links to the devices list filtered by version", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      device_on_version(org, product, firmware, "1.2.3")
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      assert view
+             |> element(~s|a[href="#{~p"/org/#{org}/#{product}/devices?firmware_version=1.2.3"}"]|)
+             |> has_element?()
+    end
+
+    test "clicking a slice navigates to the devices list filtered by version", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      device_on_version(org, product, firmware, "1.2.3")
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      render_hook(view, "view-devices-with-firmware-version", %{"version" => "1.2.3"})
+
+      assert_redirect(view, ~p"/org/#{org}/#{product}/devices?firmware_version=1.2.3")
+    end
+
+    test "ignores a version which isn't on the chart", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      device_on_version(org, product, firmware, "1.2.3")
+
+      {:ok, view, _html} = live(conn, insights_path(org, product))
+
+      render_hook(view, "view-devices-with-firmware-version", %{"version" => "6.6.6"})
+
+      assert render(view) =~ "Firmware Versions"
+    end
+  end
+end


### PR DESCRIPTION
Adds a "Firmware Versions" card to Product Insights showing how the fleet splits across the versions devices are actually reporting, sitting under Notifications in the right-hand column.

Each slice and each legend row links through to the devices list filtered to that version, so the chart answers "who's still on 1.4.0?" in one click.

## How the slices are built

`Devices.firmware_version_counts/1` groups non-deleted product devices by `firmware_metadata->>'version'`, largest group first, ties broken by semver descending so the ordering is stable.

The six largest versions get their own slice. Anything past that folds into an "Other" slice, since a donut stops being readable much past a handful of colours. A lone seventh version stays as itself rather than becoming an "Other" of one.

Devices which have never reported firmware metadata group under "Unknown". The devices list can now filter on that, using the same `"Unknown"` clause the platform filter already had, so the slice is clickable like the rest.

`Devices.firmware_versions/1` from #3020 sits nearby and reads the same column, so the docstring spells out the difference: that one keeps soft-deleted devices to give the "Only deleted devices" filter something to match, this one drops them so the counts add up to the fleet size.

The distribution is computed on mount only. That matches the Fleet Health card above it, which the auto-refresh toggle doesn't update either.

## Colours

The six categorical hues live as `--color-chart-*` custom properties with separate light and dark steps, so the legend swatches and the canvas read the same palette and both follow the theme switch. Each palette is validated against the card surface it renders on. Dark passes every check. Light flags three hues below 3:1 contrast against white, which the legend covers by spelling out every version, count and share in text. Colour never carries identity on its own.

They sit in the plain `:root` block rather than `@theme` because the slot colours are only ever read through an interpolated `var(--color-chart-#{n})`. Tailwind can't see that, and tree-shakes them out of `@theme` for want of a matching utility.

## Tooltip fix

The `ToolTip` hook called floating-ui's `computePosition` with only `offset` and `arrow`, so nothing kept a tooltip inside the viewport. Any wide tooltip near the right-hand edge of the page ran off screen; the new card was just the first one to sit there. Adding `shift` fixes it for every tooltip in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
