### PR TITLE
Serve presigned downloads from a configurable hostname

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -544,6 +544,24 @@ if config_env() == :prod do
         config :nerves_hub, S3, presigned_url_opts: []
       end
 
+      # Hand out download URLs on a hostname of our own, for a CDN or proxy in
+      # front of the bucket. Such a proxy forwards the presigned query string
+      # but addresses the bucket itself, so the URL is signed for the bucket and
+      # only then rewritten. See `NervesHub.Uploads.DownloadHost`.
+      if download_host = System.get_env("S3_DOWNLOAD_HOST") do
+        if System.get_env("S3_BUCKET_AS_HOST", "false") == "true" do
+          raise """
+          S3_DOWNLOAD_HOST and S3_BUCKET_AS_HOST cannot both be set.
+
+          S3_BUCKET_AS_HOST signs for the bucket name as the hostname, which is
+          not what a proxy in front of the bucket sends upstream, so every
+          download would fail with SignatureDoesNotMatch. Use one or the other.
+          """
+        end
+
+        config :nerves_hub, :s3_download_host, download_host
+      end
+
       config :ex_aws, :s3, bucket: System.fetch_env!("S3_BUCKET_NAME")
 
       if region = System.get_env("S3_REGION") do

--- a/docs/runtime_configuration.md
+++ b/docs/runtime_configuration.md
@@ -195,6 +195,7 @@ environment.
 | `S3_REGION` | ex_aws default | Bucket region. |
 | `S3_HOST` | ex_aws default | Endpoint host, for S3-compatible services. |
 | `S3_BUCKET_AS_HOST` | `false` | Generate presigned URLs with the bucket as the host, for providers that address buckets that way. |
+| `S3_DOWNLOAD_HOST` | — | Hostname to hand out in presigned download URLs, for a CDN or proxy in front of the bucket. The URL is signed for the bucket's virtual-hosted endpoint and only then rewritten to this host, because such a proxy forwards the query string but addresses the bucket itself. Refuses to boot alongside `S3_BUCKET_AS_HOST`. |
 
 ## Email
 

--- a/lib/nerves_hub/firmwares/upload/s3.ex
+++ b/lib/nerves_hub/firmwares/upload/s3.ex
@@ -3,6 +3,7 @@ defmodule NervesHub.Firmwares.Upload.S3 do
 
   alias ExAws.S3
   alias NervesHub.Firmwares.Upload
+  alias NervesHub.Uploads.DownloadHost
 
   # Provide URLs to devices that are valid for a day
   @firmware_url_validity_time 60 * 60 * 24
@@ -25,13 +26,16 @@ defmodule NervesHub.Firmwares.Upload.S3 do
   def download_file(firmware) do
     s3_key = firmware.upload_metadata["s3_key"]
 
-    opts = Keyword.put(presigned_url_opts(), :expires_in, @firmware_url_validity_time)
+    opts =
+      presigned_url_opts()
+      |> Keyword.put(:expires_in, @firmware_url_validity_time)
+      |> DownloadHost.presign_opts()
 
     ExAws.Config.new(:s3)
     |> S3.presigned_url(:get, bucket(), s3_key, opts)
     |> case do
       {:ok, url} ->
-        {:ok, url}
+        {:ok, DownloadHost.rewrite(url)}
 
       error ->
         error

--- a/lib/nerves_hub/uploads.ex
+++ b/lib/nerves_hub/uploads.ex
@@ -23,6 +23,62 @@ defmodule NervesHub.Uploads do
   end
 end
 
