### PR TITLE
Scope the certificate authority edit page to its org

### DIFF
--- a/lib/nerves_hub_web/live/org/certificate_authorities.ex
+++ b/lib/nerves_hub_web/live/org/certificate_authorities.ex
@@ -74,7 +74,7 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
   defp apply_action(%{assigns: %{current_scope: scope}} = socket, :edit, %{"serial" => serial}) do
     products = Products.get_products(scope)
 
-    case CACertificates.get_ca_certificate_by_serial(serial) do
+    case CACertificates.get_ca_certificate_by_org_and_serial(socket.assigns.org, serial) do
       {:ok, cert} ->
         changeset = Devices.CACertificate.changeset(cert, %{})
 
@@ -119,7 +119,8 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthorities do
   def handle_event("update_certificate_authority", %{"ca_certificate" => ca_certificate}, socket) do
     authorized!(:"certificate_authority:update", socket.assigns.current_scope)
 
-    with {:ok, cert} <- CACertificates.get_ca_certificate_by_serial(socket.assigns.serial),
+    with {:ok, cert} <-
+           CACertificates.get_ca_certificate_by_org_and_serial(socket.assigns.org, socket.assigns.serial),
          {:ok, params} <- maybe_delete_jitp(ca_certificate),
          {:ok, _cert} <- CACertificates.update_ca_certificate(cert, params) do
       socket

--- a/test/nerves_hub_web/live/org/certificate_authorities_test.exs
+++ b/test/nerves_hub_web/live/org/certificate_authorities_test.exs
@@ -351,6 +351,40 @@ defmodule NervesHubWeb.Live.Org.CertificateAuthoritiesTest do
       |> assert_path("/org/#{org.name}/settings/certificates")
       |> assert_has("div", text: "Certificate Authority not found")
     end
+
+    test "redirects when the CA belongs to another org", %{conn: conn, org: org} do
+      # CA serials are unique across the whole install, so a serial is a
+      # guessable handle on someone else's CA unless the lookup is scoped.
+      other_user = Fixtures.user_fixture()
+      other_org = Fixtures.org_fixture(other_user, %{name: "someone-else"})
+      %{db_cert: %{serial: serial}} = Fixtures.ca_certificate_fixture(other_org)
+
+      conn
+      |> visit("/org/#{org.name}/settings/certificates/#{serial}/edit")
+      |> assert_path("/org/#{org.name}/settings/certificates")
+      |> assert_has("div", text: "Certificate Authority not found")
+    end
+
+    test "does not update a CA belonging to another org", %{conn: conn, org: org} do
+      %{db_cert: %{serial: serial}} = Fixtures.ca_certificate_fixture(org)
+
+      other_user = Fixtures.user_fixture()
+      other_org = Fixtures.org_fixture(other_user, %{name: "someone-else"})
+      %{db_cert: other_ca} = Fixtures.ca_certificate_fixture(other_org)
+
+      {:ok, view, _html} = live(conn, "/org/#{org.name}/settings/certificates/#{serial}/edit")
+
+      # The edit page refuses to load another org's CA, so the serial the update
+      # event is applied to never becomes one from another org.
+      render_patch(view, "/org/#{org.name}/settings/certificates/#{other_ca.serial}/edit")
+
+      render_submit(view, "update_certificate_authority", %{
+        "ca_certificate" => %{"description" => "not yours"}
+      })
+
+      assert {:ok, %{description: nil}} =
+               CACertificates.get_ca_certificate_by_org_and_serial(other_org, other_ca.serial)
+    end
   end
 
   defp upload_file(view, file_name, file_path, form_field) do


### PR DESCRIPTION
Stacked on #3024, which noticed this and left it for a separate change.

CA serials are unique across the whole install (`ca_certificates_serial_index`, from `20181201000818_ca_certificate_global_unique.exs`), so a serial is a guessable handle on any org's CA. The edit page looked one up by serial alone, with no org check:

- a member of org A could open `/org/A/settings/certificates/<org B's serial>/edit` and read org B's CA
- an admin of org A could submit that form and rewrite org B's description and JITP settings

Both the mount and the `update_certificate_authority` handler now go through `get_ca_certificate_by_org_and_serial/2`, the lookup the delete handler and #3024's show page already use. A serial from another org gets the not-found flash and a bounce back to the list, the same as a serial that doesn't exist.

Scoping the handler as well as the mount is belt and braces: the serial it updates is the one the socket already holds, and the mount is what puts it there. The regression test for it has to take the long way round, patching to another org's serial from a legitimate edit page before pushing the update event straight at the LiveView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
