### PR TITLE
4 small UI improvements

### DIFF
--- a/lib/nerves_hub_web/controllers/session_html/new.html.heex
+++ b/lib/nerves_hub_web/controllers/session_html/new.html.heex
@@ -2,8 +2,11 @@
   <:title>
     Sign in to your account
   </:title>
-  <:subheader>
+  <:subheader :if={Application.get_env(:nerves_hub, :open_for_registrations)}>
     Don't have an account? <.link href="/register" class="hover:text-primary-hover text-primary font-semibold">Sign up for free</.link>
+  </:subheader>
+  <:subheader :if={!Application.get_env(:nerves_hub, :open_for_registrations)}>
+    Don't have an account? Please contact your platform admin.
   </:subheader>
 
   <div :if={assigns[:error_message]} role="alert" class="bg-alert-soft fill-alert ring-alert text-alert-content mt-4 mr-2 w-full rounded-sm p-3 shadow-md ring-1">

--- a/lib/nerves_hub_web/live/archive_templates/list_archives_template.html.heex
+++ b/lib/nerves_hub_web/live/archive_templates/list_archives_template.html.heex
@@ -1,140 +1,139 @@
 <NervesHubWeb.Layouts.sidebar flash={@flash} current_scope={@current_scope} sidebar_tab={@sidebar_tab}>
-  <div class="h-0 flex-1 overflow-y-auto" phx-drop-target={@uploads.archive.ref}>
-    <div class="border-base-700 h-header flex items-center gap-4 border-b px-6 py-7 text-sm font-medium">
-      <h1 class="text-base-50 text-xl leading-[30px] font-semibold">All Archives</h1>
-      <div class="bg-base-800 text-base-300 mr-auto rounded-sm px-1.5 py-0.5 text-xs">
-        {@pager_meta.total_count}
-      </div>
-
-      <div :for={entry <- @uploads.archive.entries} class="flex w-2/5 flex-col items-center pr-2 pl-4">
-        <div class="mb-1 flex justify-between">
-          <span class="text-primary text-sm dark:text-white">Uploading archive... </span>
-          <span class="text-primary text-sm dark:text-white">{entry.progress}%</span>
-        </div>
-        <div class="h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
-          <div class="bg-primary h-2.5 animate-pulse rounded-full" style={"width: #{entry.progress}%"}></div>
-        </div>
-      </div>
-
-      <form id="archive-form" phx-change="validate-firmware" class={[Enum.any?(@uploads.archive.entries) && "hidden"]}>
-        <div class="bg-base-800 border-base-600 flex gap-2 rounded border px-3 py-1.5 hover:cursor-pointer">
-          <svg class="size-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
-            <path
-              d="M4.1665 10.0001H9.99984M15.8332 10.0001H9.99984M9.99984 10.0001V4.16675M9.99984 10.0001V15.8334"
-              stroke="#A1A1AA"
-              stroke-width="1.2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-          <label for={@uploads.archive.ref} class="text-base-300 text-sm font-medium hover:cursor-pointer">Upload Archive</label>
-          <.live_file_input upload={@uploads.archive} class="hidden" />
-        </div>
-      </form>
+  <:header>
+    <h1 class="text-base-50 text-xl leading-[30px] font-semibold">All Archives</h1>
+    <div class="bg-base-800 text-base-300 mr-auto rounded-sm px-1.5 py-0.5 text-xs">
+      {@pager_meta.total_count}
     </div>
-    <%= if Enum.any?(@archives) do %>
-      <div class="listing">
-        <table>
-          <thead>
-            <tr>
-              <th>UUID</th>
-              <th phx-click="sort" phx-value-sort="version" class="cursor-pointer">
-                <Sorting.sort_icon text="Version" field="version" selected_field={@current_sort} selected_direction={@sort_direction} />
-              </th>
-              <th>Platform</th>
-              <th>Architecture</th>
-              <th>Signing Key</th>
-              <th phx-click="sort" phx-value-sort="inserted_at" class="cursor-pointer">
-                <Sorting.sort_icon text={"Uploaded on (#{zone_abbr(@time_zone)})"} field="inserted_at" selected_field={@current_sort} selected_direction={@sort_direction} />
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr :for={archive <- @archives} class="border-base-800 border-b">
-              <td>
-                <div class="flex items-center gap-2">
-                  <.link navigate={~p"/org/#{@current_scope.org}/#{@product}/archives/#{archive}"}>
-                    {archive.uuid}
-                  </.link>
-                </div>
-              </td>
 
-              <td>
-                <div class="flex items-center gap-2">
-                  {archive.version}
-                </div>
-              </td>
+    <div :for={entry <- @uploads.archive.entries} class="flex w-2/5 flex-col items-center pr-2 pl-4">
+      <div class="mb-1 flex justify-between">
+        <span class="text-primary text-sm dark:text-white">Uploading archive... </span>
+        <span class="text-primary text-sm dark:text-white">{entry.progress}%</span>
+      </div>
+      <div class="h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+        <div class="bg-primary h-2.5 animate-pulse rounded-full" style={"width: #{entry.progress}%"}></div>
+      </div>
+    </div>
 
-              <td>
-                {archive.platform}
-              </td>
+    <form id="archive-form" phx-change="validate-firmware" class={[Enum.any?(@uploads.archive.entries) && "hidden"]}>
+      <div class="bg-base-800 border-base-600 flex gap-2 rounded border px-3 py-1.5 hover:cursor-pointer">
+        <svg class="size-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+          <path
+            d="M4.1665 10.0001H9.99984M15.8332 10.0001H9.99984M9.99984 10.0001V4.16675M9.99984 10.0001V15.8334"
+            stroke="#A1A1AA"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <label for={@uploads.archive.ref} class="text-base-300 text-sm font-medium hover:cursor-pointer">Upload Archive</label>
+        <.live_file_input upload={@uploads.archive} class="hidden" />
+      </div>
+    </form>
+  </:header>
 