+defmodule NervesHub.Uploads.DownloadHost do
+  @moduledoc """
+  Serves presigned download URLs from a hostname other than the bucket's.
+
+  A CDN or proxy in front of the bucket gives downloads a hostname you control
+  and a certificate you manage, but it cannot re-sign the request. It forwards
+  the presigned query string and addresses the bucket itself, so the signature
+  has to match what the *bucket* receives rather than what the client dialled.
+
+  So a URL is signed for the bucket's virtual-hosted endpoint, which is the form
+  those proxies send upstream, and only then has its host replaced. Signing for
+  the public hostname instead fails with `SignatureDoesNotMatch`.
+
+  With `S3_DOWNLOAD_HOST` unset, nothing here changes a URL.
+  """
+
+  @doc """
+  The configured public hostname, or `nil` when downloads come straight from the
+  bucket.
+  """
+  @spec host() :: String.t() | nil
+  def host(), do: Application.get_env(:nerves_hub, :s3_download_host)
+
+  @doc """
+  Presign options that put the bucket in the host rather than the path.
+
+  Left alone when no download host is configured, so a deployment without one
+  keeps whichever addressing style it already uses.
+  """
+  @spec presign_opts(keyword()) :: keyword()
+  def presign_opts(opts) do
+    case host() do
+      nil -> opts
+      _host -> Keyword.put(opts, :virtual_host, true)
+    end
+  end
+
+  @doc """
+  Swaps the bucket's hostname for the public one, leaving the path and the query
+  (and therefore the signature) untouched.
+  """
+  @spec rewrite(String.t()) :: String.t()
+  def rewrite(url) do
+    case host() do
+      nil ->
+        url
+
+      host ->
+        url
+        |> URI.parse()
+        |> Map.merge(%{scheme: "https", host: host, port: 443, authority: nil, userinfo: nil})
+        |> URI.to_string()
+    end
+  end
+end
+
 defmodule NervesHub.Uploads.File do
   @behaviour NervesHub.Uploads
 
@@ -76,6 +132,7 @@ defmodule NervesHub.Uploads.S3 do
   @behaviour NervesHub.Uploads
 
   alias ExAws.S3
+  alias NervesHub.Uploads.DownloadHost
 
   @upload_timeout to_timeout(minute: 1)
 
@@ -113,8 +170,9 @@ defmodule NervesHub.Uploads.S3 do
     case Keyword.has_key?(opts, :signed) do
       true ->
         config = ExAws.Config.new(:s3)
-        {:ok, url} = S3.presigned_url(config, :get, bucket(), key, opts[:signed])
-        url
+        signed_opts = DownloadHost.presign_opts(opts[:signed])
+        {:ok, url} = S3.presigned_url(config, :get, bucket(), key, signed_opts)
+        DownloadHost.rewrite(url)
 
       false ->
         "https://s3.amazonaws.com/#{bucket()}#{key}"

--- a/test/nerves_hub/uploads/download_host_test.exs
+++ b/test/nerves_hub/uploads/download_host_test.exs
@@ -4,6 +4,7 @@ defmodule NervesHub.Uploads.DownloadHostTest do
 
   alias NervesHub.Firmwares.Upload.S3, as: FirmwareUpload
   alias NervesHub.Uploads.DownloadHost
+  alias NervesHub.Uploads.S3
 
   @bucket "mybucket"
   @key "firmware/1/abcdef.fw"
@@ -19,6 +20,8 @@ defmodule NervesHub.Uploads.DownloadHostTest do
     )
 
     Application.put_env(:nerves_hub, FirmwareUpload, bucket: @bucket, presigned_url_opts: [])
+    # Archives go through NervesHub.Uploads.S3, which keeps its own bucket key.
+    Application.put_env(:nerves_hub, S3, bucket: @bucket)
 
     if host = context[:download_host] do
       Application.put_env(:nerves_hub, :s3_download_host, host)
@@ -27,6 +30,7 @@ defmodule NervesHub.Uploads.DownloadHostTest do
     on_exit(fn ->
       Application.delete_env(:ex_aws, :s3)
       Application.delete_env(:nerves_hub, FirmwareUpload)
+      Application.delete_env(:nerves_hub, S3)
       Application.delete_env(:nerves_hub, :s3_download_host)
     end)
 
@@ -43,9 +47,34 @@ defmodule NervesHub.Uploads.DownloadHostTest do
       assert DownloadHost.presign_opts(expires_in: 60) == [expires_in: 60]
     end
 
-    test "download_file/1 serves from the bucket's own endpoint" do
+    test "download_file/1 is byte-identical to presigning without any of this" do
       {:ok, url} = FirmwareUpload.download_file(firmware())
+
+      assert url == presigned_as_before(url, [])
       assert URI.parse(url).host == "s3.fr-par.scw.cloud"
