### PR TITLE
Track which CA signed each device certificate

### DIFF
--- a/lib/nerves_hub/devices/advanced_query/compiler.ex
+++ b/lib/nerves_hub/devices/advanced_query/compiler.ex
@@ -111,6 +111,27 @@ defmodule NervesHub.Devices.AdvancedQuery.Compiler do
     )
   end
 
+  defp signer_ca_exists() do
+    dynamic(
+      [d],
+      fragment(
+        "EXISTS (SELECT 1 FROM device_certificates dc JOIN ca_certificates ca ON ca.ski = dc.aki WHERE dc.device_id = ?)",
+        d.id
+      )
+    )
+  end
+
+  defp signer_ca_exists(serial) do
+    dynamic(
+      [d],
+      fragment(
+        "EXISTS (SELECT 1 FROM device_certificates dc JOIN ca_certificates ca ON ca.ski = dc.aki WHERE dc.device_id = ? AND ca.serial = ?)",
+        d.id,
+        ^serial
+      )
+    )
+  end
+
   # `like`/`not like` use SQL ILIKE (case-insensitive); the value is the user's
   # pattern, so they supply `%`/`_` wildcards themselves.
   defp comparison_dynamic("identifier", "like", value), do: dynamic([d], ilike(d.identifier, ^value))
@@ -163,6 +184,20 @@ defmodule NervesHub.Devices.AdvancedQuery.Compiler do
         [d],
         fragment("NOT EXISTS (SELECT 1 FROM deployments dg WHERE dg.id = ? AND dg.name = ?)", d.deployment_id, ^name)
       )
+
+  # A device certificate records its signer's key id as its AKI, which is the
+  # CA's SKI - so the join is on that rather than a foreign key. The not-set
+  # sentinel matches devices holding no certificate from a registered CA, which
+  # covers shared secret authenticated devices as well as certificates whose
+  # signer was never registered.
+  defp comparison_dynamic("signer_ca", "=", @not_set_value), do: dynamic([d], not (^signer_ca_exists()))
+
+  defp comparison_dynamic("signer_ca", "!=", @not_set_value), do: signer_ca_exists()
+
+  # CA serials are globally unique, so the serial alone identifies the CA.
+  defp comparison_dynamic("signer_ca", "=", serial), do: signer_ca_exists(serial)
+
+  defp comparison_dynamic("signer_ca", "!=", serial), do: dynamic([d], not (^signer_ca_exists(serial)))
 
   defp comparison_dynamic("architecture", "=", value), do: dynamic([d], d.firmware_metadata["architecture"] == ^value)
 

--- a/lib/nerves_hub/devices/advanced_query/schema.ex
+++ b/lib/nerves_hub/devices/advanced_query/schema.ex
@@ -10,6 +10,7 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
 
   alias NervesHub.Devices
   alias NervesHub.Devices.Alarms
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Firmwares
   alias NervesHub.ManagedDeployments
 
@@ -64,6 +65,12 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
     "firmware_validation_status" => %{
       operators: ["=", "!="],
       values: &__MODULE__.firmware_validation_status_values/1
+    },
+    # The value is the signer CA's serial (or the not-set sentinel); the live
+    # view's schema JSON shows the CA's description in the autosuggest.
+    "signer_ca" => %{
+      operators: ["=", "!="],
+      values: &__MODULE__.signer_ca_values/1
     },
     "connection" => %{
       operators: ["=", "!="],
@@ -241,6 +248,14 @@ defmodule NervesHub.Devices.AdvancedQuery.Schema do
 
   @doc false
   def tag_values(product_id), do: Devices.distinct_tags(product_id) ++ [@not_set_value]
+
+  @doc false
+  def signer_ca_values(product_id) do
+    product_id
+    |> CACertificates.signer_cas_for_product()
+    |> Enum.map(& &1.serial)
+    |> Kernel.++([@not_set_value])
+  end
 
   @doc false
   def deployment_group_values(product_id) do

--- a/lib/nerves_hub/devices/ca_certificates.ex
+++ b/lib/nerves_hub/devices/ca_certificates.ex
@@ -12,6 +12,8 @@ defmodule NervesHub.Devices.CACertificates do
   alias NervesHub.Accounts.Org
   alias NervesHub.Certificate
   alias NervesHub.Devices.CACertificate
+  alias NervesHub.Devices.DeviceCertificate
+  alias NervesHub.Products.Product
   alias NervesHub.Repo
 
   @spec create_ca_certificate(Org.t(), map()) ::
@@ -92,6 +94,91 @@ defmodule NervesHub.Devices.CACertificates do
       preload: [jitp: :product]
     )
     |> Repo.fetch()