-              <td>
-                {archive.architecture}
-              </td>
-
-              <td>
-                <span class="bg-base-800 border-base-700 inline-flex gap-1 rounded-full border py-0.5 pr-3 pl-2.5">
-                  <code class="text-base-300 text-xs">{format_signed(archive, @org_keys)}</code>
-                </span>
-              </td>
-
-              <td>
-                <%= if is_nil(archive.inserted_at) do %>
-                  Never
-                <% else %>
-                  <.local_datetime at={archive.inserted_at} time_zone={@time_zone} zone_label={false} />
-                <% end %>
-              </td>
-
-              <%!-- <td class="actions">
-              <div class="">
-                <a class="" data-target="#" id={"actions-#{device.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" phx-click={show_menu("actions-menu-#{device.id}")}>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-                    <path
-                      d="M9.1665 10C9.1665 10.2211 9.2543 10.433 9.41058 10.5893C9.56686 10.7456 9.77882 10.8334 9.99984 10.8334C10.2209 10.8334 10.4328 10.7456 10.5891 10.5893C10.7454 10.433 10.8332 10.2211 10.8332 10C10.8332 9.77903 10.7454 9.56707 10.5891 9.41079C10.4328 9.2545 10.2209 9.16671 9.99984 9.16671C9.77882 9.16671 9.56686 9.2545 9.41058 9.41079C9.2543 9.56707 9.1665 9.77903 9.1665 10ZM9.1665 15.8334C9.1665 16.0544 9.2543 16.2663 9.41058 16.4226C9.56686 16.5789 9.77882 16.6667 9.99984 16.6667C10.2209 16.6667 10.4328 16.5789 10.5891 16.4226C10.7454 16.2663 10.8332 16.0544 10.8332 15.8334C10.8332 15.6124 10.7454 15.4004 10.5891 15.2441C10.4328 15.0878 10.2209 15 9.99984 15C9.77882 15 9.56686 15.0878 9.41058 15.2441C9.2543 15.4004 9.1665 15.6124 9.1665 15.8334ZM9.1665 4.16671C9.1665 4.38772 9.2543 4.59968 9.41058 4.75596C9.56686 4.91224 9.77882 5.00004 9.99984 5.00004C10.2209 5.00004 10.4328 4.91224 10.5891 4.75596C10.7454 4.59968 10.8332 4.38772 10.8332 4.16671C10.8332 3.94569 10.7454 3.73373 10.5891 3.57745C10.4328 3.42117 10.2209 3.33337 9.99984 3.33337C9.77882 3.33337 9.56686 3.42117 9.41058 3.57745C9.2543 3.73373 9.1665 3.94569 9.1665 4.16671Z"
-                      stroke="#A1A1AA"
-                      stroke-width="1.2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </a>
-                <div class="hidden absolute right-6 menu-box" id={"actions-menu-#{device.id}"} phx-click-away={hide_menu("actions-menu-#{device.id}")} phx-key="escape" )}>
-                  <.link phx-click="reboot-device" phx-value-device_identifier={device.identifier} class="dropdown-item">
-                    Reboot
-                  </.link>
-                  <div class="dropdown-divider"></div>
-                  <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device.identifier}/console"} class="dropdown-item">
-                    Console
-                  </.link>
-                  <div class="dropdown-divider"></div>
-                  <div class="dropdown-divider"></div>
-                  <.link phx-click="toggle-device-updates" phx-value-device_identifier={device.identifier} class="dropdown-item">
-                    <span>
-                      <%= if device.update_mode != :off, do: "Disable Updates", else: "Enable Updates" %>
-                    </span>
-                  </.link>
-
-                  <div class="dropdown-divider"></div>
-
-                  <%= link to: Routes.device_path(@socket, :export_audit_logs, @org.name, @product.name, device.identifier), class: "dropdown-item", aria: [label: "Download Audit Logs"] do %>
-                    <div class="button-icon download"></div>
-                    <span class="action-text">Download Audit Logs</span>
-                  <% end %>
-                </div>
+  <div class="h-0 flex-1 overflow-y-auto" phx-drop-target={@uploads.archive.ref}>
+    <div :if={Enum.any?(@archives)} class="listing">
+      <table>
+        <thead>
+          <tr>
+            <th>UUID</th>
+            <th phx-click="sort" phx-value-sort="version" class="cursor-pointer">
+              <Sorting.sort_icon text="Version" field="version" selected_field={@current_sort} selected_direction={@sort_direction} />
+            </th>
+            <th>Platform</th>
+            <th>Architecture</th>
+            <th>Signing Key</th>
+            <th phx-click="sort" phx-value-sort="inserted_at" class="cursor-pointer">
+              <Sorting.sort_icon text={"Uploaded on (#{zone_abbr(@time_zone)})"} field="inserted_at" selected_field={@current_sort} selected_direction={@sort_direction} />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={archive <- @archives} class="border-base-800 border-b">
+            <td>
+              <div class="flex items-center gap-2">
+                <.link navigate={~p"/org/#{@current_scope.org}/#{@product}/archives/#{archive}"}>
+                  {archive.uuid}
+                </.link>
               </div>
