### PR TITLE
Make the session cookie name configurable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,6 +28,13 @@ if domain = System.get_env("SESSION_COOKIE_DOMAIN") do
   config :nerves_hub, session_cookie_domain: domain
 end
 
+# The session cookie's name. Set it when this instance shares a parent domain
+# with another NervesHub that scopes its cookie to that parent: otherwise both
+# cookies share a name, and whichever the browser sends first wins.
+if key = System.get_env("SESSION_COOKIE_KEY") do
+  config :nerves_hub, session_cookie_key: key
+end
+
 config :nerves_hub, :device_socket_drainer,
   batch_size: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_SIZE", "1000")),
   batch_interval: String.to_integer(System.get_env("DEVICE_SOCKET_DRAINER_BATCH_INTERVAL", "4000")),

--- a/docs/runtime_configuration.md
+++ b/docs/runtime_configuration.md
@@ -223,6 +223,7 @@ sent. The addresses and names below are read in every environment.
 | `GOOGLE_CLIENT_ID` | — | Setting it enables "Sign in with Google". |
 | `GOOGLE_CLIENT_SECRET` | — | OAuth client secret. |
 | `SESSION_COOKIE_DOMAIN` | — | Scopes the session cookie to a parent domain, e.g. `.example.com`, so a sibling subdomain can read it. Used for shared-session SSO between apps. |
+| `SESSION_COOKIE_KEY` | `_nerves_hub_key` | Name of the session cookie. Set it when another NervesHub on a sibling host scopes its cookie to a shared parent domain: the browser sends both, the server reads the first, and forms fail CSRF with a 403 whenever it picks the other instance's. |
 | `LOGIN_RETURN_URLS_ALLOWED_LIST` | — | Comma-separated URLs that login is allowed to return to. Anything not listed is refused. |
 
 ## Device data retention and housekeeping

--- a/lib/nerves_hub_web/endpoint.ex
+++ b/lib/nerves_hub_web/endpoint.ex
@@ -14,13 +14,24 @@ defmodule NervesHubWeb.Endpoint do
     Application.get_env(:nerves_hub, __MODULE__)[:live_view][:signing_salt]
   end
 
+  @default_session_cookie_key "_nerves_hub_key"
+
+  # The session cookie's name, from SESSION_COOKIE_KEY. Two NervesHub instances
+  # on hosts under a shared parent domain need different names: a browser holding
+  # both cookies sends both, the server reads the first, and the one it cannot
+  # decrypt leaves the request with no session.
+  def session_cookie_key() do
+    Application.get_env(:nerves_hub, :session_cookie_key, @default_session_cookie_key)
+  end
+
   # Set SESSION_COOKIE_DOMAIN (e.g. ".example.com") to scope the session cookie
   # to a parent domain so it is shared with nerves_hub_mcp running on a sibling
-  # subdomain (SSO). Compile-time — set it before compiling.
+  # subdomain (SSO). Read per request by runtime_session/2, so this and
+  # SESSION_COOKIE_KEY both take effect at boot without recompiling.
   def session_options() do
     [
       store: :cookie,
-      key: "_nerves_hub_key",
+      key: session_cookie_key(),
       signing_salt: {__MODULE__, :fetch_signing_salt, []}
     ] ++
       case Application.get_env(:nerves_hub, :session_cookie_domain) do

--- a/lib/nerves_hub_web/plugs/prune_duplicate_session_cookie.ex
+++ b/lib/nerves_hub_web/plugs/prune_duplicate_session_cookie.ex
@@ -1,18 +1,19 @@
 defmodule NervesHubWeb.Plugs.PruneDuplicateSessionCookie do
   @moduledoc """
-  Clears a stale *host-only* `_nerves_hub_key` session cookie when the request
-  carries a duplicate.
+  Clears a stale *host-only* session cookie when the request carries a
+  duplicate.
 
   The session cookie's `Domain` was widened to a shared parent (e.g.
   `.nervescloud.com`) so it can be shared for single sign-on with other apps
   running on a sibling subdomain. Browsers that still hold a *pre-migration*
   host-only cookie (scoped to the exact host, with no `Domain`) then end up with
-  TWO `_nerves_hub_key` cookies. Both are sent on every request, and the server
+  TWO session cookies of the same name. Both are sent on every request, and the server
   reads whichever the browser lists first, so the session becomes nondeterministic
   and login can fail.
 
   The request `Cookie` header does not expose each cookie's `Domain`, so we detect
-  the situation by *count*: more than one `_nerves_hub_key=` means a duplicate is
+  the situation by *count*: more than one cookie with the session's name means a
+  duplicate is
   present. We then emit a host-only deletion (a `Set-Cookie` with no `Domain`,
   expired), which removes ONLY the host-only variant and leaves the canonical
   parent-domain cookie untouched. It is self-limiting: once the duplicate is gone
@@ -20,42 +21,48 @@ defmodule NervesHubWeb.Plugs.PruneDuplicateSessionCookie do
 
   Guarded on `:session_cookie_domain` being configured. Without it (single-host or
   dev) a lone host-only cookie *is* the real session, so we never touch it.
+
+  The name is `NervesHubWeb.Endpoint.session_cookie_key/0` (SESSION_COOKIE_KEY),
+  read per request rather than fixed at compile time, so the plug always counts
+  the cookie the session actually uses.
   """
 
   @behaviour Plug
 
   import Plug.Conn
 