+    end
+
+    test "download_file/1 is unchanged under S3_BUCKET_AS_HOST too" do
+      # The shape a Tigris custom domain uses: the bucket IS the hostname.
+      opts = [virtual_host: true, bucket_as_host: true]
+      Application.put_env(:nerves_hub, FirmwareUpload, bucket: @bucket, presigned_url_opts: opts)
+
+      {:ok, url} = FirmwareUpload.download_file(firmware())
+
+      assert url == presigned_as_before(url, opts)
+      assert URI.parse(url).host == @bucket
+    end
+
+    test "archive URLs are byte-identical too" do
+      url = S3.url(@key, signed: [expires_in: 3600])
+
+      {:ok, expected} =
+        ExAws.S3.presigned_url(ExAws.Config.new(:s3), :get, @bucket, @key,
+          expires_in: 3600,
+          start_datetime: signed_at(URI.parse(url))
+        )
+
+      assert url == expected
     end
   end
 
@@ -78,6 +107,13 @@ defmodule NervesHub.Uploads.DownloadHostTest do
       assert uri.path == "/#{@key}"
     end
 
+    test "archive URLs get the same treatment" do
+      uri = URI.parse(S3.url(@key, signed: [expires_in: 3600]))
+
+      assert uri.host == "firmware.example.com"
+      assert uri.path == "/#{@key}"
+    end
+
     test "download_file/1 signs for the bucket, not for our host" do
       {:ok, url} = FirmwareUpload.download_file(firmware())
       uri = URI.parse(url)
@@ -101,6 +137,19 @@ defmodule NervesHub.Uploads.DownloadHostTest do
   end
 
   defp firmware(), do: %{upload_metadata: %{"s3_key" => @key}}
+
+  # Rebuilds the URL the way the code did before S3_DOWNLOAD_HOST existed, at the
+  # moment the given URL was signed, so the two can be compared exactly.
+  defp presigned_as_before(url, presigned_url_opts) do
+    opts =
+      Keyword.merge(presigned_url_opts,
+        expires_in: @validity,
+        start_datetime: signed_at(URI.parse(url))
+      )
+
+    {:ok, expected} = ExAws.S3.presigned_url(ExAws.Config.new(:s3), :get, @bucket, @key, opts)
+    expected
+  end
 
   # "20260101T000000Z" -> ~N[2026-01-01 00:00:00]
   defp signed_at(uri) do