-            </td> --%>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    <% else %>
-      <div class="flex h-full items-center justify-center pb-16">
-        <span class="text-base-50 text-xl font-medium">{@product.name} doesn't have any available archives.</span>
-      </div>
-    <% end %>
+            </td>
+
+            <td>
+              <div class="flex items-center gap-2">
+                {archive.version}
+              </div>
+            </td>
+
+            <td>
+              {archive.platform}
+            </td>
+
+            <td>
+              {archive.architecture}
+            </td>
+
+            <td>
+              <span class="bg-base-800 border-base-700 inline-flex gap-1 rounded-full border py-0.5 pr-3 pl-2.5">
+                <code class="text-base-300 text-xs">{format_signed(archive, @org_keys)}</code>
+              </span>
+            </td>
+
+            <td>
+              <%= if is_nil(archive.inserted_at) do %>
+                Never
+              <% else %>
+                <.local_datetime at={archive.inserted_at} time_zone={@time_zone} zone_label={false} />
+              <% end %>
+            </td>
+
+            <%!-- <td class="actions">
+            <div class="">
+              <a class="" data-target="#" id={"actions-#{device.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" phx-click={show_menu("actions-menu-#{device.id}")}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <path
+                    d="M9.1665 10C9.1665 10.2211 9.2543 10.433 9.41058 10.5893C9.56686 10.7456 9.77882 10.8334 9.99984 10.8334C10.2209 10.8334 10.4328 10.7456 10.5891 10.5893C10.7454 10.433 10.8332 10.2211 10.8332 10C10.8332 9.77903 10.7454 9.56707 10.5891 9.41079C10.4328 9.2545 10.2209 9.16671 9.99984 9.16671C9.77882 9.16671 9.56686 9.2545 9.41058 9.41079C9.2543 9.56707 9.1665 9.77903 9.1665 10ZM9.1665 15.8334C9.1665 16.0544 9.2543 16.2663 9.41058 16.4226C9.56686 16.5789 9.77882 16.6667 9.99984 16.6667C10.2209 16.6667 10.4328 16.5789 10.5891 16.4226C10.7454 16.2663 10.8332 16.0544 10.8332 15.8334C10.8332 15.6124 10.7454 15.4004 10.5891 15.2441C10.4328 15.0878 10.2209 15 9.99984 15C9.77882 15 9.56686 15.0878 9.41058 15.2441C9.2543 15.4004 9.1665 15.6124 9.1665 15.8334ZM9.1665 4.16671C9.1665 4.38772 9.2543 4.59968 9.41058 4.75596C9.56686 4.91224 9.77882 5.00004 9.99984 5.00004C10.2209 5.00004 10.4328 4.91224 10.5891 4.75596C10.7454 4.59968 10.8332 4.38772 10.8332 4.16671C10.8332 3.94569 10.7454 3.73373 10.5891 3.57745C10.4328 3.42117 10.2209 3.33337 9.99984 3.33337C9.77882 3.33337 9.56686 3.42117 9.41058 3.57745C9.2543 3.73373 9.1665 3.94569 9.1665 4.16671Z"
+                    stroke="#A1A1AA"
+                    stroke-width="1.2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+              <div class="hidden absolute right-6 menu-box" id={"actions-menu-#{device.id}"} phx-click-away={hide_menu("actions-menu-#{device.id}")} phx-key="escape" )}>
+                <.link phx-click="reboot-device" phx-value-device_identifier={device.identifier} class="dropdown-item">
+                  Reboot
+                </.link>
+                <div class="dropdown-divider"></div>
+                <.link navigate={~p"/org/#{@org}/#{@product}/devices/#{device.identifier}/console"} class="dropdown-item">
+                  Console
+                </.link>
+                <div class="dropdown-divider"></div>
+                <div class="dropdown-divider"></div>
+                <.link phx-click="toggle-device-updates" phx-value-device_identifier={device.identifier} class="dropdown-item">
+                  <span>
+                    <%= if device.update_mode != :off, do: "Disable Updates", else: "Enable Updates" %>
+                  </span>
+                </.link>
+
+                <div class="dropdown-divider"></div>
+
+                <%= link to: Routes.device_path(@socket, :export_audit_logs, @org.name, @product.name, device.identifier), class: "dropdown-item", aria: [label: "Download Audit Logs"] do %>
+                  <div class="button-icon download"></div>
+                  <span class="action-text">Download Audit Logs</span>
+                <% end %>
+              </div>
+            </div>
+          </td> --%>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div :if={Enum.empty?(@archives)} class="flex h-full items-center justify-center pb-16">
+      <span class="text-content-muted font-mono text-xl font-medium">{@current_scope.product.name} doesn't have any available archives.</span>
+    </div>
   </div>
 
-  <Pager.render_with_page_sizes pager={@pager_meta} page_sizes={[25, 50, 100]} />
+  <:pagination pager={@pager_meta} page_sizes={[25, 50, 100]} />
 </NervesHubWeb.Layouts.sidebar>

--- a/lib/nerves_hub_web/live/archives.ex
+++ b/lib/nerves_hub_web/live/archives.ex
@@ -3,7 +3,6 @@ defmodule NervesHubWeb.Live.Archives do
 
   alias NervesHub.Accounts
   alias NervesHub.Archives
-  alias NervesHubWeb.Components.Pager
   alias NervesHubWeb.Components.Sorting
 
   embed_templates("archive_templates/*")

--- a/lib/nerves_hub_web/live/firmware.ex
+++ b/lib/nerves_hub_web/live/firmware.ex
@@ -6,7 +6,6 @@ defmodule NervesHubWeb.Live.Firmware do
   alias NervesHub.Firmwares.UpdateTool
   alias NervesHub.Firmwares.Upload
   alias NervesHub.Products
-  alias NervesHubWeb.Components.Pager
   alias NervesHubWeb.Components.Sorting
   alias Phoenix.Socket.Broadcast
 

--- a/lib/nerves_hub_web/live/firmware_templates/list_firmware_template.html.heex
+++ b/lib/nerves_hub_web/live/firmware_templates/list_firmware_template.html.heex
@@ -1,110 +1,110 @@
 <NervesHubWeb.Layouts.sidebar flash={@flash} current_scope={@current_scope} sidebar_tab={@sidebar_tab}>
+  <:header>
+    <h1 class="text-base-50 text-xl leading-[30px] font-semibold">All Firmware</h1>
+    <div class="bg-base-800 text-base-300 mr-auto rounded-sm px-1.5 py-0.5 text-xs">
+      {@pager_meta.total_count}
+    </div>
+
+    <div :for={entry <- @uploads.firmware.entries} class="flex w-2/5 flex-col items-center pr-2 pl-4">
+      <div class="mb-1 flex justify-between">
+        <span class="text-primary text-sm dark:text-white">Uploading firmware... </span>
+        <span class="text-primary text-sm dark:text-white">{entry.progress}%</span>
+      </div>
+      <div class="h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+        <div class="bg-primary h-2.5 animate-pulse rounded-full" style={"width: #{entry.progress}%"}></div>
+      </div>
+    </div>
+
+    <form id="firmware-form" phx-change="validate-firmware" class={[Enum.any?(@uploads.firmware.entries) && "hidden"]}>
+      <div class="bg-base-800 border-base-600 flex gap-2 rounded border px-3 py-1.5 hover:cursor-pointer">
+        <svg class="size-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+          <path
+            d="M4.1665 10.0001H9.99984M15.8332 10.0001H9.99984M9.99984 10.0001V4.16675M9.99984 10.0001V15.8334"
+            stroke="#A1A1AA"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <label for={@uploads.firmware.ref} class="text-base-300 text-sm font-medium hover:cursor-pointer">Upload Firmware</label>
+        <.live_file_input upload={@uploads.firmware} class="hidden" />
+      </div>
+    </form>
+  </:header>
+
   <%!-- The drop target wraps the scrolling list instead of being it, so the
         overlay can cover the whole area without scrolling along with the rows. --%>
   <div class="relative flex h-0 flex-1 flex-col" phx-drop-target={@uploads.firmware.ref}>
     <div class="h-0 flex-1 overflow-y-auto">
-      <div class="border-base-700 h-header flex items-center gap-4 border-b px-6 py-7 text-sm font-medium">
-        <h1 class="text-base-50 text-xl leading-[30px] font-semibold">All Firmware</h1>
-        <div class="bg-base-800 text-base-300 mr-auto rounded-sm px-1.5 py-0.5 text-xs">
-          {@pager_meta.total_count}
-        </div>
+      <div :if={Enum.any?(@firmware)} class="listing">
+        <table>
+          <thead>
+            <tr>
+              <th>UUID</th>
+              <th phx-click="sort" phx-value-sort="version" class="cursor-pointer">
+                <Sorting.sort_icon text="Version" field="version" selected_field={@current_sort} selected_direction={@sort_direction} />
+              </th>
+              <th>Tool</th>
+              <th>Platform</th>
+              <th>Architecture</th>
+              <th phx-click="sort" phx-value-sort="install_count" class="cursor-pointer">
+                <Sorting.sort_icon text="Install count" field="install_count" selected_field={@current_sort} selected_direction={@sort_direction} />
+              </th>
+              <th>Signing Key</th>
+              <th phx-click="sort" phx-value-sort="inserted_at" class="cursor-pointer">
+                <Sorting.sort_icon text={"Uploaded on (#{zone_abbr(@time_zone)})"} field="inserted_at" selected_field={@current_sort} selected_direction={@sort_direction} />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={firmware <- @firmware} class="border-base-800 border-b">
+              <td>
+                <div class="flex items-center gap-2">
+                  <.link patch={~p"/org/#{@current_scope.org}/#{@product}/firmware/#{firmware}"}>
+                    {firmware.uuid}
+                  </.link>
+                </div>
+              </td>
 
-        <div :for={entry <- @uploads.firmware.entries} class="flex w-2/5 flex-col items-center pr-2 pl-4">
-          <div class="mb-1 flex justify-between">
-            <span class="text-primary text-sm dark:text-white">Uploading firmware... </span>
-            <span class="text-primary text-sm dark:text-white">{entry.progress}%</span>
-          </div>
-          <div class="h-2.5 w-full rounded-full bg-gray-200 dark:bg-gray-700">
-            <div class="bg-primary h-2.5 animate-pulse rounded-full" style={"width: #{entry.progress}%"}></div>
-          </div>
-        </div>
+              <td>
+                <div class="flex items-center gap-2">
+                  {firmware.version}
+                </div>
+              </td>
 
-        <form id="firmware-form" phx-change="validate-firmware" class={[Enum.any?(@uploads.firmware.entries) && "hidden"]}>
-          <div class="bg-base-800 border-base-600 flex gap-2 rounded border px-3 py-1.5 hover:cursor-pointer">
-            <svg class="size-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
-              <path
-                d="M4.1665 10.0001H9.99984M15.8332 10.0001H9.99984M9.99984 10.0001V4.16675M9.99984 10.0001V15.8334"
-                stroke="#A1A1AA"
-                stroke-width="1.2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <label for={@uploads.firmware.ref} class="text-base-300 text-sm font-medium hover:cursor-pointer">Upload Firmware</label>
-            <.live_file_input upload={@uploads.firmware} class="hidden" />
-          </div>
-        </form>
-      </div>
-      <%= if Enum.any?(@firmware) do %>
-        <div class="listing">
-          <table>
-            <thead>
-              <tr>
-                <th>UUID</th>
-                <th phx-click="sort" phx-value-sort="version" class="cursor-pointer">
-                  <Sorting.sort_icon text="Version" field="version" selected_field={@current_sort} selected_direction={@sort_direction} />
-                </th>
-                <th>Tool</th>
-                <th>Platform</th>
-                <th>Architecture</th>
-                <th phx-click="sort" phx-value-sort="install_count" class="cursor-pointer">
-                  <Sorting.sort_icon text="Install count" field="install_count" selected_field={@current_sort} selected_direction={@sort_direction} />
-                </th>
-                <th>Signing Key</th>
-                <th phx-click="sort" phx-value-sort="inserted_at" class="cursor-pointer">
-                  <Sorting.sort_icon text={"Uploaded on (#{zone_abbr(@time_zone)})"} field="inserted_at" selected_field={@current_sort} selected_direction={@sort_direction} />
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr :for={firmware <- @firmware} class="border-base-800 border-b">
-                <td>
-                  <div class="flex items-center gap-2">
-                    <.link patch={~p"/org/#{@current_scope.org}/#{@product}/firmware/#{firmware}"}>
-                      {firmware.uuid}
-                    </.link>
-                  </div>
-                </td>
+              <td>
+                <span class="bg-base-800 border-base-700 inline-flex gap-1 rounded-full border py-0.5 pr-3 pl-2.5">
+                  <code class="text-base-300 text-xs">{firmware.tool}</code>
+                </span>
+              </td>
 
-                <td>
-                  <div class="flex items-center gap-2">
-                    {firmware.version}
-                  </div>
-                </td>
+              <td>
+                {firmware.platform}
+              </td>
 
-                <td>
-                  <span class="bg-base-800 border-base-700 inline-flex gap-1 rounded-full border py-0.5 pr-3 pl-2.5">
-                    <code class="text-base-300 text-xs">{firmware.tool}</code>
-                  </span>
-                </td>
+              <td>
+                {firmware.architecture}
+              </td>
 
-                <td>
-                  {firmware.platform}
-                </td>
+              <td>
+                {firmware.install_count || 0}
+              </td>
 
-                <td>
-                  {firmware.architecture}
-                </td>
+              <td>
+                <span class="bg-base-800 border-base-700 inline-flex gap-1 rounded-full border py-0.5 pr-3 pl-2.5">
+                  <code class="text-base-300 text-xs">{format_signed(firmware, @org_keys)}</code>
+                </span>
+              </td>
 
-                <td>
-                  {firmware.install_count || 0}
-                </td>
+              <td>
+                <%= if is_nil(firmware.inserted_at) do %>
+                  Never
+                <% else %>
+                  <.local_datetime at={firmware.inserted_at} time_zone={@time_zone} zone_label={false} />
+                <% end %>
+              </td>
 
-                <td>
-                  <span class="bg-base-800 border-base-700 inline-flex gap-1 rounded-full border py-0.5 pr-3 pl-2.5">
-                    <code class="text-base-300 text-xs">{format_signed(firmware, @org_keys)}</code>
-                  </span>
-                </td>
-
-                <td>
-                  <%= if is_nil(firmware.inserted_at) do %>
-                    Never
-                  <% else %>
-                    <.local_datetime at={firmware.inserted_at} time_zone={@time_zone} zone_label={false} />
-                  <% end %>
-                </td>
-
-                <%!-- <td class="actions">
+              <%!-- <td class="actions">
               <div class="">
                 <a class="" data-target="#" id={"actions-#{device.id}"} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" phx-click={show_menu("actions-menu-#{device.id}")}>
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
@@ -142,15 +142,14 @@
                 </div>
               </div>
             </td> --%>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      <% else %>
-        <div class="flex h-full items-center justify-center pb-16">
-          <span class="text-base-50 text-xl font-medium">{@product.name} doesn’t have any firmware yet.</span>
-        </div>
-      <% end %>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div :if={Enum.empty?(@firmware)} class="flex h-full items-center justify-center pb-16">
+        <span class="text-content-muted font-mono text-xl font-medium">{@current_scope.product.name} doesn’t have any available firmware.</span>
+      </div>
     </div>
 
     <%!-- Only shown while a file is being dragged over the page. `pointer-events-none`
@@ -167,5 +166,5 @@
     </div>
   </div>
 
-  <Pager.render_with_page_sizes pager={@pager_meta} page_sizes={[25, 50, 100]} />
+  <:pagination pager={@pager_meta} page_sizes={[25, 50, 100]} />
 </NervesHubWeb.Layouts.sidebar>

--- a/lib/nerves_hub_web/live/org/signing_keys.html.heex
+++ b/lib/nerves_hub_web/live/org/signing_keys.html.heex
@@ -7,7 +7,7 @@
     </.button>
   </:header>
 
-  <div class="px-6 py-4">
+  <div class="h-0 flex-1 overflow-y-auto px-6 py-4">
     <p class="text-base-400 mb-4 text-sm">Signing Keys are used to sign uploaded firmware, and verify the firmware on the device before the device is updated.</p>
 
     <div class="space-y-3">
@@ -52,7 +52,7 @@
     <h1 class="text-base-50 text-xl leading-[30px] font-semibold">New Signing Key</h1>
   </:header>
 
-  <div class="max-w-[650px] px-6 py-4">
+  <div class="h-0 max-w-[650px] flex-1 overflow-y-auto px-6 py-4">
     <.form :let={f} id="signing_key_form" for={@form} phx-submit="save">
       <%= if @form.action do %>
         <div class="bg-alert-soft border-alert text-alert-content mb-4 rounded border p-4 text-sm">

--- a/test/nerves_hub_web/controllers/account_controller_test.exs
+++ b/test/nerves_hub_web/controllers/account_controller_test.exs
@@ -15,7 +15,7 @@ defmodule NervesHubWeb.AccountControllerTest do
 
       build_conn()
       |> visit(~p"/register")
-      |> assert_has("h1", with: "Create a new account")
+      |> assert_has("h1", text: "Create a new account")
     end
 
     test "redirects to /login with a flash when registrations are disabled" do
@@ -24,6 +24,7 @@ defmodule NervesHubWeb.AccountControllerTest do
       build_conn()
       |> visit(~p"/register")
       |> assert_path(~p"/login")
+      |> assert_has("[role='alert']", text: "Please contact support for an invite to this platform.")
     end
   end
 
@@ -64,6 +65,26 @@ defmodule NervesHubWeb.AccountControllerTest do
       |> submit()
       |> assert_path(~p"/register")
       |> assert_has("p", with: "can't be blank", times: 3)
+
+      send_queued_emails()
+
+      refute_email_sent()
+    end
+
+    test "doesn't register an account when registrations are disabled" do
+      Application.put_env(:nerves_hub, :open_for_registrations, false)
+
+      conn =
+        post(build_conn(), ~p"/register", %{
+          "user" => %{
+            "name" => "Sgt Pepper",
+            "email" => "sgtpepper@geocities.com",
+            "password" => "JohnRingoPaulGeorge"
+          }
+        })
+
+      assert redirected_to(conn) == ~p"/login"
+      assert Accounts.get_user_by_email("sgtpepper@geocities.com") == {:error, :not_found}
 
       send_queued_emails()
 

--- a/test/nerves_hub_web/controllers/account_controller_test.exs
+++ b/test/nerves_hub_web/controllers/account_controller_test.exs
@@ -34,13 +34,13 @@ defmodule NervesHubWeb.AccountControllerTest do
 
       build_conn()
       |> visit(~p"/register")
-      |> assert_has("h1", with: "Create a new account")
+      |> assert_has("h1", text: "Create a new account")
       |> fill_in("Name", with: "Sgt Pepper")
       |> fill_in("Email address", with: "sgtpepper@geocities.com")
       |> fill_in("Password", with: "JohnRingoPaulGeorge")
       |> submit()
-      |> assert_has("h1", with: "Please confirm your email")
-      |> assert_has("p", with: "Your new account was created successfully!")
+      |> assert_has("h1", text: "Please confirm your email")
+      |> assert_has("p", text: "Your new account was created successfully!")
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
 
@@ -58,13 +58,13 @@ defmodule NervesHubWeb.AccountControllerTest do
 
       build_conn()
       |> visit(~p"/register")
-      |> assert_has("h1", with: "Create a new account")
+      |> assert_has("h1", text: "Create a new account")
       |> fill_in("Name", with: "")
       |> fill_in("Email address", with: "")
       |> fill_in("Password", with: "")
       |> submit()
       |> assert_path(~p"/register")
-      |> assert_has("p", with: "can't be blank", times: 3)
+      |> assert_has("p", text: "can't be blank", count: 3)
 
       send_queued_emails()
 
@@ -146,7 +146,7 @@ defmodule NervesHubWeb.AccountControllerTest do
       |> visit(~p"/confirm/#{encoded_token}")
       |> assert_path(~p"/confirm/#{encoded_token}")
       |> assert_has("p",
-        with: "It looks like your confirmation link has expired. A new link has been sent to your email."
+        text: "It looks like your confirmation link has expired. A new link has been sent to your email."
       )
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
@@ -170,14 +170,14 @@ defmodule NervesHubWeb.AccountControllerTest do
 
       build_conn()
       |> visit(~p"/invite/#{invite.token}")
-      |> assert_has("h1", with: "You've been invited to join #{org.name} on #{platform_name}")
+      |> assert_has("h1", text: "You've been invited to join #{org.name} on #{platform_name}")
       |> refute_has("body", text: "joe@example.com")
       |> fill_in("Name", with: "Sgt Pepper")
       |> fill_in("Password", with: "JohnRingoPaulGeorge")
       |> submit()
       |> assert_path(~p"/orgs")
-      |> assert_has("h1", with: "Welcome to NervesHub!")
-      |> assert_has("div", with: org.name)
+      |> assert_has("[role='alert']", text: "Welcome to NervesHub!")
+      |> assert_has("div", text: org.name)
 
       send_queued_emails()
 

--- a/test/nerves_hub_web/controllers/api/user_controller_test.exs
+++ b/test/nerves_hub_web/controllers/api/user_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule NervesHubWeb.API.UserControllerTest do
   use NervesHubWeb.APIConnCase, async: false
 
-  import PhoenixTest
+  import NervesHub.Support.PhoenixTestAssertions
+  import PhoenixTest, except: [assert_has: 3, assert_has: 4, refute_has: 3, refute_has: 4]
 
   alias NervesHub.Fixtures
   alias NervesHub.PlugAttack.Storage, as: PlugAttackStorage

--- a/test/nerves_hub_web/controllers/oauth_controller_test.exs
+++ b/test/nerves_hub_web/controllers/oauth_controller_test.exs
@@ -21,9 +21,9 @@ defmodule NervesHubWeb.OAuthControllerTest do
     test "shows google auth button if enabled" do
       build_conn()
       |> visit(~p"/login")
-      |> assert_has("h1", with: "Sign in to your account")
-      |> assert_has("span", with: "Or create a new account with")
-      |> assert_has("span", with: "Google")
+      |> assert_has("h1", text: "Sign in to your account")
+      |> assert_has("span", text: "Or create a new account with")
+      |> assert_has("span", text: "Google")
     end
 
     test "create new account successfully" do
@@ -36,7 +36,7 @@ defmodule NervesHubWeb.OAuthControllerTest do
       build_conn()
       |> visit(~p"/auth/google/callback?state=dummy&code=dummy&scope=email+profile&prompt=none")
       |> assert_path("/orgs")
-      |> assert_has("div", with: "Welcome back!")
+      |> assert_has("div", text: "Welcome back!")
 
       send_queued_emails()
 
@@ -51,7 +51,7 @@ defmodule NervesHubWeb.OAuthControllerTest do
 
       build_conn()
       |> visit(~p"/auth/google/callback?state=dummy&code=dummy&scope=email+profile&prompt=none")
-      |> assert_has("h1", with: "We were unable to sign you in.")
+      |> assert_has("h1", text: "We were unable to sign you in.")
     end
 
     test "doesn't send a reset password email if the user logged in with Google" do
@@ -64,11 +64,11 @@ defmodule NervesHubWeb.OAuthControllerTest do
 
       build_conn()
       |> visit(~p"/password-reset")
-      |> assert_has("h1", with: "Reset your password")
+      |> assert_has("h1", text: "Reset your password")
       |> fill_in("Email", with: user.email)
       |> submit()
       |> assert_path(~p"/password-reset")
-      |> assert_has("h1", with: "Time to check your email")
+      |> assert_has("h1", text: "Time to check your email")
 
       send_queued_emails()
 
@@ -84,7 +84,7 @@ defmodule NervesHubWeb.OAuthControllerTest do
     test "does not show google auth button if not enabled" do
       build_conn()
       |> visit(~p"/login")
-      |> assert_has("h1", with: "Sign in to your account")
+      |> assert_has("h1", text: "Sign in to your account")
       |> refute_has("span", text: "Or create a new account with")
       |> refute_has("span", text: "Google")
     end

--- a/test/nerves_hub_web/controllers/session_controller_test.exs
+++ b/test/nerves_hub_web/controllers/session_controller_test.exs
@@ -106,7 +106,7 @@ defmodule NervesHubWeb.SessionControllerTest do
       |> visit(~p"/confirm/#{encoded_token}")
       |> assert_path(~p"/confirm/#{encoded_token}")
       |> assert_has("p",
-        with: "It looks like your confirmation link has expired. A new link has been sent to your email."
+        text: "It looks like your confirmation link has expired. A new link has been sent to your email."
       )
 
       platform_name = Application.get_env(:nerves_hub, :support_email_platform_name)
@@ -164,7 +164,7 @@ defmodule NervesHubWeb.SessionControllerTest do
 
       build_conn()
       |> visit(~p"/login")
-      |> assert_has("h1", with: "Sign in to your account")
+      |> assert_has("h1", text: "Sign in to your account")
       |> fill_in("Email address", with: "sgtpepper@geocities.com")
       |> fill_in("Password", with: "JohnRingoPaulGeorge")
       |> submit()
@@ -182,7 +182,7 @@ defmodule NervesHubWeb.SessionControllerTest do
 
       build_conn()
       |> visit(~p"/orgs/new")
-      |> assert_has("h1", with: "Sign in to your account")
+      |> assert_has("h1", text: "Sign in to your account")
       |> fill_in("Email address", with: "sgtpepper@geocities.com")
       |> fill_in("Password", with: "JohnRingoPaulGeorge")
       |> submit()

--- a/test/nerves_hub_web/controllers/session_controller_test.exs
+++ b/test/nerves_hub_web/controllers/session_controller_test.exs
@@ -121,6 +121,37 @@ defmodule NervesHubWeb.SessionControllerTest do
     end
   end
 
+  describe "login page" do
+    setup do
+      previous = Application.fetch_env(:nerves_hub, :open_for_registrations)
+
+      on_exit(fn ->
+        case previous do
+          {:ok, value} -> Application.put_env(:nerves_hub, :open_for_registrations, value)
+          :error -> Application.delete_env(:nerves_hub, :open_for_registrations)
+        end
+      end)
+    end
+
+    test "links to sign up when registrations are open" do
+      Application.put_env(:nerves_hub, :open_for_registrations, true)
+
+      build_conn()
+      |> visit(~p"/login")
+      |> assert_has("a[href='/register']", text: "Sign up for free")
+      |> refute_has("p", text: "Please contact your platform admin.")
+    end
+
+    test "points to the platform admin instead of sign up when registrations are closed" do
+      Application.put_env(:nerves_hub, :open_for_registrations, false)
+
+      build_conn()
+      |> visit(~p"/login")
+      |> assert_has("p", text: "Don't have an account? Please contact your platform admin.")
+      |> refute_has("a[href='/register']")
+    end
+  end
+
   describe "create session" do
     test "redirected to the orgs page when logging in" do
       %{

--- a/test/nerves_hub_web/live/devices/show_test.exs
+++ b/test/nerves_hub_web/live/devices/show_test.exs
@@ -1519,9 +1519,9 @@ defmodule NervesHubWeb.Live.Devices.ShowTest do
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/devices/#{device.identifier}")
-      |> assert_has("option", text: firmware.version, exact_option: false)
-      |> refute_has("option", text: mismatched_architecture_firmware.version, exact_option: false)
-      |> refute_has("option", text: mismatched_platform_firmware.version, exact_option: false)
+      |> assert_has("option", text: firmware.version)
+      |> refute_has("option", text: mismatched_architecture_firmware.version)
+      |> refute_has("option", text: mismatched_platform_firmware.version)
     end
 
     test "cannot send when device is disconnected", %{

--- a/test/nerves_hub_web/live/firmware_test.exs
+++ b/test/nerves_hub_web/live/firmware_test.exs
@@ -14,7 +14,7 @@ defmodule NervesHubWeb.Live.FirmwareTest do
 
       conn
       |> visit("/org/#{org.name}/#{product.name}/firmware")
-      |> assert_has("span", text: "#{product.name} doesn’t have any firmware yet")
+      |> assert_has("span", text: "#{product.name} doesn’t have any available firmware.")
     end
 
     test "lists all firmwares", %{conn: conn, user: user, org: org, tmp_dir: tmp_dir} do
@@ -143,7 +143,7 @@ defmodule NervesHubWeb.Live.FirmwareTest do
       |> click_button("Delete")
       |> assert_path("/org/#{org.name}/#{product.name}/firmware")
       |> assert_has("div", text: "Firmware successfully deleted")
-      |> assert_has("span", text: "#{product.name} doesn’t have any firmware yet")
+      |> assert_has("span", text: "#{product.name} doesn’t have any available firmware.")
     end
 
     test "error deleting firmware when it has associated deployments", %{

--- a/test/support/browser_case.ex
+++ b/test/support/browser_case.ex
@@ -12,8 +12,9 @@ defmodule NervesHubWeb.ConnCase.Browser do
       use DefaultMocks
       use ConnCase, unquote(opts)
 
+      import NervesHub.Support.PhoenixTestAssertions
       import Phoenix.LiveViewTest
-      import PhoenixTest
+      import PhoenixTest, except: [assert_has: 3, assert_has: 4, refute_has: 3, refute_has: 4]
       import Test
 
       @moduletag :tmp_dir

--- a/test/support/phoenix_test_assertions.ex
+++ b/test/support/phoenix_test_assertions.ex
@@ -1,0 +1,33 @@
+# PhoenixTest is a test-only dependency, but test/support is also compiled in dev.
+if Code.ensure_loaded?(PhoenixTest) do
+  defmodule NervesHub.Support.PhoenixTestAssertions do
+    @moduledoc """
+    `assert_has` and `refute_has` that raise on options PhoenixTest doesn't know.
+
+    PhoenixTest silently ignores unknown options, so `with:` in place of `text:`
+    leaves an assertion that only checks the selector matches something.
+    """
+
+    # the options documented for assert_has/3 and refute_has/3 in PhoenixTest 0.12.1
+    @options [:at, :checked, :count, :exact, :label, :selected, :text, :timeout, :value]
+
+    def assert_has(session, selector, opts_or_text) do
+      PhoenixTest.assert_has(session, selector, validate_options!(opts_or_text))
+    end
+
+    def assert_has(session, selector, text, opts) do
+      PhoenixTest.assert_has(session, selector, text, validate_options!(opts))
+    end
+
+    def refute_has(session, selector, opts_or_text) do
+      PhoenixTest.refute_has(session, selector, validate_options!(opts_or_text))
+    end
+
+    def refute_has(session, selector, text, opts) do
+      PhoenixTest.refute_has(session, selector, text, validate_options!(opts))
+    end
+
+    defp validate_options!(opts) when is_list(opts), do: Keyword.validate!(opts, @options)
+    defp validate_options!(text), do: text
+  end
+end


### PR DESCRIPTION
With `open_for_registrations` off, the sign-in page still offered "Sign up for free", and following the link only bounced back to sign-in with a flash. The page now says "Don't have an account? Please contact your platform admin." instead, and the sign-up link only appears when registrations are open.

The branch also carries three smaller changes, in separate commits.

## Firmware and archive lists use the layout's slots

Both list pages drew their own header bar and pager inside the page body. They now pass them to the sidebar layout's `header` and `pagination` slots, as the device and deployment group lists already do. The empty state reads "doesn't have any available firmware" (or archives) in muted monospace.

On the firmware list, the drop overlay from #3030 now covers the list below the header rather than the header as well, because the layout renders the header outside the drop target.

## Signing keys pages scroll within the page body

The signing keys list and the new key form get the same `h-0 flex-1 overflow-y-auto` container as the other sidebar pages.

## PhoenixTest assertions that weren't checking text

PhoenixTest 0.12.1 reads the options it recognizes and silently drops anything else. In the controller tests, 21 `assert_has` calls passed `with:` or `times:` rather than `text:` and `count:`, so they only checked that the selector matched something. Three more, in the device page tests, passed `exact_option:`, which belongs to `select/3`.

Once they checked text, one expectation turned out to be wrong. Registering from an invite looked for "Welcome to NervesHub!" in an `h1`, but that text is a flash message. The test now looks at the flash, which does render.

To keep this from coming back, `assert_has` and `refute_has` in the browser test case go through a small wrapper that raises on unknown options. PhoenixTest is a test-only dependency and `test/support` also compiles in dev, so the wrapper module is only defined when PhoenixTest is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