-  @cookie "_nerves_hub_key"
+  alias NervesHubWeb.Endpoint
 
   @impl Plug
   def init(opts), do: opts
 
   @impl Plug
   def call(conn, _opts) do
-    if prune?(conn) do
+    cookie = Endpoint.session_cookie_key()
+
+    if prune?(conn, cookie) do
       # Not `delete_resp_cookie/2`: that writes `conn.resp_cookies` keyed by name,
       # which `Plug.Session` overwrites with its parent-domain cookie of the same
       # name. A raw `Set-Cookie` with no `Domain` deletes only the host-only cookie
       # and coexists with the session's parent-domain `Set-Cookie`.
       prepend_resp_headers(conn, [
-        {"set-cookie", "#{@cookie}=; path=/; max-age=0; secure; httponly; samesite=lax"}
+        {"set-cookie", "#{cookie}=; path=/; max-age=0; secure; httponly; samesite=lax"}
       ])
     else
       conn
     end
   end
 
-  defp prune?(conn), do: domain_scoped?() and duplicate_cookie?(conn)
+  defp prune?(conn, cookie), do: domain_scoped?() and duplicate_cookie?(conn, cookie)
 
   defp domain_scoped?(), do: not is_nil(Application.get_env(:nerves_hub, :session_cookie_domain))
 
-  defp duplicate_cookie?(conn) do
+  defp duplicate_cookie?(conn, cookie) do
     conn
     |> get_req_header("cookie")
     |> Enum.flat_map(&String.split(&1, ";"))
     |> Enum.map(&String.trim/1)
-    |> Enum.count(&String.starts_with?(&1, @cookie <> "="))
+    |> Enum.count(&String.starts_with?(&1, cookie <> "="))
     |> Kernel.>(1)
   end
 end

--- a/test/nerves_hub_web/endpoint_test.exs
+++ b/test/nerves_hub_web/endpoint_test.exs
@@ -1,0 +1,86 @@
+defmodule NervesHubWeb.EndpointTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias NervesHubWeb.Endpoint
+
+  # Another NervesHub on a sibling host can scope its cookie to a shared parent
+  # domain, and the browser then sends it here too -- first, if it is older.
+  @foreign "_nerves_hub_key=SFMyNTY.set-by-another-instance"
+
+  setup do
+    previous = Application.get_env(:nerves_hub, :session_cookie_key)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:nerves_hub, :session_cookie_key)
+        value -> Application.put_env(:nerves_hub, :session_cookie_key, value)
+      end
+    end)
+  end
+
+  describe "session_cookie_key/0" do
+    test "defaults to _nerves_hub_key" do
+      Application.delete_env(:nerves_hub, :session_cookie_key)
+
+      assert Endpoint.session_cookie_key() == "_nerves_hub_key"
+      assert Endpoint.session_options()[:key] == "_nerves_hub_key"
+    end
+
+    test "is taken from configuration" do
+      Application.put_env(:nerves_hub, :session_cookie_key, "_nerves_hub_qa_key")
+
+      assert Endpoint.session_cookie_key() == "_nerves_hub_qa_key"
+      assert Endpoint.session_options()[:key] == "_nerves_hub_qa_key"
+    end
+  end
+
+  describe "a foreign cookie sent ahead of this instance's" do
+    test "displaces the session when both share the default name" do
+      Application.delete_env(:nerves_hub, :session_cookie_key)
+      ours = session_cookie_for("user_token", "ours")
+
+      conn = request_with_cookies("#{@foreign}; #{ours}")
+
+      # The server reads the first cookie of that name, cannot decrypt it, and
+      # carries on with no session. That is what fails every form's CSRF check.
+      assert get_session(conn, "user_token") == nil
+    end
+
+    test "is ignored when this instance uses its own name" do
+      Application.put_env(:nerves_hub, :session_cookie_key, "_nerves_hub_qa_key")
+      ours = session_cookie_for("user_token", "ours")
+
+      conn = request_with_cookies("#{@foreign}; #{ours}")
+
+      assert get_session(conn, "user_token") == "ours"
+    end
+  end
+
+  defp request_with_cookies(header) do
+    :get
+    |> conn("/")
+    |> put_req_header("cookie", header)
+    |> with_session()
+  end
+
+  defp session_cookie_for(key, value) do
+    conn =
+      :get
+      |> conn("/")
+      |> with_session()
+      |> put_session(key, value)
+      |> send_resp(200, "")
+
+    name = Endpoint.session_cookie_key()
+    "#{name}=#{conn.resp_cookies[name].value}"
+  end
+
+  defp with_session(conn) do
+    %{conn | secret_key_base: String.duplicate("a", 64)}
+    |> Plug.Session.call(Plug.Session.init(Endpoint.session_options()))
+    |> fetch_session()
+  end
+end

