### PR TITLE
Let a ClickHouse behind a private CA be verified

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -38,6 +38,7 @@
     "Fastlaned",
     "Joken",
     "Msgpax",
+    "Scaleway",
     "UIHTML",
     "animatedelay",
     "artusdev",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -460,6 +460,27 @@ if config_env() == :prod do
       pool_count: String.to_integer(System.get_env("ANALYTICS_POOL_COUNT", "1")),
       queue_target: 3_000
 
+    # Without this, TLS verifies ClickHouse against the system CA store, which is
+    # right for ClickHouse Cloud. A managed ClickHouse behind a private CA fails
+    # that with "Unknown CA" -- Scaleway's Data Warehouse signs each deployment
+    # with its own, and exposes no plain-HTTP port to fall back to. So the CA can
+    # be supplied, the way DATABASE_PEM supplies Postgres's.
+    #
+    # It replaces the system store for these connections rather than adding to
+    # it. Mint only falls back to the system store when no :cacerts are given,
+    # and keeps verify_peer and the hostname check either way, so this narrows
+    # trust to exactly the supplied CA. The second `config` for the same key
+    # merges into the one above.
+    if clickhouse_ca_pem = System.get_env("CLICKHOUSE_CA_PEM") do
+      clickhouse_cacerts =
+        clickhouse_ca_pem
+        |> Base.decode64!()
+        |> :public_key.pem_decode()
+        |> Enum.map(fn {_, der, _} -> der end)
+
+      config :nerves_hub, NervesHub.AnalyticsRepo, transport_opts: [cacerts: clickhouse_cacerts]
+    end
+
     config :nerves_hub, :analytics_buffer,
       max_batch_size: String.to_integer(System.get_env("ANALYTICS_BUFFER_MAX_BATCH_SIZE", "1000")),
       max_delay: to_timeout(millisecond: String.to_integer(System.get_env("ANALYTICS_BUFFER_MAX_DELAY_MS", "500"))),

--- a/docs/runtime_configuration.md
+++ b/docs/runtime_configuration.md
@@ -159,6 +159,7 @@ through `health` instead.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `CLICKHOUSE_URL` | — | ClickHouse connection URL. Setting it enables analytics. |
+| `CLICKHOUSE_CA_PEM` | — | Base64-encoded PEM bundle of CA certificates to verify ClickHouse against. Replaces the system CA store for those connections rather than adding to it, so set it only for a ClickHouse behind a private CA, such as Scaleway Data Warehouse. |
 | `ANALYTICS_POOL_SIZE` | `10` | Connections per pool. |
 | `ANALYTICS_POOL_COUNT` | `1` | Number of pools. |
 | `ANALYTICS_AUTO_MIGRATOR` | `true` | Run pending ClickHouse migrations on boot. |


### PR DESCRIPTION
NervesHub can't connect to a ClickHouse whose certificate is signed by a
private CA, because TLS only verifies against the system CA store. That's
right for ClickHouse Cloud, and fatal for Scaleway's Data Warehouse, which signs
each deployment with its own CA (`O=Scaleway Data Warehouse, OU=Deployment
<id>`) and exposes no plain-HTTP port to fall back to.

The analytics migrator runs on boot, so the failure takes the release down
rather than degrading analytics:

```
Mint.TransportError: TLS client: In state wait_cert ...
  Fatal - Unknown CA
failed to start child: :analytics_repo_migrator
```

This adds `CLICKHOUSE_CA_PEM`, a base64 PEM bundle in the same shape as
`DATABASE_PEM`, passed to the connection as `transport_opts: [cacerts: ...]`.
`ch` hands `transport_opts` to Mint, and `ecto_ch` forwards repo config to `ch`
unfiltered, so no library changes are needed.

Setting it narrows trust. Mint only falls back to the system store when no
`:cacerts` are given, and keeps `verify_peer` and the hostname check either way,
so the connection trusts exactly the supplied CA. Unset, behaviour is unchanged.
It replaces the system store rather than adding to it, which the docs call out,
so it isn't for ClickHouse Cloud.

There's no unit test, because this block only evaluates under `config_env() ==
:prod`. I checked it against a live Scaleway deployment from inside its VPC
instead, driving Mint directly: the system store fails with `Unknown CA`, and
the supplied CA connects. A different CA is still rejected, so peer verification
stays on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