+  end
+
+  @doc """
+  Counts the devices in the org whose certificates were signed by each of its
+  CAs, keyed by the CA's SKI.
+
+  A device certificate records its signer's key id as its AKI, so a CA's SKI is
+  what ties the two together. Devices with more than one certificate from the
+  same CA are only counted once, and soft deleted devices are left out so the
+  count matches what the device list shows by default.
+  """
+  @spec device_counts_by_ski(Org.t()) :: %{binary() => non_neg_integer()}
+  def device_counts_by_ski(%Org{id: org_id}) do
+    from(dc in DeviceCertificate,
+      join: d in assoc(dc, :device),
+      where: dc.org_id == ^org_id,
+      where: is_nil(d.deleted_at),
+      group_by: dc.aki,
+      select: {dc.aki, count(dc.device_id, :distinct)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  The products which have devices signed by the CA, along with each product's
+  device count, ordered by product name.
+
+  The device list is scoped to a single product, so this is what a "devices
+  using this CA" link has to be broken down by.
+  """
+  @spec device_counts_by_product(CACertificate.t()) ::
+          [%{product: Product.t(), device_count: non_neg_integer()}]
+  def device_counts_by_product(%CACertificate{ski: ski, org_id: org_id}) do
+    from(dc in DeviceCertificate,
+      join: d in assoc(dc, :device),
+      join: p in assoc(d, :product),
+      where: dc.aki == ^ski,
+      where: dc.org_id == ^org_id,
+      where: is_nil(d.deleted_at),
+      where: is_nil(p.deleted_at),
+      group_by: p.id,
+      order_by: p.name,
+      select: %{product: p, device_count: count(d.id, :distinct)}
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  The org's CAs which signed a certificate held by a device in the product,
+  ordered by description then serial.
+
+  Built from the devices rather than from the org's CA list so the device list's
+  signer CA filter only offers CAs that can actually match something.
+  """
+  @spec signer_cas_for_product(pos_integer()) :: [CACertificate.t()]
+  def signer_cas_for_product(product_id) do
+    from(ca in CACertificate,
+      join: dc in DeviceCertificate,
+      on: dc.aki == ca.ski,
+      join: d in assoc(dc, :device),
+      where: d.product_id == ^product_id,
+      where: ca.org_id == d.org_id,
+      distinct: true,
+      order_by: [asc: ca.description, asc: ca.serial],
+      select: ca
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  The org's CAs matching the given SKIs, keyed by SKI.
+
+  Scoped to the org so a certificate signed by another org's CA reads as
+  unknown rather than exposing that CA.
+  """
+  @spec by_ski(Org.t() | pos_integer(), [binary()]) :: %{binary() => CACertificate.t()}
+  def by_ski(%Org{id: org_id}, skis), do: by_ski(org_id, skis)
+
+  def by_ski(org_id, skis) when is_integer(org_id) do
+    skis = Enum.reject(skis, &is_nil/1)
+
+    from(ca in CACertificate, where: ca.org_id == ^org_id and ca.ski in ^skis)
+    |> Repo.all()
+    |> Map.new(&{&1.ski, &1})
   end
 
   def update_ca_certificate(%CACertificate{} = certificate, params) do

--- a/lib/nerves_hub/devices/device_filtering.ex
+++ b/lib/nerves_hub/devices/device_filtering.ex
@@ -14,6 +14,7 @@ defmodule NervesHub.Devices.DeviceFiltering do
     connection_type: "",
     firmware_version: "",
     firmware_validation_status: "",
+    signer_ca: "",
     platform: "",
     healthy: "",
     health_status: "",
@@ -39,6 +40,7 @@ defmodule NervesHub.Devices.DeviceFiltering do
     connection_type: :string,
     firmware_version: :string,
     firmware_validation_status: :string,
+    signer_ca: :string,
     platform: :string,
     healthy: :string,
     health_status: :string,
@@ -187,6 +189,12 @@ defmodule NervesHub.Devices.DeviceFiltering do
   def filter(query, _filters, :firmware_validation_status, value)
       when value in ["validated", "not_validated", "unknown"] do
     advanced(query, "firmware_validation_status", "=", value)
+  end
+
+  # The value is the signer CA's serial, or the not-set sentinel for devices
+  # with no certificate from a CA registered with this org.
+  def filter(query, _filters, :signer_ca, value) do
+    advanced(query, "signer_ca", "=", value)
   end
 
   def filter(query, _filters, :platform, "Unknown") do

--- a/lib/nerves_hub_web/components/ca_helpers.ex
+++ b/lib/nerves_hub_web/components/ca_helpers.ex
@@ -1,6 +1,18 @@
 defmodule NervesHubWeb.Components.CAHelpers do
   use NervesHubWeb, :component
 
+  alias NervesHub.Devices.CACertificate
+  alias NervesHubWeb.Components.Utils
+
+  @doc """
+  How to refer to a CA in a sentence: its description, or its formatted serial
+  when it has none (the description is optional).
+  """
+  @spec label(CACertificate.t()) :: String.t()
+  def label(%CACertificate{description: description, serial: serial}) do
+    if description in [nil, ""], do: Utils.format_serial(serial), else: description
+  end
+
   def check_expiration_tooltip(assigns) do
     ~H"""
     <span class="tooltip-info"></span>

--- a/lib/nerves_hub_web/components/ca_helpers.ex
+++ b/lib/nerves_hub_web/components/ca_helpers.ex
@@ -13,14 +13,20 @@ defmodule NervesHubWeb.Components.CAHelpers do
     if description in [nil, ""], do: Utils.format_serial(serial), else: description
   end
 
+  attr(:id, :string, default: "check-expiration-tooltip")
+  attr(:placement, :string, default: "right")
+
   def check_expiration_tooltip(assigns) do
     ~H"""
-    <span class="tooltip-info"></span>
-    <span class="tooltip-text">
-      By default, the time validity of CA certificates is unchecked. You can
-      toggle this to check expiration to prevent device certificates
-      from being created from an expired signing CA certificate.
-    </span>
+    <div class="relative z-20 flex items-center" id={@id} phx-hook="ToolTip" data-placement={@placement}>
+      <.icon name="info" class="stroke-base-400" />
+      <div class="bg-surface-muted border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden w-max max-w-72 rounded border px-2 py-1.5 text-xs">
+        By default, the time validity of CA certificates is unchecked. You can
+        toggle this to check expiration to prevent device certificates
+        from being created from an expired signing CA certificate.
+        <div class="bg-surface-muted border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
+      </div>
+    </div>
     """
   end
 
@@ -30,7 +36,10 @@ defmodule NervesHubWeb.Components.CAHelpers do
         DateTime.after?(DateTime.utc_now(), assigns.not_after) ->
           "Expired"
 
-        DateTime.after?(DateTime.shift(DateTime.utc_now(), month: -3), assigns.not_after) ->
+        # Expires within the next three months. The shift was negative, which
+        # put the cutoff three months in the past - a window the `Expired`
+        # clause above has already taken, so this never matched.
+        DateTime.after?(DateTime.shift(DateTime.utc_now(), month: 3), assigns.not_after) ->
           "Expiring Soon"
 
         true ->
@@ -49,12 +58,9 @@ defmodule NervesHubWeb.Components.CAHelpers do
     """
   end
 
-  defp certificate_status_class(status) do
-    formatted =
-      status
-      |> String.downcase()
-      |> String.replace(" ", "-")
-
-    "certificate-status-#{formatted}"
-  end
+  # The `-content` colours are the ones defined for both themes; a bare
+  # `text-alert` stays red-500 on the light theme, which is too hot.
+  defp certificate_status_class("Expired"), do: "text-alert-content"
+  defp certificate_status_class("Expiring Soon"), do: "text-warning-content"
+  defp certificate_status_class("Current"), do: "text-base-400"
 end

--- a/lib/nerves_hub_web/components/device_page/settings_tab.ex
+++ b/lib/nerves_hub_web/components/device_page/settings_tab.ex
@@ -3,10 +3,12 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
 
   alias NervesHub.Certificate
   alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Certificates
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.Updates
   alias NervesHub.Extensions
+  alias NervesHubWeb.Components.CAHelpers
   alias NervesHubWeb.Components.Utils
   alias NervesHubWeb.LayoutView.DateTimeFormat
 
@@ -28,7 +30,15 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
   def render(assigns) do
     device = Certificates.preload_device_certificates(assigns.device, force: true)
 
-    assigns = Map.put(assigns, :device, device)
+    # A device certificate names its signer by key id (its AKI, the CA's SKI)
+    # rather than by a foreign key, and the signer may never have been
+    # registered - so the lookup can come up empty.
+    signer_cas = CACertificates.by_ski(device.org_id, Enum.map(device.device_certificates, & &1.aki))
+
+    assigns =
+      assigns
+      |> Map.put(:device, device)
+      |> Map.put(:signer_cas, signer_cas)
 
     ~H"""
     <div
@@ -201,6 +211,11 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
                   <span>Not after:</span>
                   <.local_datetime at={certificate.not_after} time_zone={@time_zone} format={:date} zone_label={false} />
                 </div>
+
+                <div class="text-base-400 text-xs tracking-wide">
+                  <span>Signer CA:</span>
+                  <.signer_ca signer_ca={@signer_cas[certificate.aki]} org={@org} />
+                </div>
               </div>
             </div>
             <div class="flex gap-2">
@@ -306,6 +321,23 @@ defmodule NervesHubWeb.Components.DevicePage.SettingsTab do
         </div>
       </div>
     </div>
+    """
+  end
+
+  attr(:signer_ca, :any, required: true)
+  attr(:org, :map, required: true)
+
+  defp signer_ca(%{signer_ca: nil} = assigns) do
+    ~H"""
+    <span>Unknown</span>
+    """
+  end
+
+  defp signer_ca(assigns) do
+    ~H"""
+    <.link navigate={~p"/org/#{@org}/settings/certificates/#{@signer_ca}"} class="hover:text-base-300 underline">
+      {CAHelpers.label(@signer_ca)}
+    </.link>
     """
   end
 

--- a/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
+++ b/lib/nerves_hub_web/controllers/api/openapi/device_controller_specs.ex
@@ -54,6 +54,7 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
           * `health_status != "healthy" or alarm_status = "with"`
           * `metric:battery_soc < 20 and updates = "enabled"`
           * `firmware_validation_status = "not_validated"`
+          * `signer_ca = "1234567890"`
           """,
           example: ~s|metric:cpu_temp > 70 and connection = "connected"|
         },
@@ -67,6 +68,12 @@ defmodule NervesHubWeb.API.OpenAPI.DeviceControllerSpecs do
           enum: ["validated", "not_validated", "unknown"]
         },
         firmware_version: %OpenApiSpex.Schema{type: :string, example: "1.10.0"},
+        signer_ca: %OpenApiSpex.Schema{
+          type: :string,
+          description:
+            "The serial of the CA which signed the device's certificate, or `:not_set` for devices with no certificate from a registered CA.",
+          example: "1234567890"
+        },
         has_no_tags: %OpenApiSpex.Schema{type: :string, enum: ["true", "false"]},
         health_status: %OpenApiSpex.Schema{
           type: :string,

--- a/lib/nerves_hub_web/live/devices/index.ex
+++ b/lib/nerves_hub_web/live/devices/index.ex
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHub.Devices.AdvancedQuery
   alias NervesHub.Devices.Alarms
   alias NervesHub.Devices.BulkActions
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.Metrics
@@ -19,6 +20,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
   alias NervesHub.Tracker
   alias NervesHubWeb.Components.AdvancedSearch
   alias NervesHubWeb.Components.BulkActionsSidebar
+  alias NervesHubWeb.Components.CAHelpers
   alias NervesHubWeb.Components.DeviceUpdateStatus
   alias NervesHubWeb.Components.FilterSidebar
   alias NervesHubWeb.Components.HealthStatus
@@ -66,6 +68,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
     |> assign(:sort_direction, "asc")
     |> assign(:paginate_opts, @default_pagination)
     |> assign(:firmware_versions, [])
+    |> assign(:signer_cas, [])
     |> assign(:platforms, [])
     |> assign(:architectures, [])
     |> assign(:advanced_query_tags, [])
@@ -723,6 +726,7 @@ defmodule NervesHubWeb.Live.Devices.Index do
         metrics_keys: Enum.sort(Enum.uniq(Metrics.default_metrics() ++ distinct_metric_keys)),
         deployment_groups: ManagedDeployments.get_deployment_groups_by_product(product),
         firmware_versions: Devices.firmware_versions(product.id),
+        signer_cas: CACertificates.signer_cas_for_product(product.id),
         platforms: Devices.platforms(product.id),
         architectures: Devices.architectures(product.id),
         advanced_query_tags: Devices.distinct_tags(product.id),
@@ -773,9 +777,17 @@ defmodule NervesHubWeb.Live.Devices.Index do
         "deleted" => AdvancedQuery.Schema.boolean_values(nil),
         "update_status" => AdvancedQuery.Schema.update_status_values(nil),
         "firmware" => firmware_suggestion_values(assigns.advanced_query_firmwares),
-        "deployment_group" => Enum.map(assigns.deployment_groups, & &1.name) ++ [AdvancedQuery.Schema.not_set_value()]
+        "deployment_group" => Enum.map(assigns.deployment_groups, & &1.name) ++ [AdvancedQuery.Schema.not_set_value()],
+        "signer_ca" => signer_ca_suggestion_values(assigns.signer_cas)
       }
     })