--- a/test/nerves_hub_web/plugs/prune_duplicate_session_cookie_test.exs
+++ b/test/nerves_hub_web/plugs/prune_duplicate_session_cookie_test.exs
@@ -49,6 +49,38 @@ defmodule NervesHubWeb.Plugs.PruneDuplicateSessionCookieTest do
     end
   end
 
+  describe "with a custom :session_cookie_key" do
+    setup do
+      previous_domain = Application.get_env(:nerves_hub, :session_cookie_domain)
+      previous_key = Application.get_env(:nerves_hub, :session_cookie_key)
+      Application.put_env(:nerves_hub, :session_cookie_domain, ".example.com")
+      Application.put_env(:nerves_hub, :session_cookie_key, "_custom_key")
+
+      on_exit(fn ->
+        restore(:session_cookie_domain, previous_domain)
+        restore(:session_cookie_key, previous_key)
+      end)
+    end
+
+    test "prunes duplicates of the configured name" do
+      conn = with_cookie("_custom_key=aaa; _custom_key=bbb")
+
+      assert [set_cookie] = set_cookies(conn)
+      assert set_cookie =~ "_custom_key=;"
+      refute set_cookie =~ @cookie
+    end
+
+    test "leaves a same-named cookie from another instance alone" do
+      # The browser sends another NervesHub's parent-domain cookie alongside ours.
+      # It has a different name here, so it is not a duplicate of our session and
+      # must not be deleted.
+      assert set_cookies(with_cookie("#{@cookie}=theirs; _custom_key=ours")) == []
+    end
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:nerves_hub, key)
+  defp restore(key, value), do: Application.put_env(:nerves_hub, key, value)
+
   test "does nothing when :session_cookie_domain is not configured" do
     previous = Application.get_env(:nerves_hub, :session_cookie_domain)
     Application.delete_env(:nerves_hub, :session_cookie_domain)


### PR DESCRIPTION
When one NervesHub instance scopes its session cookie to a parent domain, a
browser holding that cookie can't use another NervesHub instance on a sibling
host. Every form POST on the second instance fails with a bare 403.

`SESSION_COOKIE_DOMAIN` scopes the cookie to the parent for single sign-on:

```
_nerves_hub_key=…; domain=.example.com
```

So the browser sends it to every host under that domain. A second instance at,
say, `qa.example.com` sets a host-only cookie with the same name, and the browser
sends both. The server reads the first. When that's the other instance's cookie,
this one can't decrypt it and carries on with no session, so the form's CSRF
token has nothing to match.

It's hard to trace from the symptom. GET works, only POST fails, and nothing is
logged as an error because Phoenix treats a 403 as a client mistake. It
reproduces deterministically by ordering the two cookies in one request against
a running instance:

```
this instance's cookie only              -> 200
foreign cookie first, then this one's    -> 403
this one's first, then the foreign one   -> 200
```

This adds `SESSION_COOKIE_KEY`, defaulting to `_nerves_hub_key`, so existing
deployments see no change. The endpoint's session options and the LiveView
sockets both read it through `session_options/0`, so they can't disagree. The
second instance sets its own name and ignores the foreign cookie.

`PruneDuplicateSessionCookie` named the cookie in a module attribute, which is
fixed at compile time, so it would have kept counting `_nerves_hub_key` after the
name changed. It now reads the configured name per request. It couldn't have
fixed this collision anyway: it only runs with `SESSION_COOKIE_DOMAIN` set, and
it deletes the host-only cookie, which on the second instance is the correct one.

The new `endpoint_test.exs` pairs a control with the fix. With the default name,
a foreign cookie sent first displaces the session; with a distinct name, it
doesn't. Against the unchanged code the behavioural tests fail, so they exercise
the change rather than passing regardless.

I also corrected the endpoint comment calling `SESSION_COOKIE_DOMAIN`
compile-time. `runtime_session/2` builds the options on every request, which is
what `runtime.exs` already says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
