### PR TITLE
Fix a flaky Briefly cleanup assertion in the delta builder test

### DIFF
--- a/test/nerves_hub/workers/firmware_delta_builder_test.exs
+++ b/test/nerves_hub/workers/firmware_delta_builder_test.exs
@@ -93,6 +93,13 @@ defmodule NervesHub.Workers.FirmwareDeltaBuilderTest do
 
       {:ok, delta} = Firmwares.start_firmware_delta(source_firmware.id, target_firmware.id)
 
+      # Capture the work directory the builder actually uses, so the cleanup
+      # assertions below can be scoped to this test rather than to global state.
+      stub(Fwup, :create_firmware_delta_file, fn source, target, work_dir ->
+        send(self(), {:delta_work_dir, work_dir})
+        Mimic.call_original(Fwup, :create_firmware_delta_file, [source, target, work_dir])
+      end)
+
       assert :ok ==
                FirmwareDeltaBuilder.perform(%Oban.Job{
                  id: Ecto.UUID.generate(),
@@ -108,8 +115,19 @@ defmodule NervesHub.Workers.FirmwareDeltaBuilderTest do
       assert delta.status == :completed
       assert delta.size > 0
 
-      assert Enum.empty?(:ets.tab2list(Briefly.Entry.Path)),
+      assert_received {:delta_work_dir, work_dir}
+
+      refute File.exists?(work_dir),
              "Work directory should be cleaned up after delta generation"
+
+      # Scoped to this test's own entries on purpose. `Briefly.Entry.Path` is a
+      # single `:named_table, :public` table shared by the whole VM, so asserting
+      # it is empty outright fails whenever a concurrent async test happens to be
+      # holding a temp path of its own. It is keyed by owning pid, and
+      # `perform/1` runs inline here, so this test's work directory is registered
+      # against `self()`.
+      assert :ets.lookup(Briefly.Entry.Path, self()) == [],
+             "Briefly should no longer be holding a work directory for this test"
     end
 
     test "marks delta as failed on final attempt", %{


### PR DESCRIPTION
`FirmwareDeltaBuilderTest` ends its end-to-end delta test by asserting that Briefly's ETS table is empty:

```elixir
assert Enum.empty?(:ets.tab2list(Briefly.Entry.Path))
```

`Briefly.Entry.Path` is a single `:named_table, :public` table shared by every process in the VM. The file is `async: true` and CI runs `--partitions 3` with `max_cases: 8`, so the assertion fails whenever any *other* async test happens to be holding a temp path at that instant, whether or not the delta builder cleaned up after itself.

It failed exactly that way on [run 34167314975](https://github.com/nerves-hub/nerves_hub_web/actions/runs/34167314975) (Test 3/3, 1167/1168 passed) and passed on the re-run.

The assertion now covers only what this test created. A stub on `Fwup.create_firmware_delta_file/3` captures the work directory the builder actually used, so the test can check that directory is gone. That stub follows the same stub-then-`call_original` pattern the file already applies to `xdelta3` arguments. The Briefly check stays, but as `:ets.lookup(Briefly.Entry.Path, self())`: the table is a `duplicate_bag` keyed by owning pid, so a per-pid lookup is unaffected by what other tests hold.

Both assertions still bite. Removing `Briefly.cleanup/0` from `generate_firmware_delta/3` trips the lookup; removing the `cleanup_firmware_delta_files/1` call as well trips the `File.exists?` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