--- a/test/nerves_hub/uploads/download_host_test.exs
+++ b/test/nerves_hub/uploads/download_host_test.exs
@@ -1,0 +1,114 @@
+defmodule NervesHub.Uploads.DownloadHostTest do
+  # Not async: these move :s3_download_host, which every presign reads.
+  use ExUnit.Case, async: false
+
+  alias NervesHub.Firmwares.Upload.S3, as: FirmwareUpload
+  alias NervesHub.Uploads.DownloadHost
+
+  @bucket "mybucket"
+  @key "firmware/1/abcdef.fw"
+  # NervesHub.Firmwares.Upload.S3 signs firmware URLs for a day.
+  @validity 60 * 60 * 24
+
+  setup context do
+    Application.put_env(:ex_aws, :s3,
+      access_key_id: "AKIAEXAMPLE",
+      secret_access_key: "s3cret",
+      region: "fr-par",
+      host: "s3.fr-par.scw.cloud"
+    )
+
+    Application.put_env(:nerves_hub, FirmwareUpload, bucket: @bucket, presigned_url_opts: [])
+
+    if host = context[:download_host] do
+      Application.put_env(:nerves_hub, :s3_download_host, host)
+    end
+
+    on_exit(fn ->
+      Application.delete_env(:ex_aws, :s3)
+      Application.delete_env(:nerves_hub, FirmwareUpload)
+      Application.delete_env(:nerves_hub, :s3_download_host)
+    end)
+
+    :ok
+  end
+
+  describe "with no download host configured" do
+    test "rewrite/1 leaves the URL alone" do
+      url = "https://#{@bucket}.s3.fr-par.scw.cloud/#{@key}?X-Amz-Signature=abc"
+      assert DownloadHost.rewrite(url) == url
+    end
+
+    test "presign_opts/1 leaves the options alone" do
+      assert DownloadHost.presign_opts(expires_in: 60) == [expires_in: 60]
+    end
+
+    test "download_file/1 serves from the bucket's own endpoint" do
+      {:ok, url} = FirmwareUpload.download_file(firmware())
+      assert URI.parse(url).host == "s3.fr-par.scw.cloud"
+    end
+  end
+
+  describe "with a download host configured" do
+    @describetag download_host: "firmware.example.com"
+
+    test "rewrite/1 replaces the host and keeps everything that is signed" do
+      url = "https://#{@bucket}.s3.fr-par.scw.cloud/#{@key}?X-Amz-Signature=abc&X-Amz-Expires=60"
+      rewritten = DownloadHost.rewrite(url)
+
+      assert rewritten ==
+               "https://firmware.example.com/#{@key}?X-Amz-Signature=abc&X-Amz-Expires=60"
+    end
+
+    test "presign_opts/1 asks for virtual-hosted addressing" do
+      opts = DownloadHost.presign_opts(expires_in: 60)
+
+      assert opts[:virtual_host] == true
+      assert opts[:expires_in] == 60
+    end
+
+    test "download_file/1 hands out our host with the bucket in neither host nor path" do
+      {:ok, url} = FirmwareUpload.download_file(firmware())
+      uri = URI.parse(url)
+
+      assert uri.scheme == "https"
+      assert uri.host == "firmware.example.com"
+      # Path style would be "/mybucket/firmware/...", and a proxy in front of
+      # the bucket serves the key at the root.
+      assert uri.path == "/#{@key}"
+    end
+
+    test "download_file/1 signs for the bucket, not for our host" do
+      {:ok, url} = FirmwareUpload.download_file(firmware())
+      uri = URI.parse(url)
+
+      # Rebuild the same signature from the timestamp the URL carries. It only
+      # matches if the canonical request named the bucket's virtual-hosted
+      # endpoint, which is what a proxy sends upstream. Signing for
+      # firmware.example.com gives the bucket SignatureDoesNotMatch.
+      signed_at = signed_at(uri)
+
+      {:ok, expected} =
+        ExAws.S3.presigned_url(ExAws.Config.new(:s3), :get, @bucket, @key,
+          expires_in: @validity,
+          virtual_host: true,
+          start_datetime: signed_at
+        )
+
+      assert URI.parse(expected).host == "#{@bucket}.s3.fr-par.scw.cloud"
+      assert URI.parse(expected).query == uri.query
+    end
+  end
+
+  defp firmware(), do: %{upload_metadata: %{"s3_key" => @key}}
+
+  # "20260101T000000Z" -> ~N[2026-01-01 00:00:00]
+  defp signed_at(uri) do
+    <<year::binary-4, month::binary-2, day::binary-2, "T", hour::binary-2, minute::binary-2, second::binary-2, "Z">> =
+      uri.query |> URI.decode_query() |> Map.fetch!("X-Amz-Date")
+
+    [year, month, day, hour, minute, second]
+    |> Enum.map(&String.to_integer/1)
+    |> then(fn [y, mo, d, h, mi, s] -> NaiveDateTime.new!(y, mo, d, h, mi, s) end)
+  end
+end


### PR DESCRIPTION
`S3_DOWNLOAD_HOST` hands out presigned download URLs on a hostname you control,
so firmware and archives can be served through a CDN or proxy in front of the
bucket.

The awkward part is that such a proxy cannot re-sign the request. It forwards
the presigned query string and addresses the bucket itself, so the signature has
to match what the *bucket* receives rather than what the device dialled. Signing
for the public hostname returns `SignatureDoesNotMatch`.

So the URL is signed for the bucket's virtual-hosted endpoint, which is the form
those proxies send upstream, and only then has its host replaced.
`NervesHub.Uploads.DownloadHost` holds both halves: `presign_opts/1` switches
the presign to virtual-hosted addressing, and `rewrite/1` swaps the host while
leaving the path and query untouched.

Both places that presign a download use it: firmware and deltas through
`NervesHub.Firmwares.Upload.S3.download_file/1`, archives through
`NervesHub.Uploads.S3.url/2`.

This does not replace `S3_BUCKET_AS_HOST`, which exists for a provider that
resolves a custom domain to the bucket itself, as Tigris does (#1301). That one
signs with the bucket name as the hostname, which is not what a proxy in front
of a bucket sends upstream, so the two cannot be combined. Setting both raises
at boot rather than failing every download afterwards.

Unset, `S3_DOWNLOAD_HOST` adds no presign options and rewrites no URL. Rather
than assert that, the tests rebuild each URL from the timestamp it carries and
compare byte for byte, with default options and with `S3_BUCKET_AS_HOST` set,
for firmware and for archives.

I checked the behaviour against Scaleway Edge Services in front of a private
bucket before writing this. A URL signed for the bucket's virtual-hosted
endpoint returns 200 through the edge, one signed for the edge's own hostname
returns `SignatureDoesNotMatch`, and an unsigned request is refused, so the
bucket stays private rather than having to be opened up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