+  end
+
+  # Signer CA autosuggest shows the CA's description (falling back to its
+  # formatted serial), but the query value is the serial.
+  defp signer_ca_suggestion_values(signer_cas) do
+    Enum.map(signer_cas, &%{label: CAHelpers.label(&1), value: &1.serial}) ++
+      [AdvancedQuery.Schema.not_set_value()]
   end
 
   # Firmware autosuggest shows a friendly "<version> - <short uuid>" label, but

--- a/lib/nerves_hub_web/live/devices/index.html.heex
+++ b/lib/nerves_hub_web/live/devices/index.html.heex
@@ -423,6 +423,16 @@
         {"Unknown", "unknown"}
       ]}
     />
+    <:filter
+      attr="signer_ca"
+      label="Signer CA"
+      type={:select}
+      hint="Only certificate authorities which signed a certificate held by a device in this product are listed."
+      values={
+        [{"All", ""} | Enum.map(@signer_cas, &{CAHelpers.label(&1), &1.serial})] ++
+          [{"No known CA", AdvancedQuery.Schema.not_set_value()}]
+      }
+    />
     <:filter attr="platform" label="Platform" type={:select} values={[{"All", ""} | Enum.map(@platforms, &{if(&1, do: &1, else: "Unknown"), &1})]} />
     <:filter attr="tags" label="Tags" type={:text} />
     <:filter attr="has_no_tags" label="Untagged" type={:select} values={[{"All", "false"}, {"Only untagged", "true"}]} />

--- a/lib/nerves_hub_web/live/org/certificate_authorities.ex
+++ b/lib/nerves_hub_web/live/org/certificate_authorities.ex
@@ -49,6 +49,28 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
     |> render_with(&new_ca_template/1)
   end
 
+  defp apply_action(socket, :show, %{"serial" => serial}) do
+    org = socket.assigns.org
+
+    case CACertificates.get_ca_certificate_by_org_and_serial(org, serial) do
+      {:ok, cert} ->
+        device_counts = CACertificates.device_counts_by_product(cert)
+
+        socket
+        |> page_title("#{CAHelpers.label(cert)} - #{org.name}")
+        |> assign(:certificate, cert)
+        |> assign(:device_counts, device_counts)
+        |> assign(:device_count, Enum.sum_by(device_counts, & &1.device_count))
+        |> sidebar_tab(:certificates)
+        |> render_with(&show_ca_template/1)
+
+      {:error, :not_found} ->
+        socket
+        |> put_flash(:error, "Certificate Authority not found")
+        |> push_navigate(to: ~p"/org/#{org}/settings/certificates")
+    end
+  end
+
   defp apply_action(%{assigns: %{current_scope: scope}} = socket, :edit, %{"serial" => serial}) do
     products = Products.get_products(scope)
 
@@ -81,7 +103,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
          {:ok, _ca_certificate} <- CACertificates.delete_ca_certificate(ca_certificate) do
       socket
       |> put_flash(:info, "Certificate successfully deleted")
-      |> list_certificates()
+      |> push_navigate(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
       |> noreply()
     else
       _ ->
@@ -102,7 +124,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
          {:ok, _cert} <- CACertificates.update_ca_certificate(cert, params) do
       socket
       |> put_flash(:info, "Certificate Authority updated")
-      |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates")
+      |> push_patch(to: ~p"/org/#{socket.assigns.org}/settings/certificates/#{socket.assigns.serial}")
       |> noreply()
     else
       {:error, :not_found} ->
@@ -184,7 +206,11 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
 
   defp list_certificates(socket) do
     certificates = CACertificates.get_ca_certificates(socket.assigns.org)
-    assign(socket, :certificates, certificates)
+    device_counts = CACertificates.device_counts_by_ski(socket.assigns.org)
+
+    socket
+    |> assign(:certificates, certificates)
+    |> assign(:device_counts, device_counts)
   end
 
   defp uploaded_cert(socket) do

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/edit_ca_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/edit_ca_template.html.heex
@@ -79,7 +79,7 @@
         <.button style="primary" type="submit">
           Update Certificate
         </.button>
-        <.button style="secondary" type="link" patch={~p"/org/#{@org}/settings/certificates"}>
+        <.button style="secondary" type="link" patch={~p"/org/#{@org}/settings/certificates/#{@serial}"}>
           Cancel
         </.button>
       </div>

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/list_cas_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/list_cas_template.html.heex
@@ -13,20 +13,20 @@
         <tr>
           <th>Serial</th>
           <th>Description</th>
+          <th>Devices</th>
           <th>Last used</th>
           <th>Not before</th>
           <th>Not after</th>
-          <th>Check expiration?</th>
-          <th>JITP Enabled?</th>
           <th>Status</th>
-          <th></th>
         </tr>
       </thead>
       <tbody>
         <%= for cert <- @certificates do %>
           <tr class="border-base-800 isolate border-b">
             <td>
-              <code class="bg-base-800 text-base-300 rounded px-2 py-1 font-mono text-xs break-all">{Utils.format_serial(cert.serial)}</code>
+              <.link navigate={~p"/org/#{@org}/settings/certificates/#{cert}"}>
+                <code class="bg-base-800 hover:text-base-50 text-base-300 rounded px-2 py-1 font-mono text-xs break-all">{Utils.format_serial(cert.serial)}</code>
+              </.link>
             </td>
             <td>
               <%= if is_nil(cert.description) do %>
@@ -34,6 +34,9 @@
               <% else %>
                 {cert.description}
               <% end %>
+            </td>
+            <td id={"ca-#{cert.id}-device-count"} class="text-base-400">
+              {Number.Delimit.number_to_delimited(Map.get(@device_counts, cert.ski, 0), precision: 0)}
             </td>
             <td class="text-base-400">
               <%= if !is_nil(cert.last_used) do %>
@@ -48,32 +51,8 @@
             <td class="text-base-400">
               <div><.local_datetime at={cert.not_after} time_zone={@time_zone} format={:long_date} zone_label={false} /></div>
             </td>
-            <td class="text-base-400">
-              {if cert.check_expiration, do: "yes", else: "no"}
-            </td>
-            <td class="text-base-400">
-              {if is_nil(cert.jitp), do: "no", else: "yes"}
-            </td>
             <td>
               <CAHelpers.certificate_status not_after={cert.not_after} />
-            </td>
-            <td :if={authorized?(:"certificate_authority:update", @current_scope)} class="text-right">
-              <div class="flex justify-end gap-2">
-                <.link
-                  navigate={~p"/org/#{@org}/settings/certificates/#{cert}/edit"}
-                  class="bg-base-800 border-base-700 hover:bg-base-700 text-base-300 rounded border px-3 py-1.5 text-sm font-medium"
-                >
-                  Edit
-                </.link>
-                <button
-                  class="bg-base-800 border-alert hover:bg-base-700 text-alert rounded border px-3 py-1.5 text-sm font-medium"
-                  phx-click="delete-certificate-authority"
-                  phx-value-certificate_serial={cert.serial}
-                  data-confirm="Are you sure you want to delete this certificate? This can not be undone."
-                >
-                  Delete
-                </button>
-              </div>
             </td>
           </tr>
         <% end %>

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/show_ca_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/show_ca_template.html.heex
@@ -60,15 +60,7 @@
         </div>
         <div class="flex items-center justify-between gap-4">
           <dt class="text-base-400 flex items-center gap-2">
-            Check expiration <%!-- The hover tooltip the filter sidebar uses; `CAHelpers.check_expiration_tooltip/1`
-                  has no CSS behind its classes and renders as always-on text. --%>
-            <div class="relative z-20 flex items-center" id="check-expiration-hint" phx-hook="ToolTip" data-placement="right">
-              <.icon name="info" class="stroke-base-400" />
-              <div class="bg-surface-muted border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden w-max max-w-72 rounded border px-2 py-1.5 text-xs">
-                By default, the time validity of CA certificates is unchecked. You can toggle this to check expiration to prevent device certificates from being created from an expired signing CA certificate.
-                <div class="bg-surface-muted border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
-              </div>
-            </div>
+            Check expiration <CAHelpers.check_expiration_tooltip />
           </dt>
           <dd class="text-base-300">{if @certificate.check_expiration, do: "Yes", else: "No"}</dd>
         </div>

--- a/lib/nerves_hub_web/live/org/certificate_authority_templates/show_ca_template.html.heex
+++ b/lib/nerves_hub_web/live/org/certificate_authority_templates/show_ca_template.html.heex
@@ -1,0 +1,106 @@
+<NervesHubWeb.Layouts.sidebar flash={@flash} current_scope={@current_scope} sidebar_tab={@sidebar_tab}>
+  <:top_bar>
+    <.breadcrumb navigate={~p"/org/#{@org}/settings/certificates"} root_label="All Certificate Authorities" root_class="hidden whitespace-nowrap md:block">
+      <:crumb class="hidden lg:block">{CAHelpers.label(@certificate)}</:crumb>
+    </.breadcrumb>
+  </:top_bar>
+
+  <:header>
+    <h1 class="text-base-50 text-xl leading-[30px] font-semibold">{CAHelpers.label(@certificate)}</h1>
+    <div class="mr-auto"></div>
+    <.button :if={authorized?(:"certificate_authority:update", @current_scope)} type="link" navigate={~p"/org/#{@org}/settings/certificates/#{@certificate}/edit"}>
+      Edit
+    </.button>
+    <button
+      :if={authorized?(:"certificate_authority:delete", @current_scope)}
+      class="bg-base-800 border-alert hover:bg-base-700 text-alert rounded border px-3 py-1.5 text-sm font-medium"
+      type="button"
+      phx-click="delete-certificate-authority"
+      phx-value-certificate_serial={@certificate.serial}
+      data-confirm="Are you sure you want to delete this certificate? This can not be undone."
+    >
+      Delete
+    </button>
+  </:header>
+
+  <div class="flex max-w-[650px] flex-col gap-6 px-6 py-4">
+    <div class="bg-surface-raised border-base-700 flex flex-col rounded border">
+      <div class="border-base-700 flex h-14 items-center justify-between border-b px-4">
+        <div class="text-base-50 text-base font-medium">Certificate Authority</div>
+        <CAHelpers.certificate_status not_after={@certificate.not_after} />
+      </div>
+      <dl class="flex flex-col gap-3 p-4 text-sm">
+        <div class="flex justify-between gap-4">
+          <dt class="text-base-400">Serial</dt>
+          <dd>
+            <code class="bg-base-800 text-base-300 rounded px-2 py-1 font-mono text-xs break-all">{Utils.format_serial(@certificate.serial)}</code>
+          </dd>
+        </div>
+        <div class="flex justify-between gap-4">
+          <dt class="text-base-400">Description</dt>
+          <dd class="text-base-300">{@certificate.description || "-"}</dd>
+        </div>
+        <div class="flex justify-between gap-4">
+          <dt class="text-base-400">Last used</dt>
+          <dd class="text-base-300">
+            {if @certificate.last_used, do: DateTimeFormat.from_now(@certificate.last_used), else: "Never"}
+          </dd>
+        </div>
+        <div class="flex justify-between gap-4">
+          <dt class="text-base-400">Not before</dt>
+          <dd class="text-base-300">
+            <div phx-hook="SimpleDate" id="ca-not-before" class="date-time">{@certificate.not_before}</div>
+          </dd>
+        </div>
+        <div class="flex justify-between gap-4">
+          <dt class="text-base-400">Not after</dt>
+          <dd class="text-base-300">
+            <div phx-hook="SimpleDate" id="ca-not-after" class="date-time">{@certificate.not_after}</div>
+          </dd>
+        </div>
+        <div class="flex items-center justify-between gap-4">
+          <dt class="text-base-400 flex items-center gap-2">
+            Check expiration <%!-- The hover tooltip the filter sidebar uses; `CAHelpers.check_expiration_tooltip/1`
+                  has no CSS behind its classes and renders as always-on text. --%>
+            <div class="relative z-20 flex items-center" id="check-expiration-hint" phx-hook="ToolTip" data-placement="right">
+              <.icon name="info" class="stroke-base-400" />
+              <div class="bg-surface-muted border-base-700 tooltip-content absolute top-0 left-0 z-20 hidden w-max max-w-72 rounded border px-2 py-1.5 text-xs">
+                By default, the time validity of CA certificates is unchecked. You can toggle this to check expiration to prevent device certificates from being created from an expired signing CA certificate.
+                <div class="bg-surface-muted border-base-700 tooltip-arrow absolute size-2 origin-center rotate-45"></div>
+              </div>
+            </div>
+          </dt>
+          <dd class="text-base-300">{if @certificate.check_expiration, do: "Yes", else: "No"}</dd>
+        </div>
+        <div class="flex justify-between gap-4">
+          <dt class="text-base-400">Just In Time Provisioning</dt>
+          <dd class="text-base-300">
+            {if @certificate.jitp, do: "Enabled for #{@certificate.jitp.product.name}", else: "Disabled"}
+          </dd>
+        </div>
+      </dl>
+    </div>
+
+    <div id="ca-devices" class="bg-surface-raised border-base-700 flex flex-col rounded border">
+      <div class="border-base-700 flex h-14 items-center gap-2 border-b px-4">
+        <div class="text-base-50 text-base font-medium">Devices</div>
+        <div class="bg-base-800 text-base-300 rounded-sm px-1.5 py-0.5 text-xs">
+          {Number.Delimit.number_to_delimited(@device_count, precision: 0)}
+        </div>
+      </div>
+      <div class="flex flex-col px-4 py-3">
+        <div :if={@device_counts == []} class="text-base-400 text-sm">
+          No devices are using a certificate signed by this Certificate Authority.
+        </div>
+        <.link
+          :for={%{product: product, device_count: device_count} <- @device_counts}
+          navigate={~p"/org/#{@org}/#{product}/devices?#{[signer_ca: @certificate.serial]}"}
+          class="hover:bg-base-800 -mx-2 flex items-center justify-between gap-4 rounded px-2 py-1.5"
+        >
+          <span class="text-base-300 text-sm">{product.name}</span>
+          <span class="text-base-400 text-sm">{Number.Delimit.number_to_delimited(device_count, precision: 0)}</span>
+        </.link>
+      </div>
+    </div>
+  </div>
+</NervesHubWeb.Layouts.sidebar>

--- a/lib/nerves_hub_web/router.ex
+++ b/lib/nerves_hub_web/router.ex
@@ -332,6 +332,7 @@ defmodule NervesHubWeb.Router do
 
       live("/org/:org_name/settings/certificates", CertificateAuthorities, :index)
       live("/org/:org_name/settings/certificates/new", CertificateAuthorities, :new)
+      live("/org/:org_name/settings/certificates/:serial", CertificateAuthorities, :show)
       live("/org/:org_name/settings/delete", Delete)
 
       live(

--- a/priv/repo/migrations/20260908120000_add_aki_index_to_device_certificates.exs
+++ b/priv/repo/migrations/20260908120000_add_aki_index_to_device_certificates.exs
@@ -1,0 +1,14 @@
+defmodule NervesHub.Repo.Migrations.AddAkiIndexToDeviceCertificates do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change() do
+    # Signer CA lookups match `device_certificates.aki` against
+    # `ca_certificates.ski`, both to count the devices using a CA and to filter
+    # the device list by one. Include `device_id` so the counts can be answered
+    # from the index alone.
+    create(index(:device_certificates, [:aki, :device_id], concurrently: true))
+  end
+end

--- a/test/nerves_hub/devices/advanced_query/compiler_test.exs
+++ b/test/nerves_hub/devices/advanced_query/compiler_test.exs
@@ -6,6 +6,7 @@ defmodule NervesHub.Devices.AdvancedQuery.CompilerTest do
 
   alias NervesHub.Devices.AdvancedQuery.Compiler
   alias NervesHub.Devices.AdvancedQuery.Parser
+  alias NervesHub.Devices.AdvancedQuery.Schema
   alias NervesHub.Devices.Device
   alias NervesHub.Fixtures
   alias NervesHub.ManagedDeployments.DeploymentGroup
@@ -193,6 +194,38 @@ defmodule NervesHub.Devices.AdvancedQuery.CompilerTest do
     test "health_status unknown matches devices with no health record", %{product: product} do
       assert run(product, ~s|health_status = "unknown"|) == ["never_connected", "untagged"]
       assert run(product, ~s|health_status != "unknown"|) == ["connected", "tagged"]
+    end
+
+    test "signer_ca matches devices whose certificate that CA signed", %{
+      product: product,
+      org: org,
+      tagged: tagged,
+      untagged: untagged
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+      other_ca = Fixtures.ca_certificate_fixture(org)
+
+      Fixtures.device_certificate_fixture_for_ca(tagged, ca)
+      Fixtures.device_certificate_fixture_for_ca(untagged, other_ca)
+
+      assert run(product, ~s|signer_ca = "#{ca.db_cert.serial}"|) == ["tagged"]
+
+      assert run(product, ~s|signer_ca != "#{ca.db_cert.serial}"|) ==
+               ["connected", "never_connected", "untagged"]
+    end
+
+    test "signer_ca not set matches devices with no certificate from a registered CA", %{
+      product: product,
+      org: org,
+      tagged: tagged
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+      Fixtures.device_certificate_fixture_for_ca(tagged, ca)
+
+      not_set = Schema.not_set_value()
+
+      assert run(product, ~s|signer_ca = "#{not_set}"|) == ["connected", "never_connected", "untagged"]
+      assert run(product, ~s|signer_ca != "#{not_set}"|) == ["tagged"]
     end
 
     test "health_status inequality includes devices with no health record", %{product: product} do

--- a/test/nerves_hub/devices/advanced_query/schema_test.exs
+++ b/test/nerves_hub/devices/advanced_query/schema_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
 
   alias NervesHub.AdvancedQueryFixtures
   alias NervesHub.Devices.AdvancedQuery.Schema
+  alias NervesHub.Fixtures
 
   # No product needed: these only exercise the static whitelist.
   describe "column?/1" do
@@ -10,6 +11,7 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
       assert Schema.column?("platform")
       assert Schema.column?("tags")
       assert Schema.column?("deployment_group")
+      assert Schema.column?("signer_ca")
       assert Schema.column?("search")
       refute Schema.column?("bogus")
       refute Schema.column?("")
@@ -29,6 +31,7 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
       assert Schema.operators("tags") == ["contains", "not_contains"]
       assert Schema.operators("update_status") == ["is", "is not"]
       assert Schema.operators("firmware_validation_status") == ["=", "!="]
+      assert Schema.operators("signer_ca") == ["=", "!="]
       assert Schema.operators("identifier") == ["like", "not like"]
       assert Schema.operators("search") == ["like", "not like"]
     end
@@ -103,11 +106,27 @@ defmodule NervesHub.Devices.AdvancedQuery.SchemaTest do
       refute Schema.value?("firmware", "00000000-0000-0000-0000-000000000000", product.id)
     end
 
+    test "validates signer_ca against the CAs which signed the product's devices", %{
+      product: product,
+      org: org,
+      tagged: tagged
+    } do
+      used = Fixtures.ca_certificate_fixture(org)
+      unused = Fixtures.ca_certificate_fixture(org)
+      Fixtures.device_certificate_fixture_for_ca(tagged, used)
+
+      assert Schema.value?("signer_ca", used.db_cert.serial, product.id)
+      refute Schema.value?("signer_ca", unused.db_cert.serial, product.id)
+      refute Schema.value?("signer_ca", "nope", product.id)
+    end
+
     test "the not-set sentinel is valid for nullable columns", %{product: product} do
       assert Schema.value?("tags", ":not_set", product.id)
       assert Schema.value?("deployment_group", ":not_set", product.id)
+      assert Schema.value?("signer_ca", ":not_set", product.id)
       assert Schema.not_set_value() in Schema.values("tags", product.id)
       assert Schema.not_set_value() in Schema.values("deployment_group", product.id)
+      assert Schema.not_set_value() in Schema.values("signer_ca", product.id)
     end
   end
 end

--- a/test/nerves_hub/devices/ca_certificates_test.exs
+++ b/test/nerves_hub/devices/ca_certificates_test.exs
@@ -1,0 +1,202 @@
+defmodule NervesHub.Devices.CACertificatesTest do
+  use NervesHub.DataCase, async: true
+
+  alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
+  alias NervesHub.Fixtures
+
+  setup do
+    user = Fixtures.user_fixture()
+    org = Fixtures.org_fixture(user)
+    product = Fixtures.product_fixture(user, org)
+    org_key = Fixtures.org_key_fixture(org, user)
+    firmware = Fixtures.firmware_fixture(org_key, product)
+
+    %{user: user, org: org, product: product, firmware: firmware, org_key: org_key}
+  end
+
+  describe "device_counts_by_ski/1" do
+    test "counts the devices signed by each CA", %{org: org, product: product, firmware: firmware} do
+      ca_one = Fixtures.ca_certificate_fixture(org)
+      ca_two = Fixtures.ca_certificate_fixture(org)
+
+      for _ <- 1..2 do
+        device = Fixtures.device_fixture(org, product, firmware)
+        Fixtures.device_certificate_fixture_for_ca(device, ca_one)
+      end
+
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca_two)
+
+      counts = CACertificates.device_counts_by_ski(org)
+
+      assert counts[ca_one.db_cert.ski] == 2
+      assert counts[ca_two.db_cert.ski] == 1
+    end
+
+    test "counts a device with several certificates from the same CA once", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+      device = Fixtures.device_fixture(org, product, firmware)
+
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      assert CACertificates.device_counts_by_ski(org)[ca.db_cert.ski] == 1
+    end
+
+    test "leaves out soft deleted devices", %{org: org, product: product, firmware: firmware} do
+      ca = Fixtures.ca_certificate_fixture(org)
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      {:ok, _device} = Devices.delete_device(device)
+
+      refute Map.has_key?(CACertificates.device_counts_by_ski(org), ca.db_cert.ski)
+    end
+
+    test "has no entry for a CA which signed nothing", %{org: org} do
+      ca = Fixtures.ca_certificate_fixture(org)
+
+      assert CACertificates.device_counts_by_ski(org) == %{}
+      refute Map.has_key?(CACertificates.device_counts_by_ski(org), ca.db_cert.ski)
+    end
+
+    test "does not count another org's devices", %{org: org, product: product, firmware: firmware} do
+      ca = Fixtures.ca_certificate_fixture(org)
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      other_user = Fixtures.user_fixture()
+      other_org = Fixtures.org_fixture(other_user)
+
+      assert CACertificates.device_counts_by_ski(other_org) == %{}
+    end
+  end
+
+  describe "device_counts_by_product/1" do
+    test "breaks the count down by product, ordered by name", %{
+      user: user,
+      org: org,
+      product: product,
+      firmware: firmware,
+      org_key: org_key
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+
+      other_product = Fixtures.product_fixture(user, org, %{name: "AAA other product"})
+      other_firmware = Fixtures.firmware_fixture(org_key, other_product)
+
+      for _ <- 1..2 do
+        device = Fixtures.device_fixture(org, product, firmware)
+        Fixtures.device_certificate_fixture_for_ca(device, ca)
+      end
+
+      device = Fixtures.device_fixture(org, other_product, other_firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      assert [
+               %{product: %{id: other_id}, device_count: 1},
+               %{product: %{id: id}, device_count: 2}
+             ] = CACertificates.device_counts_by_product(ca.db_cert)
+
+      assert other_id == other_product.id
+      assert id == product.id
+    end
+
+    test "is empty for a CA which signed nothing", %{org: org} do
+      ca = Fixtures.ca_certificate_fixture(org)
+
+      assert CACertificates.device_counts_by_product(ca.db_cert) == []
+    end
+
+    test "leaves out soft deleted devices", %{org: org, product: product, firmware: firmware} do
+      ca = Fixtures.ca_certificate_fixture(org)
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      {:ok, _device} = Devices.delete_device(device)
+
+      assert CACertificates.device_counts_by_product(ca.db_cert) == []
+    end
+  end
+
+  describe "signer_cas_for_product/1" do
+    test "only returns CAs which signed a certificate held by a device in the product", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      used = Fixtures.ca_certificate_fixture(org)
+      _unused = Fixtures.ca_certificate_fixture(org)
+
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, used)
+
+      assert [ca] = CACertificates.signer_cas_for_product(product.id)
+      assert ca.id == used.db_cert.id
+    end
+
+    test "returns each CA once no matter how many devices use it", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+
+      for _ <- 1..3 do
+        device = Fixtures.device_fixture(org, product, firmware)
+        Fixtures.device_certificate_fixture_for_ca(device, ca)
+      end
+
+      assert [_ca] = CACertificates.signer_cas_for_product(product.id)
+    end
+
+    test "does not return CAs used only by another product", %{
+      user: user,
+      org: org,
+      product: product,
+      firmware: firmware,
+      org_key: org_key
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      other_product = Fixtures.product_fixture(user, org, %{name: "other product"})
+      _other_firmware = Fixtures.firmware_fixture(org_key, other_product)
+
+      assert CACertificates.signer_cas_for_product(other_product.id) == []
+    end
+  end
+
+  describe "by_ski/2" do
+    test "returns the org's CAs keyed by SKI", %{org: org} do
+      ca_one = Fixtures.ca_certificate_fixture(org)
+      ca_two = Fixtures.ca_certificate_fixture(org)
+
+      found = CACertificates.by_ski(org, [ca_one.db_cert.ski, ca_two.db_cert.ski])
+
+      assert found[ca_one.db_cert.ski].id == ca_one.db_cert.id
+      assert found[ca_two.db_cert.ski].id == ca_two.db_cert.id
+    end
+
+    test "ignores nil SKIs and unknown ones", %{org: org} do
+      ca = Fixtures.ca_certificate_fixture(org)
+
+      assert %{} == CACertificates.by_ski(org, [nil])
+      assert map_size(CACertificates.by_ski(org, [nil, ca.db_cert.ski, "nope"])) == 1
+    end
+
+    test "does not return another org's CA", %{org: org} do
+      other_user = Fixtures.user_fixture()
+      other_org = Fixtures.org_fixture(other_user)
+      other_ca = Fixtures.ca_certificate_fixture(other_org)
+
+      assert CACertificates.by_ski(org, [other_ca.db_cert.ski]) == %{}
+    end
+  end
+end

--- a/test/nerves_hub/devices/device_filtering_test.exs
+++ b/test/nerves_hub/devices/device_filtering_test.exs
@@ -3,6 +3,7 @@ defmodule NervesHub.Devices.DeviceFilteringTest do
 
   import Ecto.Query
 
+  alias NervesHub.Devices.AdvancedQuery.Schema
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceFiltering
   alias NervesHub.Devices.Health
@@ -399,6 +400,57 @@ defmodule NervesHub.Devices.DeviceFilteringTest do
       query = base_query(product)
       result = DeviceFiltering.filter(query, %{}, :firmware_validation_status, "bogus") |> identifiers()
       assert device.identifier in result
+    end
+  end
+
+  describe "filter/4 :signer_ca" do
+    test "filters devices by the CA which signed their certificate", %{org: org, product: product, firmware: firmware} do
+      ca = Fixtures.ca_certificate_fixture(org)
+      other_ca = Fixtures.ca_certificate_fixture(org)
+
+      signed = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(signed, ca)
+
+      other = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(other, other_ca)
+
+      no_certificate = Fixtures.device_fixture(org, product, firmware)
+
+      query = base_query(product)
+      result = DeviceFiltering.filter(query, %{}, :signer_ca, ca.db_cert.serial) |> identifiers()
+
+      assert signed.identifier in result
+      refute other.identifier in result
+      refute no_certificate.identifier in result
+    end
+
+    test "the not set sentinel matches devices with no certificate from a registered CA", %{
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+
+      signed = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(signed, ca)
+
+      no_certificate = Fixtures.device_fixture(org, product, firmware)
+
+      query = base_query(product)
+      result = DeviceFiltering.filter(query, %{}, :signer_ca, Schema.not_set_value()) |> identifiers()
+
+      assert no_certificate.identifier in result
+      refute signed.identifier in result
+    end
+
+    test "an unknown serial matches nothing", %{org: org, product: product, firmware: firmware} do
+      ca = Fixtures.ca_certificate_fixture(org)
+      device = Fixtures.device_fixture(org, product, firmware)
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      query = base_query(product)
+
+      assert DeviceFiltering.filter(query, %{}, :signer_ca, "nope") |> identifiers() == []
     end
   end
 

--- a/test/nerves_hub_web/components/ca_helpers_test.exs
+++ b/test/nerves_hub_web/components/ca_helpers_test.exs
@@ -1,0 +1,48 @@
+defmodule NervesHubWeb.Components.CAHelpersTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias NervesHub.Devices.CACertificate
+  alias NervesHubWeb.Components.CAHelpers
+
+  defp status(not_after) do
+    render_component(&CAHelpers.certificate_status/1, not_after: not_after)
+  end
+
+  describe "certificate_status/1" do
+    test "a CA with months left is current" do
+      html = status(DateTime.shift(DateTime.utc_now(), year: 1))
+
+      assert html =~ "Current"
+      assert html =~ "text-base-400"
+    end
+
+    test "a CA inside its last three months is expiring soon" do
+      html = status(DateTime.shift(DateTime.utc_now(), month: 1))
+
+      assert html =~ "Expiring Soon"
+      assert html =~ "text-warning-content"
+    end
+
+    test "a CA past its not_after is expired" do
+      html = status(DateTime.shift(DateTime.utc_now(), day: -1))
+
+      assert html =~ "Expired"
+      assert html =~ "text-alert-content"
+    end
+  end
+
+  describe "label/1" do
+    test "is the description when the CA has one" do
+      assert CAHelpers.label(%CACertificate{description: "Factory signer", serial: "1"}) ==
+               "Factory signer"
+    end
+
+    test "falls back to the formatted serial when the description is missing" do
+      for description <- [nil, ""] do
+        assert CAHelpers.label(%CACertificate{description: description, serial: "255"}) == "FF"
+      end
+    end
+  end
+end

--- a/test/nerves_hub_web/live/devices/index_filter_data_test.exs
+++ b/test/nerves_hub_web/live/devices/index_filter_data_test.exs
@@ -47,7 +47,7 @@ defmodule NervesHubWeb.Live.Devices.IndexFilterDataTest do
       [:nerves_hub, :repo, :query],
       fn _event, _measurements, %{query: query}, _config ->
         cond do
-          # `Devices.distinct_tags/1`, one of the nine filter dropdown queries
+          # `Devices.distinct_tags/1`, one of the ten filter dropdown queries
           String.contains?(query, "DISTINCT unnest") ->
             :counters.add(counter, 2, 1)
 

--- a/test/nerves_hub_web/live/devices/index_test.exs
+++ b/test/nerves_hub_web/live/devices/index_test.exs
@@ -8,6 +8,7 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
   alias NervesHub.DeviceEvents
   alias NervesHub.DeviceLink.DeviceInfo
   alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
   alias NervesHub.Devices.Connections
   alias NervesHub.Devices.Device
   alias NervesHub.Devices.DeviceConnection
@@ -718,6 +719,29 @@ defmodule NervesHubWeb.Live.Devices.IndexTest do
       |> select("Firmware Validation", option: "Unknown")
       |> assert_has("#device-count", text: "1", timeout: 1_000)
       |> assert_has("div a", text: device.identifier)
+    end
+
+    test "by signer CA", %{conn: conn, fixture: fixture} do
+      %{device: device, firmware: firmware, org: org, product: product} = fixture
+
+      ca = Fixtures.ca_certificate_fixture(org)
+      {:ok, ca_cert} = CACertificates.update_ca_certificate(ca.db_cert, %{description: "Factory signer"})
+
+      signed = Fixtures.device_fixture(org, product, firmware, %{})
+      Fixtures.device_certificate_fixture_for_ca(signed, ca)
+
+      conn
+      |> visit(device_index_path(fixture))
+      |> assert_has("#device-count", text: "2", timeout: 1000)
+      |> select("Signer CA", option: ca_cert.description)
+      |> assert_has("#device-count", text: "1", timeout: 1_000)
+      |> assert_has("div a", text: signed.identifier)
+      |> refute_has("div a", text: device.identifier)
+      # the fixture device's certificate was signed by a CA which isn't registered
+      |> select("Signer CA", option: "No known CA")
+      |> assert_has("#device-count", text: "1", timeout: 1_000)
+      |> assert_has("div a", text: device.identifier)
+      |> refute_has("div a", text: signed.identifier)
     end
 
     test "by several tags", %{conn: conn, fixture: fixture} do

--- a/test/nerves_hub_web/live/devices/show/settings_tab_test.exs
+++ b/test/nerves_hub_web/live/devices/show/settings_tab_test.exs
@@ -2,6 +2,8 @@ defmodule NervesHubWeb.Live.Devices.Show.SettingsTabTest do
   use NervesHubWeb.ConnCase.Browser, async: true
 
   alias NervesHub.Devices
+  alias NervesHub.Devices.CACertificates
+  alias NervesHub.Fixtures
   alias NervesHub.Repo
   alias NervesHubWeb.Components.Utils
 
@@ -74,6 +76,34 @@ defmodule NervesHubWeb.Live.Devices.Show.SettingsTabTest do
       device = Repo.preload(device, :device_certificates, force: true)
 
       assert Enum.empty?(device.device_certificates)
+    end
+
+    test "shows the signer CA when it is registered with the org", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      ca = Fixtures.ca_certificate_fixture(org)
+      {:ok, ca_cert} = CACertificates.update_ca_certificate(ca.db_cert, %{description: "Factory signer"})
+      Fixtures.device_certificate_fixture_for_ca(device, ca)
+
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices/#{device}/settings")
+      |> assert_has("div", text: "Signer CA:")
+      |> assert_has("a[href='/org/#{org.name}/settings/certificates/#{ca_cert.serial}']", text: "Factory signer")
+    end
+
+    test "shows the signer CA as unknown when it was never registered", %{
+      conn: conn,
+      org: org,
+      product: product,
+      device: device
+    } do
+      # The fixture device's certificate is signed by a CA which isn't in the DB.
+      conn
+      |> visit(~p"/org/#{org}/#{product}/devices/#{device}/settings")
+      |> assert_has("div", text: "Signer CA: Unknown")
     end
 
     test "can download certificate", %{conn: conn, org: org, product: product, device: device} do

--- a/test/nerves_hub_web/live/org/certificate_authorities_test.exs
+++ b/test/nerves_hub_web/live/org/certificate_authorities_test.exs
@@ -21,6 +21,97 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
     end
   end
 
+  describe "index device counts" do
+    test "counts the devices using each CA", %{conn: conn, org: org, product: product, firmware: firmware} do
+      %{db_cert: in_use} = ca = Fixtures.ca_certificate_fixture(org)
+      %{db_cert: unused} = Fixtures.ca_certificate_fixture(org)
+
+      for _ <- 1..2 do
+        device = Fixtures.device_fixture(org, product, firmware)
+        Fixtures.device_certificate_fixture_for_ca(device, ca)
+      end
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates")
+      |> assert_has("th", text: "Devices")
+      |> assert_has("#ca-#{in_use.id}-device-count", text: "2")
+      |> assert_has("#ca-#{unused.id}-device-count", text: "0")
+    end
+  end
+
+  describe "show" do
+    test "shows the CA's details", %{conn: conn, org: org} do
+      %{db_cert: ca_cert} = Fixtures.ca_certificate_fixture(org)
+      {:ok, ca_cert} = CACertificates.update_ca_certificate(ca_cert, %{description: "Factory signer"})
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates/#{ca_cert.serial}")
+      |> assert_has("h1", text: "Factory signer")
+      |> assert_has("a[href='/org/#{org.name}/settings/certificates']", text: "All Certificate Authorities")
+      |> assert_has("code", text: Utils.format_serial(ca_cert.serial))
+      |> assert_has("dd", text: "Never")
+      |> assert_has("dd", text: "Disabled")
+      |> assert_has("a", text: "Edit")
+    end
+
+    test "falls back to the serial when the CA has no description", %{conn: conn, org: org} do
+      %{db_cert: %{serial: serial}} = Fixtures.ca_certificate_fixture(org)
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates/#{serial}")
+      |> assert_has("h1", text: Utils.format_serial(serial))
+    end
+
+    test "shows the devices using the CA, linked to each product's filtered device list", %{
+      conn: conn,
+      org: org,
+      product: product,
+      firmware: firmware
+    } do
+      %{db_cert: %{serial: serial}} = ca = Fixtures.ca_certificate_fixture(org)
+
+      for _ <- 1..2 do
+        device = Fixtures.device_fixture(org, product, firmware)
+        Fixtures.device_certificate_fixture_for_ca(device, ca)
+      end
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates/#{serial}")
+      |> assert_has("#ca-devices", text: "Devices")
+      |> assert_has("#ca-devices", text: product.name)
+      |> assert_has("#ca-devices a[href='/org/#{org.name}/#{product.name}/devices?signer_ca=#{serial}']", text: "2")
+    end
+
+    test "says so when no devices are using the CA", %{conn: conn, org: org} do
+      %{db_cert: %{serial: serial}} = Fixtures.ca_certificate_fixture(org)
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates/#{serial}")
+      |> assert_has("#ca-devices", text: "No devices are using a certificate signed by this Certificate Authority.")
+      |> refute_has("#ca-devices a")
+    end
+
+    test "is reachable from the list", %{conn: conn, org: org} do
+      %{db_cert: %{serial: serial}} = Fixtures.ca_certificate_fixture(org)
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates")
+      |> click_link("a[href='/org/#{org.name}/settings/certificates/#{serial}']", "")
+      |> assert_path("/org/#{org.name}/settings/certificates/#{serial}")
+    end
+
+    test "redirects when the CA belongs to another org", %{conn: conn, org: org} do
+      other_user = Fixtures.user_fixture()
+      other_org = Fixtures.org_fixture(other_user, %{name: "someone-else"})
+      %{db_cert: %{serial: serial}} = Fixtures.ca_certificate_fixture(other_org)
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates/#{serial}")
+      |> assert_path("/org/#{org.name}/settings/certificates")
+      |> assert_has("div", text: "Certificate Authority not found")
+    end
+  end
+
   describe "new" do
     test "CA is created on success", %{conn: conn, org: org, tmp_dir: tmp_dir} do
       description = "My ca"
@@ -52,7 +143,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_path("/org/#{org.name}/settings/certificates")
       |> assert_has("div", text: "Certificate Authority created")
       |> assert_has("h1", text: "Certificate Authorities")
-      |> assert_has("tr > td > code")
+      |> assert_has("tr > td > a > code")
 
       {:ok, ca} = File.read!(ca_file_path) |> X509.Certificate.from_pem()
 
@@ -167,7 +258,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_path("/org/#{org.name}/settings/certificates")
       |> assert_has("div", text: "Certificate Authority created")
       |> assert_has("h1", text: "Certificate Authorities")
-      |> assert_has("tr > td > code")
+      |> assert_has("tr > td > a > code")
 
       {:ok, ca} = File.read!(ca_file_path) |> X509.Certificate.from_pem()
 
@@ -183,31 +274,41 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
   end
 
   describe "delete" do
-    test "deletes  certificate authority", %{conn: conn, org: org} do
+    test "deletes the certificate authority from its show page", %{conn: conn, org: org} do
       %{db_cert: ca} = Fixtures.ca_certificate_fixture(org)
 
       conn
-      |> visit("/org/#{org.name}/settings/certificates")
-      |> assert_has("h1", text: "Certificate Authorities")
-      |> assert_has("code", text: Utils.format_serial(ca.serial))
+      |> visit("/org/#{org.name}/settings/certificates/#{ca.serial}")
       |> click_button("Delete")
+      |> assert_path("/org/#{org.name}/settings/certificates")
       |> assert_has("div", text: "Certificate successfully deleted")
+      |> assert_has("h1", text: "Certificate Authorities")
       |> refute_has("code", text: Utils.format_serial(ca.serial))
 
       assert {:error, :not_found} = CACertificates.get_ca_certificate_by_serial(ca.serial)
     end
 
     test "shows error when delete fails", %{conn: conn, org: org} do
-      %{db_cert: _ca} = Fixtures.ca_certificate_fixture(org)
+      %{db_cert: ca} = Fixtures.ca_certificate_fixture(org)
 
       stub(CACertificates, :delete_ca_certificate, fn _ ->
         {:error, :cannot_delete}
       end)
 
       conn
-      |> visit("/org/#{org.name}/settings/certificates")
+      |> visit("/org/#{org.name}/settings/certificates/#{ca.serial}")
       |> click_button("Delete")
       |> assert_has("div", text: "Failed to delete certificate. Please contact support if this happens again.")
+    end
+
+    test "the list no longer offers per-row edit and delete", %{conn: conn, org: org} do
+      %{db_cert: ca} = Fixtures.ca_certificate_fixture(org)
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates")
+      |> assert_has("code", text: Utils.format_serial(ca.serial))
+      |> refute_has("tbody button")
+      |> refute_has("a[href='/org/#{org.name}/settings/certificates/#{ca.serial}/edit']")
     end
   end
 
@@ -220,7 +321,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_has("h1", text: "Edit Certificate Authority")
       |> fill_in("Description", with: "a new description")
       |> click_button("Update Certificate")
-      |> assert_path("/org/#{org.name}/settings/certificates")
+      |> assert_path("/org/#{org.name}/settings/certificates/#{serial}")
       |> assert_has("div", text: "Certificate Authority updated")
 
       assert {:ok, %{description: "a new description", serial: ^serial}} =

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -509,6 +509,19 @@ defmodule NervesHub.Fixtures do
     %{db_cert: device_cert, cert: cert}
   end
 
+  @doc """
+  A device certificate signed by the CA built by `ca_certificate_fixture/2`, so
+  the certificate's AKI is the CA's SKI - the way the two are tied together.
+  """
+  def device_certificate_fixture_for_ca(%Devices.Device{} = device, %{cert: ca_cert, key: ca_key}) do
+    otp_cert =
+      X509.PrivateKey.new_ec(:secp256r1)
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new("/CN=#{device.identifier}", ca_cert, ca_key)
+
+    device_certificate_fixture(device, otp_cert)
+  end
+
   def device_certificate_fixture_without_der(%Devices.Device{} = device, cert) do
     fixture = device_certificate_fixture(device, cert)
 


### PR DESCRIPTION
A device certificate names its signer by key id: `device_certificates.aki` holds the CA's `ski`. There's no foreign key, and nothing in the UI followed that link. Opening a device told you it had a certificate but not who signed it, and the Certificate Authorities list gave no way to tell a signer with a fleet behind it from one nothing uses.

Closes https://github.com/nerves-hub/nerves_hub_web/issues/659

## Device settings

Each certificate now shows `Signer CA:` alongside its serial and validity, linking to the CA.

The lookup is scoped to the device's org, so a certificate signed by another org's CA reads "Unknown" rather than exposing that CA. Certificates whose signer was never registered read "Unknown" too. That includes the NervesHubCA-signed certificates the AKI validation lets through from other orgs.

## A show page for a CA

There wasn't one. The only per-CA page was the edit form, whose save is gated on `certificate_authority:update`, so it's the wrong place to send a viewer who just wants to look. `/org/:org/settings/certificates/:serial` shows the CA's details and a Devices card: the total, then a row per product linking to that product's device list filtered by this CA.

The device list is scoped to one product and a CA is scoped to the org, so per-product rows are the only shape a working link can take.

The list page loses its per-row Edit and Delete buttons and the `Check expiration?` / `JITP Enabled?` columns; the serial links to the show page, and Delete lives there now. It gains a Devices count.

## Filtering

A `Signer CA` select in the device list sidebar, built from the CAs that signed a certificate held by a device in this product. That's the same treatment the firmware version filter got in #3020, and it carries the same kind of hint tooltip explaining why a CA you expected might be missing. A "No known CA" option covers shared secret devices and unregistered signers.

It goes through the same filter map as every other sidebar filter, so `filters[signer_ca]` works on the device list API. There's a matching `signer_ca` advanced query column supporting `=` and `!=`:

```
signer_ca = "613033017807900175"
signer_ca != ":not_set" and connection = "connected"
```

Autosuggest shows the CA's description and sends the serial, the way `firmware` shows a version and sends a UUID. The OpenAPI spec documents both.

## The index

`device_certificates` had no index on `aki`, so every count and every filtered device list would sequential-scan it. This adds `(aki, device_id)` concurrently. The device id is in there so the counts can be answered from the index alone.

## Two things in `CAHelpers` that stopped working

Both are casualties of #2494, which deleted the old SCSS. The components survived; the CSS they depended on didn't.

`check_expiration_tooltip/1` styles nothing: `tooltip-info` and `tooltip-text` have no rules behind them any more, and `display: none` was the line that made it a tooltip. Without it the text is always on, which is the paragraph sitting in the middle of the new and edit CA forms. It's rebuilt on the `ToolTip` hook, the same shape `HealthStatus` uses, so it degrades to hidden rather than to visible. The show page calls it instead of carrying its own copy.

`certificate_status/1` had the same problem with more at stake: `.certificate-status-expired` (red) and `.certificate-status-expiring-soon` (amber) went with the SCSS, so an expired CA rendered in the same colour as a current one. It now returns `text-alert-content` / `text-warning-content` / `text-base-400` rather than class names Tailwind's `@source` scanning can't see.

Writing the first test for `certificate_status/1` turned up a third problem. "Expiring Soon" was unreachable:

```elixir
DateTime.after?(DateTime.shift(DateTime.utc_now(), month: -3), assigns.not_after)
```

A negative shift puts the cutoff three months in the *past*, so the clause only matched certificates that expired over three months ago, which the `Expired` clause above it had already taken. The shift is now positive, and the status has test coverage for all three branches.

## Noticed but not fixed

The edit page looks a CA up by serial alone, with no org check. Serials are globally unique, so a member of one org can open and save another org's CA. The show page added here uses `get_ca_certificate_by_org_and_serial/2`. Fixing edit is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
